### PR TITLE
Update files `go-swagger` thinks need changes

### DIFF
--- a/pkg/gen/adminapi/adminoperations/admin_users/create_admin_user.go
+++ b/pkg/gen/adminapi/adminoperations/admin_users/create_admin_user.go
@@ -29,12 +29,12 @@ func NewCreateAdminUser(ctx *middleware.Context, handler CreateAdminUserHandler)
 	return &CreateAdminUser{Context: ctx, Handler: handler}
 }
 
-/*
-	CreateAdminUser swagger:route POST /admin_users admin_users createAdminUser
+/* CreateAdminUser swagger:route POST /admin_users admin_users createAdminUser
 
 create an admin user
 
 creates and returns an admin user record
+
 */
 type CreateAdminUser struct {
 	Context *middleware.Context

--- a/pkg/gen/adminapi/adminoperations/admin_users/create_admin_user_responses.go
+++ b/pkg/gen/adminapi/adminoperations/admin_users/create_admin_user_responses.go
@@ -16,8 +16,7 @@ import (
 // CreateAdminUserCreatedCode is the HTTP code returned for type CreateAdminUserCreated
 const CreateAdminUserCreatedCode int = 201
 
-/*
-CreateAdminUserCreated Successfully created Admin User
+/*CreateAdminUserCreated Successfully created Admin User
 
 swagger:response createAdminUserCreated
 */
@@ -61,8 +60,7 @@ func (o *CreateAdminUserCreated) WriteResponse(rw http.ResponseWriter, producer 
 // CreateAdminUserBadRequestCode is the HTTP code returned for type CreateAdminUserBadRequest
 const CreateAdminUserBadRequestCode int = 400
 
-/*
-CreateAdminUserBadRequest Invalid Request
+/*CreateAdminUserBadRequest Invalid Request
 
 swagger:response createAdminUserBadRequest
 */
@@ -86,8 +84,7 @@ func (o *CreateAdminUserBadRequest) WriteResponse(rw http.ResponseWriter, produc
 // CreateAdminUserUnauthorizedCode is the HTTP code returned for type CreateAdminUserUnauthorized
 const CreateAdminUserUnauthorizedCode int = 401
 
-/*
-CreateAdminUserUnauthorized Must be authenticated to use this end point
+/*CreateAdminUserUnauthorized Must be authenticated to use this end point
 
 swagger:response createAdminUserUnauthorized
 */
@@ -111,8 +108,7 @@ func (o *CreateAdminUserUnauthorized) WriteResponse(rw http.ResponseWriter, prod
 // CreateAdminUserForbiddenCode is the HTTP code returned for type CreateAdminUserForbidden
 const CreateAdminUserForbiddenCode int = 403
 
-/*
-CreateAdminUserForbidden Not authorized to create an admin user
+/*CreateAdminUserForbidden Not authorized to create an admin user
 
 swagger:response createAdminUserForbidden
 */
@@ -136,8 +132,7 @@ func (o *CreateAdminUserForbidden) WriteResponse(rw http.ResponseWriter, produce
 // CreateAdminUserInternalServerErrorCode is the HTTP code returned for type CreateAdminUserInternalServerError
 const CreateAdminUserInternalServerErrorCode int = 500
 
-/*
-CreateAdminUserInternalServerError Server error
+/*CreateAdminUserInternalServerError Server error
 
 swagger:response createAdminUserInternalServerError
 */

--- a/pkg/gen/adminapi/adminoperations/admin_users/get_admin_user.go
+++ b/pkg/gen/adminapi/adminoperations/admin_users/get_admin_user.go
@@ -29,12 +29,12 @@ func NewGetAdminUser(ctx *middleware.Context, handler GetAdminUserHandler) *GetA
 	return &GetAdminUser{Context: ctx, Handler: handler}
 }
 
-/*
-	GetAdminUser swagger:route GET /admin_users/{adminUserId} admin_users getAdminUser
+/* GetAdminUser swagger:route GET /admin_users/{adminUserId} admin_users getAdminUser
 
-# Fetch a specific admin user
+Fetch a specific admin user
 
 Returns a single admin user
+
 */
 type GetAdminUser struct {
 	Context *middleware.Context

--- a/pkg/gen/adminapi/adminoperations/admin_users/get_admin_user_responses.go
+++ b/pkg/gen/adminapi/adminoperations/admin_users/get_admin_user_responses.go
@@ -16,8 +16,7 @@ import (
 // GetAdminUserOKCode is the HTTP code returned for type GetAdminUserOK
 const GetAdminUserOKCode int = 200
 
-/*
-GetAdminUserOK success
+/*GetAdminUserOK success
 
 swagger:response getAdminUserOK
 */
@@ -61,8 +60,7 @@ func (o *GetAdminUserOK) WriteResponse(rw http.ResponseWriter, producer runtime.
 // GetAdminUserBadRequestCode is the HTTP code returned for type GetAdminUserBadRequest
 const GetAdminUserBadRequestCode int = 400
 
-/*
-GetAdminUserBadRequest invalid request
+/*GetAdminUserBadRequest invalid request
 
 swagger:response getAdminUserBadRequest
 */
@@ -86,8 +84,7 @@ func (o *GetAdminUserBadRequest) WriteResponse(rw http.ResponseWriter, producer 
 // GetAdminUserUnauthorizedCode is the HTTP code returned for type GetAdminUserUnauthorized
 const GetAdminUserUnauthorizedCode int = 401
 
-/*
-GetAdminUserUnauthorized request requires user authentication
+/*GetAdminUserUnauthorized request requires user authentication
 
 swagger:response getAdminUserUnauthorized
 */
@@ -111,8 +108,7 @@ func (o *GetAdminUserUnauthorized) WriteResponse(rw http.ResponseWriter, produce
 // GetAdminUserNotFoundCode is the HTTP code returned for type GetAdminUserNotFound
 const GetAdminUserNotFoundCode int = 404
 
-/*
-GetAdminUserNotFound admin user not found
+/*GetAdminUserNotFound admin user not found
 
 swagger:response getAdminUserNotFound
 */
@@ -136,8 +132,7 @@ func (o *GetAdminUserNotFound) WriteResponse(rw http.ResponseWriter, producer ru
 // GetAdminUserInternalServerErrorCode is the HTTP code returned for type GetAdminUserInternalServerError
 const GetAdminUserInternalServerErrorCode int = 500
 
-/*
-GetAdminUserInternalServerError server error
+/*GetAdminUserInternalServerError server error
 
 swagger:response getAdminUserInternalServerError
 */

--- a/pkg/gen/adminapi/adminoperations/admin_users/index_admin_users.go
+++ b/pkg/gen/adminapi/adminoperations/admin_users/index_admin_users.go
@@ -29,12 +29,12 @@ func NewIndexAdminUsers(ctx *middleware.Context, handler IndexAdminUsersHandler)
 	return &IndexAdminUsers{Context: ctx, Handler: handler}
 }
 
-/*
-	IndexAdminUsers swagger:route GET /admin_users admin_users indexAdminUsers
+/* IndexAdminUsers swagger:route GET /admin_users admin_users indexAdminUsers
 
-# List admin users
+List admin users
 
 Returns a list of admin users
+
 */
 type IndexAdminUsers struct {
 	Context *middleware.Context

--- a/pkg/gen/adminapi/adminoperations/admin_users/index_admin_users_responses.go
+++ b/pkg/gen/adminapi/adminoperations/admin_users/index_admin_users_responses.go
@@ -16,8 +16,7 @@ import (
 // IndexAdminUsersOKCode is the HTTP code returned for type IndexAdminUsersOK
 const IndexAdminUsersOKCode int = 200
 
-/*
-IndexAdminUsersOK success
+/*IndexAdminUsersOK success
 
 swagger:response indexAdminUsersOK
 */
@@ -86,8 +85,7 @@ func (o *IndexAdminUsersOK) WriteResponse(rw http.ResponseWriter, producer runti
 // IndexAdminUsersBadRequestCode is the HTTP code returned for type IndexAdminUsersBadRequest
 const IndexAdminUsersBadRequestCode int = 400
 
-/*
-IndexAdminUsersBadRequest invalid request
+/*IndexAdminUsersBadRequest invalid request
 
 swagger:response indexAdminUsersBadRequest
 */
@@ -111,8 +109,7 @@ func (o *IndexAdminUsersBadRequest) WriteResponse(rw http.ResponseWriter, produc
 // IndexAdminUsersUnauthorizedCode is the HTTP code returned for type IndexAdminUsersUnauthorized
 const IndexAdminUsersUnauthorizedCode int = 401
 
-/*
-IndexAdminUsersUnauthorized request requires user authentication
+/*IndexAdminUsersUnauthorized request requires user authentication
 
 swagger:response indexAdminUsersUnauthorized
 */
@@ -136,8 +133,7 @@ func (o *IndexAdminUsersUnauthorized) WriteResponse(rw http.ResponseWriter, prod
 // IndexAdminUsersNotFoundCode is the HTTP code returned for type IndexAdminUsersNotFound
 const IndexAdminUsersNotFoundCode int = 404
 
-/*
-IndexAdminUsersNotFound admin users not found
+/*IndexAdminUsersNotFound admin users not found
 
 swagger:response indexAdminUsersNotFound
 */
@@ -161,8 +157,7 @@ func (o *IndexAdminUsersNotFound) WriteResponse(rw http.ResponseWriter, producer
 // IndexAdminUsersInternalServerErrorCode is the HTTP code returned for type IndexAdminUsersInternalServerError
 const IndexAdminUsersInternalServerErrorCode int = 500
 
-/*
-IndexAdminUsersInternalServerError server error
+/*IndexAdminUsersInternalServerError server error
 
 swagger:response indexAdminUsersInternalServerError
 */

--- a/pkg/gen/adminapi/adminoperations/admin_users/update_admin_user.go
+++ b/pkg/gen/adminapi/adminoperations/admin_users/update_admin_user.go
@@ -29,10 +29,10 @@ func NewUpdateAdminUser(ctx *middleware.Context, handler UpdateAdminUserHandler)
 	return &UpdateAdminUser{Context: ctx, Handler: handler}
 }
 
-/*
-	UpdateAdminUser swagger:route PATCH /admin_users/{adminUserId} admin_users updateAdminUser
+/* UpdateAdminUser swagger:route PATCH /admin_users/{adminUserId} admin_users updateAdminUser
 
 Updates an admin user
+
 */
 type UpdateAdminUser struct {
 	Context *middleware.Context

--- a/pkg/gen/adminapi/adminoperations/admin_users/update_admin_user_responses.go
+++ b/pkg/gen/adminapi/adminoperations/admin_users/update_admin_user_responses.go
@@ -16,8 +16,7 @@ import (
 // UpdateAdminUserOKCode is the HTTP code returned for type UpdateAdminUserOK
 const UpdateAdminUserOKCode int = 200
 
-/*
-UpdateAdminUserOK Successfully updated Admin User
+/*UpdateAdminUserOK Successfully updated Admin User
 
 swagger:response updateAdminUserOK
 */
@@ -61,8 +60,7 @@ func (o *UpdateAdminUserOK) WriteResponse(rw http.ResponseWriter, producer runti
 // UpdateAdminUserBadRequestCode is the HTTP code returned for type UpdateAdminUserBadRequest
 const UpdateAdminUserBadRequestCode int = 400
 
-/*
-UpdateAdminUserBadRequest Invalid Request
+/*UpdateAdminUserBadRequest Invalid Request
 
 swagger:response updateAdminUserBadRequest
 */
@@ -86,8 +84,7 @@ func (o *UpdateAdminUserBadRequest) WriteResponse(rw http.ResponseWriter, produc
 // UpdateAdminUserUnauthorizedCode is the HTTP code returned for type UpdateAdminUserUnauthorized
 const UpdateAdminUserUnauthorizedCode int = 401
 
-/*
-UpdateAdminUserUnauthorized Must be authenticated to use this end point
+/*UpdateAdminUserUnauthorized Must be authenticated to use this end point
 
 swagger:response updateAdminUserUnauthorized
 */
@@ -111,8 +108,7 @@ func (o *UpdateAdminUserUnauthorized) WriteResponse(rw http.ResponseWriter, prod
 // UpdateAdminUserForbiddenCode is the HTTP code returned for type UpdateAdminUserForbidden
 const UpdateAdminUserForbiddenCode int = 403
 
-/*
-UpdateAdminUserForbidden Not authorized to update an admin user
+/*UpdateAdminUserForbidden Not authorized to update an admin user
 
 swagger:response updateAdminUserForbidden
 */
@@ -136,8 +132,7 @@ func (o *UpdateAdminUserForbidden) WriteResponse(rw http.ResponseWriter, produce
 // UpdateAdminUserInternalServerErrorCode is the HTTP code returned for type UpdateAdminUserInternalServerError
 const UpdateAdminUserInternalServerErrorCode int = 500
 
-/*
-UpdateAdminUserInternalServerError Server error
+/*UpdateAdminUserInternalServerError Server error
 
 swagger:response updateAdminUserInternalServerError
 */

--- a/pkg/gen/adminapi/adminoperations/electronic_order/get_electronic_orders_totals.go
+++ b/pkg/gen/adminapi/adminoperations/electronic_order/get_electronic_orders_totals.go
@@ -29,12 +29,12 @@ func NewGetElectronicOrdersTotals(ctx *middleware.Context, handler GetElectronic
 	return &GetElectronicOrdersTotals{Context: ctx, Handler: handler}
 }
 
-/*
-	GetElectronicOrdersTotals swagger:route GET /electronic_orders/totals electronic_order getElectronicOrdersTotals
+/* GetElectronicOrdersTotals swagger:route GET /electronic_orders/totals electronic_order getElectronicOrdersTotals
 
-# Get total counts for the orders stored in MilMove
+Get total counts for the orders stored in MilMove
 
 Returns a list of record counts for orders
+
 */
 type GetElectronicOrdersTotals struct {
 	Context *middleware.Context

--- a/pkg/gen/adminapi/adminoperations/electronic_order/get_electronic_orders_totals_responses.go
+++ b/pkg/gen/adminapi/adminoperations/electronic_order/get_electronic_orders_totals_responses.go
@@ -16,8 +16,7 @@ import (
 // GetElectronicOrdersTotalsOKCode is the HTTP code returned for type GetElectronicOrdersTotalsOK
 const GetElectronicOrdersTotalsOKCode int = 200
 
-/*
-GetElectronicOrdersTotalsOK success
+/*GetElectronicOrdersTotalsOK success
 
 swagger:response getElectronicOrdersTotalsOK
 */
@@ -64,8 +63,7 @@ func (o *GetElectronicOrdersTotalsOK) WriteResponse(rw http.ResponseWriter, prod
 // GetElectronicOrdersTotalsBadRequestCode is the HTTP code returned for type GetElectronicOrdersTotalsBadRequest
 const GetElectronicOrdersTotalsBadRequestCode int = 400
 
-/*
-GetElectronicOrdersTotalsBadRequest invalid request
+/*GetElectronicOrdersTotalsBadRequest invalid request
 
 swagger:response getElectronicOrdersTotalsBadRequest
 */
@@ -89,8 +87,7 @@ func (o *GetElectronicOrdersTotalsBadRequest) WriteResponse(rw http.ResponseWrit
 // GetElectronicOrdersTotalsUnauthorizedCode is the HTTP code returned for type GetElectronicOrdersTotalsUnauthorized
 const GetElectronicOrdersTotalsUnauthorizedCode int = 401
 
-/*
-GetElectronicOrdersTotalsUnauthorized request requires user authentication
+/*GetElectronicOrdersTotalsUnauthorized request requires user authentication
 
 swagger:response getElectronicOrdersTotalsUnauthorized
 */
@@ -114,8 +111,7 @@ func (o *GetElectronicOrdersTotalsUnauthorized) WriteResponse(rw http.ResponseWr
 // GetElectronicOrdersTotalsNotFoundCode is the HTTP code returned for type GetElectronicOrdersTotalsNotFound
 const GetElectronicOrdersTotalsNotFoundCode int = 404
 
-/*
-GetElectronicOrdersTotalsNotFound not found
+/*GetElectronicOrdersTotalsNotFound not found
 
 swagger:response getElectronicOrdersTotalsNotFound
 */
@@ -139,8 +135,7 @@ func (o *GetElectronicOrdersTotalsNotFound) WriteResponse(rw http.ResponseWriter
 // GetElectronicOrdersTotalsInternalServerErrorCode is the HTTP code returned for type GetElectronicOrdersTotalsInternalServerError
 const GetElectronicOrdersTotalsInternalServerErrorCode int = 500
 
-/*
-GetElectronicOrdersTotalsInternalServerError server error
+/*GetElectronicOrdersTotalsInternalServerError server error
 
 swagger:response getElectronicOrdersTotalsInternalServerError
 */

--- a/pkg/gen/adminapi/adminoperations/electronic_order/index_electronic_orders.go
+++ b/pkg/gen/adminapi/adminoperations/electronic_order/index_electronic_orders.go
@@ -29,12 +29,12 @@ func NewIndexElectronicOrders(ctx *middleware.Context, handler IndexElectronicOr
 	return &IndexElectronicOrders{Context: ctx, Handler: handler}
 }
 
-/*
-	IndexElectronicOrders swagger:route GET /electronic_orders electronic_order indexElectronicOrders
+/* IndexElectronicOrders swagger:route GET /electronic_orders electronic_order indexElectronicOrders
 
-# List electronic orders
+List electronic orders
 
 Returns a list of electronic orders
+
 */
 type IndexElectronicOrders struct {
 	Context *middleware.Context

--- a/pkg/gen/adminapi/adminoperations/electronic_order/index_electronic_orders_responses.go
+++ b/pkg/gen/adminapi/adminoperations/electronic_order/index_electronic_orders_responses.go
@@ -16,8 +16,7 @@ import (
 // IndexElectronicOrdersOKCode is the HTTP code returned for type IndexElectronicOrdersOK
 const IndexElectronicOrdersOKCode int = 200
 
-/*
-IndexElectronicOrdersOK success
+/*IndexElectronicOrdersOK success
 
 swagger:response indexElectronicOrdersOK
 */
@@ -86,8 +85,7 @@ func (o *IndexElectronicOrdersOK) WriteResponse(rw http.ResponseWriter, producer
 // IndexElectronicOrdersBadRequestCode is the HTTP code returned for type IndexElectronicOrdersBadRequest
 const IndexElectronicOrdersBadRequestCode int = 400
 
-/*
-IndexElectronicOrdersBadRequest invalid request
+/*IndexElectronicOrdersBadRequest invalid request
 
 swagger:response indexElectronicOrdersBadRequest
 */
@@ -111,8 +109,7 @@ func (o *IndexElectronicOrdersBadRequest) WriteResponse(rw http.ResponseWriter, 
 // IndexElectronicOrdersUnauthorizedCode is the HTTP code returned for type IndexElectronicOrdersUnauthorized
 const IndexElectronicOrdersUnauthorizedCode int = 401
 
-/*
-IndexElectronicOrdersUnauthorized request requires user authentication
+/*IndexElectronicOrdersUnauthorized request requires user authentication
 
 swagger:response indexElectronicOrdersUnauthorized
 */
@@ -136,8 +133,7 @@ func (o *IndexElectronicOrdersUnauthorized) WriteResponse(rw http.ResponseWriter
 // IndexElectronicOrdersNotFoundCode is the HTTP code returned for type IndexElectronicOrdersNotFound
 const IndexElectronicOrdersNotFoundCode int = 404
 
-/*
-IndexElectronicOrdersNotFound not found
+/*IndexElectronicOrdersNotFound not found
 
 swagger:response indexElectronicOrdersNotFound
 */
@@ -161,8 +157,7 @@ func (o *IndexElectronicOrdersNotFound) WriteResponse(rw http.ResponseWriter, pr
 // IndexElectronicOrdersInternalServerErrorCode is the HTTP code returned for type IndexElectronicOrdersInternalServerError
 const IndexElectronicOrdersInternalServerErrorCode int = 500
 
-/*
-IndexElectronicOrdersInternalServerError server error
+/*IndexElectronicOrdersInternalServerError server error
 
 swagger:response indexElectronicOrdersInternalServerError
 */

--- a/pkg/gen/adminapi/adminoperations/move/get_move.go
+++ b/pkg/gen/adminapi/adminoperations/move/get_move.go
@@ -29,12 +29,12 @@ func NewGetMove(ctx *middleware.Context, handler GetMoveHandler) *GetMove {
 	return &GetMove{Context: ctx, Handler: handler}
 }
 
-/*
-	GetMove swagger:route GET /moves/{moveID} move getMove
+/* GetMove swagger:route GET /moves/{moveID} move getMove
 
-# Get information about a move
+Get information about a move
 
 Returns the given move and its relevant info
+
 */
 type GetMove struct {
 	Context *middleware.Context

--- a/pkg/gen/adminapi/adminoperations/move/get_move_responses.go
+++ b/pkg/gen/adminapi/adminoperations/move/get_move_responses.go
@@ -16,8 +16,7 @@ import (
 // GetMoveOKCode is the HTTP code returned for type GetMoveOK
 const GetMoveOKCode int = 200
 
-/*
-GetMoveOK Success
+/*GetMoveOK Success
 
 swagger:response getMoveOK
 */
@@ -61,8 +60,7 @@ func (o *GetMoveOK) WriteResponse(rw http.ResponseWriter, producer runtime.Produ
 // GetMoveBadRequestCode is the HTTP code returned for type GetMoveBadRequest
 const GetMoveBadRequestCode int = 400
 
-/*
-GetMoveBadRequest Invalid request
+/*GetMoveBadRequest Invalid request
 
 swagger:response getMoveBadRequest
 */
@@ -86,8 +84,7 @@ func (o *GetMoveBadRequest) WriteResponse(rw http.ResponseWriter, producer runti
 // GetMoveUnauthorizedCode is the HTTP code returned for type GetMoveUnauthorized
 const GetMoveUnauthorizedCode int = 401
 
-/*
-GetMoveUnauthorized Must be authenticated to use this endpoint
+/*GetMoveUnauthorized Must be authenticated to use this endpoint
 
 swagger:response getMoveUnauthorized
 */
@@ -111,8 +108,7 @@ func (o *GetMoveUnauthorized) WriteResponse(rw http.ResponseWriter, producer run
 // GetMoveNotFoundCode is the HTTP code returned for type GetMoveNotFound
 const GetMoveNotFoundCode int = 404
 
-/*
-GetMoveNotFound Move not found
+/*GetMoveNotFound Move not found
 
 swagger:response getMoveNotFound
 */
@@ -136,8 +132,7 @@ func (o *GetMoveNotFound) WriteResponse(rw http.ResponseWriter, producer runtime
 // GetMoveInternalServerErrorCode is the HTTP code returned for type GetMoveInternalServerError
 const GetMoveInternalServerErrorCode int = 500
 
-/*
-GetMoveInternalServerError Server error
+/*GetMoveInternalServerError Server error
 
 swagger:response getMoveInternalServerError
 */

--- a/pkg/gen/adminapi/adminoperations/move/index_moves.go
+++ b/pkg/gen/adminapi/adminoperations/move/index_moves.go
@@ -29,12 +29,12 @@ func NewIndexMoves(ctx *middleware.Context, handler IndexMovesHandler) *IndexMov
 	return &IndexMoves{Context: ctx, Handler: handler}
 }
 
-/*
-	IndexMoves swagger:route GET /moves move indexMoves
+/* IndexMoves swagger:route GET /moves move indexMoves
 
-# List moves
+List moves
 
 Returns a list of moves
+
 */
 type IndexMoves struct {
 	Context *middleware.Context

--- a/pkg/gen/adminapi/adminoperations/move/index_moves_responses.go
+++ b/pkg/gen/adminapi/adminoperations/move/index_moves_responses.go
@@ -16,8 +16,7 @@ import (
 // IndexMovesOKCode is the HTTP code returned for type IndexMovesOK
 const IndexMovesOKCode int = 200
 
-/*
-IndexMovesOK success
+/*IndexMovesOK success
 
 swagger:response indexMovesOK
 */
@@ -86,8 +85,7 @@ func (o *IndexMovesOK) WriteResponse(rw http.ResponseWriter, producer runtime.Pr
 // IndexMovesBadRequestCode is the HTTP code returned for type IndexMovesBadRequest
 const IndexMovesBadRequestCode int = 400
 
-/*
-IndexMovesBadRequest invalid request
+/*IndexMovesBadRequest invalid request
 
 swagger:response indexMovesBadRequest
 */
@@ -111,8 +109,7 @@ func (o *IndexMovesBadRequest) WriteResponse(rw http.ResponseWriter, producer ru
 // IndexMovesUnauthorizedCode is the HTTP code returned for type IndexMovesUnauthorized
 const IndexMovesUnauthorizedCode int = 401
 
-/*
-IndexMovesUnauthorized request requires user authentication
+/*IndexMovesUnauthorized request requires user authentication
 
 swagger:response indexMovesUnauthorized
 */
@@ -136,8 +133,7 @@ func (o *IndexMovesUnauthorized) WriteResponse(rw http.ResponseWriter, producer 
 // IndexMovesNotFoundCode is the HTTP code returned for type IndexMovesNotFound
 const IndexMovesNotFoundCode int = 404
 
-/*
-IndexMovesNotFound not found
+/*IndexMovesNotFound not found
 
 swagger:response indexMovesNotFound
 */
@@ -161,8 +157,7 @@ func (o *IndexMovesNotFound) WriteResponse(rw http.ResponseWriter, producer runt
 // IndexMovesInternalServerErrorCode is the HTTP code returned for type IndexMovesInternalServerError
 const IndexMovesInternalServerErrorCode int = 500
 
-/*
-IndexMovesInternalServerError server error
+/*IndexMovesInternalServerError server error
 
 swagger:response indexMovesInternalServerError
 */

--- a/pkg/gen/adminapi/adminoperations/move/update_move.go
+++ b/pkg/gen/adminapi/adminoperations/move/update_move.go
@@ -29,12 +29,13 @@ func NewUpdateMove(ctx *middleware.Context, handler UpdateMoveHandler) *UpdateMo
 	return &UpdateMove{Context: ctx, Handler: handler}
 }
 
-/*
-	UpdateMove swagger:route PATCH /moves/{moveID} move updateMove
+/* UpdateMove swagger:route PATCH /moves/{moveID} move updateMove
 
-# Disables or re-enables a move
+Disables or re-enables a move
 
 Allows the user to change the `show` field on the selected field to either `True` or `False`. A "shown" move will appear to all users as normal, a "hidden" move will not be returned or editable using any other endpoint (besides those in the Support API), and thus effectively deactivated.
+
+
 */
 type UpdateMove struct {
 	Context *middleware.Context

--- a/pkg/gen/adminapi/adminoperations/move/update_move_responses.go
+++ b/pkg/gen/adminapi/adminoperations/move/update_move_responses.go
@@ -16,8 +16,7 @@ import (
 // UpdateMoveOKCode is the HTTP code returned for type UpdateMoveOK
 const UpdateMoveOKCode int = 200
 
-/*
-UpdateMoveOK Successfully updated the Mov
+/*UpdateMoveOK Successfully updated the Mov
 
 swagger:response updateMoveOK
 */
@@ -61,8 +60,7 @@ func (o *UpdateMoveOK) WriteResponse(rw http.ResponseWriter, producer runtime.Pr
 // UpdateMoveBadRequestCode is the HTTP code returned for type UpdateMoveBadRequest
 const UpdateMoveBadRequestCode int = 400
 
-/*
-UpdateMoveBadRequest Invalid request
+/*UpdateMoveBadRequest Invalid request
 
 swagger:response updateMoveBadRequest
 */
@@ -86,8 +84,7 @@ func (o *UpdateMoveBadRequest) WriteResponse(rw http.ResponseWriter, producer ru
 // UpdateMoveUnauthorizedCode is the HTTP code returned for type UpdateMoveUnauthorized
 const UpdateMoveUnauthorizedCode int = 401
 
-/*
-UpdateMoveUnauthorized Must be authenticated to use this endpoint
+/*UpdateMoveUnauthorized Must be authenticated to use this endpoint
 
 swagger:response updateMoveUnauthorized
 */
@@ -111,8 +108,7 @@ func (o *UpdateMoveUnauthorized) WriteResponse(rw http.ResponseWriter, producer 
 // UpdateMoveForbiddenCode is the HTTP code returned for type UpdateMoveForbidden
 const UpdateMoveForbiddenCode int = 403
 
-/*
-UpdateMoveForbidden Not authorized to update this move
+/*UpdateMoveForbidden Not authorized to update this move
 
 swagger:response updateMoveForbidden
 */
@@ -136,8 +132,7 @@ func (o *UpdateMoveForbidden) WriteResponse(rw http.ResponseWriter, producer run
 // UpdateMoveNotFoundCode is the HTTP code returned for type UpdateMoveNotFound
 const UpdateMoveNotFoundCode int = 404
 
-/*
-UpdateMoveNotFound Move not found
+/*UpdateMoveNotFound Move not found
 
 swagger:response updateMoveNotFound
 */
@@ -161,8 +156,7 @@ func (o *UpdateMoveNotFound) WriteResponse(rw http.ResponseWriter, producer runt
 // UpdateMoveUnprocessableEntityCode is the HTTP code returned for type UpdateMoveUnprocessableEntity
 const UpdateMoveUnprocessableEntityCode int = 422
 
-/*
-UpdateMoveUnprocessableEntity Invalid input
+/*UpdateMoveUnprocessableEntity Invalid input
 
 swagger:response updateMoveUnprocessableEntity
 */
@@ -186,8 +180,7 @@ func (o *UpdateMoveUnprocessableEntity) WriteResponse(rw http.ResponseWriter, pr
 // UpdateMoveInternalServerErrorCode is the HTTP code returned for type UpdateMoveInternalServerError
 const UpdateMoveInternalServerErrorCode int = 500
 
-/*
-UpdateMoveInternalServerError Server error
+/*UpdateMoveInternalServerError Server error
 
 swagger:response updateMoveInternalServerError
 */

--- a/pkg/gen/adminapi/adminoperations/mymove_api.go
+++ b/pkg/gen/adminapi/adminoperations/mymove_api.go
@@ -135,8 +135,7 @@ func NewMymoveAPI(spec *loads.Document) *MymoveAPI {
 	}
 }
 
-/*
-MymoveAPI The Admin API is a RESTful API that enables the Admin application for MilMove.
+/*MymoveAPI The Admin API is a RESTful API that enables the Admin application for MilMove.
 
 All endpoints are located under `/admin/v1`.
 */

--- a/pkg/gen/adminapi/adminoperations/notification/index_notifications.go
+++ b/pkg/gen/adminapi/adminoperations/notification/index_notifications.go
@@ -29,12 +29,12 @@ func NewIndexNotifications(ctx *middleware.Context, handler IndexNotificationsHa
 	return &IndexNotifications{Context: ctx, Handler: handler}
 }
 
-/*
-	IndexNotifications swagger:route GET /notifications notification indexNotifications
+/* IndexNotifications swagger:route GET /notifications notification indexNotifications
 
-# List notifications
+List notifications
 
 Returns a list of notifications that have been sent to service members
+
 */
 type IndexNotifications struct {
 	Context *middleware.Context

--- a/pkg/gen/adminapi/adminoperations/notification/index_notifications_responses.go
+++ b/pkg/gen/adminapi/adminoperations/notification/index_notifications_responses.go
@@ -16,8 +16,7 @@ import (
 // IndexNotificationsOKCode is the HTTP code returned for type IndexNotificationsOK
 const IndexNotificationsOKCode int = 200
 
-/*
-IndexNotificationsOK success
+/*IndexNotificationsOK success
 
 swagger:response indexNotificationsOK
 */
@@ -86,8 +85,7 @@ func (o *IndexNotificationsOK) WriteResponse(rw http.ResponseWriter, producer ru
 // IndexNotificationsBadRequestCode is the HTTP code returned for type IndexNotificationsBadRequest
 const IndexNotificationsBadRequestCode int = 400
 
-/*
-IndexNotificationsBadRequest invalid request
+/*IndexNotificationsBadRequest invalid request
 
 swagger:response indexNotificationsBadRequest
 */
@@ -111,8 +109,7 @@ func (o *IndexNotificationsBadRequest) WriteResponse(rw http.ResponseWriter, pro
 // IndexNotificationsUnauthorizedCode is the HTTP code returned for type IndexNotificationsUnauthorized
 const IndexNotificationsUnauthorizedCode int = 401
 
-/*
-IndexNotificationsUnauthorized request requires user authentication
+/*IndexNotificationsUnauthorized request requires user authentication
 
 swagger:response indexNotificationsUnauthorized
 */
@@ -136,8 +133,7 @@ func (o *IndexNotificationsUnauthorized) WriteResponse(rw http.ResponseWriter, p
 // IndexNotificationsNotFoundCode is the HTTP code returned for type IndexNotificationsNotFound
 const IndexNotificationsNotFoundCode int = 404
 
-/*
-IndexNotificationsNotFound not found
+/*IndexNotificationsNotFound not found
 
 swagger:response indexNotificationsNotFound
 */
@@ -161,8 +157,7 @@ func (o *IndexNotificationsNotFound) WriteResponse(rw http.ResponseWriter, produ
 // IndexNotificationsInternalServerErrorCode is the HTTP code returned for type IndexNotificationsInternalServerError
 const IndexNotificationsInternalServerErrorCode int = 500
 
-/*
-IndexNotificationsInternalServerError server error
+/*IndexNotificationsInternalServerError server error
 
 swagger:response indexNotificationsInternalServerError
 */

--- a/pkg/gen/adminapi/adminoperations/office/index_offices.go
+++ b/pkg/gen/adminapi/adminoperations/office/index_offices.go
@@ -29,12 +29,12 @@ func NewIndexOffices(ctx *middleware.Context, handler IndexOfficesHandler) *Inde
 	return &IndexOffices{Context: ctx, Handler: handler}
 }
 
-/*
-	IndexOffices swagger:route GET /offices office indexOffices
+/* IndexOffices swagger:route GET /offices office indexOffices
 
-# List transportation offices
+List transportation offices
 
 Returns a list of transportation offices
+
 */
 type IndexOffices struct {
 	Context *middleware.Context

--- a/pkg/gen/adminapi/adminoperations/office/index_offices_responses.go
+++ b/pkg/gen/adminapi/adminoperations/office/index_offices_responses.go
@@ -16,8 +16,7 @@ import (
 // IndexOfficesOKCode is the HTTP code returned for type IndexOfficesOK
 const IndexOfficesOKCode int = 200
 
-/*
-IndexOfficesOK success
+/*IndexOfficesOK success
 
 swagger:response indexOfficesOK
 */
@@ -86,8 +85,7 @@ func (o *IndexOfficesOK) WriteResponse(rw http.ResponseWriter, producer runtime.
 // IndexOfficesBadRequestCode is the HTTP code returned for type IndexOfficesBadRequest
 const IndexOfficesBadRequestCode int = 400
 
-/*
-IndexOfficesBadRequest invalid request
+/*IndexOfficesBadRequest invalid request
 
 swagger:response indexOfficesBadRequest
 */
@@ -111,8 +109,7 @@ func (o *IndexOfficesBadRequest) WriteResponse(rw http.ResponseWriter, producer 
 // IndexOfficesUnauthorizedCode is the HTTP code returned for type IndexOfficesUnauthorized
 const IndexOfficesUnauthorizedCode int = 401
 
-/*
-IndexOfficesUnauthorized request requires user authentication
+/*IndexOfficesUnauthorized request requires user authentication
 
 swagger:response indexOfficesUnauthorized
 */
@@ -136,8 +133,7 @@ func (o *IndexOfficesUnauthorized) WriteResponse(rw http.ResponseWriter, produce
 // IndexOfficesNotFoundCode is the HTTP code returned for type IndexOfficesNotFound
 const IndexOfficesNotFoundCode int = 404
 
-/*
-IndexOfficesNotFound office not found
+/*IndexOfficesNotFound office not found
 
 swagger:response indexOfficesNotFound
 */
@@ -161,8 +157,7 @@ func (o *IndexOfficesNotFound) WriteResponse(rw http.ResponseWriter, producer ru
 // IndexOfficesInternalServerErrorCode is the HTTP code returned for type IndexOfficesInternalServerError
 const IndexOfficesInternalServerErrorCode int = 500
 
-/*
-IndexOfficesInternalServerError server error
+/*IndexOfficesInternalServerError server error
 
 swagger:response indexOfficesInternalServerError
 */

--- a/pkg/gen/adminapi/adminoperations/office_users/create_office_user.go
+++ b/pkg/gen/adminapi/adminoperations/office_users/create_office_user.go
@@ -29,12 +29,12 @@ func NewCreateOfficeUser(ctx *middleware.Context, handler CreateOfficeUserHandle
 	return &CreateOfficeUser{Context: ctx, Handler: handler}
 }
 
-/*
-	CreateOfficeUser swagger:route POST /office_users office_users createOfficeUser
+/* CreateOfficeUser swagger:route POST /office_users office_users createOfficeUser
 
 create an office user
 
 creates and returns an office user record
+
 */
 type CreateOfficeUser struct {
 	Context *middleware.Context

--- a/pkg/gen/adminapi/adminoperations/office_users/create_office_user_responses.go
+++ b/pkg/gen/adminapi/adminoperations/office_users/create_office_user_responses.go
@@ -16,8 +16,7 @@ import (
 // CreateOfficeUserCreatedCode is the HTTP code returned for type CreateOfficeUserCreated
 const CreateOfficeUserCreatedCode int = 201
 
-/*
-CreateOfficeUserCreated Successfully created Office User
+/*CreateOfficeUserCreated Successfully created Office User
 
 swagger:response createOfficeUserCreated
 */
@@ -61,8 +60,7 @@ func (o *CreateOfficeUserCreated) WriteResponse(rw http.ResponseWriter, producer
 // CreateOfficeUserUnprocessableEntityCode is the HTTP code returned for type CreateOfficeUserUnprocessableEntity
 const CreateOfficeUserUnprocessableEntityCode int = 422
 
-/*
-CreateOfficeUserUnprocessableEntity validation error
+/*CreateOfficeUserUnprocessableEntity validation error
 
 swagger:response createOfficeUserUnprocessableEntity
 */
@@ -106,8 +104,7 @@ func (o *CreateOfficeUserUnprocessableEntity) WriteResponse(rw http.ResponseWrit
 // CreateOfficeUserInternalServerErrorCode is the HTTP code returned for type CreateOfficeUserInternalServerError
 const CreateOfficeUserInternalServerErrorCode int = 500
 
-/*
-CreateOfficeUserInternalServerError internal server error
+/*CreateOfficeUserInternalServerError internal server error
 
 swagger:response createOfficeUserInternalServerError
 */

--- a/pkg/gen/adminapi/adminoperations/office_users/get_office_user.go
+++ b/pkg/gen/adminapi/adminoperations/office_users/get_office_user.go
@@ -29,12 +29,12 @@ func NewGetOfficeUser(ctx *middleware.Context, handler GetOfficeUserHandler) *Ge
 	return &GetOfficeUser{Context: ctx, Handler: handler}
 }
 
-/*
-	GetOfficeUser swagger:route GET /office_users/{officeUserId} office_users getOfficeUser
+/* GetOfficeUser swagger:route GET /office_users/{officeUserId} office_users getOfficeUser
 
-# Get an office user
+Get an office user
 
 Returns the given office user
+
 */
 type GetOfficeUser struct {
 	Context *middleware.Context

--- a/pkg/gen/adminapi/adminoperations/office_users/get_office_user_responses.go
+++ b/pkg/gen/adminapi/adminoperations/office_users/get_office_user_responses.go
@@ -16,8 +16,7 @@ import (
 // GetOfficeUserOKCode is the HTTP code returned for type GetOfficeUserOK
 const GetOfficeUserOKCode int = 200
 
-/*
-GetOfficeUserOK success
+/*GetOfficeUserOK success
 
 swagger:response getOfficeUserOK
 */
@@ -61,8 +60,7 @@ func (o *GetOfficeUserOK) WriteResponse(rw http.ResponseWriter, producer runtime
 // GetOfficeUserBadRequestCode is the HTTP code returned for type GetOfficeUserBadRequest
 const GetOfficeUserBadRequestCode int = 400
 
-/*
-GetOfficeUserBadRequest invalid request
+/*GetOfficeUserBadRequest invalid request
 
 swagger:response getOfficeUserBadRequest
 */
@@ -86,8 +84,7 @@ func (o *GetOfficeUserBadRequest) WriteResponse(rw http.ResponseWriter, producer
 // GetOfficeUserUnauthorizedCode is the HTTP code returned for type GetOfficeUserUnauthorized
 const GetOfficeUserUnauthorizedCode int = 401
 
-/*
-GetOfficeUserUnauthorized request requires user authentication
+/*GetOfficeUserUnauthorized request requires user authentication
 
 swagger:response getOfficeUserUnauthorized
 */
@@ -111,8 +108,7 @@ func (o *GetOfficeUserUnauthorized) WriteResponse(rw http.ResponseWriter, produc
 // GetOfficeUserNotFoundCode is the HTTP code returned for type GetOfficeUserNotFound
 const GetOfficeUserNotFoundCode int = 404
 
-/*
-GetOfficeUserNotFound office not found
+/*GetOfficeUserNotFound office not found
 
 swagger:response getOfficeUserNotFound
 */
@@ -136,8 +132,7 @@ func (o *GetOfficeUserNotFound) WriteResponse(rw http.ResponseWriter, producer r
 // GetOfficeUserInternalServerErrorCode is the HTTP code returned for type GetOfficeUserInternalServerError
 const GetOfficeUserInternalServerErrorCode int = 500
 
-/*
-GetOfficeUserInternalServerError server error
+/*GetOfficeUserInternalServerError server error
 
 swagger:response getOfficeUserInternalServerError
 */

--- a/pkg/gen/adminapi/adminoperations/office_users/index_office_users.go
+++ b/pkg/gen/adminapi/adminoperations/office_users/index_office_users.go
@@ -29,12 +29,12 @@ func NewIndexOfficeUsers(ctx *middleware.Context, handler IndexOfficeUsersHandle
 	return &IndexOfficeUsers{Context: ctx, Handler: handler}
 }
 
-/*
-	IndexOfficeUsers swagger:route GET /office_users office_users indexOfficeUsers
+/* IndexOfficeUsers swagger:route GET /office_users office_users indexOfficeUsers
 
-# List office users
+List office users
 
 Returns a list of office users
+
 */
 type IndexOfficeUsers struct {
 	Context *middleware.Context

--- a/pkg/gen/adminapi/adminoperations/office_users/index_office_users_responses.go
+++ b/pkg/gen/adminapi/adminoperations/office_users/index_office_users_responses.go
@@ -16,8 +16,7 @@ import (
 // IndexOfficeUsersOKCode is the HTTP code returned for type IndexOfficeUsersOK
 const IndexOfficeUsersOKCode int = 200
 
-/*
-IndexOfficeUsersOK success
+/*IndexOfficeUsersOK success
 
 swagger:response indexOfficeUsersOK
 */
@@ -86,8 +85,7 @@ func (o *IndexOfficeUsersOK) WriteResponse(rw http.ResponseWriter, producer runt
 // IndexOfficeUsersBadRequestCode is the HTTP code returned for type IndexOfficeUsersBadRequest
 const IndexOfficeUsersBadRequestCode int = 400
 
-/*
-IndexOfficeUsersBadRequest invalid request
+/*IndexOfficeUsersBadRequest invalid request
 
 swagger:response indexOfficeUsersBadRequest
 */
@@ -111,8 +109,7 @@ func (o *IndexOfficeUsersBadRequest) WriteResponse(rw http.ResponseWriter, produ
 // IndexOfficeUsersUnauthorizedCode is the HTTP code returned for type IndexOfficeUsersUnauthorized
 const IndexOfficeUsersUnauthorizedCode int = 401
 
-/*
-IndexOfficeUsersUnauthorized request requires user authentication
+/*IndexOfficeUsersUnauthorized request requires user authentication
 
 swagger:response indexOfficeUsersUnauthorized
 */
@@ -136,8 +133,7 @@ func (o *IndexOfficeUsersUnauthorized) WriteResponse(rw http.ResponseWriter, pro
 // IndexOfficeUsersNotFoundCode is the HTTP code returned for type IndexOfficeUsersNotFound
 const IndexOfficeUsersNotFoundCode int = 404
 
-/*
-IndexOfficeUsersNotFound office not found
+/*IndexOfficeUsersNotFound office not found
 
 swagger:response indexOfficeUsersNotFound
 */
@@ -161,8 +157,7 @@ func (o *IndexOfficeUsersNotFound) WriteResponse(rw http.ResponseWriter, produce
 // IndexOfficeUsersInternalServerErrorCode is the HTTP code returned for type IndexOfficeUsersInternalServerError
 const IndexOfficeUsersInternalServerErrorCode int = 500
 
-/*
-IndexOfficeUsersInternalServerError server error
+/*IndexOfficeUsersInternalServerError server error
 
 swagger:response indexOfficeUsersInternalServerError
 */

--- a/pkg/gen/adminapi/adminoperations/office_users/update_office_user.go
+++ b/pkg/gen/adminapi/adminoperations/office_users/update_office_user.go
@@ -29,10 +29,10 @@ func NewUpdateOfficeUser(ctx *middleware.Context, handler UpdateOfficeUserHandle
 	return &UpdateOfficeUser{Context: ctx, Handler: handler}
 }
 
-/*
-	UpdateOfficeUser swagger:route PATCH /office_users/{officeUserId} office_users updateOfficeUser
+/* UpdateOfficeUser swagger:route PATCH /office_users/{officeUserId} office_users updateOfficeUser
 
 Updates an office user
+
 */
 type UpdateOfficeUser struct {
 	Context *middleware.Context

--- a/pkg/gen/adminapi/adminoperations/office_users/update_office_user_responses.go
+++ b/pkg/gen/adminapi/adminoperations/office_users/update_office_user_responses.go
@@ -16,8 +16,7 @@ import (
 // UpdateOfficeUserOKCode is the HTTP code returned for type UpdateOfficeUserOK
 const UpdateOfficeUserOKCode int = 200
 
-/*
-UpdateOfficeUserOK Successfully updated Office User
+/*UpdateOfficeUserOK Successfully updated Office User
 
 swagger:response updateOfficeUserOK
 */
@@ -61,8 +60,7 @@ func (o *UpdateOfficeUserOK) WriteResponse(rw http.ResponseWriter, producer runt
 // UpdateOfficeUserBadRequestCode is the HTTP code returned for type UpdateOfficeUserBadRequest
 const UpdateOfficeUserBadRequestCode int = 400
 
-/*
-UpdateOfficeUserBadRequest Invalid Request
+/*UpdateOfficeUserBadRequest Invalid Request
 
 swagger:response updateOfficeUserBadRequest
 */
@@ -86,8 +84,7 @@ func (o *UpdateOfficeUserBadRequest) WriteResponse(rw http.ResponseWriter, produ
 // UpdateOfficeUserUnauthorizedCode is the HTTP code returned for type UpdateOfficeUserUnauthorized
 const UpdateOfficeUserUnauthorizedCode int = 401
 
-/*
-UpdateOfficeUserUnauthorized Must be authenticated to use this end point
+/*UpdateOfficeUserUnauthorized Must be authenticated to use this end point
 
 swagger:response updateOfficeUserUnauthorized
 */
@@ -111,8 +108,7 @@ func (o *UpdateOfficeUserUnauthorized) WriteResponse(rw http.ResponseWriter, pro
 // UpdateOfficeUserForbiddenCode is the HTTP code returned for type UpdateOfficeUserForbidden
 const UpdateOfficeUserForbiddenCode int = 403
 
-/*
-UpdateOfficeUserForbidden Not authorized to update an office user
+/*UpdateOfficeUserForbidden Not authorized to update an office user
 
 swagger:response updateOfficeUserForbidden
 */
@@ -136,8 +132,7 @@ func (o *UpdateOfficeUserForbidden) WriteResponse(rw http.ResponseWriter, produc
 // UpdateOfficeUserInternalServerErrorCode is the HTTP code returned for type UpdateOfficeUserInternalServerError
 const UpdateOfficeUserInternalServerErrorCode int = 500
 
-/*
-UpdateOfficeUserInternalServerError Server error
+/*UpdateOfficeUserInternalServerError Server error
 
 swagger:response updateOfficeUserInternalServerError
 */

--- a/pkg/gen/adminapi/adminoperations/organization/index_organizations.go
+++ b/pkg/gen/adminapi/adminoperations/organization/index_organizations.go
@@ -29,12 +29,12 @@ func NewIndexOrganizations(ctx *middleware.Context, handler IndexOrganizationsHa
 	return &IndexOrganizations{Context: ctx, Handler: handler}
 }
 
-/*
-	IndexOrganizations swagger:route GET /organizations organization indexOrganizations
+/* IndexOrganizations swagger:route GET /organizations organization indexOrganizations
 
-# List organizations
+List organizations
 
 Returns a list of organizations
+
 */
 type IndexOrganizations struct {
 	Context *middleware.Context

--- a/pkg/gen/adminapi/adminoperations/organization/index_organizations_responses.go
+++ b/pkg/gen/adminapi/adminoperations/organization/index_organizations_responses.go
@@ -16,8 +16,7 @@ import (
 // IndexOrganizationsOKCode is the HTTP code returned for type IndexOrganizationsOK
 const IndexOrganizationsOKCode int = 200
 
-/*
-IndexOrganizationsOK success
+/*IndexOrganizationsOK success
 
 swagger:response indexOrganizationsOK
 */
@@ -86,8 +85,7 @@ func (o *IndexOrganizationsOK) WriteResponse(rw http.ResponseWriter, producer ru
 // IndexOrganizationsBadRequestCode is the HTTP code returned for type IndexOrganizationsBadRequest
 const IndexOrganizationsBadRequestCode int = 400
 
-/*
-IndexOrganizationsBadRequest invalid request
+/*IndexOrganizationsBadRequest invalid request
 
 swagger:response indexOrganizationsBadRequest
 */
@@ -111,8 +109,7 @@ func (o *IndexOrganizationsBadRequest) WriteResponse(rw http.ResponseWriter, pro
 // IndexOrganizationsUnauthorizedCode is the HTTP code returned for type IndexOrganizationsUnauthorized
 const IndexOrganizationsUnauthorizedCode int = 401
 
-/*
-IndexOrganizationsUnauthorized request requires user authentication
+/*IndexOrganizationsUnauthorized request requires user authentication
 
 swagger:response indexOrganizationsUnauthorized
 */
@@ -136,8 +133,7 @@ func (o *IndexOrganizationsUnauthorized) WriteResponse(rw http.ResponseWriter, p
 // IndexOrganizationsNotFoundCode is the HTTP code returned for type IndexOrganizationsNotFound
 const IndexOrganizationsNotFoundCode int = 404
 
-/*
-IndexOrganizationsNotFound not found
+/*IndexOrganizationsNotFound not found
 
 swagger:response indexOrganizationsNotFound
 */
@@ -161,8 +157,7 @@ func (o *IndexOrganizationsNotFound) WriteResponse(rw http.ResponseWriter, produ
 // IndexOrganizationsInternalServerErrorCode is the HTTP code returned for type IndexOrganizationsInternalServerError
 const IndexOrganizationsInternalServerErrorCode int = 500
 
-/*
-IndexOrganizationsInternalServerError server error
+/*IndexOrganizationsInternalServerError server error
 
 swagger:response indexOrganizationsInternalServerError
 */

--- a/pkg/gen/adminapi/adminoperations/transportation_service_provider_performances/get_t_s_p_p.go
+++ b/pkg/gen/adminapi/adminoperations/transportation_service_provider_performances/get_t_s_p_p.go
@@ -29,12 +29,12 @@ func NewGetTSPP(ctx *middleware.Context, handler GetTSPPHandler) *GetTSPP {
 	return &GetTSPP{Context: ctx, Handler: handler}
 }
 
-/*
-	GetTSPP swagger:route GET /transportation_service_provider_performances/{tsppId} transportation_service_provider_performances getTSPP
+/* GetTSPP swagger:route GET /transportation_service_provider_performances/{tsppId} transportation_service_provider_performances getTSPP
 
-# Fetch a specific tspp
+Fetch a specific tspp
 
 Returns a single tspp
+
 */
 type GetTSPP struct {
 	Context *middleware.Context

--- a/pkg/gen/adminapi/adminoperations/transportation_service_provider_performances/get_t_s_p_p_responses.go
+++ b/pkg/gen/adminapi/adminoperations/transportation_service_provider_performances/get_t_s_p_p_responses.go
@@ -16,8 +16,7 @@ import (
 // GetTSPPOKCode is the HTTP code returned for type GetTSPPOK
 const GetTSPPOKCode int = 200
 
-/*
-GetTSPPOK success
+/*GetTSPPOK success
 
 swagger:response getTSPPOK
 */
@@ -61,8 +60,7 @@ func (o *GetTSPPOK) WriteResponse(rw http.ResponseWriter, producer runtime.Produ
 // GetTSPPBadRequestCode is the HTTP code returned for type GetTSPPBadRequest
 const GetTSPPBadRequestCode int = 400
 
-/*
-GetTSPPBadRequest invalid request
+/*GetTSPPBadRequest invalid request
 
 swagger:response getTSPPBadRequest
 */
@@ -86,8 +84,7 @@ func (o *GetTSPPBadRequest) WriteResponse(rw http.ResponseWriter, producer runti
 // GetTSPPUnauthorizedCode is the HTTP code returned for type GetTSPPUnauthorized
 const GetTSPPUnauthorizedCode int = 401
 
-/*
-GetTSPPUnauthorized request requires user authentication
+/*GetTSPPUnauthorized request requires user authentication
 
 swagger:response getTSPPUnauthorized
 */
@@ -111,8 +108,7 @@ func (o *GetTSPPUnauthorized) WriteResponse(rw http.ResponseWriter, producer run
 // GetTSPPNotFoundCode is the HTTP code returned for type GetTSPPNotFound
 const GetTSPPNotFoundCode int = 404
 
-/*
-GetTSPPNotFound tspp not found
+/*GetTSPPNotFound tspp not found
 
 swagger:response getTSPPNotFound
 */
@@ -136,8 +132,7 @@ func (o *GetTSPPNotFound) WriteResponse(rw http.ResponseWriter, producer runtime
 // GetTSPPInternalServerErrorCode is the HTTP code returned for type GetTSPPInternalServerError
 const GetTSPPInternalServerErrorCode int = 500
 
-/*
-GetTSPPInternalServerError server error
+/*GetTSPPInternalServerError server error
 
 swagger:response getTSPPInternalServerError
 */

--- a/pkg/gen/adminapi/adminoperations/transportation_service_provider_performances/index_t_s_p_ps.go
+++ b/pkg/gen/adminapi/adminoperations/transportation_service_provider_performances/index_t_s_p_ps.go
@@ -29,12 +29,12 @@ func NewIndexTSPPs(ctx *middleware.Context, handler IndexTSPPsHandler) *IndexTSP
 	return &IndexTSPPs{Context: ctx, Handler: handler}
 }
 
-/*
-	IndexTSPPs swagger:route GET /transportation_service_provider_performances transportation_service_provider_performances indexTSPPs
+/* IndexTSPPs swagger:route GET /transportation_service_provider_performances transportation_service_provider_performances indexTSPPs
 
 List transportation service provider performances (TSPPs)
 
 Returns a list of transportation service provider performances (TSPPs)
+
 */
 type IndexTSPPs struct {
 	Context *middleware.Context

--- a/pkg/gen/adminapi/adminoperations/transportation_service_provider_performances/index_t_s_p_ps_responses.go
+++ b/pkg/gen/adminapi/adminoperations/transportation_service_provider_performances/index_t_s_p_ps_responses.go
@@ -16,8 +16,7 @@ import (
 // IndexTSPPsOKCode is the HTTP code returned for type IndexTSPPsOK
 const IndexTSPPsOKCode int = 200
 
-/*
-IndexTSPPsOK success
+/*IndexTSPPsOK success
 
 swagger:response indexTSPPsOK
 */
@@ -86,8 +85,7 @@ func (o *IndexTSPPsOK) WriteResponse(rw http.ResponseWriter, producer runtime.Pr
 // IndexTSPPsBadRequestCode is the HTTP code returned for type IndexTSPPsBadRequest
 const IndexTSPPsBadRequestCode int = 400
 
-/*
-IndexTSPPsBadRequest invalid request
+/*IndexTSPPsBadRequest invalid request
 
 swagger:response indexTSPPsBadRequest
 */
@@ -111,8 +109,7 @@ func (o *IndexTSPPsBadRequest) WriteResponse(rw http.ResponseWriter, producer ru
 // IndexTSPPsUnauthorizedCode is the HTTP code returned for type IndexTSPPsUnauthorized
 const IndexTSPPsUnauthorizedCode int = 401
 
-/*
-IndexTSPPsUnauthorized request requires user authentication
+/*IndexTSPPsUnauthorized request requires user authentication
 
 swagger:response indexTSPPsUnauthorized
 */
@@ -136,8 +133,7 @@ func (o *IndexTSPPsUnauthorized) WriteResponse(rw http.ResponseWriter, producer 
 // IndexTSPPsNotFoundCode is the HTTP code returned for type IndexTSPPsNotFound
 const IndexTSPPsNotFoundCode int = 404
 
-/*
-IndexTSPPsNotFound office not found
+/*IndexTSPPsNotFound office not found
 
 swagger:response indexTSPPsNotFound
 */
@@ -161,8 +157,7 @@ func (o *IndexTSPPsNotFound) WriteResponse(rw http.ResponseWriter, producer runt
 // IndexTSPPsInternalServerErrorCode is the HTTP code returned for type IndexTSPPsInternalServerError
 const IndexTSPPsInternalServerErrorCode int = 500
 
-/*
-IndexTSPPsInternalServerError server error
+/*IndexTSPPsInternalServerError server error
 
 swagger:response indexTSPPsInternalServerError
 */

--- a/pkg/gen/adminapi/adminoperations/upload/get_upload.go
+++ b/pkg/gen/adminapi/adminoperations/upload/get_upload.go
@@ -29,12 +29,12 @@ func NewGetUpload(ctx *middleware.Context, handler GetUploadHandler) *GetUpload 
 	return &GetUpload{Context: ctx, Handler: handler}
 }
 
-/*
-	GetUpload swagger:route GET /uploads/{uploadId} upload getUpload
+/* GetUpload swagger:route GET /uploads/{uploadId} upload getUpload
 
-# Get information about an upload
+Get information about an upload
 
 Returns the given upload and information about the uploader and move
+
 */
 type GetUpload struct {
 	Context *middleware.Context

--- a/pkg/gen/adminapi/adminoperations/upload/get_upload_responses.go
+++ b/pkg/gen/adminapi/adminoperations/upload/get_upload_responses.go
@@ -16,8 +16,7 @@ import (
 // GetUploadOKCode is the HTTP code returned for type GetUploadOK
 const GetUploadOKCode int = 200
 
-/*
-GetUploadOK success
+/*GetUploadOK success
 
 swagger:response getUploadOK
 */
@@ -61,8 +60,7 @@ func (o *GetUploadOK) WriteResponse(rw http.ResponseWriter, producer runtime.Pro
 // GetUploadBadRequestCode is the HTTP code returned for type GetUploadBadRequest
 const GetUploadBadRequestCode int = 400
 
-/*
-GetUploadBadRequest invalid request
+/*GetUploadBadRequest invalid request
 
 swagger:response getUploadBadRequest
 */
@@ -86,8 +84,7 @@ func (o *GetUploadBadRequest) WriteResponse(rw http.ResponseWriter, producer run
 // GetUploadUnauthorizedCode is the HTTP code returned for type GetUploadUnauthorized
 const GetUploadUnauthorizedCode int = 401
 
-/*
-GetUploadUnauthorized request requires user authentication
+/*GetUploadUnauthorized request requires user authentication
 
 swagger:response getUploadUnauthorized
 */
@@ -111,8 +108,7 @@ func (o *GetUploadUnauthorized) WriteResponse(rw http.ResponseWriter, producer r
 // GetUploadNotFoundCode is the HTTP code returned for type GetUploadNotFound
 const GetUploadNotFoundCode int = 404
 
-/*
-GetUploadNotFound upload not found
+/*GetUploadNotFound upload not found
 
 swagger:response getUploadNotFound
 */
@@ -136,8 +132,7 @@ func (o *GetUploadNotFound) WriteResponse(rw http.ResponseWriter, producer runti
 // GetUploadInternalServerErrorCode is the HTTP code returned for type GetUploadInternalServerError
 const GetUploadInternalServerErrorCode int = 500
 
-/*
-GetUploadInternalServerError server error
+/*GetUploadInternalServerError server error
 
 swagger:response getUploadInternalServerError
 */

--- a/pkg/gen/adminapi/adminoperations/users/get_user.go
+++ b/pkg/gen/adminapi/adminoperations/users/get_user.go
@@ -29,12 +29,12 @@ func NewGetUser(ctx *middleware.Context, handler GetUserHandler) *GetUser {
 	return &GetUser{Context: ctx, Handler: handler}
 }
 
-/*
-	GetUser swagger:route GET /users/{userId} users getUser
+/* GetUser swagger:route GET /users/{userId} users getUser
 
-# Get information about a user
+Get information about a user
 
 Returns the given user and their sessions
+
 */
 type GetUser struct {
 	Context *middleware.Context

--- a/pkg/gen/adminapi/adminoperations/users/get_user_responses.go
+++ b/pkg/gen/adminapi/adminoperations/users/get_user_responses.go
@@ -16,8 +16,7 @@ import (
 // GetUserOKCode is the HTTP code returned for type GetUserOK
 const GetUserOKCode int = 200
 
-/*
-GetUserOK success
+/*GetUserOK success
 
 swagger:response getUserOK
 */
@@ -61,8 +60,7 @@ func (o *GetUserOK) WriteResponse(rw http.ResponseWriter, producer runtime.Produ
 // GetUserBadRequestCode is the HTTP code returned for type GetUserBadRequest
 const GetUserBadRequestCode int = 400
 
-/*
-GetUserBadRequest invalid request
+/*GetUserBadRequest invalid request
 
 swagger:response getUserBadRequest
 */
@@ -86,8 +84,7 @@ func (o *GetUserBadRequest) WriteResponse(rw http.ResponseWriter, producer runti
 // GetUserUnauthorizedCode is the HTTP code returned for type GetUserUnauthorized
 const GetUserUnauthorizedCode int = 401
 
-/*
-GetUserUnauthorized request requires user authentication
+/*GetUserUnauthorized request requires user authentication
 
 swagger:response getUserUnauthorized
 */
@@ -111,8 +108,7 @@ func (o *GetUserUnauthorized) WriteResponse(rw http.ResponseWriter, producer run
 // GetUserNotFoundCode is the HTTP code returned for type GetUserNotFound
 const GetUserNotFoundCode int = 404
 
-/*
-GetUserNotFound user not found
+/*GetUserNotFound user not found
 
 swagger:response getUserNotFound
 */
@@ -136,8 +132,7 @@ func (o *GetUserNotFound) WriteResponse(rw http.ResponseWriter, producer runtime
 // GetUserInternalServerErrorCode is the HTTP code returned for type GetUserInternalServerError
 const GetUserInternalServerErrorCode int = 500
 
-/*
-GetUserInternalServerError server error
+/*GetUserInternalServerError server error
 
 swagger:response getUserInternalServerError
 */

--- a/pkg/gen/adminapi/adminoperations/users/index_users.go
+++ b/pkg/gen/adminapi/adminoperations/users/index_users.go
@@ -29,12 +29,12 @@ func NewIndexUsers(ctx *middleware.Context, handler IndexUsersHandler) *IndexUse
 	return &IndexUsers{Context: ctx, Handler: handler}
 }
 
-/*
-	IndexUsers swagger:route GET /users users indexUsers
+/* IndexUsers swagger:route GET /users users indexUsers
 
-# List users
+List users
 
 Returns a list of users
+
 */
 type IndexUsers struct {
 	Context *middleware.Context

--- a/pkg/gen/adminapi/adminoperations/users/index_users_responses.go
+++ b/pkg/gen/adminapi/adminoperations/users/index_users_responses.go
@@ -16,8 +16,7 @@ import (
 // IndexUsersOKCode is the HTTP code returned for type IndexUsersOK
 const IndexUsersOKCode int = 200
 
-/*
-IndexUsersOK success
+/*IndexUsersOK success
 
 swagger:response indexUsersOK
 */
@@ -86,8 +85,7 @@ func (o *IndexUsersOK) WriteResponse(rw http.ResponseWriter, producer runtime.Pr
 // IndexUsersBadRequestCode is the HTTP code returned for type IndexUsersBadRequest
 const IndexUsersBadRequestCode int = 400
 
-/*
-IndexUsersBadRequest invalid request
+/*IndexUsersBadRequest invalid request
 
 swagger:response indexUsersBadRequest
 */
@@ -111,8 +109,7 @@ func (o *IndexUsersBadRequest) WriteResponse(rw http.ResponseWriter, producer ru
 // IndexUsersUnauthorizedCode is the HTTP code returned for type IndexUsersUnauthorized
 const IndexUsersUnauthorizedCode int = 401
 
-/*
-IndexUsersUnauthorized request requires user authentication
+/*IndexUsersUnauthorized request requires user authentication
 
 swagger:response indexUsersUnauthorized
 */
@@ -136,8 +133,7 @@ func (o *IndexUsersUnauthorized) WriteResponse(rw http.ResponseWriter, producer 
 // IndexUsersNotFoundCode is the HTTP code returned for type IndexUsersNotFound
 const IndexUsersNotFoundCode int = 404
 
-/*
-IndexUsersNotFound users not found
+/*IndexUsersNotFound users not found
 
 swagger:response indexUsersNotFound
 */
@@ -161,8 +157,7 @@ func (o *IndexUsersNotFound) WriteResponse(rw http.ResponseWriter, producer runt
 // IndexUsersInternalServerErrorCode is the HTTP code returned for type IndexUsersInternalServerError
 const IndexUsersInternalServerErrorCode int = 500
 
-/*
-IndexUsersInternalServerError server error
+/*IndexUsersInternalServerError server error
 
 swagger:response indexUsersInternalServerError
 */

--- a/pkg/gen/adminapi/adminoperations/users/update_user.go
+++ b/pkg/gen/adminapi/adminoperations/users/update_user.go
@@ -29,10 +29,10 @@ func NewUpdateUser(ctx *middleware.Context, handler UpdateUserHandler) *UpdateUs
 	return &UpdateUser{Context: ctx, Handler: handler}
 }
 
-/*
-	UpdateUser swagger:route PATCH /users/{userId} users updateUser
+/* UpdateUser swagger:route PATCH /users/{userId} users updateUser
 
 Update a user's session or active status
+
 */
 type UpdateUser struct {
 	Context *middleware.Context

--- a/pkg/gen/adminapi/adminoperations/users/update_user_responses.go
+++ b/pkg/gen/adminapi/adminoperations/users/update_user_responses.go
@@ -16,8 +16,7 @@ import (
 // UpdateUserOKCode is the HTTP code returned for type UpdateUserOK
 const UpdateUserOKCode int = 200
 
-/*
-UpdateUserOK Successfully updated User
+/*UpdateUserOK Successfully updated User
 
 swagger:response updateUserOK
 */
@@ -61,8 +60,7 @@ func (o *UpdateUserOK) WriteResponse(rw http.ResponseWriter, producer runtime.Pr
 // UpdateUserBadRequestCode is the HTTP code returned for type UpdateUserBadRequest
 const UpdateUserBadRequestCode int = 400
 
-/*
-UpdateUserBadRequest Invalid Request
+/*UpdateUserBadRequest Invalid Request
 
 swagger:response updateUserBadRequest
 */
@@ -86,8 +84,7 @@ func (o *UpdateUserBadRequest) WriteResponse(rw http.ResponseWriter, producer ru
 // UpdateUserUnauthorizedCode is the HTTP code returned for type UpdateUserUnauthorized
 const UpdateUserUnauthorizedCode int = 401
 
-/*
-UpdateUserUnauthorized Must be authenticated to use this end point
+/*UpdateUserUnauthorized Must be authenticated to use this end point
 
 swagger:response updateUserUnauthorized
 */
@@ -111,8 +108,7 @@ func (o *UpdateUserUnauthorized) WriteResponse(rw http.ResponseWriter, producer 
 // UpdateUserForbiddenCode is the HTTP code returned for type UpdateUserForbidden
 const UpdateUserForbiddenCode int = 403
 
-/*
-UpdateUserForbidden Not authorized to update this user
+/*UpdateUserForbidden Not authorized to update this user
 
 swagger:response updateUserForbidden
 */
@@ -136,8 +132,7 @@ func (o *UpdateUserForbidden) WriteResponse(rw http.ResponseWriter, producer run
 // UpdateUserNotFoundCode is the HTTP code returned for type UpdateUserNotFound
 const UpdateUserNotFoundCode int = 404
 
-/*
-UpdateUserNotFound Not found
+/*UpdateUserNotFound Not found
 
 swagger:response updateUserNotFound
 */
@@ -161,8 +156,7 @@ func (o *UpdateUserNotFound) WriteResponse(rw http.ResponseWriter, producer runt
 // UpdateUserUnprocessableEntityCode is the HTTP code returned for type UpdateUserUnprocessableEntity
 const UpdateUserUnprocessableEntityCode int = 422
 
-/*
-UpdateUserUnprocessableEntity Validation error
+/*UpdateUserUnprocessableEntity Validation error
 
 swagger:response updateUserUnprocessableEntity
 */
@@ -206,8 +200,7 @@ func (o *UpdateUserUnprocessableEntity) WriteResponse(rw http.ResponseWriter, pr
 // UpdateUserInternalServerErrorCode is the HTTP code returned for type UpdateUserInternalServerError
 const UpdateUserInternalServerErrorCode int = 500
 
-/*
-UpdateUserInternalServerError Server error
+/*UpdateUserInternalServerError Server error
 
 swagger:response updateUserInternalServerError
 */

--- a/pkg/gen/adminapi/adminoperations/webhook_subscriptions/create_webhook_subscription.go
+++ b/pkg/gen/adminapi/adminoperations/webhook_subscriptions/create_webhook_subscription.go
@@ -29,12 +29,12 @@ func NewCreateWebhookSubscription(ctx *middleware.Context, handler CreateWebhook
 	return &CreateWebhookSubscription{Context: ctx, Handler: handler}
 }
 
-/*
-	CreateWebhookSubscription swagger:route POST /webhook_subscriptions webhook_subscriptions createWebhookSubscription
+/* CreateWebhookSubscription swagger:route POST /webhook_subscriptions webhook_subscriptions createWebhookSubscription
 
 create a webhook subscription
 
 creates and returns a webhook subscription
+
 */
 type CreateWebhookSubscription struct {
 	Context *middleware.Context

--- a/pkg/gen/adminapi/adminoperations/webhook_subscriptions/create_webhook_subscription_responses.go
+++ b/pkg/gen/adminapi/adminoperations/webhook_subscriptions/create_webhook_subscription_responses.go
@@ -16,8 +16,7 @@ import (
 // CreateWebhookSubscriptionCreatedCode is the HTTP code returned for type CreateWebhookSubscriptionCreated
 const CreateWebhookSubscriptionCreatedCode int = 201
 
-/*
-CreateWebhookSubscriptionCreated Successfully created webhook subscription
+/*CreateWebhookSubscriptionCreated Successfully created webhook subscription
 
 swagger:response createWebhookSubscriptionCreated
 */
@@ -61,8 +60,7 @@ func (o *CreateWebhookSubscriptionCreated) WriteResponse(rw http.ResponseWriter,
 // CreateWebhookSubscriptionBadRequestCode is the HTTP code returned for type CreateWebhookSubscriptionBadRequest
 const CreateWebhookSubscriptionBadRequestCode int = 400
 
-/*
-CreateWebhookSubscriptionBadRequest Invalid Request
+/*CreateWebhookSubscriptionBadRequest Invalid Request
 
 swagger:response createWebhookSubscriptionBadRequest
 */
@@ -86,8 +84,7 @@ func (o *CreateWebhookSubscriptionBadRequest) WriteResponse(rw http.ResponseWrit
 // CreateWebhookSubscriptionUnauthorizedCode is the HTTP code returned for type CreateWebhookSubscriptionUnauthorized
 const CreateWebhookSubscriptionUnauthorizedCode int = 401
 
-/*
-CreateWebhookSubscriptionUnauthorized Must be authenticated to use this end point
+/*CreateWebhookSubscriptionUnauthorized Must be authenticated to use this end point
 
 swagger:response createWebhookSubscriptionUnauthorized
 */
@@ -111,8 +108,7 @@ func (o *CreateWebhookSubscriptionUnauthorized) WriteResponse(rw http.ResponseWr
 // CreateWebhookSubscriptionForbiddenCode is the HTTP code returned for type CreateWebhookSubscriptionForbidden
 const CreateWebhookSubscriptionForbiddenCode int = 403
 
-/*
-CreateWebhookSubscriptionForbidden Not authorized to create a webhook subscription
+/*CreateWebhookSubscriptionForbidden Not authorized to create a webhook subscription
 
 swagger:response createWebhookSubscriptionForbidden
 */
@@ -136,8 +132,7 @@ func (o *CreateWebhookSubscriptionForbidden) WriteResponse(rw http.ResponseWrite
 // CreateWebhookSubscriptionInternalServerErrorCode is the HTTP code returned for type CreateWebhookSubscriptionInternalServerError
 const CreateWebhookSubscriptionInternalServerErrorCode int = 500
 
-/*
-CreateWebhookSubscriptionInternalServerError Server error
+/*CreateWebhookSubscriptionInternalServerError Server error
 
 swagger:response createWebhookSubscriptionInternalServerError
 */

--- a/pkg/gen/adminapi/adminoperations/webhook_subscriptions/get_webhook_subscription.go
+++ b/pkg/gen/adminapi/adminoperations/webhook_subscriptions/get_webhook_subscription.go
@@ -29,12 +29,12 @@ func NewGetWebhookSubscription(ctx *middleware.Context, handler GetWebhookSubscr
 	return &GetWebhookSubscription{Context: ctx, Handler: handler}
 }
 
-/*
-	GetWebhookSubscription swagger:route GET /webhook_subscriptions/{webhookSubscriptionId} webhook_subscriptions getWebhookSubscription
+/* GetWebhookSubscription swagger:route GET /webhook_subscriptions/{webhookSubscriptionId} webhook_subscriptions getWebhookSubscription
 
-# Get information about a webhook subscription
+Get information about a webhook subscription
 
 Returns the given webhook subscription and its details
+
 */
 type GetWebhookSubscription struct {
 	Context *middleware.Context

--- a/pkg/gen/adminapi/adminoperations/webhook_subscriptions/get_webhook_subscription_responses.go
+++ b/pkg/gen/adminapi/adminoperations/webhook_subscriptions/get_webhook_subscription_responses.go
@@ -16,8 +16,7 @@ import (
 // GetWebhookSubscriptionOKCode is the HTTP code returned for type GetWebhookSubscriptionOK
 const GetWebhookSubscriptionOKCode int = 200
 
-/*
-GetWebhookSubscriptionOK success
+/*GetWebhookSubscriptionOK success
 
 swagger:response getWebhookSubscriptionOK
 */
@@ -61,8 +60,7 @@ func (o *GetWebhookSubscriptionOK) WriteResponse(rw http.ResponseWriter, produce
 // GetWebhookSubscriptionBadRequestCode is the HTTP code returned for type GetWebhookSubscriptionBadRequest
 const GetWebhookSubscriptionBadRequestCode int = 400
 
-/*
-GetWebhookSubscriptionBadRequest invalid request
+/*GetWebhookSubscriptionBadRequest invalid request
 
 swagger:response getWebhookSubscriptionBadRequest
 */
@@ -86,8 +84,7 @@ func (o *GetWebhookSubscriptionBadRequest) WriteResponse(rw http.ResponseWriter,
 // GetWebhookSubscriptionUnauthorizedCode is the HTTP code returned for type GetWebhookSubscriptionUnauthorized
 const GetWebhookSubscriptionUnauthorizedCode int = 401
 
-/*
-GetWebhookSubscriptionUnauthorized request requires user authentication
+/*GetWebhookSubscriptionUnauthorized request requires user authentication
 
 swagger:response getWebhookSubscriptionUnauthorized
 */
@@ -111,8 +108,7 @@ func (o *GetWebhookSubscriptionUnauthorized) WriteResponse(rw http.ResponseWrite
 // GetWebhookSubscriptionNotFoundCode is the HTTP code returned for type GetWebhookSubscriptionNotFound
 const GetWebhookSubscriptionNotFoundCode int = 404
 
-/*
-GetWebhookSubscriptionNotFound subscription not found
+/*GetWebhookSubscriptionNotFound subscription not found
 
 swagger:response getWebhookSubscriptionNotFound
 */
@@ -136,8 +132,7 @@ func (o *GetWebhookSubscriptionNotFound) WriteResponse(rw http.ResponseWriter, p
 // GetWebhookSubscriptionInternalServerErrorCode is the HTTP code returned for type GetWebhookSubscriptionInternalServerError
 const GetWebhookSubscriptionInternalServerErrorCode int = 500
 
-/*
-GetWebhookSubscriptionInternalServerError server error
+/*GetWebhookSubscriptionInternalServerError server error
 
 swagger:response getWebhookSubscriptionInternalServerError
 */

--- a/pkg/gen/adminapi/adminoperations/webhook_subscriptions/index_webhook_subscriptions.go
+++ b/pkg/gen/adminapi/adminoperations/webhook_subscriptions/index_webhook_subscriptions.go
@@ -29,12 +29,12 @@ func NewIndexWebhookSubscriptions(ctx *middleware.Context, handler IndexWebhookS
 	return &IndexWebhookSubscriptions{Context: ctx, Handler: handler}
 }
 
-/*
-	IndexWebhookSubscriptions swagger:route GET /webhook_subscriptions webhook_subscriptions indexWebhookSubscriptions
+/* IndexWebhookSubscriptions swagger:route GET /webhook_subscriptions webhook_subscriptions indexWebhookSubscriptions
 
-# Lists webhook subscriptions
+Lists webhook subscriptions
 
 Returns a list of webhook subscriptions
+
 */
 type IndexWebhookSubscriptions struct {
 	Context *middleware.Context

--- a/pkg/gen/adminapi/adminoperations/webhook_subscriptions/index_webhook_subscriptions_responses.go
+++ b/pkg/gen/adminapi/adminoperations/webhook_subscriptions/index_webhook_subscriptions_responses.go
@@ -16,8 +16,7 @@ import (
 // IndexWebhookSubscriptionsOKCode is the HTTP code returned for type IndexWebhookSubscriptionsOK
 const IndexWebhookSubscriptionsOKCode int = 200
 
-/*
-IndexWebhookSubscriptionsOK success
+/*IndexWebhookSubscriptionsOK success
 
 swagger:response indexWebhookSubscriptionsOK
 */
@@ -86,8 +85,7 @@ func (o *IndexWebhookSubscriptionsOK) WriteResponse(rw http.ResponseWriter, prod
 // IndexWebhookSubscriptionsBadRequestCode is the HTTP code returned for type IndexWebhookSubscriptionsBadRequest
 const IndexWebhookSubscriptionsBadRequestCode int = 400
 
-/*
-IndexWebhookSubscriptionsBadRequest Invalid request
+/*IndexWebhookSubscriptionsBadRequest Invalid request
 
 swagger:response indexWebhookSubscriptionsBadRequest
 */
@@ -111,8 +109,7 @@ func (o *IndexWebhookSubscriptionsBadRequest) WriteResponse(rw http.ResponseWrit
 // IndexWebhookSubscriptionsUnauthorizedCode is the HTTP code returned for type IndexWebhookSubscriptionsUnauthorized
 const IndexWebhookSubscriptionsUnauthorizedCode int = 401
 
-/*
-IndexWebhookSubscriptionsUnauthorized Not authenticated for this endpoint
+/*IndexWebhookSubscriptionsUnauthorized Not authenticated for this endpoint
 
 swagger:response indexWebhookSubscriptionsUnauthorized
 */
@@ -136,8 +133,7 @@ func (o *IndexWebhookSubscriptionsUnauthorized) WriteResponse(rw http.ResponseWr
 // IndexWebhookSubscriptionsNotFoundCode is the HTTP code returned for type IndexWebhookSubscriptionsNotFound
 const IndexWebhookSubscriptionsNotFoundCode int = 404
 
-/*
-IndexWebhookSubscriptionsNotFound Webhook subscriptions not found
+/*IndexWebhookSubscriptionsNotFound Webhook subscriptions not found
 
 swagger:response indexWebhookSubscriptionsNotFound
 */
@@ -161,8 +157,7 @@ func (o *IndexWebhookSubscriptionsNotFound) WriteResponse(rw http.ResponseWriter
 // IndexWebhookSubscriptionsInternalServerErrorCode is the HTTP code returned for type IndexWebhookSubscriptionsInternalServerError
 const IndexWebhookSubscriptionsInternalServerErrorCode int = 500
 
-/*
-IndexWebhookSubscriptionsInternalServerError Server error
+/*IndexWebhookSubscriptionsInternalServerError Server error
 
 swagger:response indexWebhookSubscriptionsInternalServerError
 */

--- a/pkg/gen/adminapi/adminoperations/webhook_subscriptions/update_webhook_subscription.go
+++ b/pkg/gen/adminapi/adminoperations/webhook_subscriptions/update_webhook_subscription.go
@@ -29,10 +29,10 @@ func NewUpdateWebhookSubscription(ctx *middleware.Context, handler UpdateWebhook
 	return &UpdateWebhookSubscription{Context: ctx, Handler: handler}
 }
 
-/*
-	UpdateWebhookSubscription swagger:route PATCH /webhook_subscriptions/{webhookSubscriptionId} webhook_subscriptions updateWebhookSubscription
+/* UpdateWebhookSubscription swagger:route PATCH /webhook_subscriptions/{webhookSubscriptionId} webhook_subscriptions updateWebhookSubscription
 
 Update a webhook subscription
+
 */
 type UpdateWebhookSubscription struct {
 	Context *middleware.Context

--- a/pkg/gen/adminapi/adminoperations/webhook_subscriptions/update_webhook_subscription_responses.go
+++ b/pkg/gen/adminapi/adminoperations/webhook_subscriptions/update_webhook_subscription_responses.go
@@ -16,8 +16,7 @@ import (
 // UpdateWebhookSubscriptionOKCode is the HTTP code returned for type UpdateWebhookSubscriptionOK
 const UpdateWebhookSubscriptionOKCode int = 200
 
-/*
-UpdateWebhookSubscriptionOK Successfully updated webhook subscription
+/*UpdateWebhookSubscriptionOK Successfully updated webhook subscription
 
 swagger:response updateWebhookSubscriptionOK
 */
@@ -61,8 +60,7 @@ func (o *UpdateWebhookSubscriptionOK) WriteResponse(rw http.ResponseWriter, prod
 // UpdateWebhookSubscriptionBadRequestCode is the HTTP code returned for type UpdateWebhookSubscriptionBadRequest
 const UpdateWebhookSubscriptionBadRequestCode int = 400
 
-/*
-UpdateWebhookSubscriptionBadRequest Invalid Request
+/*UpdateWebhookSubscriptionBadRequest Invalid Request
 
 swagger:response updateWebhookSubscriptionBadRequest
 */
@@ -86,8 +84,7 @@ func (o *UpdateWebhookSubscriptionBadRequest) WriteResponse(rw http.ResponseWrit
 // UpdateWebhookSubscriptionUnauthorizedCode is the HTTP code returned for type UpdateWebhookSubscriptionUnauthorized
 const UpdateWebhookSubscriptionUnauthorizedCode int = 401
 
-/*
-UpdateWebhookSubscriptionUnauthorized Must be authenticated to use this end point
+/*UpdateWebhookSubscriptionUnauthorized Must be authenticated to use this end point
 
 swagger:response updateWebhookSubscriptionUnauthorized
 */
@@ -111,8 +108,7 @@ func (o *UpdateWebhookSubscriptionUnauthorized) WriteResponse(rw http.ResponseWr
 // UpdateWebhookSubscriptionForbiddenCode is the HTTP code returned for type UpdateWebhookSubscriptionForbidden
 const UpdateWebhookSubscriptionForbiddenCode int = 403
 
-/*
-UpdateWebhookSubscriptionForbidden Not authorized to update this webhook subscription
+/*UpdateWebhookSubscriptionForbidden Not authorized to update this webhook subscription
 
 swagger:response updateWebhookSubscriptionForbidden
 */
@@ -136,8 +132,7 @@ func (o *UpdateWebhookSubscriptionForbidden) WriteResponse(rw http.ResponseWrite
 // UpdateWebhookSubscriptionNotFoundCode is the HTTP code returned for type UpdateWebhookSubscriptionNotFound
 const UpdateWebhookSubscriptionNotFoundCode int = 404
 
-/*
-UpdateWebhookSubscriptionNotFound subscription not found
+/*UpdateWebhookSubscriptionNotFound subscription not found
 
 swagger:response updateWebhookSubscriptionNotFound
 */
@@ -161,8 +156,7 @@ func (o *UpdateWebhookSubscriptionNotFound) WriteResponse(rw http.ResponseWriter
 // UpdateWebhookSubscriptionPreconditionFailedCode is the HTTP code returned for type UpdateWebhookSubscriptionPreconditionFailed
 const UpdateWebhookSubscriptionPreconditionFailedCode int = 412
 
-/*
-UpdateWebhookSubscriptionPreconditionFailed Precondition failed
+/*UpdateWebhookSubscriptionPreconditionFailed Precondition failed
 
 swagger:response updateWebhookSubscriptionPreconditionFailed
 */
@@ -186,8 +180,7 @@ func (o *UpdateWebhookSubscriptionPreconditionFailed) WriteResponse(rw http.Resp
 // UpdateWebhookSubscriptionUnprocessableEntityCode is the HTTP code returned for type UpdateWebhookSubscriptionUnprocessableEntity
 const UpdateWebhookSubscriptionUnprocessableEntityCode int = 422
 
-/*
-UpdateWebhookSubscriptionUnprocessableEntity Validation error
+/*UpdateWebhookSubscriptionUnprocessableEntity Validation error
 
 swagger:response updateWebhookSubscriptionUnprocessableEntity
 */
@@ -231,8 +224,7 @@ func (o *UpdateWebhookSubscriptionUnprocessableEntity) WriteResponse(rw http.Res
 // UpdateWebhookSubscriptionInternalServerErrorCode is the HTTP code returned for type UpdateWebhookSubscriptionInternalServerError
 const UpdateWebhookSubscriptionInternalServerErrorCode int = 500
 
-/*
-UpdateWebhookSubscriptionInternalServerError Server error
+/*UpdateWebhookSubscriptionInternalServerError Server error
 
 swagger:response updateWebhookSubscriptionInternalServerError
 */

--- a/pkg/gen/adminapi/doc.go
+++ b/pkg/gen/adminapi/doc.go
@@ -2,22 +2,22 @@
 
 // Package adminapi MilMove Admin API
 //
-//	The Admin API is a RESTful API that enables the Admin application for MilMove.
+//  The Admin API is a RESTful API that enables the Admin application for MilMove.
 //
-//	All endpoints are located under `/admin/v1`.
+//  All endpoints are located under `/admin/v1`.
 //
-//	Schemes:
-//	  http
-//	Host: localhost
-//	BasePath: /admin/v1
-//	Version: 1.0.0
-//	License: MIT https://github.com/transcom/mymove/blob/master/LICENSE.md
+//  Schemes:
+//    http
+//  Host: localhost
+//  BasePath: /admin/v1
+//  Version: 1.0.0
+//  License: MIT https://github.com/transcom/mymove/blob/master/LICENSE.md
 //
-//	Consumes:
-//	  - application/json
+//  Consumes:
+//    - application/json
 //
-//	Produces:
-//	  - application/json
+//  Produces:
+//    - application/json
 //
 // swagger:meta
 package adminapi

--- a/pkg/gen/ghcapi/doc.go
+++ b/pkg/gen/ghcapi/doc.go
@@ -2,24 +2,24 @@
 
 // Package ghcapi MilMove GHC API
 //
-//	The GHC API is a RESTful API that enables the Office application for MilMove.
+//  The GHC API is a RESTful API that enables the Office application for MilMove.
 //
-//	All endpoints are located under `/ghc/v1`.
+//  All endpoints are located under `/ghc/v1`.
 //
-//	Schemes:
-//	  http
-//	Host: localhost
-//	BasePath: /ghc/v1
-//	Version: 0.0.1
-//	License: MIT https://opensource.org/licenses/MIT
-//	Contact: <dp3@truss.works>
+//  Schemes:
+//    http
+//  Host: localhost
+//  BasePath: /ghc/v1
+//  Version: 0.0.1
+//  License: MIT https://opensource.org/licenses/MIT
+//  Contact: <dp3@truss.works>
 //
-//	Consumes:
-//	  - application/json
+//  Consumes:
+//    - application/json
 //
-//	Produces:
-//	  - application/pdf
-//	  - application/json
+//  Produces:
+//    - application/pdf
+//    - application/json
 //
 // swagger:meta
 package ghcapi

--- a/pkg/gen/ghcapi/ghcoperations/customer/get_customer.go
+++ b/pkg/gen/ghcapi/ghcoperations/customer/get_customer.go
@@ -29,12 +29,12 @@ func NewGetCustomer(ctx *middleware.Context, handler GetCustomerHandler) *GetCus
 	return &GetCustomer{Context: ctx, Handler: handler}
 }
 
-/*
-	GetCustomer swagger:route GET /customer/{customerID} customer getCustomer
-
-# Returns a given customer
+/* GetCustomer swagger:route GET /customer/{customerID} customer getCustomer
 
 Returns a given customer
+
+Returns a given customer
+
 */
 type GetCustomer struct {
 	Context *middleware.Context

--- a/pkg/gen/ghcapi/ghcoperations/customer/get_customer_responses.go
+++ b/pkg/gen/ghcapi/ghcoperations/customer/get_customer_responses.go
@@ -16,8 +16,7 @@ import (
 // GetCustomerOKCode is the HTTP code returned for type GetCustomerOK
 const GetCustomerOKCode int = 200
 
-/*
-GetCustomerOK Successfully retrieved information on an individual customer
+/*GetCustomerOK Successfully retrieved information on an individual customer
 
 swagger:response getCustomerOK
 */
@@ -61,8 +60,7 @@ func (o *GetCustomerOK) WriteResponse(rw http.ResponseWriter, producer runtime.P
 // GetCustomerBadRequestCode is the HTTP code returned for type GetCustomerBadRequest
 const GetCustomerBadRequestCode int = 400
 
-/*
-GetCustomerBadRequest The request payload is invalid
+/*GetCustomerBadRequest The request payload is invalid
 
 swagger:response getCustomerBadRequest
 */
@@ -106,8 +104,7 @@ func (o *GetCustomerBadRequest) WriteResponse(rw http.ResponseWriter, producer r
 // GetCustomerUnauthorizedCode is the HTTP code returned for type GetCustomerUnauthorized
 const GetCustomerUnauthorizedCode int = 401
 
-/*
-GetCustomerUnauthorized The request was denied
+/*GetCustomerUnauthorized The request was denied
 
 swagger:response getCustomerUnauthorized
 */
@@ -151,8 +148,7 @@ func (o *GetCustomerUnauthorized) WriteResponse(rw http.ResponseWriter, producer
 // GetCustomerForbiddenCode is the HTTP code returned for type GetCustomerForbidden
 const GetCustomerForbiddenCode int = 403
 
-/*
-GetCustomerForbidden The request was denied
+/*GetCustomerForbidden The request was denied
 
 swagger:response getCustomerForbidden
 */
@@ -196,8 +192,7 @@ func (o *GetCustomerForbidden) WriteResponse(rw http.ResponseWriter, producer ru
 // GetCustomerNotFoundCode is the HTTP code returned for type GetCustomerNotFound
 const GetCustomerNotFoundCode int = 404
 
-/*
-GetCustomerNotFound The requested resource wasn't found
+/*GetCustomerNotFound The requested resource wasn't found
 
 swagger:response getCustomerNotFound
 */
@@ -241,8 +236,7 @@ func (o *GetCustomerNotFound) WriteResponse(rw http.ResponseWriter, producer run
 // GetCustomerInternalServerErrorCode is the HTTP code returned for type GetCustomerInternalServerError
 const GetCustomerInternalServerErrorCode int = 500
 
-/*
-GetCustomerInternalServerError A server error occurred
+/*GetCustomerInternalServerError A server error occurred
 
 swagger:response getCustomerInternalServerError
 */

--- a/pkg/gen/ghcapi/ghcoperations/customer/update_customer.go
+++ b/pkg/gen/ghcapi/ghcoperations/customer/update_customer.go
@@ -29,12 +29,12 @@ func NewUpdateCustomer(ctx *middleware.Context, handler UpdateCustomerHandler) *
 	return &UpdateCustomer{Context: ctx, Handler: handler}
 }
 
-/*
-	UpdateCustomer swagger:route PATCH /customer/{customerID} customer updateCustomer
+/* UpdateCustomer swagger:route PATCH /customer/{customerID} customer updateCustomer
 
-# Updates customer info
+Updates customer info
 
 Updates customer info by ID
+
 */
 type UpdateCustomer struct {
 	Context *middleware.Context

--- a/pkg/gen/ghcapi/ghcoperations/customer/update_customer_responses.go
+++ b/pkg/gen/ghcapi/ghcoperations/customer/update_customer_responses.go
@@ -16,8 +16,7 @@ import (
 // UpdateCustomerOKCode is the HTTP code returned for type UpdateCustomerOK
 const UpdateCustomerOKCode int = 200
 
-/*
-UpdateCustomerOK updated instance of orders
+/*UpdateCustomerOK updated instance of orders
 
 swagger:response updateCustomerOK
 */
@@ -61,8 +60,7 @@ func (o *UpdateCustomerOK) WriteResponse(rw http.ResponseWriter, producer runtim
 // UpdateCustomerBadRequestCode is the HTTP code returned for type UpdateCustomerBadRequest
 const UpdateCustomerBadRequestCode int = 400
 
-/*
-UpdateCustomerBadRequest The request payload is invalid
+/*UpdateCustomerBadRequest The request payload is invalid
 
 swagger:response updateCustomerBadRequest
 */
@@ -106,8 +104,7 @@ func (o *UpdateCustomerBadRequest) WriteResponse(rw http.ResponseWriter, produce
 // UpdateCustomerUnauthorizedCode is the HTTP code returned for type UpdateCustomerUnauthorized
 const UpdateCustomerUnauthorizedCode int = 401
 
-/*
-UpdateCustomerUnauthorized The request was denied
+/*UpdateCustomerUnauthorized The request was denied
 
 swagger:response updateCustomerUnauthorized
 */
@@ -151,8 +148,7 @@ func (o *UpdateCustomerUnauthorized) WriteResponse(rw http.ResponseWriter, produ
 // UpdateCustomerForbiddenCode is the HTTP code returned for type UpdateCustomerForbidden
 const UpdateCustomerForbiddenCode int = 403
 
-/*
-UpdateCustomerForbidden The request was denied
+/*UpdateCustomerForbidden The request was denied
 
 swagger:response updateCustomerForbidden
 */
@@ -196,8 +192,7 @@ func (o *UpdateCustomerForbidden) WriteResponse(rw http.ResponseWriter, producer
 // UpdateCustomerNotFoundCode is the HTTP code returned for type UpdateCustomerNotFound
 const UpdateCustomerNotFoundCode int = 404
 
-/*
-UpdateCustomerNotFound The requested resource wasn't found
+/*UpdateCustomerNotFound The requested resource wasn't found
 
 swagger:response updateCustomerNotFound
 */
@@ -241,8 +236,7 @@ func (o *UpdateCustomerNotFound) WriteResponse(rw http.ResponseWriter, producer 
 // UpdateCustomerPreconditionFailedCode is the HTTP code returned for type UpdateCustomerPreconditionFailed
 const UpdateCustomerPreconditionFailedCode int = 412
 
-/*
-UpdateCustomerPreconditionFailed Precondition failed
+/*UpdateCustomerPreconditionFailed Precondition failed
 
 swagger:response updateCustomerPreconditionFailed
 */
@@ -286,8 +280,7 @@ func (o *UpdateCustomerPreconditionFailed) WriteResponse(rw http.ResponseWriter,
 // UpdateCustomerUnprocessableEntityCode is the HTTP code returned for type UpdateCustomerUnprocessableEntity
 const UpdateCustomerUnprocessableEntityCode int = 422
 
-/*
-UpdateCustomerUnprocessableEntity The payload was unprocessable.
+/*UpdateCustomerUnprocessableEntity The payload was unprocessable.
 
 swagger:response updateCustomerUnprocessableEntity
 */
@@ -331,8 +324,7 @@ func (o *UpdateCustomerUnprocessableEntity) WriteResponse(rw http.ResponseWriter
 // UpdateCustomerInternalServerErrorCode is the HTTP code returned for type UpdateCustomerInternalServerError
 const UpdateCustomerInternalServerErrorCode int = 500
 
-/*
-UpdateCustomerInternalServerError A server error occurred
+/*UpdateCustomerInternalServerError A server error occurred
 
 swagger:response updateCustomerInternalServerError
 */

--- a/pkg/gen/ghcapi/ghcoperations/customer_support_remarks/create_customer_support_remark_for_move.go
+++ b/pkg/gen/ghcapi/ghcoperations/customer_support_remarks/create_customer_support_remark_for_move.go
@@ -29,12 +29,12 @@ func NewCreateCustomerSupportRemarkForMove(ctx *middleware.Context, handler Crea
 	return &CreateCustomerSupportRemarkForMove{Context: ctx, Handler: handler}
 }
 
-/*
-	CreateCustomerSupportRemarkForMove swagger:route POST /moves/{locator}/customer-support-remarks customerSupportRemarks createCustomerSupportRemarkForMove
-
-# Creates a customer support remark for a move
+/* CreateCustomerSupportRemarkForMove swagger:route POST /moves/{locator}/customer-support-remarks customerSupportRemarks createCustomerSupportRemarkForMove
 
 Creates a customer support remark for a move
+
+Creates a customer support remark for a move
+
 */
 type CreateCustomerSupportRemarkForMove struct {
 	Context *middleware.Context

--- a/pkg/gen/ghcapi/ghcoperations/customer_support_remarks/create_customer_support_remark_for_move_responses.go
+++ b/pkg/gen/ghcapi/ghcoperations/customer_support_remarks/create_customer_support_remark_for_move_responses.go
@@ -16,8 +16,7 @@ import (
 // CreateCustomerSupportRemarkForMoveOKCode is the HTTP code returned for type CreateCustomerSupportRemarkForMoveOK
 const CreateCustomerSupportRemarkForMoveOKCode int = 200
 
-/*
-CreateCustomerSupportRemarkForMoveOK Successfully created customer support remark
+/*CreateCustomerSupportRemarkForMoveOK Successfully created customer support remark
 
 swagger:response createCustomerSupportRemarkForMoveOK
 */
@@ -61,8 +60,7 @@ func (o *CreateCustomerSupportRemarkForMoveOK) WriteResponse(rw http.ResponseWri
 // CreateCustomerSupportRemarkForMoveBadRequestCode is the HTTP code returned for type CreateCustomerSupportRemarkForMoveBadRequest
 const CreateCustomerSupportRemarkForMoveBadRequestCode int = 400
 
-/*
-CreateCustomerSupportRemarkForMoveBadRequest The request payload is invalid
+/*CreateCustomerSupportRemarkForMoveBadRequest The request payload is invalid
 
 swagger:response createCustomerSupportRemarkForMoveBadRequest
 */
@@ -106,8 +104,7 @@ func (o *CreateCustomerSupportRemarkForMoveBadRequest) WriteResponse(rw http.Res
 // CreateCustomerSupportRemarkForMoveNotFoundCode is the HTTP code returned for type CreateCustomerSupportRemarkForMoveNotFound
 const CreateCustomerSupportRemarkForMoveNotFoundCode int = 404
 
-/*
-CreateCustomerSupportRemarkForMoveNotFound The requested resource wasn't found
+/*CreateCustomerSupportRemarkForMoveNotFound The requested resource wasn't found
 
 swagger:response createCustomerSupportRemarkForMoveNotFound
 */
@@ -151,8 +148,7 @@ func (o *CreateCustomerSupportRemarkForMoveNotFound) WriteResponse(rw http.Respo
 // CreateCustomerSupportRemarkForMoveUnprocessableEntityCode is the HTTP code returned for type CreateCustomerSupportRemarkForMoveUnprocessableEntity
 const CreateCustomerSupportRemarkForMoveUnprocessableEntityCode int = 422
 
-/*
-CreateCustomerSupportRemarkForMoveUnprocessableEntity The payload was unprocessable.
+/*CreateCustomerSupportRemarkForMoveUnprocessableEntity The payload was unprocessable.
 
 swagger:response createCustomerSupportRemarkForMoveUnprocessableEntity
 */
@@ -196,8 +192,7 @@ func (o *CreateCustomerSupportRemarkForMoveUnprocessableEntity) WriteResponse(rw
 // CreateCustomerSupportRemarkForMoveInternalServerErrorCode is the HTTP code returned for type CreateCustomerSupportRemarkForMoveInternalServerError
 const CreateCustomerSupportRemarkForMoveInternalServerErrorCode int = 500
 
-/*
-CreateCustomerSupportRemarkForMoveInternalServerError A server error occurred
+/*CreateCustomerSupportRemarkForMoveInternalServerError A server error occurred
 
 swagger:response createCustomerSupportRemarkForMoveInternalServerError
 */

--- a/pkg/gen/ghcapi/ghcoperations/customer_support_remarks/delete_customer_support_remark.go
+++ b/pkg/gen/ghcapi/ghcoperations/customer_support_remarks/delete_customer_support_remark.go
@@ -29,12 +29,12 @@ func NewDeleteCustomerSupportRemark(ctx *middleware.Context, handler DeleteCusto
 	return &DeleteCustomerSupportRemark{Context: ctx, Handler: handler}
 }
 
-/*
-	DeleteCustomerSupportRemark swagger:route DELETE /customer-support-remarks/{customerSupportRemarkID} customerSupportRemarks deleteCustomerSupportRemark
-
-# Soft deletes a customer support remark by ID
+/* DeleteCustomerSupportRemark swagger:route DELETE /customer-support-remarks/{customerSupportRemarkID} customerSupportRemarks deleteCustomerSupportRemark
 
 Soft deletes a customer support remark by ID
+
+Soft deletes a customer support remark by ID
+
 */
 type DeleteCustomerSupportRemark struct {
 	Context *middleware.Context

--- a/pkg/gen/ghcapi/ghcoperations/customer_support_remarks/delete_customer_support_remark_responses.go
+++ b/pkg/gen/ghcapi/ghcoperations/customer_support_remarks/delete_customer_support_remark_responses.go
@@ -16,8 +16,7 @@ import (
 // DeleteCustomerSupportRemarkNoContentCode is the HTTP code returned for type DeleteCustomerSupportRemarkNoContent
 const DeleteCustomerSupportRemarkNoContentCode int = 204
 
-/*
-DeleteCustomerSupportRemarkNoContent Successfully soft deleted the shipment
+/*DeleteCustomerSupportRemarkNoContent Successfully soft deleted the shipment
 
 swagger:response deleteCustomerSupportRemarkNoContent
 */
@@ -41,8 +40,7 @@ func (o *DeleteCustomerSupportRemarkNoContent) WriteResponse(rw http.ResponseWri
 // DeleteCustomerSupportRemarkBadRequestCode is the HTTP code returned for type DeleteCustomerSupportRemarkBadRequest
 const DeleteCustomerSupportRemarkBadRequestCode int = 400
 
-/*
-DeleteCustomerSupportRemarkBadRequest The request payload is invalid
+/*DeleteCustomerSupportRemarkBadRequest The request payload is invalid
 
 swagger:response deleteCustomerSupportRemarkBadRequest
 */
@@ -86,8 +84,7 @@ func (o *DeleteCustomerSupportRemarkBadRequest) WriteResponse(rw http.ResponseWr
 // DeleteCustomerSupportRemarkForbiddenCode is the HTTP code returned for type DeleteCustomerSupportRemarkForbidden
 const DeleteCustomerSupportRemarkForbiddenCode int = 403
 
-/*
-DeleteCustomerSupportRemarkForbidden The request was denied
+/*DeleteCustomerSupportRemarkForbidden The request was denied
 
 swagger:response deleteCustomerSupportRemarkForbidden
 */
@@ -131,8 +128,7 @@ func (o *DeleteCustomerSupportRemarkForbidden) WriteResponse(rw http.ResponseWri
 // DeleteCustomerSupportRemarkNotFoundCode is the HTTP code returned for type DeleteCustomerSupportRemarkNotFound
 const DeleteCustomerSupportRemarkNotFoundCode int = 404
 
-/*
-DeleteCustomerSupportRemarkNotFound The requested resource wasn't found
+/*DeleteCustomerSupportRemarkNotFound The requested resource wasn't found
 
 swagger:response deleteCustomerSupportRemarkNotFound
 */
@@ -176,8 +172,7 @@ func (o *DeleteCustomerSupportRemarkNotFound) WriteResponse(rw http.ResponseWrit
 // DeleteCustomerSupportRemarkConflictCode is the HTTP code returned for type DeleteCustomerSupportRemarkConflict
 const DeleteCustomerSupportRemarkConflictCode int = 409
 
-/*
-DeleteCustomerSupportRemarkConflict Conflict error
+/*DeleteCustomerSupportRemarkConflict Conflict error
 
 swagger:response deleteCustomerSupportRemarkConflict
 */
@@ -221,8 +216,7 @@ func (o *DeleteCustomerSupportRemarkConflict) WriteResponse(rw http.ResponseWrit
 // DeleteCustomerSupportRemarkUnprocessableEntityCode is the HTTP code returned for type DeleteCustomerSupportRemarkUnprocessableEntity
 const DeleteCustomerSupportRemarkUnprocessableEntityCode int = 422
 
-/*
-DeleteCustomerSupportRemarkUnprocessableEntity The payload was unprocessable.
+/*DeleteCustomerSupportRemarkUnprocessableEntity The payload was unprocessable.
 
 swagger:response deleteCustomerSupportRemarkUnprocessableEntity
 */
@@ -266,8 +260,7 @@ func (o *DeleteCustomerSupportRemarkUnprocessableEntity) WriteResponse(rw http.R
 // DeleteCustomerSupportRemarkInternalServerErrorCode is the HTTP code returned for type DeleteCustomerSupportRemarkInternalServerError
 const DeleteCustomerSupportRemarkInternalServerErrorCode int = 500
 
-/*
-DeleteCustomerSupportRemarkInternalServerError A server error occurred
+/*DeleteCustomerSupportRemarkInternalServerError A server error occurred
 
 swagger:response deleteCustomerSupportRemarkInternalServerError
 */

--- a/pkg/gen/ghcapi/ghcoperations/customer_support_remarks/get_customer_support_remarks_for_move.go
+++ b/pkg/gen/ghcapi/ghcoperations/customer_support_remarks/get_customer_support_remarks_for_move.go
@@ -29,12 +29,12 @@ func NewGetCustomerSupportRemarksForMove(ctx *middleware.Context, handler GetCus
 	return &GetCustomerSupportRemarksForMove{Context: ctx, Handler: handler}
 }
 
-/*
-	GetCustomerSupportRemarksForMove swagger:route GET /moves/{locator}/customer-support-remarks customerSupportRemarks getCustomerSupportRemarksForMove
+/* GetCustomerSupportRemarksForMove swagger:route GET /moves/{locator}/customer-support-remarks customerSupportRemarks getCustomerSupportRemarksForMove
 
 Fetches customer support remarks using the move code (locator).
 
 Fetches customer support remarks for a move
+
 */
 type GetCustomerSupportRemarksForMove struct {
 	Context *middleware.Context

--- a/pkg/gen/ghcapi/ghcoperations/customer_support_remarks/get_customer_support_remarks_for_move_responses.go
+++ b/pkg/gen/ghcapi/ghcoperations/customer_support_remarks/get_customer_support_remarks_for_move_responses.go
@@ -16,8 +16,7 @@ import (
 // GetCustomerSupportRemarksForMoveOKCode is the HTTP code returned for type GetCustomerSupportRemarksForMoveOK
 const GetCustomerSupportRemarksForMoveOKCode int = 200
 
-/*
-GetCustomerSupportRemarksForMoveOK Successfully retrieved all line items for a move task order
+/*GetCustomerSupportRemarksForMoveOK Successfully retrieved all line items for a move task order
 
 swagger:response getCustomerSupportRemarksForMoveOK
 */
@@ -64,8 +63,7 @@ func (o *GetCustomerSupportRemarksForMoveOK) WriteResponse(rw http.ResponseWrite
 // GetCustomerSupportRemarksForMoveForbiddenCode is the HTTP code returned for type GetCustomerSupportRemarksForMoveForbidden
 const GetCustomerSupportRemarksForMoveForbiddenCode int = 403
 
-/*
-GetCustomerSupportRemarksForMoveForbidden The request was denied
+/*GetCustomerSupportRemarksForMoveForbidden The request was denied
 
 swagger:response getCustomerSupportRemarksForMoveForbidden
 */
@@ -109,8 +107,7 @@ func (o *GetCustomerSupportRemarksForMoveForbidden) WriteResponse(rw http.Respon
 // GetCustomerSupportRemarksForMoveNotFoundCode is the HTTP code returned for type GetCustomerSupportRemarksForMoveNotFound
 const GetCustomerSupportRemarksForMoveNotFoundCode int = 404
 
-/*
-GetCustomerSupportRemarksForMoveNotFound The requested resource wasn't found
+/*GetCustomerSupportRemarksForMoveNotFound The requested resource wasn't found
 
 swagger:response getCustomerSupportRemarksForMoveNotFound
 */
@@ -154,8 +151,7 @@ func (o *GetCustomerSupportRemarksForMoveNotFound) WriteResponse(rw http.Respons
 // GetCustomerSupportRemarksForMoveUnprocessableEntityCode is the HTTP code returned for type GetCustomerSupportRemarksForMoveUnprocessableEntity
 const GetCustomerSupportRemarksForMoveUnprocessableEntityCode int = 422
 
-/*
-GetCustomerSupportRemarksForMoveUnprocessableEntity The payload was unprocessable.
+/*GetCustomerSupportRemarksForMoveUnprocessableEntity The payload was unprocessable.
 
 swagger:response getCustomerSupportRemarksForMoveUnprocessableEntity
 */
@@ -199,8 +195,7 @@ func (o *GetCustomerSupportRemarksForMoveUnprocessableEntity) WriteResponse(rw h
 // GetCustomerSupportRemarksForMoveInternalServerErrorCode is the HTTP code returned for type GetCustomerSupportRemarksForMoveInternalServerError
 const GetCustomerSupportRemarksForMoveInternalServerErrorCode int = 500
 
-/*
-GetCustomerSupportRemarksForMoveInternalServerError A server error occurred
+/*GetCustomerSupportRemarksForMoveInternalServerError A server error occurred
 
 swagger:response getCustomerSupportRemarksForMoveInternalServerError
 */

--- a/pkg/gen/ghcapi/ghcoperations/customer_support_remarks/update_customer_support_remark_for_move.go
+++ b/pkg/gen/ghcapi/ghcoperations/customer_support_remarks/update_customer_support_remark_for_move.go
@@ -29,12 +29,12 @@ func NewUpdateCustomerSupportRemarkForMove(ctx *middleware.Context, handler Upda
 	return &UpdateCustomerSupportRemarkForMove{Context: ctx, Handler: handler}
 }
 
-/*
-	UpdateCustomerSupportRemarkForMove swagger:route PATCH /customer-support-remarks/{customerSupportRemarkID} customerSupportRemarks updateCustomerSupportRemarkForMove
-
-# Updates a customer support remark for a move
+/* UpdateCustomerSupportRemarkForMove swagger:route PATCH /customer-support-remarks/{customerSupportRemarkID} customerSupportRemarks updateCustomerSupportRemarkForMove
 
 Updates a customer support remark for a move
+
+Updates a customer support remark for a move
+
 */
 type UpdateCustomerSupportRemarkForMove struct {
 	Context *middleware.Context

--- a/pkg/gen/ghcapi/ghcoperations/customer_support_remarks/update_customer_support_remark_for_move_responses.go
+++ b/pkg/gen/ghcapi/ghcoperations/customer_support_remarks/update_customer_support_remark_for_move_responses.go
@@ -16,8 +16,7 @@ import (
 // UpdateCustomerSupportRemarkForMoveOKCode is the HTTP code returned for type UpdateCustomerSupportRemarkForMoveOK
 const UpdateCustomerSupportRemarkForMoveOKCode int = 200
 
-/*
-UpdateCustomerSupportRemarkForMoveOK Successfully updated customer support remark
+/*UpdateCustomerSupportRemarkForMoveOK Successfully updated customer support remark
 
 swagger:response updateCustomerSupportRemarkForMoveOK
 */
@@ -61,8 +60,7 @@ func (o *UpdateCustomerSupportRemarkForMoveOK) WriteResponse(rw http.ResponseWri
 // UpdateCustomerSupportRemarkForMoveBadRequestCode is the HTTP code returned for type UpdateCustomerSupportRemarkForMoveBadRequest
 const UpdateCustomerSupportRemarkForMoveBadRequestCode int = 400
 
-/*
-UpdateCustomerSupportRemarkForMoveBadRequest The request payload is invalid
+/*UpdateCustomerSupportRemarkForMoveBadRequest The request payload is invalid
 
 swagger:response updateCustomerSupportRemarkForMoveBadRequest
 */
@@ -106,8 +104,7 @@ func (o *UpdateCustomerSupportRemarkForMoveBadRequest) WriteResponse(rw http.Res
 // UpdateCustomerSupportRemarkForMoveForbiddenCode is the HTTP code returned for type UpdateCustomerSupportRemarkForMoveForbidden
 const UpdateCustomerSupportRemarkForMoveForbiddenCode int = 403
 
-/*
-UpdateCustomerSupportRemarkForMoveForbidden The request was denied
+/*UpdateCustomerSupportRemarkForMoveForbidden The request was denied
 
 swagger:response updateCustomerSupportRemarkForMoveForbidden
 */
@@ -151,8 +148,7 @@ func (o *UpdateCustomerSupportRemarkForMoveForbidden) WriteResponse(rw http.Resp
 // UpdateCustomerSupportRemarkForMoveNotFoundCode is the HTTP code returned for type UpdateCustomerSupportRemarkForMoveNotFound
 const UpdateCustomerSupportRemarkForMoveNotFoundCode int = 404
 
-/*
-UpdateCustomerSupportRemarkForMoveNotFound The requested resource wasn't found
+/*UpdateCustomerSupportRemarkForMoveNotFound The requested resource wasn't found
 
 swagger:response updateCustomerSupportRemarkForMoveNotFound
 */
@@ -196,8 +192,7 @@ func (o *UpdateCustomerSupportRemarkForMoveNotFound) WriteResponse(rw http.Respo
 // UpdateCustomerSupportRemarkForMoveUnprocessableEntityCode is the HTTP code returned for type UpdateCustomerSupportRemarkForMoveUnprocessableEntity
 const UpdateCustomerSupportRemarkForMoveUnprocessableEntityCode int = 422
 
-/*
-UpdateCustomerSupportRemarkForMoveUnprocessableEntity The payload was unprocessable.
+/*UpdateCustomerSupportRemarkForMoveUnprocessableEntity The payload was unprocessable.
 
 swagger:response updateCustomerSupportRemarkForMoveUnprocessableEntity
 */
@@ -241,8 +236,7 @@ func (o *UpdateCustomerSupportRemarkForMoveUnprocessableEntity) WriteResponse(rw
 // UpdateCustomerSupportRemarkForMoveInternalServerErrorCode is the HTTP code returned for type UpdateCustomerSupportRemarkForMoveInternalServerError
 const UpdateCustomerSupportRemarkForMoveInternalServerErrorCode int = 500
 
-/*
-UpdateCustomerSupportRemarkForMoveInternalServerError A server error occurred
+/*UpdateCustomerSupportRemarkForMoveInternalServerError A server error occurred
 
 swagger:response updateCustomerSupportRemarkForMoveInternalServerError
 */

--- a/pkg/gen/ghcapi/ghcoperations/evaluation_reports/create_evaluation_report.go
+++ b/pkg/gen/ghcapi/ghcoperations/evaluation_reports/create_evaluation_report.go
@@ -29,12 +29,12 @@ func NewCreateEvaluationReport(ctx *middleware.Context, handler CreateEvaluation
 	return &CreateEvaluationReport{Context: ctx, Handler: handler}
 }
 
-/*
-	CreateEvaluationReport swagger:route POST /moves/{locator}/evaluation-reports evaluationReports createEvaluationReport
-
-# Creates an evaluation report
+/* CreateEvaluationReport swagger:route POST /moves/{locator}/evaluation-reports evaluationReports createEvaluationReport
 
 Creates an evaluation report
+
+Creates an evaluation report
+
 */
 type CreateEvaluationReport struct {
 	Context *middleware.Context

--- a/pkg/gen/ghcapi/ghcoperations/evaluation_reports/create_evaluation_report_responses.go
+++ b/pkg/gen/ghcapi/ghcoperations/evaluation_reports/create_evaluation_report_responses.go
@@ -16,8 +16,7 @@ import (
 // CreateEvaluationReportOKCode is the HTTP code returned for type CreateEvaluationReportOK
 const CreateEvaluationReportOKCode int = 200
 
-/*
-CreateEvaluationReportOK Successfully created evaluation report
+/*CreateEvaluationReportOK Successfully created evaluation report
 
 swagger:response createEvaluationReportOK
 */
@@ -61,8 +60,7 @@ func (o *CreateEvaluationReportOK) WriteResponse(rw http.ResponseWriter, produce
 // CreateEvaluationReportBadRequestCode is the HTTP code returned for type CreateEvaluationReportBadRequest
 const CreateEvaluationReportBadRequestCode int = 400
 
-/*
-CreateEvaluationReportBadRequest The request payload is invalid
+/*CreateEvaluationReportBadRequest The request payload is invalid
 
 swagger:response createEvaluationReportBadRequest
 */
@@ -106,8 +104,7 @@ func (o *CreateEvaluationReportBadRequest) WriteResponse(rw http.ResponseWriter,
 // CreateEvaluationReportNotFoundCode is the HTTP code returned for type CreateEvaluationReportNotFound
 const CreateEvaluationReportNotFoundCode int = 404
 
-/*
-CreateEvaluationReportNotFound The requested resource wasn't found
+/*CreateEvaluationReportNotFound The requested resource wasn't found
 
 swagger:response createEvaluationReportNotFound
 */
@@ -151,8 +148,7 @@ func (o *CreateEvaluationReportNotFound) WriteResponse(rw http.ResponseWriter, p
 // CreateEvaluationReportUnprocessableEntityCode is the HTTP code returned for type CreateEvaluationReportUnprocessableEntity
 const CreateEvaluationReportUnprocessableEntityCode int = 422
 
-/*
-CreateEvaluationReportUnprocessableEntity The payload was unprocessable.
+/*CreateEvaluationReportUnprocessableEntity The payload was unprocessable.
 
 swagger:response createEvaluationReportUnprocessableEntity
 */
@@ -196,8 +192,7 @@ func (o *CreateEvaluationReportUnprocessableEntity) WriteResponse(rw http.Respon
 // CreateEvaluationReportInternalServerErrorCode is the HTTP code returned for type CreateEvaluationReportInternalServerError
 const CreateEvaluationReportInternalServerErrorCode int = 500
 
-/*
-CreateEvaluationReportInternalServerError A server error occurred
+/*CreateEvaluationReportInternalServerError A server error occurred
 
 swagger:response createEvaluationReportInternalServerError
 */

--- a/pkg/gen/ghcapi/ghcoperations/evaluation_reports/delete_evaluation_report.go
+++ b/pkg/gen/ghcapi/ghcoperations/evaluation_reports/delete_evaluation_report.go
@@ -29,12 +29,12 @@ func NewDeleteEvaluationReport(ctx *middleware.Context, handler DeleteEvaluation
 	return &DeleteEvaluationReport{Context: ctx, Handler: handler}
 }
 
-/*
-	DeleteEvaluationReport swagger:route DELETE /evaluation-reports/{reportID} evaluationReports deleteEvaluationReport
-
-# Soft deletes an evaluation report by ID
+/* DeleteEvaluationReport swagger:route DELETE /evaluation-reports/{reportID} evaluationReports deleteEvaluationReport
 
 Soft deletes an evaluation report by ID
+
+Soft deletes an evaluation report by ID
+
 */
 type DeleteEvaluationReport struct {
 	Context *middleware.Context

--- a/pkg/gen/ghcapi/ghcoperations/evaluation_reports/delete_evaluation_report_responses.go
+++ b/pkg/gen/ghcapi/ghcoperations/evaluation_reports/delete_evaluation_report_responses.go
@@ -16,8 +16,7 @@ import (
 // DeleteEvaluationReportNoContentCode is the HTTP code returned for type DeleteEvaluationReportNoContent
 const DeleteEvaluationReportNoContentCode int = 204
 
-/*
-DeleteEvaluationReportNoContent Successfully soft deleted the report
+/*DeleteEvaluationReportNoContent Successfully soft deleted the report
 
 swagger:response deleteEvaluationReportNoContent
 */
@@ -41,8 +40,7 @@ func (o *DeleteEvaluationReportNoContent) WriteResponse(rw http.ResponseWriter, 
 // DeleteEvaluationReportBadRequestCode is the HTTP code returned for type DeleteEvaluationReportBadRequest
 const DeleteEvaluationReportBadRequestCode int = 400
 
-/*
-DeleteEvaluationReportBadRequest The request payload is invalid
+/*DeleteEvaluationReportBadRequest The request payload is invalid
 
 swagger:response deleteEvaluationReportBadRequest
 */
@@ -86,8 +84,7 @@ func (o *DeleteEvaluationReportBadRequest) WriteResponse(rw http.ResponseWriter,
 // DeleteEvaluationReportForbiddenCode is the HTTP code returned for type DeleteEvaluationReportForbidden
 const DeleteEvaluationReportForbiddenCode int = 403
 
-/*
-DeleteEvaluationReportForbidden The request was denied
+/*DeleteEvaluationReportForbidden The request was denied
 
 swagger:response deleteEvaluationReportForbidden
 */
@@ -131,8 +128,7 @@ func (o *DeleteEvaluationReportForbidden) WriteResponse(rw http.ResponseWriter, 
 // DeleteEvaluationReportNotFoundCode is the HTTP code returned for type DeleteEvaluationReportNotFound
 const DeleteEvaluationReportNotFoundCode int = 404
 
-/*
-DeleteEvaluationReportNotFound The requested resource wasn't found
+/*DeleteEvaluationReportNotFound The requested resource wasn't found
 
 swagger:response deleteEvaluationReportNotFound
 */
@@ -176,8 +172,7 @@ func (o *DeleteEvaluationReportNotFound) WriteResponse(rw http.ResponseWriter, p
 // DeleteEvaluationReportConflictCode is the HTTP code returned for type DeleteEvaluationReportConflict
 const DeleteEvaluationReportConflictCode int = 409
 
-/*
-DeleteEvaluationReportConflict Conflict error
+/*DeleteEvaluationReportConflict Conflict error
 
 swagger:response deleteEvaluationReportConflict
 */
@@ -221,8 +216,7 @@ func (o *DeleteEvaluationReportConflict) WriteResponse(rw http.ResponseWriter, p
 // DeleteEvaluationReportUnprocessableEntityCode is the HTTP code returned for type DeleteEvaluationReportUnprocessableEntity
 const DeleteEvaluationReportUnprocessableEntityCode int = 422
 
-/*
-DeleteEvaluationReportUnprocessableEntity The payload was unprocessable.
+/*DeleteEvaluationReportUnprocessableEntity The payload was unprocessable.
 
 swagger:response deleteEvaluationReportUnprocessableEntity
 */
@@ -266,8 +260,7 @@ func (o *DeleteEvaluationReportUnprocessableEntity) WriteResponse(rw http.Respon
 // DeleteEvaluationReportInternalServerErrorCode is the HTTP code returned for type DeleteEvaluationReportInternalServerError
 const DeleteEvaluationReportInternalServerErrorCode int = 500
 
-/*
-DeleteEvaluationReportInternalServerError A server error occurred
+/*DeleteEvaluationReportInternalServerError A server error occurred
 
 swagger:response deleteEvaluationReportInternalServerError
 */

--- a/pkg/gen/ghcapi/ghcoperations/evaluation_reports/download_evaluation_report.go
+++ b/pkg/gen/ghcapi/ghcoperations/evaluation_reports/download_evaluation_report.go
@@ -29,12 +29,12 @@ func NewDownloadEvaluationReport(ctx *middleware.Context, handler DownloadEvalua
 	return &DownloadEvaluationReport{Context: ctx, Handler: handler}
 }
 
-/*
-	DownloadEvaluationReport swagger:route GET /evaluation-reports/{reportID}/download evaluationReports downloadEvaluationReport
-
-# Downloads an evaluation report as a PDF
+/* DownloadEvaluationReport swagger:route GET /evaluation-reports/{reportID}/download evaluationReports downloadEvaluationReport
 
 Downloads an evaluation report as a PDF
+
+Downloads an evaluation report as a PDF
+
 */
 type DownloadEvaluationReport struct {
 	Context *middleware.Context

--- a/pkg/gen/ghcapi/ghcoperations/evaluation_reports/download_evaluation_report_responses.go
+++ b/pkg/gen/ghcapi/ghcoperations/evaluation_reports/download_evaluation_report_responses.go
@@ -17,8 +17,7 @@ import (
 // DownloadEvaluationReportOKCode is the HTTP code returned for type DownloadEvaluationReportOK
 const DownloadEvaluationReportOKCode int = 200
 
-/*
-DownloadEvaluationReportOK Evaluation report PDF
+/*DownloadEvaluationReportOK Evaluation report PDF
 
 swagger:response downloadEvaluationReportOK
 */
@@ -82,8 +81,7 @@ func (o *DownloadEvaluationReportOK) WriteResponse(rw http.ResponseWriter, produ
 // DownloadEvaluationReportForbiddenCode is the HTTP code returned for type DownloadEvaluationReportForbidden
 const DownloadEvaluationReportForbiddenCode int = 403
 
-/*
-DownloadEvaluationReportForbidden The request was denied
+/*DownloadEvaluationReportForbidden The request was denied
 
 swagger:response downloadEvaluationReportForbidden
 */
@@ -127,8 +125,7 @@ func (o *DownloadEvaluationReportForbidden) WriteResponse(rw http.ResponseWriter
 // DownloadEvaluationReportNotFoundCode is the HTTP code returned for type DownloadEvaluationReportNotFound
 const DownloadEvaluationReportNotFoundCode int = 404
 
-/*
-DownloadEvaluationReportNotFound The requested resource wasn't found
+/*DownloadEvaluationReportNotFound The requested resource wasn't found
 
 swagger:response downloadEvaluationReportNotFound
 */
@@ -172,8 +169,7 @@ func (o *DownloadEvaluationReportNotFound) WriteResponse(rw http.ResponseWriter,
 // DownloadEvaluationReportInternalServerErrorCode is the HTTP code returned for type DownloadEvaluationReportInternalServerError
 const DownloadEvaluationReportInternalServerErrorCode int = 500
 
-/*
-DownloadEvaluationReportInternalServerError A server error occurred
+/*DownloadEvaluationReportInternalServerError A server error occurred
 
 swagger:response downloadEvaluationReportInternalServerError
 */

--- a/pkg/gen/ghcapi/ghcoperations/evaluation_reports/get_evaluation_report.go
+++ b/pkg/gen/ghcapi/ghcoperations/evaluation_reports/get_evaluation_report.go
@@ -29,12 +29,12 @@ func NewGetEvaluationReport(ctx *middleware.Context, handler GetEvaluationReport
 	return &GetEvaluationReport{Context: ctx, Handler: handler}
 }
 
-/*
-	GetEvaluationReport swagger:route GET /evaluation-reports/{reportID} evaluationReports getEvaluationReport
-
-# Gets an evaluation report by ID
+/* GetEvaluationReport swagger:route GET /evaluation-reports/{reportID} evaluationReports getEvaluationReport
 
 Gets an evaluation report by ID
+
+Gets an evaluation report by ID
+
 */
 type GetEvaluationReport struct {
 	Context *middleware.Context

--- a/pkg/gen/ghcapi/ghcoperations/evaluation_reports/get_evaluation_report_responses.go
+++ b/pkg/gen/ghcapi/ghcoperations/evaluation_reports/get_evaluation_report_responses.go
@@ -16,8 +16,7 @@ import (
 // GetEvaluationReportOKCode is the HTTP code returned for type GetEvaluationReportOK
 const GetEvaluationReportOKCode int = 200
 
-/*
-GetEvaluationReportOK Successfully got the report
+/*GetEvaluationReportOK Successfully got the report
 
 swagger:response getEvaluationReportOK
 */
@@ -61,8 +60,7 @@ func (o *GetEvaluationReportOK) WriteResponse(rw http.ResponseWriter, producer r
 // GetEvaluationReportBadRequestCode is the HTTP code returned for type GetEvaluationReportBadRequest
 const GetEvaluationReportBadRequestCode int = 400
 
-/*
-GetEvaluationReportBadRequest The request payload is invalid
+/*GetEvaluationReportBadRequest The request payload is invalid
 
 swagger:response getEvaluationReportBadRequest
 */
@@ -106,8 +104,7 @@ func (o *GetEvaluationReportBadRequest) WriteResponse(rw http.ResponseWriter, pr
 // GetEvaluationReportForbiddenCode is the HTTP code returned for type GetEvaluationReportForbidden
 const GetEvaluationReportForbiddenCode int = 403
 
-/*
-GetEvaluationReportForbidden The request was denied
+/*GetEvaluationReportForbidden The request was denied
 
 swagger:response getEvaluationReportForbidden
 */
@@ -151,8 +148,7 @@ func (o *GetEvaluationReportForbidden) WriteResponse(rw http.ResponseWriter, pro
 // GetEvaluationReportNotFoundCode is the HTTP code returned for type GetEvaluationReportNotFound
 const GetEvaluationReportNotFoundCode int = 404
 
-/*
-GetEvaluationReportNotFound The requested resource wasn't found
+/*GetEvaluationReportNotFound The requested resource wasn't found
 
 swagger:response getEvaluationReportNotFound
 */
@@ -196,8 +192,7 @@ func (o *GetEvaluationReportNotFound) WriteResponse(rw http.ResponseWriter, prod
 // GetEvaluationReportInternalServerErrorCode is the HTTP code returned for type GetEvaluationReportInternalServerError
 const GetEvaluationReportInternalServerErrorCode int = 500
 
-/*
-GetEvaluationReportInternalServerError A server error occurred
+/*GetEvaluationReportInternalServerError A server error occurred
 
 swagger:response getEvaluationReportInternalServerError
 */

--- a/pkg/gen/ghcapi/ghcoperations/evaluation_reports/get_p_w_s_violations.go
+++ b/pkg/gen/ghcapi/ghcoperations/evaluation_reports/get_p_w_s_violations.go
@@ -29,12 +29,12 @@ func NewGetPWSViolations(ctx *middleware.Context, handler GetPWSViolationsHandle
 	return &GetPWSViolations{Context: ctx, Handler: handler}
 }
 
-/*
-	GetPWSViolations swagger:route GET /pws-violations evaluationReports getPWSViolations
-
-# Fetch the possible PWS violations for an evaluation report
+/* GetPWSViolations swagger:route GET /pws-violations evaluationReports getPWSViolations
 
 Fetch the possible PWS violations for an evaluation report
+
+Fetch the possible PWS violations for an evaluation report
+
 */
 type GetPWSViolations struct {
 	Context *middleware.Context

--- a/pkg/gen/ghcapi/ghcoperations/evaluation_reports/get_p_w_s_violations_responses.go
+++ b/pkg/gen/ghcapi/ghcoperations/evaluation_reports/get_p_w_s_violations_responses.go
@@ -16,8 +16,7 @@ import (
 // GetPWSViolationsOKCode is the HTTP code returned for type GetPWSViolationsOK
 const GetPWSViolationsOKCode int = 200
 
-/*
-GetPWSViolationsOK Successfully retrieved the PWS violations
+/*GetPWSViolationsOK Successfully retrieved the PWS violations
 
 swagger:response getPWSViolationsOK
 */
@@ -64,8 +63,7 @@ func (o *GetPWSViolationsOK) WriteResponse(rw http.ResponseWriter, producer runt
 // GetPWSViolationsBadRequestCode is the HTTP code returned for type GetPWSViolationsBadRequest
 const GetPWSViolationsBadRequestCode int = 400
 
-/*
-GetPWSViolationsBadRequest The request payload is invalid
+/*GetPWSViolationsBadRequest The request payload is invalid
 
 swagger:response getPWSViolationsBadRequest
 */
@@ -109,8 +107,7 @@ func (o *GetPWSViolationsBadRequest) WriteResponse(rw http.ResponseWriter, produ
 // GetPWSViolationsForbiddenCode is the HTTP code returned for type GetPWSViolationsForbidden
 const GetPWSViolationsForbiddenCode int = 403
 
-/*
-GetPWSViolationsForbidden The request was denied
+/*GetPWSViolationsForbidden The request was denied
 
 swagger:response getPWSViolationsForbidden
 */
@@ -154,8 +151,7 @@ func (o *GetPWSViolationsForbidden) WriteResponse(rw http.ResponseWriter, produc
 // GetPWSViolationsNotFoundCode is the HTTP code returned for type GetPWSViolationsNotFound
 const GetPWSViolationsNotFoundCode int = 404
 
-/*
-GetPWSViolationsNotFound The requested resource wasn't found
+/*GetPWSViolationsNotFound The requested resource wasn't found
 
 swagger:response getPWSViolationsNotFound
 */
@@ -199,8 +195,7 @@ func (o *GetPWSViolationsNotFound) WriteResponse(rw http.ResponseWriter, produce
 // GetPWSViolationsInternalServerErrorCode is the HTTP code returned for type GetPWSViolationsInternalServerError
 const GetPWSViolationsInternalServerErrorCode int = 500
 
-/*
-GetPWSViolationsInternalServerError A server error occurred
+/*GetPWSViolationsInternalServerError A server error occurred
 
 swagger:response getPWSViolationsInternalServerError
 */

--- a/pkg/gen/ghcapi/ghcoperations/evaluation_reports/save_evaluation_report.go
+++ b/pkg/gen/ghcapi/ghcoperations/evaluation_reports/save_evaluation_report.go
@@ -29,12 +29,12 @@ func NewSaveEvaluationReport(ctx *middleware.Context, handler SaveEvaluationRepo
 	return &SaveEvaluationReport{Context: ctx, Handler: handler}
 }
 
-/*
-	SaveEvaluationReport swagger:route PUT /evaluation-reports/{reportID} evaluationReports saveEvaluationReport
-
-# Saves an evaluation report as a draft
+/* SaveEvaluationReport swagger:route PUT /evaluation-reports/{reportID} evaluationReports saveEvaluationReport
 
 Saves an evaluation report as a draft
+
+Saves an evaluation report as a draft
+
 */
 type SaveEvaluationReport struct {
 	Context *middleware.Context

--- a/pkg/gen/ghcapi/ghcoperations/evaluation_reports/save_evaluation_report_responses.go
+++ b/pkg/gen/ghcapi/ghcoperations/evaluation_reports/save_evaluation_report_responses.go
@@ -16,8 +16,7 @@ import (
 // SaveEvaluationReportNoContentCode is the HTTP code returned for type SaveEvaluationReportNoContent
 const SaveEvaluationReportNoContentCode int = 204
 
-/*
-SaveEvaluationReportNoContent Successfully saved the report
+/*SaveEvaluationReportNoContent Successfully saved the report
 
 swagger:response saveEvaluationReportNoContent
 */
@@ -41,8 +40,7 @@ func (o *SaveEvaluationReportNoContent) WriteResponse(rw http.ResponseWriter, pr
 // SaveEvaluationReportBadRequestCode is the HTTP code returned for type SaveEvaluationReportBadRequest
 const SaveEvaluationReportBadRequestCode int = 400
 
-/*
-SaveEvaluationReportBadRequest The request payload is invalid
+/*SaveEvaluationReportBadRequest The request payload is invalid
 
 swagger:response saveEvaluationReportBadRequest
 */
@@ -86,8 +84,7 @@ func (o *SaveEvaluationReportBadRequest) WriteResponse(rw http.ResponseWriter, p
 // SaveEvaluationReportForbiddenCode is the HTTP code returned for type SaveEvaluationReportForbidden
 const SaveEvaluationReportForbiddenCode int = 403
 
-/*
-SaveEvaluationReportForbidden The request was denied
+/*SaveEvaluationReportForbidden The request was denied
 
 swagger:response saveEvaluationReportForbidden
 */
@@ -131,8 +128,7 @@ func (o *SaveEvaluationReportForbidden) WriteResponse(rw http.ResponseWriter, pr
 // SaveEvaluationReportNotFoundCode is the HTTP code returned for type SaveEvaluationReportNotFound
 const SaveEvaluationReportNotFoundCode int = 404
 
-/*
-SaveEvaluationReportNotFound The requested resource wasn't found
+/*SaveEvaluationReportNotFound The requested resource wasn't found
 
 swagger:response saveEvaluationReportNotFound
 */
@@ -176,8 +172,7 @@ func (o *SaveEvaluationReportNotFound) WriteResponse(rw http.ResponseWriter, pro
 // SaveEvaluationReportConflictCode is the HTTP code returned for type SaveEvaluationReportConflict
 const SaveEvaluationReportConflictCode int = 409
 
-/*
-SaveEvaluationReportConflict Conflict error
+/*SaveEvaluationReportConflict Conflict error
 
 swagger:response saveEvaluationReportConflict
 */
@@ -221,8 +216,7 @@ func (o *SaveEvaluationReportConflict) WriteResponse(rw http.ResponseWriter, pro
 // SaveEvaluationReportPreconditionFailedCode is the HTTP code returned for type SaveEvaluationReportPreconditionFailed
 const SaveEvaluationReportPreconditionFailedCode int = 412
 
-/*
-SaveEvaluationReportPreconditionFailed Precondition failed
+/*SaveEvaluationReportPreconditionFailed Precondition failed
 
 swagger:response saveEvaluationReportPreconditionFailed
 */
@@ -266,8 +260,7 @@ func (o *SaveEvaluationReportPreconditionFailed) WriteResponse(rw http.ResponseW
 // SaveEvaluationReportUnprocessableEntityCode is the HTTP code returned for type SaveEvaluationReportUnprocessableEntity
 const SaveEvaluationReportUnprocessableEntityCode int = 422
 
-/*
-SaveEvaluationReportUnprocessableEntity The payload was unprocessable.
+/*SaveEvaluationReportUnprocessableEntity The payload was unprocessable.
 
 swagger:response saveEvaluationReportUnprocessableEntity
 */
@@ -311,8 +304,7 @@ func (o *SaveEvaluationReportUnprocessableEntity) WriteResponse(rw http.Response
 // SaveEvaluationReportInternalServerErrorCode is the HTTP code returned for type SaveEvaluationReportInternalServerError
 const SaveEvaluationReportInternalServerErrorCode int = 500
 
-/*
-SaveEvaluationReportInternalServerError A server error occurred
+/*SaveEvaluationReportInternalServerError A server error occurred
 
 swagger:response saveEvaluationReportInternalServerError
 */

--- a/pkg/gen/ghcapi/ghcoperations/evaluation_reports/submit_evaluation_report.go
+++ b/pkg/gen/ghcapi/ghcoperations/evaluation_reports/submit_evaluation_report.go
@@ -29,12 +29,12 @@ func NewSubmitEvaluationReport(ctx *middleware.Context, handler SubmitEvaluation
 	return &SubmitEvaluationReport{Context: ctx, Handler: handler}
 }
 
-/*
-	SubmitEvaluationReport swagger:route POST /evaluation-reports/{reportID}/submit evaluationReports submitEvaluationReport
-
-# Submits an evaluation report
+/* SubmitEvaluationReport swagger:route POST /evaluation-reports/{reportID}/submit evaluationReports submitEvaluationReport
 
 Submits an evaluation report
+
+Submits an evaluation report
+
 */
 type SubmitEvaluationReport struct {
 	Context *middleware.Context

--- a/pkg/gen/ghcapi/ghcoperations/evaluation_reports/submit_evaluation_report_responses.go
+++ b/pkg/gen/ghcapi/ghcoperations/evaluation_reports/submit_evaluation_report_responses.go
@@ -16,8 +16,7 @@ import (
 // SubmitEvaluationReportNoContentCode is the HTTP code returned for type SubmitEvaluationReportNoContent
 const SubmitEvaluationReportNoContentCode int = 204
 
-/*
-SubmitEvaluationReportNoContent Successfully submitted an evaluation report with the provided ID
+/*SubmitEvaluationReportNoContent Successfully submitted an evaluation report with the provided ID
 
 swagger:response submitEvaluationReportNoContent
 */
@@ -41,8 +40,7 @@ func (o *SubmitEvaluationReportNoContent) WriteResponse(rw http.ResponseWriter, 
 // SubmitEvaluationReportForbiddenCode is the HTTP code returned for type SubmitEvaluationReportForbidden
 const SubmitEvaluationReportForbiddenCode int = 403
 
-/*
-SubmitEvaluationReportForbidden The request was denied
+/*SubmitEvaluationReportForbidden The request was denied
 
 swagger:response submitEvaluationReportForbidden
 */
@@ -86,8 +84,7 @@ func (o *SubmitEvaluationReportForbidden) WriteResponse(rw http.ResponseWriter, 
 // SubmitEvaluationReportNotFoundCode is the HTTP code returned for type SubmitEvaluationReportNotFound
 const SubmitEvaluationReportNotFoundCode int = 404
 
-/*
-SubmitEvaluationReportNotFound The requested resource wasn't found
+/*SubmitEvaluationReportNotFound The requested resource wasn't found
 
 swagger:response submitEvaluationReportNotFound
 */
@@ -131,8 +128,7 @@ func (o *SubmitEvaluationReportNotFound) WriteResponse(rw http.ResponseWriter, p
 // SubmitEvaluationReportPreconditionFailedCode is the HTTP code returned for type SubmitEvaluationReportPreconditionFailed
 const SubmitEvaluationReportPreconditionFailedCode int = 412
 
-/*
-SubmitEvaluationReportPreconditionFailed Precondition failed
+/*SubmitEvaluationReportPreconditionFailed Precondition failed
 
 swagger:response submitEvaluationReportPreconditionFailed
 */
@@ -176,8 +172,7 @@ func (o *SubmitEvaluationReportPreconditionFailed) WriteResponse(rw http.Respons
 // SubmitEvaluationReportUnprocessableEntityCode is the HTTP code returned for type SubmitEvaluationReportUnprocessableEntity
 const SubmitEvaluationReportUnprocessableEntityCode int = 422
 
-/*
-SubmitEvaluationReportUnprocessableEntity The payload was unprocessable.
+/*SubmitEvaluationReportUnprocessableEntity The payload was unprocessable.
 
 swagger:response submitEvaluationReportUnprocessableEntity
 */
@@ -221,8 +216,7 @@ func (o *SubmitEvaluationReportUnprocessableEntity) WriteResponse(rw http.Respon
 // SubmitEvaluationReportInternalServerErrorCode is the HTTP code returned for type SubmitEvaluationReportInternalServerError
 const SubmitEvaluationReportInternalServerErrorCode int = 500
 
-/*
-SubmitEvaluationReportInternalServerError A server error occurred
+/*SubmitEvaluationReportInternalServerError A server error occurred
 
 swagger:response submitEvaluationReportInternalServerError
 */

--- a/pkg/gen/ghcapi/ghcoperations/ghc_documents/get_document.go
+++ b/pkg/gen/ghcapi/ghcoperations/ghc_documents/get_document.go
@@ -29,12 +29,12 @@ func NewGetDocument(ctx *middleware.Context, handler GetDocumentHandler) *GetDoc
 	return &GetDocument{Context: ctx, Handler: handler}
 }
 
-/*
-	GetDocument swagger:route GET /documents/{documentId} ghcDocuments getDocument
+/* GetDocument swagger:route GET /documents/{documentId} ghcDocuments getDocument
 
-# Returns a document
+Returns a document
 
 Returns a document and its uploads
+
 */
 type GetDocument struct {
 	Context *middleware.Context

--- a/pkg/gen/ghcapi/ghcoperations/ghc_documents/get_document_responses.go
+++ b/pkg/gen/ghcapi/ghcoperations/ghc_documents/get_document_responses.go
@@ -16,8 +16,7 @@ import (
 // GetDocumentOKCode is the HTTP code returned for type GetDocumentOK
 const GetDocumentOKCode int = 200
 
-/*
-GetDocumentOK the requested document
+/*GetDocumentOK the requested document
 
 swagger:response getDocumentOK
 */
@@ -61,8 +60,7 @@ func (o *GetDocumentOK) WriteResponse(rw http.ResponseWriter, producer runtime.P
 // GetDocumentBadRequestCode is the HTTP code returned for type GetDocumentBadRequest
 const GetDocumentBadRequestCode int = 400
 
-/*
-GetDocumentBadRequest The request payload is invalid
+/*GetDocumentBadRequest The request payload is invalid
 
 swagger:response getDocumentBadRequest
 */
@@ -106,8 +104,7 @@ func (o *GetDocumentBadRequest) WriteResponse(rw http.ResponseWriter, producer r
 // GetDocumentUnauthorizedCode is the HTTP code returned for type GetDocumentUnauthorized
 const GetDocumentUnauthorizedCode int = 401
 
-/*
-GetDocumentUnauthorized The request was denied
+/*GetDocumentUnauthorized The request was denied
 
 swagger:response getDocumentUnauthorized
 */
@@ -151,8 +148,7 @@ func (o *GetDocumentUnauthorized) WriteResponse(rw http.ResponseWriter, producer
 // GetDocumentForbiddenCode is the HTTP code returned for type GetDocumentForbidden
 const GetDocumentForbiddenCode int = 403
 
-/*
-GetDocumentForbidden The request was denied
+/*GetDocumentForbidden The request was denied
 
 swagger:response getDocumentForbidden
 */
@@ -196,8 +192,7 @@ func (o *GetDocumentForbidden) WriteResponse(rw http.ResponseWriter, producer ru
 // GetDocumentNotFoundCode is the HTTP code returned for type GetDocumentNotFound
 const GetDocumentNotFoundCode int = 404
 
-/*
-GetDocumentNotFound The requested resource wasn't found
+/*GetDocumentNotFound The requested resource wasn't found
 
 swagger:response getDocumentNotFound
 */
@@ -241,8 +236,7 @@ func (o *GetDocumentNotFound) WriteResponse(rw http.ResponseWriter, producer run
 // GetDocumentPreconditionFailedCode is the HTTP code returned for type GetDocumentPreconditionFailed
 const GetDocumentPreconditionFailedCode int = 412
 
-/*
-GetDocumentPreconditionFailed Precondition failed
+/*GetDocumentPreconditionFailed Precondition failed
 
 swagger:response getDocumentPreconditionFailed
 */
@@ -286,8 +280,7 @@ func (o *GetDocumentPreconditionFailed) WriteResponse(rw http.ResponseWriter, pr
 // GetDocumentUnprocessableEntityCode is the HTTP code returned for type GetDocumentUnprocessableEntity
 const GetDocumentUnprocessableEntityCode int = 422
 
-/*
-GetDocumentUnprocessableEntity The payload was unprocessable.
+/*GetDocumentUnprocessableEntity The payload was unprocessable.
 
 swagger:response getDocumentUnprocessableEntity
 */
@@ -331,8 +324,7 @@ func (o *GetDocumentUnprocessableEntity) WriteResponse(rw http.ResponseWriter, p
 // GetDocumentInternalServerErrorCode is the HTTP code returned for type GetDocumentInternalServerError
 const GetDocumentInternalServerErrorCode int = 500
 
-/*
-GetDocumentInternalServerError A server error occurred
+/*GetDocumentInternalServerError A server error occurred
 
 swagger:response getDocumentInternalServerError
 */

--- a/pkg/gen/ghcapi/ghcoperations/move/get_move.go
+++ b/pkg/gen/ghcapi/ghcoperations/move/get_move.go
@@ -29,12 +29,12 @@ func NewGetMove(ctx *middleware.Context, handler GetMoveHandler) *GetMove {
 	return &GetMove{Context: ctx, Handler: handler}
 }
 
-/*
-	GetMove swagger:route GET /move/{locator} move getMove
+/* GetMove swagger:route GET /move/{locator} move getMove
 
-# Returns a given move
+Returns a given move
 
 Returns a given move for a unique alphanumeric locator string
+
 */
 type GetMove struct {
 	Context *middleware.Context

--- a/pkg/gen/ghcapi/ghcoperations/move/get_move_counseling_evaluation_reports_list.go
+++ b/pkg/gen/ghcapi/ghcoperations/move/get_move_counseling_evaluation_reports_list.go
@@ -29,12 +29,12 @@ func NewGetMoveCounselingEvaluationReportsList(ctx *middleware.Context, handler 
 	return &GetMoveCounselingEvaluationReportsList{Context: ctx, Handler: handler}
 }
 
-/*
-	GetMoveCounselingEvaluationReportsList swagger:route GET /moves/{moveID}/counseling-evaluation-reports-list move getMoveCounselingEvaluationReportsList
-
-# Returns counseling evaluation reports for the specified move that are visible to the current office user
+/* GetMoveCounselingEvaluationReportsList swagger:route GET /moves/{moveID}/counseling-evaluation-reports-list move getMoveCounselingEvaluationReportsList
 
 Returns counseling evaluation reports for the specified move that are visible to the current office user
+
+Returns counseling evaluation reports for the specified move that are visible to the current office user
+
 */
 type GetMoveCounselingEvaluationReportsList struct {
 	Context *middleware.Context

--- a/pkg/gen/ghcapi/ghcoperations/move/get_move_counseling_evaluation_reports_list_responses.go
+++ b/pkg/gen/ghcapi/ghcoperations/move/get_move_counseling_evaluation_reports_list_responses.go
@@ -16,8 +16,7 @@ import (
 // GetMoveCounselingEvaluationReportsListOKCode is the HTTP code returned for type GetMoveCounselingEvaluationReportsListOK
 const GetMoveCounselingEvaluationReportsListOKCode int = 200
 
-/*
-GetMoveCounselingEvaluationReportsListOK Successfully retrieved the move's evaluation reports
+/*GetMoveCounselingEvaluationReportsListOK Successfully retrieved the move's evaluation reports
 
 swagger:response getMoveCounselingEvaluationReportsListOK
 */
@@ -64,8 +63,7 @@ func (o *GetMoveCounselingEvaluationReportsListOK) WriteResponse(rw http.Respons
 // GetMoveCounselingEvaluationReportsListBadRequestCode is the HTTP code returned for type GetMoveCounselingEvaluationReportsListBadRequest
 const GetMoveCounselingEvaluationReportsListBadRequestCode int = 400
 
-/*
-GetMoveCounselingEvaluationReportsListBadRequest The request payload is invalid
+/*GetMoveCounselingEvaluationReportsListBadRequest The request payload is invalid
 
 swagger:response getMoveCounselingEvaluationReportsListBadRequest
 */
@@ -109,8 +107,7 @@ func (o *GetMoveCounselingEvaluationReportsListBadRequest) WriteResponse(rw http
 // GetMoveCounselingEvaluationReportsListUnauthorizedCode is the HTTP code returned for type GetMoveCounselingEvaluationReportsListUnauthorized
 const GetMoveCounselingEvaluationReportsListUnauthorizedCode int = 401
 
-/*
-GetMoveCounselingEvaluationReportsListUnauthorized The request was denied
+/*GetMoveCounselingEvaluationReportsListUnauthorized The request was denied
 
 swagger:response getMoveCounselingEvaluationReportsListUnauthorized
 */
@@ -154,8 +151,7 @@ func (o *GetMoveCounselingEvaluationReportsListUnauthorized) WriteResponse(rw ht
 // GetMoveCounselingEvaluationReportsListForbiddenCode is the HTTP code returned for type GetMoveCounselingEvaluationReportsListForbidden
 const GetMoveCounselingEvaluationReportsListForbiddenCode int = 403
 
-/*
-GetMoveCounselingEvaluationReportsListForbidden The request was denied
+/*GetMoveCounselingEvaluationReportsListForbidden The request was denied
 
 swagger:response getMoveCounselingEvaluationReportsListForbidden
 */
@@ -199,8 +195,7 @@ func (o *GetMoveCounselingEvaluationReportsListForbidden) WriteResponse(rw http.
 // GetMoveCounselingEvaluationReportsListNotFoundCode is the HTTP code returned for type GetMoveCounselingEvaluationReportsListNotFound
 const GetMoveCounselingEvaluationReportsListNotFoundCode int = 404
 
-/*
-GetMoveCounselingEvaluationReportsListNotFound The requested resource wasn't found
+/*GetMoveCounselingEvaluationReportsListNotFound The requested resource wasn't found
 
 swagger:response getMoveCounselingEvaluationReportsListNotFound
 */
@@ -244,8 +239,7 @@ func (o *GetMoveCounselingEvaluationReportsListNotFound) WriteResponse(rw http.R
 // GetMoveCounselingEvaluationReportsListInternalServerErrorCode is the HTTP code returned for type GetMoveCounselingEvaluationReportsListInternalServerError
 const GetMoveCounselingEvaluationReportsListInternalServerErrorCode int = 500
 
-/*
-GetMoveCounselingEvaluationReportsListInternalServerError A server error occurred
+/*GetMoveCounselingEvaluationReportsListInternalServerError A server error occurred
 
 swagger:response getMoveCounselingEvaluationReportsListInternalServerError
 */

--- a/pkg/gen/ghcapi/ghcoperations/move/get_move_history.go
+++ b/pkg/gen/ghcapi/ghcoperations/move/get_move_history.go
@@ -29,12 +29,12 @@ func NewGetMoveHistory(ctx *middleware.Context, handler GetMoveHistoryHandler) *
 	return &GetMoveHistory{Context: ctx, Handler: handler}
 }
 
-/*
-	GetMoveHistory swagger:route GET /move/{locator}/history move getMoveHistory
+/* GetMoveHistory swagger:route GET /move/{locator}/history move getMoveHistory
 
-# Returns the history of an identified move
+Returns the history of an identified move
 
 Returns the history for a given move for a unique alphanumeric locator string
+
 */
 type GetMoveHistory struct {
 	Context *middleware.Context

--- a/pkg/gen/ghcapi/ghcoperations/move/get_move_history_responses.go
+++ b/pkg/gen/ghcapi/ghcoperations/move/get_move_history_responses.go
@@ -16,8 +16,7 @@ import (
 // GetMoveHistoryOKCode is the HTTP code returned for type GetMoveHistoryOK
 const GetMoveHistoryOKCode int = 200
 
-/*
-GetMoveHistoryOK Successfully retrieved the individual move history
+/*GetMoveHistoryOK Successfully retrieved the individual move history
 
 swagger:response getMoveHistoryOK
 */
@@ -61,8 +60,7 @@ func (o *GetMoveHistoryOK) WriteResponse(rw http.ResponseWriter, producer runtim
 // GetMoveHistoryBadRequestCode is the HTTP code returned for type GetMoveHistoryBadRequest
 const GetMoveHistoryBadRequestCode int = 400
 
-/*
-GetMoveHistoryBadRequest The request payload is invalid
+/*GetMoveHistoryBadRequest The request payload is invalid
 
 swagger:response getMoveHistoryBadRequest
 */
@@ -106,8 +104,7 @@ func (o *GetMoveHistoryBadRequest) WriteResponse(rw http.ResponseWriter, produce
 // GetMoveHistoryUnauthorizedCode is the HTTP code returned for type GetMoveHistoryUnauthorized
 const GetMoveHistoryUnauthorizedCode int = 401
 
-/*
-GetMoveHistoryUnauthorized The request was denied
+/*GetMoveHistoryUnauthorized The request was denied
 
 swagger:response getMoveHistoryUnauthorized
 */
@@ -151,8 +148,7 @@ func (o *GetMoveHistoryUnauthorized) WriteResponse(rw http.ResponseWriter, produ
 // GetMoveHistoryForbiddenCode is the HTTP code returned for type GetMoveHistoryForbidden
 const GetMoveHistoryForbiddenCode int = 403
 
-/*
-GetMoveHistoryForbidden The request was denied
+/*GetMoveHistoryForbidden The request was denied
 
 swagger:response getMoveHistoryForbidden
 */
@@ -196,8 +192,7 @@ func (o *GetMoveHistoryForbidden) WriteResponse(rw http.ResponseWriter, producer
 // GetMoveHistoryNotFoundCode is the HTTP code returned for type GetMoveHistoryNotFound
 const GetMoveHistoryNotFoundCode int = 404
 
-/*
-GetMoveHistoryNotFound The requested resource wasn't found
+/*GetMoveHistoryNotFound The requested resource wasn't found
 
 swagger:response getMoveHistoryNotFound
 */
@@ -241,8 +236,7 @@ func (o *GetMoveHistoryNotFound) WriteResponse(rw http.ResponseWriter, producer 
 // GetMoveHistoryInternalServerErrorCode is the HTTP code returned for type GetMoveHistoryInternalServerError
 const GetMoveHistoryInternalServerErrorCode int = 500
 
-/*
-GetMoveHistoryInternalServerError A server error occurred
+/*GetMoveHistoryInternalServerError A server error occurred
 
 swagger:response getMoveHistoryInternalServerError
 */

--- a/pkg/gen/ghcapi/ghcoperations/move/get_move_responses.go
+++ b/pkg/gen/ghcapi/ghcoperations/move/get_move_responses.go
@@ -16,8 +16,7 @@ import (
 // GetMoveOKCode is the HTTP code returned for type GetMoveOK
 const GetMoveOKCode int = 200
 
-/*
-GetMoveOK Successfully retrieved the individual move
+/*GetMoveOK Successfully retrieved the individual move
 
 swagger:response getMoveOK
 */
@@ -61,8 +60,7 @@ func (o *GetMoveOK) WriteResponse(rw http.ResponseWriter, producer runtime.Produ
 // GetMoveBadRequestCode is the HTTP code returned for type GetMoveBadRequest
 const GetMoveBadRequestCode int = 400
 
-/*
-GetMoveBadRequest The request payload is invalid
+/*GetMoveBadRequest The request payload is invalid
 
 swagger:response getMoveBadRequest
 */
@@ -106,8 +104,7 @@ func (o *GetMoveBadRequest) WriteResponse(rw http.ResponseWriter, producer runti
 // GetMoveUnauthorizedCode is the HTTP code returned for type GetMoveUnauthorized
 const GetMoveUnauthorizedCode int = 401
 
-/*
-GetMoveUnauthorized The request was denied
+/*GetMoveUnauthorized The request was denied
 
 swagger:response getMoveUnauthorized
 */
@@ -151,8 +148,7 @@ func (o *GetMoveUnauthorized) WriteResponse(rw http.ResponseWriter, producer run
 // GetMoveForbiddenCode is the HTTP code returned for type GetMoveForbidden
 const GetMoveForbiddenCode int = 403
 
-/*
-GetMoveForbidden The request was denied
+/*GetMoveForbidden The request was denied
 
 swagger:response getMoveForbidden
 */
@@ -196,8 +192,7 @@ func (o *GetMoveForbidden) WriteResponse(rw http.ResponseWriter, producer runtim
 // GetMoveNotFoundCode is the HTTP code returned for type GetMoveNotFound
 const GetMoveNotFoundCode int = 404
 
-/*
-GetMoveNotFound The requested resource wasn't found
+/*GetMoveNotFound The requested resource wasn't found
 
 swagger:response getMoveNotFound
 */
@@ -241,8 +236,7 @@ func (o *GetMoveNotFound) WriteResponse(rw http.ResponseWriter, producer runtime
 // GetMoveInternalServerErrorCode is the HTTP code returned for type GetMoveInternalServerError
 const GetMoveInternalServerErrorCode int = 500
 
-/*
-GetMoveInternalServerError A server error occurred
+/*GetMoveInternalServerError A server error occurred
 
 swagger:response getMoveInternalServerError
 */

--- a/pkg/gen/ghcapi/ghcoperations/move/get_move_shipment_evaluation_reports_list.go
+++ b/pkg/gen/ghcapi/ghcoperations/move/get_move_shipment_evaluation_reports_list.go
@@ -29,12 +29,12 @@ func NewGetMoveShipmentEvaluationReportsList(ctx *middleware.Context, handler Ge
 	return &GetMoveShipmentEvaluationReportsList{Context: ctx, Handler: handler}
 }
 
-/*
-	GetMoveShipmentEvaluationReportsList swagger:route GET /moves/{moveID}/shipment-evaluation-reports-list move getMoveShipmentEvaluationReportsList
-
-# Returns shipment evaluation reports for the specified move that are visible to the current office user
+/* GetMoveShipmentEvaluationReportsList swagger:route GET /moves/{moveID}/shipment-evaluation-reports-list move getMoveShipmentEvaluationReportsList
 
 Returns shipment evaluation reports for the specified move that are visible to the current office user
+
+Returns shipment evaluation reports for the specified move that are visible to the current office user
+
 */
 type GetMoveShipmentEvaluationReportsList struct {
 	Context *middleware.Context

--- a/pkg/gen/ghcapi/ghcoperations/move/get_move_shipment_evaluation_reports_list_responses.go
+++ b/pkg/gen/ghcapi/ghcoperations/move/get_move_shipment_evaluation_reports_list_responses.go
@@ -16,8 +16,7 @@ import (
 // GetMoveShipmentEvaluationReportsListOKCode is the HTTP code returned for type GetMoveShipmentEvaluationReportsListOK
 const GetMoveShipmentEvaluationReportsListOKCode int = 200
 
-/*
-GetMoveShipmentEvaluationReportsListOK Successfully retrieved the move's evaluation reports
+/*GetMoveShipmentEvaluationReportsListOK Successfully retrieved the move's evaluation reports
 
 swagger:response getMoveShipmentEvaluationReportsListOK
 */
@@ -64,8 +63,7 @@ func (o *GetMoveShipmentEvaluationReportsListOK) WriteResponse(rw http.ResponseW
 // GetMoveShipmentEvaluationReportsListBadRequestCode is the HTTP code returned for type GetMoveShipmentEvaluationReportsListBadRequest
 const GetMoveShipmentEvaluationReportsListBadRequestCode int = 400
 
-/*
-GetMoveShipmentEvaluationReportsListBadRequest The request payload is invalid
+/*GetMoveShipmentEvaluationReportsListBadRequest The request payload is invalid
 
 swagger:response getMoveShipmentEvaluationReportsListBadRequest
 */
@@ -109,8 +107,7 @@ func (o *GetMoveShipmentEvaluationReportsListBadRequest) WriteResponse(rw http.R
 // GetMoveShipmentEvaluationReportsListUnauthorizedCode is the HTTP code returned for type GetMoveShipmentEvaluationReportsListUnauthorized
 const GetMoveShipmentEvaluationReportsListUnauthorizedCode int = 401
 
-/*
-GetMoveShipmentEvaluationReportsListUnauthorized The request was denied
+/*GetMoveShipmentEvaluationReportsListUnauthorized The request was denied
 
 swagger:response getMoveShipmentEvaluationReportsListUnauthorized
 */
@@ -154,8 +151,7 @@ func (o *GetMoveShipmentEvaluationReportsListUnauthorized) WriteResponse(rw http
 // GetMoveShipmentEvaluationReportsListForbiddenCode is the HTTP code returned for type GetMoveShipmentEvaluationReportsListForbidden
 const GetMoveShipmentEvaluationReportsListForbiddenCode int = 403
 
-/*
-GetMoveShipmentEvaluationReportsListForbidden The request was denied
+/*GetMoveShipmentEvaluationReportsListForbidden The request was denied
 
 swagger:response getMoveShipmentEvaluationReportsListForbidden
 */
@@ -199,8 +195,7 @@ func (o *GetMoveShipmentEvaluationReportsListForbidden) WriteResponse(rw http.Re
 // GetMoveShipmentEvaluationReportsListNotFoundCode is the HTTP code returned for type GetMoveShipmentEvaluationReportsListNotFound
 const GetMoveShipmentEvaluationReportsListNotFoundCode int = 404
 
-/*
-GetMoveShipmentEvaluationReportsListNotFound The requested resource wasn't found
+/*GetMoveShipmentEvaluationReportsListNotFound The requested resource wasn't found
 
 swagger:response getMoveShipmentEvaluationReportsListNotFound
 */
@@ -244,8 +239,7 @@ func (o *GetMoveShipmentEvaluationReportsListNotFound) WriteResponse(rw http.Res
 // GetMoveShipmentEvaluationReportsListInternalServerErrorCode is the HTTP code returned for type GetMoveShipmentEvaluationReportsListInternalServerError
 const GetMoveShipmentEvaluationReportsListInternalServerErrorCode int = 500
 
-/*
-GetMoveShipmentEvaluationReportsListInternalServerError A server error occurred
+/*GetMoveShipmentEvaluationReportsListInternalServerError A server error occurred
 
 swagger:response getMoveShipmentEvaluationReportsListInternalServerError
 */

--- a/pkg/gen/ghcapi/ghcoperations/move/search_moves.go
+++ b/pkg/gen/ghcapi/ghcoperations/move/search_moves.go
@@ -36,12 +36,13 @@ func NewSearchMoves(ctx *middleware.Context, handler SearchMovesHandler) *Search
 	return &SearchMoves{Context: ctx, Handler: handler}
 }
 
-/*
-	SearchMoves swagger:route POST /moves/search move searchMoves
+/* SearchMoves swagger:route POST /moves/search move searchMoves
 
-# Search moves by locator, DOD ID, or customer name
+Search moves by locator, DOD ID, or customer name
 
 Search moves by locator, DOD ID, or customer name. Used by QAE and CSR users.
+
+
 */
 type SearchMoves struct {
 	Context *middleware.Context

--- a/pkg/gen/ghcapi/ghcoperations/move/search_moves_responses.go
+++ b/pkg/gen/ghcapi/ghcoperations/move/search_moves_responses.go
@@ -16,8 +16,7 @@ import (
 // SearchMovesOKCode is the HTTP code returned for type SearchMovesOK
 const SearchMovesOKCode int = 200
 
-/*
-SearchMovesOK Successfully returned all moves matching the criteria
+/*SearchMovesOK Successfully returned all moves matching the criteria
 
 swagger:response searchMovesOK
 */
@@ -61,8 +60,7 @@ func (o *SearchMovesOK) WriteResponse(rw http.ResponseWriter, producer runtime.P
 // SearchMovesForbiddenCode is the HTTP code returned for type SearchMovesForbidden
 const SearchMovesForbiddenCode int = 403
 
-/*
-SearchMovesForbidden The request was denied
+/*SearchMovesForbidden The request was denied
 
 swagger:response searchMovesForbidden
 */
@@ -106,8 +104,7 @@ func (o *SearchMovesForbidden) WriteResponse(rw http.ResponseWriter, producer ru
 // SearchMovesInternalServerErrorCode is the HTTP code returned for type SearchMovesInternalServerError
 const SearchMovesInternalServerErrorCode int = 500
 
-/*
-SearchMovesInternalServerError A server error occurred
+/*SearchMovesInternalServerError A server error occurred
 
 swagger:response searchMovesInternalServerError
 */

--- a/pkg/gen/ghcapi/ghcoperations/move/set_financial_review_flag.go
+++ b/pkg/gen/ghcapi/ghcoperations/move/set_financial_review_flag.go
@@ -34,12 +34,12 @@ func NewSetFinancialReviewFlag(ctx *middleware.Context, handler SetFinancialRevi
 	return &SetFinancialReviewFlag{Context: ctx, Handler: handler}
 }
 
-/*
-	SetFinancialReviewFlag swagger:route POST /moves/{moveID}/financial-review-flag move setFinancialReviewFlag
+/* SetFinancialReviewFlag swagger:route POST /moves/{moveID}/financial-review-flag move setFinancialReviewFlag
 
-# Flags a move for financial office review
+Flags a move for financial office review
 
 This sets a flag which indicates that the move should be reviewed by a fincancial office. For example, if the origin or destination address of a shipment is far from the duty location and may incur excess costs to the customer.
+
 */
 type SetFinancialReviewFlag struct {
 	Context *middleware.Context

--- a/pkg/gen/ghcapi/ghcoperations/move/set_financial_review_flag_responses.go
+++ b/pkg/gen/ghcapi/ghcoperations/move/set_financial_review_flag_responses.go
@@ -16,8 +16,7 @@ import (
 // SetFinancialReviewFlagOKCode is the HTTP code returned for type SetFinancialReviewFlagOK
 const SetFinancialReviewFlagOKCode int = 200
 
-/*
-SetFinancialReviewFlagOK updated Move
+/*SetFinancialReviewFlagOK updated Move
 
 swagger:response setFinancialReviewFlagOK
 */
@@ -61,8 +60,7 @@ func (o *SetFinancialReviewFlagOK) WriteResponse(rw http.ResponseWriter, produce
 // SetFinancialReviewFlagForbiddenCode is the HTTP code returned for type SetFinancialReviewFlagForbidden
 const SetFinancialReviewFlagForbiddenCode int = 403
 
-/*
-SetFinancialReviewFlagForbidden The request was denied
+/*SetFinancialReviewFlagForbidden The request was denied
 
 swagger:response setFinancialReviewFlagForbidden
 */
@@ -106,8 +104,7 @@ func (o *SetFinancialReviewFlagForbidden) WriteResponse(rw http.ResponseWriter, 
 // SetFinancialReviewFlagNotFoundCode is the HTTP code returned for type SetFinancialReviewFlagNotFound
 const SetFinancialReviewFlagNotFoundCode int = 404
 
-/*
-SetFinancialReviewFlagNotFound The requested resource wasn't found
+/*SetFinancialReviewFlagNotFound The requested resource wasn't found
 
 swagger:response setFinancialReviewFlagNotFound
 */
@@ -151,8 +148,7 @@ func (o *SetFinancialReviewFlagNotFound) WriteResponse(rw http.ResponseWriter, p
 // SetFinancialReviewFlagPreconditionFailedCode is the HTTP code returned for type SetFinancialReviewFlagPreconditionFailed
 const SetFinancialReviewFlagPreconditionFailedCode int = 412
 
-/*
-SetFinancialReviewFlagPreconditionFailed Precondition failed
+/*SetFinancialReviewFlagPreconditionFailed Precondition failed
 
 swagger:response setFinancialReviewFlagPreconditionFailed
 */
@@ -196,8 +192,7 @@ func (o *SetFinancialReviewFlagPreconditionFailed) WriteResponse(rw http.Respons
 // SetFinancialReviewFlagUnprocessableEntityCode is the HTTP code returned for type SetFinancialReviewFlagUnprocessableEntity
 const SetFinancialReviewFlagUnprocessableEntityCode int = 422
 
-/*
-SetFinancialReviewFlagUnprocessableEntity The payload was unprocessable.
+/*SetFinancialReviewFlagUnprocessableEntity The payload was unprocessable.
 
 swagger:response setFinancialReviewFlagUnprocessableEntity
 */
@@ -241,8 +236,7 @@ func (o *SetFinancialReviewFlagUnprocessableEntity) WriteResponse(rw http.Respon
 // SetFinancialReviewFlagInternalServerErrorCode is the HTTP code returned for type SetFinancialReviewFlagInternalServerError
 const SetFinancialReviewFlagInternalServerErrorCode int = 500
 
-/*
-SetFinancialReviewFlagInternalServerError A server error occurred
+/*SetFinancialReviewFlagInternalServerError A server error occurred
 
 swagger:response setFinancialReviewFlagInternalServerError
 */

--- a/pkg/gen/ghcapi/ghcoperations/move_task_order/get_entitlements.go
+++ b/pkg/gen/ghcapi/ghcoperations/move_task_order/get_entitlements.go
@@ -29,12 +29,12 @@ func NewGetEntitlements(ctx *middleware.Context, handler GetEntitlementsHandler)
 	return &GetEntitlements{Context: ctx, Handler: handler}
 }
 
-/*
-	GetEntitlements swagger:route GET /move-task-orders/{moveTaskOrderID}/entitlements moveTaskOrder getEntitlements
+/* GetEntitlements swagger:route GET /move-task-orders/{moveTaskOrderID}/entitlements moveTaskOrder getEntitlements
 
-# Gets entitlements for a move by ID
+Gets entitlements for a move by ID
 
 Gets entitlements
+
 */
 type GetEntitlements struct {
 	Context *middleware.Context

--- a/pkg/gen/ghcapi/ghcoperations/move_task_order/get_entitlements_responses.go
+++ b/pkg/gen/ghcapi/ghcoperations/move_task_order/get_entitlements_responses.go
@@ -16,8 +16,7 @@ import (
 // GetEntitlementsOKCode is the HTTP code returned for type GetEntitlementsOK
 const GetEntitlementsOKCode int = 200
 
-/*
-GetEntitlementsOK Successfully retrieved entitlements
+/*GetEntitlementsOK Successfully retrieved entitlements
 
 swagger:response getEntitlementsOK
 */
@@ -61,8 +60,7 @@ func (o *GetEntitlementsOK) WriteResponse(rw http.ResponseWriter, producer runti
 // GetEntitlementsBadRequestCode is the HTTP code returned for type GetEntitlementsBadRequest
 const GetEntitlementsBadRequestCode int = 400
 
-/*
-GetEntitlementsBadRequest The request payload is invalid
+/*GetEntitlementsBadRequest The request payload is invalid
 
 swagger:response getEntitlementsBadRequest
 */
@@ -106,8 +104,7 @@ func (o *GetEntitlementsBadRequest) WriteResponse(rw http.ResponseWriter, produc
 // GetEntitlementsUnauthorizedCode is the HTTP code returned for type GetEntitlementsUnauthorized
 const GetEntitlementsUnauthorizedCode int = 401
 
-/*
-GetEntitlementsUnauthorized The request was denied
+/*GetEntitlementsUnauthorized The request was denied
 
 swagger:response getEntitlementsUnauthorized
 */
@@ -151,8 +148,7 @@ func (o *GetEntitlementsUnauthorized) WriteResponse(rw http.ResponseWriter, prod
 // GetEntitlementsForbiddenCode is the HTTP code returned for type GetEntitlementsForbidden
 const GetEntitlementsForbiddenCode int = 403
 
-/*
-GetEntitlementsForbidden The request was denied
+/*GetEntitlementsForbidden The request was denied
 
 swagger:response getEntitlementsForbidden
 */
@@ -196,8 +192,7 @@ func (o *GetEntitlementsForbidden) WriteResponse(rw http.ResponseWriter, produce
 // GetEntitlementsNotFoundCode is the HTTP code returned for type GetEntitlementsNotFound
 const GetEntitlementsNotFoundCode int = 404
 
-/*
-GetEntitlementsNotFound The requested resource wasn't found
+/*GetEntitlementsNotFound The requested resource wasn't found
 
 swagger:response getEntitlementsNotFound
 */
@@ -241,8 +236,7 @@ func (o *GetEntitlementsNotFound) WriteResponse(rw http.ResponseWriter, producer
 // GetEntitlementsInternalServerErrorCode is the HTTP code returned for type GetEntitlementsInternalServerError
 const GetEntitlementsInternalServerErrorCode int = 500
 
-/*
-GetEntitlementsInternalServerError A server error occurred
+/*GetEntitlementsInternalServerError A server error occurred
 
 swagger:response getEntitlementsInternalServerError
 */

--- a/pkg/gen/ghcapi/ghcoperations/move_task_order/get_move_task_order.go
+++ b/pkg/gen/ghcapi/ghcoperations/move_task_order/get_move_task_order.go
@@ -29,12 +29,12 @@ func NewGetMoveTaskOrder(ctx *middleware.Context, handler GetMoveTaskOrderHandle
 	return &GetMoveTaskOrder{Context: ctx, Handler: handler}
 }
 
-/*
-	GetMoveTaskOrder swagger:route GET /move-task-orders/{moveTaskOrderID} moveTaskOrder getMoveTaskOrder
+/* GetMoveTaskOrder swagger:route GET /move-task-orders/{moveTaskOrderID} moveTaskOrder getMoveTaskOrder
 
-# Gets a move by ID
+Gets a move by ID
 
 Gets a move
+
 */
 type GetMoveTaskOrder struct {
 	Context *middleware.Context

--- a/pkg/gen/ghcapi/ghcoperations/move_task_order/get_move_task_order_responses.go
+++ b/pkg/gen/ghcapi/ghcoperations/move_task_order/get_move_task_order_responses.go
@@ -16,8 +16,7 @@ import (
 // GetMoveTaskOrderOKCode is the HTTP code returned for type GetMoveTaskOrderOK
 const GetMoveTaskOrderOKCode int = 200
 
-/*
-GetMoveTaskOrderOK Successfully retrieved move task order
+/*GetMoveTaskOrderOK Successfully retrieved move task order
 
 swagger:response getMoveTaskOrderOK
 */
@@ -61,8 +60,7 @@ func (o *GetMoveTaskOrderOK) WriteResponse(rw http.ResponseWriter, producer runt
 // GetMoveTaskOrderBadRequestCode is the HTTP code returned for type GetMoveTaskOrderBadRequest
 const GetMoveTaskOrderBadRequestCode int = 400
 
-/*
-GetMoveTaskOrderBadRequest The request payload is invalid
+/*GetMoveTaskOrderBadRequest The request payload is invalid
 
 swagger:response getMoveTaskOrderBadRequest
 */
@@ -106,8 +104,7 @@ func (o *GetMoveTaskOrderBadRequest) WriteResponse(rw http.ResponseWriter, produ
 // GetMoveTaskOrderUnauthorizedCode is the HTTP code returned for type GetMoveTaskOrderUnauthorized
 const GetMoveTaskOrderUnauthorizedCode int = 401
 
-/*
-GetMoveTaskOrderUnauthorized The request was denied
+/*GetMoveTaskOrderUnauthorized The request was denied
 
 swagger:response getMoveTaskOrderUnauthorized
 */
@@ -151,8 +148,7 @@ func (o *GetMoveTaskOrderUnauthorized) WriteResponse(rw http.ResponseWriter, pro
 // GetMoveTaskOrderForbiddenCode is the HTTP code returned for type GetMoveTaskOrderForbidden
 const GetMoveTaskOrderForbiddenCode int = 403
 
-/*
-GetMoveTaskOrderForbidden The request was denied
+/*GetMoveTaskOrderForbidden The request was denied
 
 swagger:response getMoveTaskOrderForbidden
 */
@@ -196,8 +192,7 @@ func (o *GetMoveTaskOrderForbidden) WriteResponse(rw http.ResponseWriter, produc
 // GetMoveTaskOrderNotFoundCode is the HTTP code returned for type GetMoveTaskOrderNotFound
 const GetMoveTaskOrderNotFoundCode int = 404
 
-/*
-GetMoveTaskOrderNotFound The requested resource wasn't found
+/*GetMoveTaskOrderNotFound The requested resource wasn't found
 
 swagger:response getMoveTaskOrderNotFound
 */
@@ -241,8 +236,7 @@ func (o *GetMoveTaskOrderNotFound) WriteResponse(rw http.ResponseWriter, produce
 // GetMoveTaskOrderInternalServerErrorCode is the HTTP code returned for type GetMoveTaskOrderInternalServerError
 const GetMoveTaskOrderInternalServerErrorCode int = 500
 
-/*
-GetMoveTaskOrderInternalServerError A server error occurred
+/*GetMoveTaskOrderInternalServerError A server error occurred
 
 swagger:response getMoveTaskOrderInternalServerError
 */

--- a/pkg/gen/ghcapi/ghcoperations/move_task_order/update_m_t_o_reviewed_billable_weights_at.go
+++ b/pkg/gen/ghcapi/ghcoperations/move_task_order/update_m_t_o_reviewed_billable_weights_at.go
@@ -29,10 +29,10 @@ func NewUpdateMTOReviewedBillableWeightsAt(ctx *middleware.Context, handler Upda
 	return &UpdateMTOReviewedBillableWeightsAt{Context: ctx, Handler: handler}
 }
 
-/*
-	UpdateMTOReviewedBillableWeightsAt swagger:route PATCH /move-task-orders/{moveTaskOrderID}/billable-weights-reviewed-at moveTaskOrder updateMTOReviewedBillableWeightsAt
+/* UpdateMTOReviewedBillableWeightsAt swagger:route PATCH /move-task-orders/{moveTaskOrderID}/billable-weights-reviewed-at moveTaskOrder updateMTOReviewedBillableWeightsAt
 
 Changes move (move task order) billableWeightsReviewedAt field to a timestamp
+
 */
 type UpdateMTOReviewedBillableWeightsAt struct {
 	Context *middleware.Context

--- a/pkg/gen/ghcapi/ghcoperations/move_task_order/update_m_t_o_reviewed_billable_weights_at_responses.go
+++ b/pkg/gen/ghcapi/ghcoperations/move_task_order/update_m_t_o_reviewed_billable_weights_at_responses.go
@@ -16,8 +16,7 @@ import (
 // UpdateMTOReviewedBillableWeightsAtOKCode is the HTTP code returned for type UpdateMTOReviewedBillableWeightsAtOK
 const UpdateMTOReviewedBillableWeightsAtOKCode int = 200
 
-/*
-UpdateMTOReviewedBillableWeightsAtOK Successfully updated move task order billableWeightsReviewedAt field
+/*UpdateMTOReviewedBillableWeightsAtOK Successfully updated move task order billableWeightsReviewedAt field
 
 swagger:response updateMTOReviewedBillableWeightsAtOK
 */
@@ -61,8 +60,7 @@ func (o *UpdateMTOReviewedBillableWeightsAtOK) WriteResponse(rw http.ResponseWri
 // UpdateMTOReviewedBillableWeightsAtBadRequestCode is the HTTP code returned for type UpdateMTOReviewedBillableWeightsAtBadRequest
 const UpdateMTOReviewedBillableWeightsAtBadRequestCode int = 400
 
-/*
-UpdateMTOReviewedBillableWeightsAtBadRequest The request payload is invalid
+/*UpdateMTOReviewedBillableWeightsAtBadRequest The request payload is invalid
 
 swagger:response updateMTOReviewedBillableWeightsAtBadRequest
 */
@@ -106,8 +104,7 @@ func (o *UpdateMTOReviewedBillableWeightsAtBadRequest) WriteResponse(rw http.Res
 // UpdateMTOReviewedBillableWeightsAtUnauthorizedCode is the HTTP code returned for type UpdateMTOReviewedBillableWeightsAtUnauthorized
 const UpdateMTOReviewedBillableWeightsAtUnauthorizedCode int = 401
 
-/*
-UpdateMTOReviewedBillableWeightsAtUnauthorized The request was denied
+/*UpdateMTOReviewedBillableWeightsAtUnauthorized The request was denied
 
 swagger:response updateMTOReviewedBillableWeightsAtUnauthorized
 */
@@ -151,8 +148,7 @@ func (o *UpdateMTOReviewedBillableWeightsAtUnauthorized) WriteResponse(rw http.R
 // UpdateMTOReviewedBillableWeightsAtForbiddenCode is the HTTP code returned for type UpdateMTOReviewedBillableWeightsAtForbidden
 const UpdateMTOReviewedBillableWeightsAtForbiddenCode int = 403
 
-/*
-UpdateMTOReviewedBillableWeightsAtForbidden The request was denied
+/*UpdateMTOReviewedBillableWeightsAtForbidden The request was denied
 
 swagger:response updateMTOReviewedBillableWeightsAtForbidden
 */
@@ -196,8 +192,7 @@ func (o *UpdateMTOReviewedBillableWeightsAtForbidden) WriteResponse(rw http.Resp
 // UpdateMTOReviewedBillableWeightsAtNotFoundCode is the HTTP code returned for type UpdateMTOReviewedBillableWeightsAtNotFound
 const UpdateMTOReviewedBillableWeightsAtNotFoundCode int = 404
 
-/*
-UpdateMTOReviewedBillableWeightsAtNotFound The requested resource wasn't found
+/*UpdateMTOReviewedBillableWeightsAtNotFound The requested resource wasn't found
 
 swagger:response updateMTOReviewedBillableWeightsAtNotFound
 */
@@ -241,8 +236,7 @@ func (o *UpdateMTOReviewedBillableWeightsAtNotFound) WriteResponse(rw http.Respo
 // UpdateMTOReviewedBillableWeightsAtConflictCode is the HTTP code returned for type UpdateMTOReviewedBillableWeightsAtConflict
 const UpdateMTOReviewedBillableWeightsAtConflictCode int = 409
 
-/*
-UpdateMTOReviewedBillableWeightsAtConflict Conflict error
+/*UpdateMTOReviewedBillableWeightsAtConflict Conflict error
 
 swagger:response updateMTOReviewedBillableWeightsAtConflict
 */
@@ -286,8 +280,7 @@ func (o *UpdateMTOReviewedBillableWeightsAtConflict) WriteResponse(rw http.Respo
 // UpdateMTOReviewedBillableWeightsAtPreconditionFailedCode is the HTTP code returned for type UpdateMTOReviewedBillableWeightsAtPreconditionFailed
 const UpdateMTOReviewedBillableWeightsAtPreconditionFailedCode int = 412
 
-/*
-UpdateMTOReviewedBillableWeightsAtPreconditionFailed Precondition failed
+/*UpdateMTOReviewedBillableWeightsAtPreconditionFailed Precondition failed
 
 swagger:response updateMTOReviewedBillableWeightsAtPreconditionFailed
 */
@@ -331,8 +324,7 @@ func (o *UpdateMTOReviewedBillableWeightsAtPreconditionFailed) WriteResponse(rw 
 // UpdateMTOReviewedBillableWeightsAtUnprocessableEntityCode is the HTTP code returned for type UpdateMTOReviewedBillableWeightsAtUnprocessableEntity
 const UpdateMTOReviewedBillableWeightsAtUnprocessableEntityCode int = 422
 
-/*
-UpdateMTOReviewedBillableWeightsAtUnprocessableEntity The payload was unprocessable.
+/*UpdateMTOReviewedBillableWeightsAtUnprocessableEntity The payload was unprocessable.
 
 swagger:response updateMTOReviewedBillableWeightsAtUnprocessableEntity
 */
@@ -376,8 +368,7 @@ func (o *UpdateMTOReviewedBillableWeightsAtUnprocessableEntity) WriteResponse(rw
 // UpdateMTOReviewedBillableWeightsAtInternalServerErrorCode is the HTTP code returned for type UpdateMTOReviewedBillableWeightsAtInternalServerError
 const UpdateMTOReviewedBillableWeightsAtInternalServerErrorCode int = 500
 
-/*
-UpdateMTOReviewedBillableWeightsAtInternalServerError A server error occurred
+/*UpdateMTOReviewedBillableWeightsAtInternalServerError A server error occurred
 
 swagger:response updateMTOReviewedBillableWeightsAtInternalServerError
 */

--- a/pkg/gen/ghcapi/ghcoperations/move_task_order/update_m_t_o_status_service_counseling_completed.go
+++ b/pkg/gen/ghcapi/ghcoperations/move_task_order/update_m_t_o_status_service_counseling_completed.go
@@ -29,12 +29,12 @@ func NewUpdateMTOStatusServiceCounselingCompleted(ctx *middleware.Context, handl
 	return &UpdateMTOStatusServiceCounselingCompleted{Context: ctx, Handler: handler}
 }
 
-/*
-	UpdateMTOStatusServiceCounselingCompleted swagger:route PATCH /move-task-orders/{moveTaskOrderID}/status/service-counseling-completed moveTaskOrder updateMTOStatusServiceCounselingCompleted
-
-# Changes move (move task order) status to service counseling completed
+/* UpdateMTOStatusServiceCounselingCompleted swagger:route PATCH /move-task-orders/{moveTaskOrderID}/status/service-counseling-completed moveTaskOrder updateMTOStatusServiceCounselingCompleted
 
 Changes move (move task order) status to service counseling completed
+
+Changes move (move task order) status to service counseling completed
+
 */
 type UpdateMTOStatusServiceCounselingCompleted struct {
 	Context *middleware.Context

--- a/pkg/gen/ghcapi/ghcoperations/move_task_order/update_m_t_o_status_service_counseling_completed_responses.go
+++ b/pkg/gen/ghcapi/ghcoperations/move_task_order/update_m_t_o_status_service_counseling_completed_responses.go
@@ -16,8 +16,7 @@ import (
 // UpdateMTOStatusServiceCounselingCompletedOKCode is the HTTP code returned for type UpdateMTOStatusServiceCounselingCompletedOK
 const UpdateMTOStatusServiceCounselingCompletedOKCode int = 200
 
-/*
-UpdateMTOStatusServiceCounselingCompletedOK Successfully updated move task order status
+/*UpdateMTOStatusServiceCounselingCompletedOK Successfully updated move task order status
 
 swagger:response updateMTOStatusServiceCounselingCompletedOK
 */
@@ -61,8 +60,7 @@ func (o *UpdateMTOStatusServiceCounselingCompletedOK) WriteResponse(rw http.Resp
 // UpdateMTOStatusServiceCounselingCompletedBadRequestCode is the HTTP code returned for type UpdateMTOStatusServiceCounselingCompletedBadRequest
 const UpdateMTOStatusServiceCounselingCompletedBadRequestCode int = 400
 
-/*
-UpdateMTOStatusServiceCounselingCompletedBadRequest The request payload is invalid
+/*UpdateMTOStatusServiceCounselingCompletedBadRequest The request payload is invalid
 
 swagger:response updateMTOStatusServiceCounselingCompletedBadRequest
 */
@@ -106,8 +104,7 @@ func (o *UpdateMTOStatusServiceCounselingCompletedBadRequest) WriteResponse(rw h
 // UpdateMTOStatusServiceCounselingCompletedUnauthorizedCode is the HTTP code returned for type UpdateMTOStatusServiceCounselingCompletedUnauthorized
 const UpdateMTOStatusServiceCounselingCompletedUnauthorizedCode int = 401
 
-/*
-UpdateMTOStatusServiceCounselingCompletedUnauthorized The request was denied
+/*UpdateMTOStatusServiceCounselingCompletedUnauthorized The request was denied
 
 swagger:response updateMTOStatusServiceCounselingCompletedUnauthorized
 */
@@ -151,8 +148,7 @@ func (o *UpdateMTOStatusServiceCounselingCompletedUnauthorized) WriteResponse(rw
 // UpdateMTOStatusServiceCounselingCompletedForbiddenCode is the HTTP code returned for type UpdateMTOStatusServiceCounselingCompletedForbidden
 const UpdateMTOStatusServiceCounselingCompletedForbiddenCode int = 403
 
-/*
-UpdateMTOStatusServiceCounselingCompletedForbidden The request was denied
+/*UpdateMTOStatusServiceCounselingCompletedForbidden The request was denied
 
 swagger:response updateMTOStatusServiceCounselingCompletedForbidden
 */
@@ -196,8 +192,7 @@ func (o *UpdateMTOStatusServiceCounselingCompletedForbidden) WriteResponse(rw ht
 // UpdateMTOStatusServiceCounselingCompletedNotFoundCode is the HTTP code returned for type UpdateMTOStatusServiceCounselingCompletedNotFound
 const UpdateMTOStatusServiceCounselingCompletedNotFoundCode int = 404
 
-/*
-UpdateMTOStatusServiceCounselingCompletedNotFound The requested resource wasn't found
+/*UpdateMTOStatusServiceCounselingCompletedNotFound The requested resource wasn't found
 
 swagger:response updateMTOStatusServiceCounselingCompletedNotFound
 */
@@ -241,8 +236,7 @@ func (o *UpdateMTOStatusServiceCounselingCompletedNotFound) WriteResponse(rw htt
 // UpdateMTOStatusServiceCounselingCompletedConflictCode is the HTTP code returned for type UpdateMTOStatusServiceCounselingCompletedConflict
 const UpdateMTOStatusServiceCounselingCompletedConflictCode int = 409
 
-/*
-UpdateMTOStatusServiceCounselingCompletedConflict Conflict error
+/*UpdateMTOStatusServiceCounselingCompletedConflict Conflict error
 
 swagger:response updateMTOStatusServiceCounselingCompletedConflict
 */
@@ -286,8 +280,7 @@ func (o *UpdateMTOStatusServiceCounselingCompletedConflict) WriteResponse(rw htt
 // UpdateMTOStatusServiceCounselingCompletedPreconditionFailedCode is the HTTP code returned for type UpdateMTOStatusServiceCounselingCompletedPreconditionFailed
 const UpdateMTOStatusServiceCounselingCompletedPreconditionFailedCode int = 412
 
-/*
-UpdateMTOStatusServiceCounselingCompletedPreconditionFailed Precondition failed
+/*UpdateMTOStatusServiceCounselingCompletedPreconditionFailed Precondition failed
 
 swagger:response updateMTOStatusServiceCounselingCompletedPreconditionFailed
 */
@@ -331,8 +324,7 @@ func (o *UpdateMTOStatusServiceCounselingCompletedPreconditionFailed) WriteRespo
 // UpdateMTOStatusServiceCounselingCompletedUnprocessableEntityCode is the HTTP code returned for type UpdateMTOStatusServiceCounselingCompletedUnprocessableEntity
 const UpdateMTOStatusServiceCounselingCompletedUnprocessableEntityCode int = 422
 
-/*
-UpdateMTOStatusServiceCounselingCompletedUnprocessableEntity The payload was unprocessable.
+/*UpdateMTOStatusServiceCounselingCompletedUnprocessableEntity The payload was unprocessable.
 
 swagger:response updateMTOStatusServiceCounselingCompletedUnprocessableEntity
 */
@@ -376,8 +368,7 @@ func (o *UpdateMTOStatusServiceCounselingCompletedUnprocessableEntity) WriteResp
 // UpdateMTOStatusServiceCounselingCompletedInternalServerErrorCode is the HTTP code returned for type UpdateMTOStatusServiceCounselingCompletedInternalServerError
 const UpdateMTOStatusServiceCounselingCompletedInternalServerErrorCode int = 500
 
-/*
-UpdateMTOStatusServiceCounselingCompletedInternalServerError A server error occurred
+/*UpdateMTOStatusServiceCounselingCompletedInternalServerError A server error occurred
 
 swagger:response updateMTOStatusServiceCounselingCompletedInternalServerError
 */

--- a/pkg/gen/ghcapi/ghcoperations/move_task_order/update_move_t_i_o_remarks.go
+++ b/pkg/gen/ghcapi/ghcoperations/move_task_order/update_move_t_i_o_remarks.go
@@ -29,10 +29,10 @@ func NewUpdateMoveTIORemarks(ctx *middleware.Context, handler UpdateMoveTIORemar
 	return &UpdateMoveTIORemarks{Context: ctx, Handler: handler}
 }
 
-/*
-	UpdateMoveTIORemarks swagger:route PATCH /move-task-orders/{moveTaskOrderID}/tio-remarks moveTaskOrder updateMoveTIORemarks
+/* UpdateMoveTIORemarks swagger:route PATCH /move-task-orders/{moveTaskOrderID}/tio-remarks moveTaskOrder updateMoveTIORemarks
 
 Changes move (move task order) billableWeightsReviewedAt field to a timestamp
+
 */
 type UpdateMoveTIORemarks struct {
 	Context *middleware.Context

--- a/pkg/gen/ghcapi/ghcoperations/move_task_order/update_move_t_i_o_remarks_responses.go
+++ b/pkg/gen/ghcapi/ghcoperations/move_task_order/update_move_t_i_o_remarks_responses.go
@@ -16,8 +16,7 @@ import (
 // UpdateMoveTIORemarksOKCode is the HTTP code returned for type UpdateMoveTIORemarksOK
 const UpdateMoveTIORemarksOKCode int = 200
 
-/*
-UpdateMoveTIORemarksOK Successfully updated move task order tioRemarks field
+/*UpdateMoveTIORemarksOK Successfully updated move task order tioRemarks field
 
 swagger:response updateMoveTIORemarksOK
 */
@@ -61,8 +60,7 @@ func (o *UpdateMoveTIORemarksOK) WriteResponse(rw http.ResponseWriter, producer 
 // UpdateMoveTIORemarksBadRequestCode is the HTTP code returned for type UpdateMoveTIORemarksBadRequest
 const UpdateMoveTIORemarksBadRequestCode int = 400
 
-/*
-UpdateMoveTIORemarksBadRequest The request payload is invalid
+/*UpdateMoveTIORemarksBadRequest The request payload is invalid
 
 swagger:response updateMoveTIORemarksBadRequest
 */
@@ -106,8 +104,7 @@ func (o *UpdateMoveTIORemarksBadRequest) WriteResponse(rw http.ResponseWriter, p
 // UpdateMoveTIORemarksUnauthorizedCode is the HTTP code returned for type UpdateMoveTIORemarksUnauthorized
 const UpdateMoveTIORemarksUnauthorizedCode int = 401
 
-/*
-UpdateMoveTIORemarksUnauthorized The request was denied
+/*UpdateMoveTIORemarksUnauthorized The request was denied
 
 swagger:response updateMoveTIORemarksUnauthorized
 */
@@ -151,8 +148,7 @@ func (o *UpdateMoveTIORemarksUnauthorized) WriteResponse(rw http.ResponseWriter,
 // UpdateMoveTIORemarksForbiddenCode is the HTTP code returned for type UpdateMoveTIORemarksForbidden
 const UpdateMoveTIORemarksForbiddenCode int = 403
 
-/*
-UpdateMoveTIORemarksForbidden The request was denied
+/*UpdateMoveTIORemarksForbidden The request was denied
 
 swagger:response updateMoveTIORemarksForbidden
 */
@@ -196,8 +192,7 @@ func (o *UpdateMoveTIORemarksForbidden) WriteResponse(rw http.ResponseWriter, pr
 // UpdateMoveTIORemarksNotFoundCode is the HTTP code returned for type UpdateMoveTIORemarksNotFound
 const UpdateMoveTIORemarksNotFoundCode int = 404
 
-/*
-UpdateMoveTIORemarksNotFound The requested resource wasn't found
+/*UpdateMoveTIORemarksNotFound The requested resource wasn't found
 
 swagger:response updateMoveTIORemarksNotFound
 */
@@ -241,8 +236,7 @@ func (o *UpdateMoveTIORemarksNotFound) WriteResponse(rw http.ResponseWriter, pro
 // UpdateMoveTIORemarksConflictCode is the HTTP code returned for type UpdateMoveTIORemarksConflict
 const UpdateMoveTIORemarksConflictCode int = 409
 
-/*
-UpdateMoveTIORemarksConflict Conflict error
+/*UpdateMoveTIORemarksConflict Conflict error
 
 swagger:response updateMoveTIORemarksConflict
 */
@@ -286,8 +280,7 @@ func (o *UpdateMoveTIORemarksConflict) WriteResponse(rw http.ResponseWriter, pro
 // UpdateMoveTIORemarksPreconditionFailedCode is the HTTP code returned for type UpdateMoveTIORemarksPreconditionFailed
 const UpdateMoveTIORemarksPreconditionFailedCode int = 412
 
-/*
-UpdateMoveTIORemarksPreconditionFailed Precondition failed
+/*UpdateMoveTIORemarksPreconditionFailed Precondition failed
 
 swagger:response updateMoveTIORemarksPreconditionFailed
 */
@@ -331,8 +324,7 @@ func (o *UpdateMoveTIORemarksPreconditionFailed) WriteResponse(rw http.ResponseW
 // UpdateMoveTIORemarksUnprocessableEntityCode is the HTTP code returned for type UpdateMoveTIORemarksUnprocessableEntity
 const UpdateMoveTIORemarksUnprocessableEntityCode int = 422
 
-/*
-UpdateMoveTIORemarksUnprocessableEntity The payload was unprocessable.
+/*UpdateMoveTIORemarksUnprocessableEntity The payload was unprocessable.
 
 swagger:response updateMoveTIORemarksUnprocessableEntity
 */
@@ -376,8 +368,7 @@ func (o *UpdateMoveTIORemarksUnprocessableEntity) WriteResponse(rw http.Response
 // UpdateMoveTIORemarksInternalServerErrorCode is the HTTP code returned for type UpdateMoveTIORemarksInternalServerError
 const UpdateMoveTIORemarksInternalServerErrorCode int = 500
 
-/*
-UpdateMoveTIORemarksInternalServerError A server error occurred
+/*UpdateMoveTIORemarksInternalServerError A server error occurred
 
 swagger:response updateMoveTIORemarksInternalServerError
 */

--- a/pkg/gen/ghcapi/ghcoperations/move_task_order/update_move_task_order.go
+++ b/pkg/gen/ghcapi/ghcoperations/move_task_order/update_move_task_order.go
@@ -29,12 +29,12 @@ func NewUpdateMoveTaskOrder(ctx *middleware.Context, handler UpdateMoveTaskOrder
 	return &UpdateMoveTaskOrder{Context: ctx, Handler: handler}
 }
 
-/*
-	UpdateMoveTaskOrder swagger:route PATCH /move-task-orders/{moveTaskOrderID} moveTaskOrder updateMoveTaskOrder
-
-# Updates a move by ID
+/* UpdateMoveTaskOrder swagger:route PATCH /move-task-orders/{moveTaskOrderID} moveTaskOrder updateMoveTaskOrder
 
 Updates a move by ID
+
+Updates a move by ID
+
 */
 type UpdateMoveTaskOrder struct {
 	Context *middleware.Context

--- a/pkg/gen/ghcapi/ghcoperations/move_task_order/update_move_task_order_responses.go
+++ b/pkg/gen/ghcapi/ghcoperations/move_task_order/update_move_task_order_responses.go
@@ -16,8 +16,7 @@ import (
 // UpdateMoveTaskOrderOKCode is the HTTP code returned for type UpdateMoveTaskOrderOK
 const UpdateMoveTaskOrderOKCode int = 200
 
-/*
-UpdateMoveTaskOrderOK Successfully retrieved move task order
+/*UpdateMoveTaskOrderOK Successfully retrieved move task order
 
 swagger:response updateMoveTaskOrderOK
 */
@@ -61,8 +60,7 @@ func (o *UpdateMoveTaskOrderOK) WriteResponse(rw http.ResponseWriter, producer r
 // UpdateMoveTaskOrderBadRequestCode is the HTTP code returned for type UpdateMoveTaskOrderBadRequest
 const UpdateMoveTaskOrderBadRequestCode int = 400
 
-/*
-UpdateMoveTaskOrderBadRequest The request payload is invalid
+/*UpdateMoveTaskOrderBadRequest The request payload is invalid
 
 swagger:response updateMoveTaskOrderBadRequest
 */
@@ -106,8 +104,7 @@ func (o *UpdateMoveTaskOrderBadRequest) WriteResponse(rw http.ResponseWriter, pr
 // UpdateMoveTaskOrderUnauthorizedCode is the HTTP code returned for type UpdateMoveTaskOrderUnauthorized
 const UpdateMoveTaskOrderUnauthorizedCode int = 401
 
-/*
-UpdateMoveTaskOrderUnauthorized The request was denied
+/*UpdateMoveTaskOrderUnauthorized The request was denied
 
 swagger:response updateMoveTaskOrderUnauthorized
 */
@@ -151,8 +148,7 @@ func (o *UpdateMoveTaskOrderUnauthorized) WriteResponse(rw http.ResponseWriter, 
 // UpdateMoveTaskOrderForbiddenCode is the HTTP code returned for type UpdateMoveTaskOrderForbidden
 const UpdateMoveTaskOrderForbiddenCode int = 403
 
-/*
-UpdateMoveTaskOrderForbidden The request was denied
+/*UpdateMoveTaskOrderForbidden The request was denied
 
 swagger:response updateMoveTaskOrderForbidden
 */
@@ -196,8 +192,7 @@ func (o *UpdateMoveTaskOrderForbidden) WriteResponse(rw http.ResponseWriter, pro
 // UpdateMoveTaskOrderNotFoundCode is the HTTP code returned for type UpdateMoveTaskOrderNotFound
 const UpdateMoveTaskOrderNotFoundCode int = 404
 
-/*
-UpdateMoveTaskOrderNotFound The requested resource wasn't found
+/*UpdateMoveTaskOrderNotFound The requested resource wasn't found
 
 swagger:response updateMoveTaskOrderNotFound
 */
@@ -241,8 +236,7 @@ func (o *UpdateMoveTaskOrderNotFound) WriteResponse(rw http.ResponseWriter, prod
 // UpdateMoveTaskOrderPreconditionFailedCode is the HTTP code returned for type UpdateMoveTaskOrderPreconditionFailed
 const UpdateMoveTaskOrderPreconditionFailedCode int = 412
 
-/*
-UpdateMoveTaskOrderPreconditionFailed Precondition failed
+/*UpdateMoveTaskOrderPreconditionFailed Precondition failed
 
 swagger:response updateMoveTaskOrderPreconditionFailed
 */
@@ -286,8 +280,7 @@ func (o *UpdateMoveTaskOrderPreconditionFailed) WriteResponse(rw http.ResponseWr
 // UpdateMoveTaskOrderUnprocessableEntityCode is the HTTP code returned for type UpdateMoveTaskOrderUnprocessableEntity
 const UpdateMoveTaskOrderUnprocessableEntityCode int = 422
 
-/*
-UpdateMoveTaskOrderUnprocessableEntity The payload was unprocessable.
+/*UpdateMoveTaskOrderUnprocessableEntity The payload was unprocessable.
 
 swagger:response updateMoveTaskOrderUnprocessableEntity
 */
@@ -331,8 +324,7 @@ func (o *UpdateMoveTaskOrderUnprocessableEntity) WriteResponse(rw http.ResponseW
 // UpdateMoveTaskOrderInternalServerErrorCode is the HTTP code returned for type UpdateMoveTaskOrderInternalServerError
 const UpdateMoveTaskOrderInternalServerErrorCode int = 500
 
-/*
-UpdateMoveTaskOrderInternalServerError A server error occurred
+/*UpdateMoveTaskOrderInternalServerError A server error occurred
 
 swagger:response updateMoveTaskOrderInternalServerError
 */

--- a/pkg/gen/ghcapi/ghcoperations/move_task_order/update_move_task_order_status.go
+++ b/pkg/gen/ghcapi/ghcoperations/move_task_order/update_move_task_order_status.go
@@ -29,12 +29,12 @@ func NewUpdateMoveTaskOrderStatus(ctx *middleware.Context, handler UpdateMoveTas
 	return &UpdateMoveTaskOrderStatus{Context: ctx, Handler: handler}
 }
 
-/*
-	UpdateMoveTaskOrderStatus swagger:route PATCH /move-task-orders/{moveTaskOrderID}/status moveTaskOrder updateMoveTaskOrderStatus
+/* UpdateMoveTaskOrderStatus swagger:route PATCH /move-task-orders/{moveTaskOrderID}/status moveTaskOrder updateMoveTaskOrderStatus
 
-# Change the status of a move task order to make it available to prime
+Change the status of a move task order to make it available to prime
 
 Changes move task order status to make it available to prime
+
 */
 type UpdateMoveTaskOrderStatus struct {
 	Context *middleware.Context

--- a/pkg/gen/ghcapi/ghcoperations/move_task_order/update_move_task_order_status_responses.go
+++ b/pkg/gen/ghcapi/ghcoperations/move_task_order/update_move_task_order_status_responses.go
@@ -16,8 +16,7 @@ import (
 // UpdateMoveTaskOrderStatusOKCode is the HTTP code returned for type UpdateMoveTaskOrderStatusOK
 const UpdateMoveTaskOrderStatusOKCode int = 200
 
-/*
-UpdateMoveTaskOrderStatusOK Successfully updated move task order status
+/*UpdateMoveTaskOrderStatusOK Successfully updated move task order status
 
 swagger:response updateMoveTaskOrderStatusOK
 */
@@ -61,8 +60,7 @@ func (o *UpdateMoveTaskOrderStatusOK) WriteResponse(rw http.ResponseWriter, prod
 // UpdateMoveTaskOrderStatusBadRequestCode is the HTTP code returned for type UpdateMoveTaskOrderStatusBadRequest
 const UpdateMoveTaskOrderStatusBadRequestCode int = 400
 
-/*
-UpdateMoveTaskOrderStatusBadRequest The request payload is invalid
+/*UpdateMoveTaskOrderStatusBadRequest The request payload is invalid
 
 swagger:response updateMoveTaskOrderStatusBadRequest
 */
@@ -106,8 +104,7 @@ func (o *UpdateMoveTaskOrderStatusBadRequest) WriteResponse(rw http.ResponseWrit
 // UpdateMoveTaskOrderStatusUnauthorizedCode is the HTTP code returned for type UpdateMoveTaskOrderStatusUnauthorized
 const UpdateMoveTaskOrderStatusUnauthorizedCode int = 401
 
-/*
-UpdateMoveTaskOrderStatusUnauthorized The request was denied
+/*UpdateMoveTaskOrderStatusUnauthorized The request was denied
 
 swagger:response updateMoveTaskOrderStatusUnauthorized
 */
@@ -151,8 +148,7 @@ func (o *UpdateMoveTaskOrderStatusUnauthorized) WriteResponse(rw http.ResponseWr
 // UpdateMoveTaskOrderStatusForbiddenCode is the HTTP code returned for type UpdateMoveTaskOrderStatusForbidden
 const UpdateMoveTaskOrderStatusForbiddenCode int = 403
 
-/*
-UpdateMoveTaskOrderStatusForbidden The request was denied
+/*UpdateMoveTaskOrderStatusForbidden The request was denied
 
 swagger:response updateMoveTaskOrderStatusForbidden
 */
@@ -196,8 +192,7 @@ func (o *UpdateMoveTaskOrderStatusForbidden) WriteResponse(rw http.ResponseWrite
 // UpdateMoveTaskOrderStatusNotFoundCode is the HTTP code returned for type UpdateMoveTaskOrderStatusNotFound
 const UpdateMoveTaskOrderStatusNotFoundCode int = 404
 
-/*
-UpdateMoveTaskOrderStatusNotFound The requested resource wasn't found
+/*UpdateMoveTaskOrderStatusNotFound The requested resource wasn't found
 
 swagger:response updateMoveTaskOrderStatusNotFound
 */
@@ -241,8 +236,7 @@ func (o *UpdateMoveTaskOrderStatusNotFound) WriteResponse(rw http.ResponseWriter
 // UpdateMoveTaskOrderStatusConflictCode is the HTTP code returned for type UpdateMoveTaskOrderStatusConflict
 const UpdateMoveTaskOrderStatusConflictCode int = 409
 
-/*
-UpdateMoveTaskOrderStatusConflict Conflict error
+/*UpdateMoveTaskOrderStatusConflict Conflict error
 
 swagger:response updateMoveTaskOrderStatusConflict
 */
@@ -286,8 +280,7 @@ func (o *UpdateMoveTaskOrderStatusConflict) WriteResponse(rw http.ResponseWriter
 // UpdateMoveTaskOrderStatusPreconditionFailedCode is the HTTP code returned for type UpdateMoveTaskOrderStatusPreconditionFailed
 const UpdateMoveTaskOrderStatusPreconditionFailedCode int = 412
 
-/*
-UpdateMoveTaskOrderStatusPreconditionFailed Precondition failed
+/*UpdateMoveTaskOrderStatusPreconditionFailed Precondition failed
 
 swagger:response updateMoveTaskOrderStatusPreconditionFailed
 */
@@ -331,8 +324,7 @@ func (o *UpdateMoveTaskOrderStatusPreconditionFailed) WriteResponse(rw http.Resp
 // UpdateMoveTaskOrderStatusUnprocessableEntityCode is the HTTP code returned for type UpdateMoveTaskOrderStatusUnprocessableEntity
 const UpdateMoveTaskOrderStatusUnprocessableEntityCode int = 422
 
-/*
-UpdateMoveTaskOrderStatusUnprocessableEntity The payload was unprocessable.
+/*UpdateMoveTaskOrderStatusUnprocessableEntity The payload was unprocessable.
 
 swagger:response updateMoveTaskOrderStatusUnprocessableEntity
 */
@@ -376,8 +368,7 @@ func (o *UpdateMoveTaskOrderStatusUnprocessableEntity) WriteResponse(rw http.Res
 // UpdateMoveTaskOrderStatusInternalServerErrorCode is the HTTP code returned for type UpdateMoveTaskOrderStatusInternalServerError
 const UpdateMoveTaskOrderStatusInternalServerErrorCode int = 500
 
-/*
-UpdateMoveTaskOrderStatusInternalServerError A server error occurred
+/*UpdateMoveTaskOrderStatusInternalServerError A server error occurred
 
 swagger:response updateMoveTaskOrderStatusInternalServerError
 */

--- a/pkg/gen/ghcapi/ghcoperations/mto_agent/fetch_m_t_o_agent_list.go
+++ b/pkg/gen/ghcapi/ghcoperations/mto_agent/fetch_m_t_o_agent_list.go
@@ -29,12 +29,12 @@ func NewFetchMTOAgentList(ctx *middleware.Context, handler FetchMTOAgentListHand
 	return &FetchMTOAgentList{Context: ctx, Handler: handler}
 }
 
-/*
-	FetchMTOAgentList swagger:route GET /move_task_orders/{moveTaskOrderID}/mto_shipments/{shipmentID}/mto-agents mtoAgent fetchMTOAgentList
+/* FetchMTOAgentList swagger:route GET /move_task_orders/{moveTaskOrderID}/mto_shipments/{shipmentID}/mto-agents mtoAgent fetchMTOAgentList
 
 Fetch move task order agents.
 
 Fetches a list of agents associated with a move task order.
+
 */
 type FetchMTOAgentList struct {
 	Context *middleware.Context

--- a/pkg/gen/ghcapi/ghcoperations/mto_agent/fetch_m_t_o_agent_list_responses.go
+++ b/pkg/gen/ghcapi/ghcoperations/mto_agent/fetch_m_t_o_agent_list_responses.go
@@ -16,8 +16,7 @@ import (
 // FetchMTOAgentListOKCode is the HTTP code returned for type FetchMTOAgentListOK
 const FetchMTOAgentListOKCode int = 200
 
-/*
-FetchMTOAgentListOK Successfully retrieved all agents for a move task order
+/*FetchMTOAgentListOK Successfully retrieved all agents for a move task order
 
 swagger:response fetchMTOAgentListOK
 */
@@ -64,8 +63,7 @@ func (o *FetchMTOAgentListOK) WriteResponse(rw http.ResponseWriter, producer run
 // FetchMTOAgentListNotFoundCode is the HTTP code returned for type FetchMTOAgentListNotFound
 const FetchMTOAgentListNotFoundCode int = 404
 
-/*
-FetchMTOAgentListNotFound The requested resource wasn't found
+/*FetchMTOAgentListNotFound The requested resource wasn't found
 
 swagger:response fetchMTOAgentListNotFound
 */
@@ -109,8 +107,7 @@ func (o *FetchMTOAgentListNotFound) WriteResponse(rw http.ResponseWriter, produc
 // FetchMTOAgentListUnprocessableEntityCode is the HTTP code returned for type FetchMTOAgentListUnprocessableEntity
 const FetchMTOAgentListUnprocessableEntityCode int = 422
 
-/*
-FetchMTOAgentListUnprocessableEntity The payload was unprocessable.
+/*FetchMTOAgentListUnprocessableEntity The payload was unprocessable.
 
 swagger:response fetchMTOAgentListUnprocessableEntity
 */
@@ -154,8 +151,7 @@ func (o *FetchMTOAgentListUnprocessableEntity) WriteResponse(rw http.ResponseWri
 // FetchMTOAgentListInternalServerErrorCode is the HTTP code returned for type FetchMTOAgentListInternalServerError
 const FetchMTOAgentListInternalServerErrorCode int = 500
 
-/*
-FetchMTOAgentListInternalServerError A server error occurred
+/*FetchMTOAgentListInternalServerError A server error occurred
 
 swagger:response fetchMTOAgentListInternalServerError
 */

--- a/pkg/gen/ghcapi/ghcoperations/mto_service_item/get_m_t_o_service_item.go
+++ b/pkg/gen/ghcapi/ghcoperations/mto_service_item/get_m_t_o_service_item.go
@@ -29,12 +29,12 @@ func NewGetMTOServiceItem(ctx *middleware.Context, handler GetMTOServiceItemHand
 	return &GetMTOServiceItem{Context: ctx, Handler: handler}
 }
 
-/*
-	GetMTOServiceItem swagger:route GET /move-task-orders/{moveTaskOrderID}/service-items/{mtoServiceItemID} mtoServiceItem getMTOServiceItem
-
-# Gets a line item by ID for a move by ID
+/* GetMTOServiceItem swagger:route GET /move-task-orders/{moveTaskOrderID}/service-items/{mtoServiceItemID} mtoServiceItem getMTOServiceItem
 
 Gets a line item by ID for a move by ID
+
+Gets a line item by ID for a move by ID
+
 */
 type GetMTOServiceItem struct {
 	Context *middleware.Context

--- a/pkg/gen/ghcapi/ghcoperations/mto_service_item/get_m_t_o_service_item_responses.go
+++ b/pkg/gen/ghcapi/ghcoperations/mto_service_item/get_m_t_o_service_item_responses.go
@@ -16,8 +16,7 @@ import (
 // GetMTOServiceItemOKCode is the HTTP code returned for type GetMTOServiceItemOK
 const GetMTOServiceItemOKCode int = 200
 
-/*
-GetMTOServiceItemOK Successfully retrieved a line item for a move task order by ID
+/*GetMTOServiceItemOK Successfully retrieved a line item for a move task order by ID
 
 swagger:response getMTOServiceItemOK
 */
@@ -61,8 +60,7 @@ func (o *GetMTOServiceItemOK) WriteResponse(rw http.ResponseWriter, producer run
 // GetMTOServiceItemBadRequestCode is the HTTP code returned for type GetMTOServiceItemBadRequest
 const GetMTOServiceItemBadRequestCode int = 400
 
-/*
-GetMTOServiceItemBadRequest The request payload is invalid
+/*GetMTOServiceItemBadRequest The request payload is invalid
 
 swagger:response getMTOServiceItemBadRequest
 */
@@ -106,8 +104,7 @@ func (o *GetMTOServiceItemBadRequest) WriteResponse(rw http.ResponseWriter, prod
 // GetMTOServiceItemUnauthorizedCode is the HTTP code returned for type GetMTOServiceItemUnauthorized
 const GetMTOServiceItemUnauthorizedCode int = 401
 
-/*
-GetMTOServiceItemUnauthorized The request was denied
+/*GetMTOServiceItemUnauthorized The request was denied
 
 swagger:response getMTOServiceItemUnauthorized
 */
@@ -151,8 +148,7 @@ func (o *GetMTOServiceItemUnauthorized) WriteResponse(rw http.ResponseWriter, pr
 // GetMTOServiceItemForbiddenCode is the HTTP code returned for type GetMTOServiceItemForbidden
 const GetMTOServiceItemForbiddenCode int = 403
 
-/*
-GetMTOServiceItemForbidden The request was denied
+/*GetMTOServiceItemForbidden The request was denied
 
 swagger:response getMTOServiceItemForbidden
 */
@@ -196,8 +192,7 @@ func (o *GetMTOServiceItemForbidden) WriteResponse(rw http.ResponseWriter, produ
 // GetMTOServiceItemNotFoundCode is the HTTP code returned for type GetMTOServiceItemNotFound
 const GetMTOServiceItemNotFoundCode int = 404
 
-/*
-GetMTOServiceItemNotFound The requested resource wasn't found
+/*GetMTOServiceItemNotFound The requested resource wasn't found
 
 swagger:response getMTOServiceItemNotFound
 */
@@ -241,8 +236,7 @@ func (o *GetMTOServiceItemNotFound) WriteResponse(rw http.ResponseWriter, produc
 // GetMTOServiceItemInternalServerErrorCode is the HTTP code returned for type GetMTOServiceItemInternalServerError
 const GetMTOServiceItemInternalServerErrorCode int = 500
 
-/*
-GetMTOServiceItemInternalServerError A server error occurred
+/*GetMTOServiceItemInternalServerError A server error occurred
 
 swagger:response getMTOServiceItemInternalServerError
 */

--- a/pkg/gen/ghcapi/ghcoperations/mto_service_item/list_m_t_o_service_items.go
+++ b/pkg/gen/ghcapi/ghcoperations/mto_service_item/list_m_t_o_service_items.go
@@ -29,12 +29,12 @@ func NewListMTOServiceItems(ctx *middleware.Context, handler ListMTOServiceItems
 	return &ListMTOServiceItems{Context: ctx, Handler: handler}
 }
 
-/*
-	ListMTOServiceItems swagger:route GET /move_task_orders/{moveTaskOrderID}/mto_service_items mtoServiceItem listMTOServiceItems
-
-# Gets all line items for a move
+/* ListMTOServiceItems swagger:route GET /move_task_orders/{moveTaskOrderID}/mto_service_items mtoServiceItem listMTOServiceItems
 
 Gets all line items for a move
+
+Gets all line items for a move
+
 */
 type ListMTOServiceItems struct {
 	Context *middleware.Context

--- a/pkg/gen/ghcapi/ghcoperations/mto_service_item/list_m_t_o_service_items_responses.go
+++ b/pkg/gen/ghcapi/ghcoperations/mto_service_item/list_m_t_o_service_items_responses.go
@@ -16,8 +16,7 @@ import (
 // ListMTOServiceItemsOKCode is the HTTP code returned for type ListMTOServiceItemsOK
 const ListMTOServiceItemsOKCode int = 200
 
-/*
-ListMTOServiceItemsOK Successfully retrieved all line items for a move task order
+/*ListMTOServiceItemsOK Successfully retrieved all line items for a move task order
 
 swagger:response listMTOServiceItemsOK
 */
@@ -64,8 +63,7 @@ func (o *ListMTOServiceItemsOK) WriteResponse(rw http.ResponseWriter, producer r
 // ListMTOServiceItemsNotFoundCode is the HTTP code returned for type ListMTOServiceItemsNotFound
 const ListMTOServiceItemsNotFoundCode int = 404
 
-/*
-ListMTOServiceItemsNotFound The requested resource wasn't found
+/*ListMTOServiceItemsNotFound The requested resource wasn't found
 
 swagger:response listMTOServiceItemsNotFound
 */
@@ -109,8 +107,7 @@ func (o *ListMTOServiceItemsNotFound) WriteResponse(rw http.ResponseWriter, prod
 // ListMTOServiceItemsUnprocessableEntityCode is the HTTP code returned for type ListMTOServiceItemsUnprocessableEntity
 const ListMTOServiceItemsUnprocessableEntityCode int = 422
 
-/*
-ListMTOServiceItemsUnprocessableEntity The payload was unprocessable.
+/*ListMTOServiceItemsUnprocessableEntity The payload was unprocessable.
 
 swagger:response listMTOServiceItemsUnprocessableEntity
 */
@@ -154,8 +151,7 @@ func (o *ListMTOServiceItemsUnprocessableEntity) WriteResponse(rw http.ResponseW
 // ListMTOServiceItemsInternalServerErrorCode is the HTTP code returned for type ListMTOServiceItemsInternalServerError
 const ListMTOServiceItemsInternalServerErrorCode int = 500
 
-/*
-ListMTOServiceItemsInternalServerError A server error occurred
+/*ListMTOServiceItemsInternalServerError A server error occurred
 
 swagger:response listMTOServiceItemsInternalServerError
 */

--- a/pkg/gen/ghcapi/ghcoperations/mto_service_item/update_m_t_o_service_item.go
+++ b/pkg/gen/ghcapi/ghcoperations/mto_service_item/update_m_t_o_service_item.go
@@ -29,12 +29,12 @@ func NewUpdateMTOServiceItem(ctx *middleware.Context, handler UpdateMTOServiceIt
 	return &UpdateMTOServiceItem{Context: ctx, Handler: handler}
 }
 
-/*
-	UpdateMTOServiceItem swagger:route PATCH /move-task-orders/{moveTaskOrderID}/service-items/{mtoServiceItemID} mtoServiceItem updateMTOServiceItem
-
-# Updates a service item by ID for a move by ID
+/* UpdateMTOServiceItem swagger:route PATCH /move-task-orders/{moveTaskOrderID}/service-items/{mtoServiceItemID} mtoServiceItem updateMTOServiceItem
 
 Updates a service item by ID for a move by ID
+
+Updates a service item by ID for a move by ID
+
 */
 type UpdateMTOServiceItem struct {
 	Context *middleware.Context

--- a/pkg/gen/ghcapi/ghcoperations/mto_service_item/update_m_t_o_service_item_responses.go
+++ b/pkg/gen/ghcapi/ghcoperations/mto_service_item/update_m_t_o_service_item_responses.go
@@ -16,8 +16,7 @@ import (
 // UpdateMTOServiceItemOKCode is the HTTP code returned for type UpdateMTOServiceItemOK
 const UpdateMTOServiceItemOKCode int = 200
 
-/*
-UpdateMTOServiceItemOK Successfully updated move task order status
+/*UpdateMTOServiceItemOK Successfully updated move task order status
 
 swagger:response updateMTOServiceItemOK
 */
@@ -61,8 +60,7 @@ func (o *UpdateMTOServiceItemOK) WriteResponse(rw http.ResponseWriter, producer 
 // UpdateMTOServiceItemBadRequestCode is the HTTP code returned for type UpdateMTOServiceItemBadRequest
 const UpdateMTOServiceItemBadRequestCode int = 400
 
-/*
-UpdateMTOServiceItemBadRequest The request payload is invalid
+/*UpdateMTOServiceItemBadRequest The request payload is invalid
 
 swagger:response updateMTOServiceItemBadRequest
 */
@@ -106,8 +104,7 @@ func (o *UpdateMTOServiceItemBadRequest) WriteResponse(rw http.ResponseWriter, p
 // UpdateMTOServiceItemUnauthorizedCode is the HTTP code returned for type UpdateMTOServiceItemUnauthorized
 const UpdateMTOServiceItemUnauthorizedCode int = 401
 
-/*
-UpdateMTOServiceItemUnauthorized The request was denied
+/*UpdateMTOServiceItemUnauthorized The request was denied
 
 swagger:response updateMTOServiceItemUnauthorized
 */
@@ -151,8 +148,7 @@ func (o *UpdateMTOServiceItemUnauthorized) WriteResponse(rw http.ResponseWriter,
 // UpdateMTOServiceItemForbiddenCode is the HTTP code returned for type UpdateMTOServiceItemForbidden
 const UpdateMTOServiceItemForbiddenCode int = 403
 
-/*
-UpdateMTOServiceItemForbidden The request was denied
+/*UpdateMTOServiceItemForbidden The request was denied
 
 swagger:response updateMTOServiceItemForbidden
 */
@@ -196,8 +192,7 @@ func (o *UpdateMTOServiceItemForbidden) WriteResponse(rw http.ResponseWriter, pr
 // UpdateMTOServiceItemNotFoundCode is the HTTP code returned for type UpdateMTOServiceItemNotFound
 const UpdateMTOServiceItemNotFoundCode int = 404
 
-/*
-UpdateMTOServiceItemNotFound The requested resource wasn't found
+/*UpdateMTOServiceItemNotFound The requested resource wasn't found
 
 swagger:response updateMTOServiceItemNotFound
 */
@@ -241,8 +236,7 @@ func (o *UpdateMTOServiceItemNotFound) WriteResponse(rw http.ResponseWriter, pro
 // UpdateMTOServiceItemPreconditionFailedCode is the HTTP code returned for type UpdateMTOServiceItemPreconditionFailed
 const UpdateMTOServiceItemPreconditionFailedCode int = 412
 
-/*
-UpdateMTOServiceItemPreconditionFailed Precondition failed
+/*UpdateMTOServiceItemPreconditionFailed Precondition failed
 
 swagger:response updateMTOServiceItemPreconditionFailed
 */
@@ -286,8 +280,7 @@ func (o *UpdateMTOServiceItemPreconditionFailed) WriteResponse(rw http.ResponseW
 // UpdateMTOServiceItemInternalServerErrorCode is the HTTP code returned for type UpdateMTOServiceItemInternalServerError
 const UpdateMTOServiceItemInternalServerErrorCode int = 500
 
-/*
-UpdateMTOServiceItemInternalServerError A server error occurred
+/*UpdateMTOServiceItemInternalServerError A server error occurred
 
 swagger:response updateMTOServiceItemInternalServerError
 */

--- a/pkg/gen/ghcapi/ghcoperations/mto_service_item/update_m_t_o_service_item_status.go
+++ b/pkg/gen/ghcapi/ghcoperations/mto_service_item/update_m_t_o_service_item_status.go
@@ -29,12 +29,12 @@ func NewUpdateMTOServiceItemStatus(ctx *middleware.Context, handler UpdateMTOSer
 	return &UpdateMTOServiceItemStatus{Context: ctx, Handler: handler}
 }
 
-/*
-	UpdateMTOServiceItemStatus swagger:route PATCH /move-task-orders/{moveTaskOrderID}/service-items/{mtoServiceItemID}/status mtoServiceItem updateMTOServiceItemStatus
+/* UpdateMTOServiceItemStatus swagger:route PATCH /move-task-orders/{moveTaskOrderID}/service-items/{mtoServiceItemID}/status mtoServiceItem updateMTOServiceItemStatus
 
-# Change the status of a line item for a move by ID
+Change the status of a line item for a move by ID
 
 Changes the status of a line item for a move by ID
+
 */
 type UpdateMTOServiceItemStatus struct {
 	Context *middleware.Context

--- a/pkg/gen/ghcapi/ghcoperations/mto_service_item/update_m_t_o_service_item_status_responses.go
+++ b/pkg/gen/ghcapi/ghcoperations/mto_service_item/update_m_t_o_service_item_status_responses.go
@@ -16,8 +16,7 @@ import (
 // UpdateMTOServiceItemStatusOKCode is the HTTP code returned for type UpdateMTOServiceItemStatusOK
 const UpdateMTOServiceItemStatusOKCode int = 200
 
-/*
-UpdateMTOServiceItemStatusOK Successfully updated status for a line item for a move task order by ID
+/*UpdateMTOServiceItemStatusOK Successfully updated status for a line item for a move task order by ID
 
 swagger:response updateMTOServiceItemStatusOK
 */
@@ -61,8 +60,7 @@ func (o *UpdateMTOServiceItemStatusOK) WriteResponse(rw http.ResponseWriter, pro
 // UpdateMTOServiceItemStatusBadRequestCode is the HTTP code returned for type UpdateMTOServiceItemStatusBadRequest
 const UpdateMTOServiceItemStatusBadRequestCode int = 400
 
-/*
-UpdateMTOServiceItemStatusBadRequest The request payload is invalid
+/*UpdateMTOServiceItemStatusBadRequest The request payload is invalid
 
 swagger:response updateMTOServiceItemStatusBadRequest
 */
@@ -106,8 +104,7 @@ func (o *UpdateMTOServiceItemStatusBadRequest) WriteResponse(rw http.ResponseWri
 // UpdateMTOServiceItemStatusUnauthorizedCode is the HTTP code returned for type UpdateMTOServiceItemStatusUnauthorized
 const UpdateMTOServiceItemStatusUnauthorizedCode int = 401
 
-/*
-UpdateMTOServiceItemStatusUnauthorized The request was denied
+/*UpdateMTOServiceItemStatusUnauthorized The request was denied
 
 swagger:response updateMTOServiceItemStatusUnauthorized
 */
@@ -151,8 +148,7 @@ func (o *UpdateMTOServiceItemStatusUnauthorized) WriteResponse(rw http.ResponseW
 // UpdateMTOServiceItemStatusForbiddenCode is the HTTP code returned for type UpdateMTOServiceItemStatusForbidden
 const UpdateMTOServiceItemStatusForbiddenCode int = 403
 
-/*
-UpdateMTOServiceItemStatusForbidden The request was denied
+/*UpdateMTOServiceItemStatusForbidden The request was denied
 
 swagger:response updateMTOServiceItemStatusForbidden
 */
@@ -196,8 +192,7 @@ func (o *UpdateMTOServiceItemStatusForbidden) WriteResponse(rw http.ResponseWrit
 // UpdateMTOServiceItemStatusNotFoundCode is the HTTP code returned for type UpdateMTOServiceItemStatusNotFound
 const UpdateMTOServiceItemStatusNotFoundCode int = 404
 
-/*
-UpdateMTOServiceItemStatusNotFound The requested resource wasn't found
+/*UpdateMTOServiceItemStatusNotFound The requested resource wasn't found
 
 swagger:response updateMTOServiceItemStatusNotFound
 */
@@ -241,8 +236,7 @@ func (o *UpdateMTOServiceItemStatusNotFound) WriteResponse(rw http.ResponseWrite
 // UpdateMTOServiceItemStatusPreconditionFailedCode is the HTTP code returned for type UpdateMTOServiceItemStatusPreconditionFailed
 const UpdateMTOServiceItemStatusPreconditionFailedCode int = 412
 
-/*
-UpdateMTOServiceItemStatusPreconditionFailed Precondition failed
+/*UpdateMTOServiceItemStatusPreconditionFailed Precondition failed
 
 swagger:response updateMTOServiceItemStatusPreconditionFailed
 */
@@ -286,8 +280,7 @@ func (o *UpdateMTOServiceItemStatusPreconditionFailed) WriteResponse(rw http.Res
 // UpdateMTOServiceItemStatusUnprocessableEntityCode is the HTTP code returned for type UpdateMTOServiceItemStatusUnprocessableEntity
 const UpdateMTOServiceItemStatusUnprocessableEntityCode int = 422
 
-/*
-UpdateMTOServiceItemStatusUnprocessableEntity The payload was unprocessable.
+/*UpdateMTOServiceItemStatusUnprocessableEntity The payload was unprocessable.
 
 swagger:response updateMTOServiceItemStatusUnprocessableEntity
 */
@@ -331,8 +324,7 @@ func (o *UpdateMTOServiceItemStatusUnprocessableEntity) WriteResponse(rw http.Re
 // UpdateMTOServiceItemStatusInternalServerErrorCode is the HTTP code returned for type UpdateMTOServiceItemStatusInternalServerError
 const UpdateMTOServiceItemStatusInternalServerErrorCode int = 500
 
-/*
-UpdateMTOServiceItemStatusInternalServerError A server error occurred
+/*UpdateMTOServiceItemStatusInternalServerError A server error occurred
 
 swagger:response updateMTOServiceItemStatusInternalServerError
 */

--- a/pkg/gen/ghcapi/ghcoperations/mto_shipment/create_m_t_o_shipment.go
+++ b/pkg/gen/ghcapi/ghcoperations/mto_shipment/create_m_t_o_shipment.go
@@ -29,8 +29,7 @@ func NewCreateMTOShipment(ctx *middleware.Context, handler CreateMTOShipmentHand
 	return &CreateMTOShipment{Context: ctx, Handler: handler}
 }
 
-/*
-	CreateMTOShipment swagger:route POST /mto-shipments mtoShipment createMTOShipment
+/* CreateMTOShipment swagger:route POST /mto-shipments mtoShipment createMTOShipment
 
 createMTOShipment
 
@@ -46,6 +45,8 @@ Optional fields include:
 * Customer Remarks
 * Releasing / Receiving agents
 * An array of optional accessorial service item codes
+
+
 */
 type CreateMTOShipment struct {
 	Context *middleware.Context

--- a/pkg/gen/ghcapi/ghcoperations/mto_shipment/create_m_t_o_shipment_responses.go
+++ b/pkg/gen/ghcapi/ghcoperations/mto_shipment/create_m_t_o_shipment_responses.go
@@ -16,8 +16,7 @@ import (
 // CreateMTOShipmentOKCode is the HTTP code returned for type CreateMTOShipmentOK
 const CreateMTOShipmentOKCode int = 200
 
-/*
-CreateMTOShipmentOK Successfully created a MTO shipment.
+/*CreateMTOShipmentOK Successfully created a MTO shipment.
 
 swagger:response createMTOShipmentOK
 */
@@ -61,8 +60,7 @@ func (o *CreateMTOShipmentOK) WriteResponse(rw http.ResponseWriter, producer run
 // CreateMTOShipmentBadRequestCode is the HTTP code returned for type CreateMTOShipmentBadRequest
 const CreateMTOShipmentBadRequestCode int = 400
 
-/*
-CreateMTOShipmentBadRequest The request payload is invalid
+/*CreateMTOShipmentBadRequest The request payload is invalid
 
 swagger:response createMTOShipmentBadRequest
 */
@@ -106,8 +104,7 @@ func (o *CreateMTOShipmentBadRequest) WriteResponse(rw http.ResponseWriter, prod
 // CreateMTOShipmentNotFoundCode is the HTTP code returned for type CreateMTOShipmentNotFound
 const CreateMTOShipmentNotFoundCode int = 404
 
-/*
-CreateMTOShipmentNotFound The requested resource wasn't found
+/*CreateMTOShipmentNotFound The requested resource wasn't found
 
 swagger:response createMTOShipmentNotFound
 */
@@ -151,8 +148,7 @@ func (o *CreateMTOShipmentNotFound) WriteResponse(rw http.ResponseWriter, produc
 // CreateMTOShipmentUnprocessableEntityCode is the HTTP code returned for type CreateMTOShipmentUnprocessableEntity
 const CreateMTOShipmentUnprocessableEntityCode int = 422
 
-/*
-CreateMTOShipmentUnprocessableEntity The payload was unprocessable.
+/*CreateMTOShipmentUnprocessableEntity The payload was unprocessable.
 
 swagger:response createMTOShipmentUnprocessableEntity
 */
@@ -196,8 +192,7 @@ func (o *CreateMTOShipmentUnprocessableEntity) WriteResponse(rw http.ResponseWri
 // CreateMTOShipmentInternalServerErrorCode is the HTTP code returned for type CreateMTOShipmentInternalServerError
 const CreateMTOShipmentInternalServerErrorCode int = 500
 
-/*
-CreateMTOShipmentInternalServerError A server error occurred
+/*CreateMTOShipmentInternalServerError A server error occurred
 
 swagger:response createMTOShipmentInternalServerError
 */

--- a/pkg/gen/ghcapi/ghcoperations/mto_shipment/get_shipment.go
+++ b/pkg/gen/ghcapi/ghcoperations/mto_shipment/get_shipment.go
@@ -29,12 +29,12 @@ func NewGetShipment(ctx *middleware.Context, handler GetShipmentHandler) *GetShi
 	return &GetShipment{Context: ctx, Handler: handler}
 }
 
-/*
-	GetShipment swagger:route GET /shipments/{shipmentID} mtoShipment getShipment
+/* GetShipment swagger:route GET /shipments/{shipmentID} mtoShipment getShipment
 
 fetches a shipment by ID
 
 fetches a shipment by ID
+
 */
 type GetShipment struct {
 	Context *middleware.Context

--- a/pkg/gen/ghcapi/ghcoperations/mto_shipment/get_shipment_responses.go
+++ b/pkg/gen/ghcapi/ghcoperations/mto_shipment/get_shipment_responses.go
@@ -16,8 +16,7 @@ import (
 // GetShipmentOKCode is the HTTP code returned for type GetShipmentOK
 const GetShipmentOKCode int = 200
 
-/*
-GetShipmentOK Successfully fetched the shipment
+/*GetShipmentOK Successfully fetched the shipment
 
 swagger:response getShipmentOK
 */
@@ -61,8 +60,7 @@ func (o *GetShipmentOK) WriteResponse(rw http.ResponseWriter, producer runtime.P
 // GetShipmentBadRequestCode is the HTTP code returned for type GetShipmentBadRequest
 const GetShipmentBadRequestCode int = 400
 
-/*
-GetShipmentBadRequest The request payload is invalid
+/*GetShipmentBadRequest The request payload is invalid
 
 swagger:response getShipmentBadRequest
 */
@@ -106,8 +104,7 @@ func (o *GetShipmentBadRequest) WriteResponse(rw http.ResponseWriter, producer r
 // GetShipmentForbiddenCode is the HTTP code returned for type GetShipmentForbidden
 const GetShipmentForbiddenCode int = 403
 
-/*
-GetShipmentForbidden The request was denied
+/*GetShipmentForbidden The request was denied
 
 swagger:response getShipmentForbidden
 */
@@ -151,8 +148,7 @@ func (o *GetShipmentForbidden) WriteResponse(rw http.ResponseWriter, producer ru
 // GetShipmentNotFoundCode is the HTTP code returned for type GetShipmentNotFound
 const GetShipmentNotFoundCode int = 404
 
-/*
-GetShipmentNotFound The requested resource wasn't found
+/*GetShipmentNotFound The requested resource wasn't found
 
 swagger:response getShipmentNotFound
 */
@@ -196,8 +192,7 @@ func (o *GetShipmentNotFound) WriteResponse(rw http.ResponseWriter, producer run
 // GetShipmentUnprocessableEntityCode is the HTTP code returned for type GetShipmentUnprocessableEntity
 const GetShipmentUnprocessableEntityCode int = 422
 
-/*
-GetShipmentUnprocessableEntity The payload was unprocessable.
+/*GetShipmentUnprocessableEntity The payload was unprocessable.
 
 swagger:response getShipmentUnprocessableEntity
 */
@@ -241,8 +236,7 @@ func (o *GetShipmentUnprocessableEntity) WriteResponse(rw http.ResponseWriter, p
 // GetShipmentInternalServerErrorCode is the HTTP code returned for type GetShipmentInternalServerError
 const GetShipmentInternalServerErrorCode int = 500
 
-/*
-GetShipmentInternalServerError A server error occurred
+/*GetShipmentInternalServerError A server error occurred
 
 swagger:response getShipmentInternalServerError
 */

--- a/pkg/gen/ghcapi/ghcoperations/mto_shipment/list_m_t_o_shipments.go
+++ b/pkg/gen/ghcapi/ghcoperations/mto_shipment/list_m_t_o_shipments.go
@@ -29,12 +29,12 @@ func NewListMTOShipments(ctx *middleware.Context, handler ListMTOShipmentsHandle
 	return &ListMTOShipments{Context: ctx, Handler: handler}
 }
 
-/*
-	ListMTOShipments swagger:route GET /move_task_orders/{moveTaskOrderID}/mto_shipments mtoShipment listMTOShipments
-
-# Gets all shipments for a move task order
+/* ListMTOShipments swagger:route GET /move_task_orders/{moveTaskOrderID}/mto_shipments mtoShipment listMTOShipments
 
 Gets all shipments for a move task order
+
+Gets all shipments for a move task order
+
 */
 type ListMTOShipments struct {
 	Context *middleware.Context

--- a/pkg/gen/ghcapi/ghcoperations/mto_shipment/list_m_t_o_shipments_responses.go
+++ b/pkg/gen/ghcapi/ghcoperations/mto_shipment/list_m_t_o_shipments_responses.go
@@ -16,8 +16,7 @@ import (
 // ListMTOShipmentsOKCode is the HTTP code returned for type ListMTOShipmentsOK
 const ListMTOShipmentsOKCode int = 200
 
-/*
-ListMTOShipmentsOK Successfully retrieved all mto shipments for a move task order
+/*ListMTOShipmentsOK Successfully retrieved all mto shipments for a move task order
 
 swagger:response listMTOShipmentsOK
 */
@@ -64,8 +63,7 @@ func (o *ListMTOShipmentsOK) WriteResponse(rw http.ResponseWriter, producer runt
 // ListMTOShipmentsForbiddenCode is the HTTP code returned for type ListMTOShipmentsForbidden
 const ListMTOShipmentsForbiddenCode int = 403
 
-/*
-ListMTOShipmentsForbidden The request was denied
+/*ListMTOShipmentsForbidden The request was denied
 
 swagger:response listMTOShipmentsForbidden
 */
@@ -109,8 +107,7 @@ func (o *ListMTOShipmentsForbidden) WriteResponse(rw http.ResponseWriter, produc
 // ListMTOShipmentsNotFoundCode is the HTTP code returned for type ListMTOShipmentsNotFound
 const ListMTOShipmentsNotFoundCode int = 404
 
-/*
-ListMTOShipmentsNotFound The requested resource wasn't found
+/*ListMTOShipmentsNotFound The requested resource wasn't found
 
 swagger:response listMTOShipmentsNotFound
 */
@@ -154,8 +151,7 @@ func (o *ListMTOShipmentsNotFound) WriteResponse(rw http.ResponseWriter, produce
 // ListMTOShipmentsUnprocessableEntityCode is the HTTP code returned for type ListMTOShipmentsUnprocessableEntity
 const ListMTOShipmentsUnprocessableEntityCode int = 422
 
-/*
-ListMTOShipmentsUnprocessableEntity The payload was unprocessable.
+/*ListMTOShipmentsUnprocessableEntity The payload was unprocessable.
 
 swagger:response listMTOShipmentsUnprocessableEntity
 */
@@ -199,8 +195,7 @@ func (o *ListMTOShipmentsUnprocessableEntity) WriteResponse(rw http.ResponseWrit
 // ListMTOShipmentsInternalServerErrorCode is the HTTP code returned for type ListMTOShipmentsInternalServerError
 const ListMTOShipmentsInternalServerErrorCode int = 500
 
-/*
-ListMTOShipmentsInternalServerError A server error occurred
+/*ListMTOShipmentsInternalServerError A server error occurred
 
 swagger:response listMTOShipmentsInternalServerError
 */

--- a/pkg/gen/ghcapi/ghcoperations/mto_shipment/update_m_t_o_shipment.go
+++ b/pkg/gen/ghcapi/ghcoperations/mto_shipment/update_m_t_o_shipment.go
@@ -29,8 +29,7 @@ func NewUpdateMTOShipment(ctx *middleware.Context, handler UpdateMTOShipmentHand
 	return &UpdateMTOShipment{Context: ctx, Handler: handler}
 }
 
-/*
-	UpdateMTOShipment swagger:route PATCH /move_task_orders/{moveTaskOrderID}/mto_shipments/{shipmentID} mtoShipment updateMTOShipment
+/* UpdateMTOShipment swagger:route PATCH /move_task_orders/{moveTaskOrderID}/mto_shipments/{shipmentID} mtoShipment updateMTOShipment
 
 updateMTOShipment
 
@@ -49,6 +48,8 @@ Optional fields include:
 * Customer Remarks
 * Counselor Remarks
 * Releasing / Receiving agents
+
+
 */
 type UpdateMTOShipment struct {
 	Context *middleware.Context

--- a/pkg/gen/ghcapi/ghcoperations/mto_shipment/update_m_t_o_shipment_responses.go
+++ b/pkg/gen/ghcapi/ghcoperations/mto_shipment/update_m_t_o_shipment_responses.go
@@ -16,8 +16,7 @@ import (
 // UpdateMTOShipmentOKCode is the HTTP code returned for type UpdateMTOShipmentOK
 const UpdateMTOShipmentOKCode int = 200
 
-/*
-UpdateMTOShipmentOK Successfully updated the specified MTO shipment.
+/*UpdateMTOShipmentOK Successfully updated the specified MTO shipment.
 
 swagger:response updateMTOShipmentOK
 */
@@ -61,8 +60,7 @@ func (o *UpdateMTOShipmentOK) WriteResponse(rw http.ResponseWriter, producer run
 // UpdateMTOShipmentBadRequestCode is the HTTP code returned for type UpdateMTOShipmentBadRequest
 const UpdateMTOShipmentBadRequestCode int = 400
 
-/*
-UpdateMTOShipmentBadRequest The request payload is invalid
+/*UpdateMTOShipmentBadRequest The request payload is invalid
 
 swagger:response updateMTOShipmentBadRequest
 */
@@ -106,8 +104,7 @@ func (o *UpdateMTOShipmentBadRequest) WriteResponse(rw http.ResponseWriter, prod
 // UpdateMTOShipmentUnauthorizedCode is the HTTP code returned for type UpdateMTOShipmentUnauthorized
 const UpdateMTOShipmentUnauthorizedCode int = 401
 
-/*
-UpdateMTOShipmentUnauthorized The request was denied
+/*UpdateMTOShipmentUnauthorized The request was denied
 
 swagger:response updateMTOShipmentUnauthorized
 */
@@ -151,8 +148,7 @@ func (o *UpdateMTOShipmentUnauthorized) WriteResponse(rw http.ResponseWriter, pr
 // UpdateMTOShipmentForbiddenCode is the HTTP code returned for type UpdateMTOShipmentForbidden
 const UpdateMTOShipmentForbiddenCode int = 403
 
-/*
-UpdateMTOShipmentForbidden The request was denied
+/*UpdateMTOShipmentForbidden The request was denied
 
 swagger:response updateMTOShipmentForbidden
 */
@@ -196,8 +192,7 @@ func (o *UpdateMTOShipmentForbidden) WriteResponse(rw http.ResponseWriter, produ
 // UpdateMTOShipmentNotFoundCode is the HTTP code returned for type UpdateMTOShipmentNotFound
 const UpdateMTOShipmentNotFoundCode int = 404
 
-/*
-UpdateMTOShipmentNotFound The requested resource wasn't found
+/*UpdateMTOShipmentNotFound The requested resource wasn't found
 
 swagger:response updateMTOShipmentNotFound
 */
@@ -241,8 +236,7 @@ func (o *UpdateMTOShipmentNotFound) WriteResponse(rw http.ResponseWriter, produc
 // UpdateMTOShipmentPreconditionFailedCode is the HTTP code returned for type UpdateMTOShipmentPreconditionFailed
 const UpdateMTOShipmentPreconditionFailedCode int = 412
 
-/*
-UpdateMTOShipmentPreconditionFailed Precondition failed
+/*UpdateMTOShipmentPreconditionFailed Precondition failed
 
 swagger:response updateMTOShipmentPreconditionFailed
 */
@@ -286,8 +280,7 @@ func (o *UpdateMTOShipmentPreconditionFailed) WriteResponse(rw http.ResponseWrit
 // UpdateMTOShipmentUnprocessableEntityCode is the HTTP code returned for type UpdateMTOShipmentUnprocessableEntity
 const UpdateMTOShipmentUnprocessableEntityCode int = 422
 
-/*
-UpdateMTOShipmentUnprocessableEntity The payload was unprocessable.
+/*UpdateMTOShipmentUnprocessableEntity The payload was unprocessable.
 
 swagger:response updateMTOShipmentUnprocessableEntity
 */
@@ -331,8 +324,7 @@ func (o *UpdateMTOShipmentUnprocessableEntity) WriteResponse(rw http.ResponseWri
 // UpdateMTOShipmentInternalServerErrorCode is the HTTP code returned for type UpdateMTOShipmentInternalServerError
 const UpdateMTOShipmentInternalServerErrorCode int = 500
 
-/*
-UpdateMTOShipmentInternalServerError A server error occurred
+/*UpdateMTOShipmentInternalServerError A server error occurred
 
 swagger:response updateMTOShipmentInternalServerError
 */

--- a/pkg/gen/ghcapi/ghcoperations/mymove_api.go
+++ b/pkg/gen/ghcapi/ghcoperations/mymove_api.go
@@ -258,8 +258,7 @@ func NewMymoveAPI(spec *loads.Document) *MymoveAPI {
 	}
 }
 
-/*
-MymoveAPI The GHC API is a RESTful API that enables the Office application for MilMove.
+/*MymoveAPI The GHC API is a RESTful API that enables the Office application for MilMove.
 
 All endpoints are located under `/ghc/v1`.
 */

--- a/pkg/gen/ghcapi/ghcoperations/order/acknowledge_excess_weight_risk.go
+++ b/pkg/gen/ghcapi/ghcoperations/order/acknowledge_excess_weight_risk.go
@@ -29,12 +29,12 @@ func NewAcknowledgeExcessWeightRisk(ctx *middleware.Context, handler Acknowledge
 	return &AcknowledgeExcessWeightRisk{Context: ctx, Handler: handler}
 }
 
-/*
-	AcknowledgeExcessWeightRisk swagger:route POST /orders/{orderID}/acknowledge-excess-weight-risk order acknowledgeExcessWeightRisk
-
-# Saves the date and time a TOO acknowledged the excess weight risk by dismissing the alert
+/* AcknowledgeExcessWeightRisk swagger:route POST /orders/{orderID}/acknowledge-excess-weight-risk order acknowledgeExcessWeightRisk
 
 Saves the date and time a TOO acknowledged the excess weight risk by dismissing the alert
+
+Saves the date and time a TOO acknowledged the excess weight risk by dismissing the alert
+
 */
 type AcknowledgeExcessWeightRisk struct {
 	Context *middleware.Context

--- a/pkg/gen/ghcapi/ghcoperations/order/acknowledge_excess_weight_risk_responses.go
+++ b/pkg/gen/ghcapi/ghcoperations/order/acknowledge_excess_weight_risk_responses.go
@@ -16,8 +16,7 @@ import (
 // AcknowledgeExcessWeightRiskOKCode is the HTTP code returned for type AcknowledgeExcessWeightRiskOK
 const AcknowledgeExcessWeightRiskOKCode int = 200
 
-/*
-AcknowledgeExcessWeightRiskOK updated Move
+/*AcknowledgeExcessWeightRiskOK updated Move
 
 swagger:response acknowledgeExcessWeightRiskOK
 */
@@ -61,8 +60,7 @@ func (o *AcknowledgeExcessWeightRiskOK) WriteResponse(rw http.ResponseWriter, pr
 // AcknowledgeExcessWeightRiskForbiddenCode is the HTTP code returned for type AcknowledgeExcessWeightRiskForbidden
 const AcknowledgeExcessWeightRiskForbiddenCode int = 403
 
-/*
-AcknowledgeExcessWeightRiskForbidden The request was denied
+/*AcknowledgeExcessWeightRiskForbidden The request was denied
 
 swagger:response acknowledgeExcessWeightRiskForbidden
 */
@@ -106,8 +104,7 @@ func (o *AcknowledgeExcessWeightRiskForbidden) WriteResponse(rw http.ResponseWri
 // AcknowledgeExcessWeightRiskNotFoundCode is the HTTP code returned for type AcknowledgeExcessWeightRiskNotFound
 const AcknowledgeExcessWeightRiskNotFoundCode int = 404
 
-/*
-AcknowledgeExcessWeightRiskNotFound The requested resource wasn't found
+/*AcknowledgeExcessWeightRiskNotFound The requested resource wasn't found
 
 swagger:response acknowledgeExcessWeightRiskNotFound
 */
@@ -151,8 +148,7 @@ func (o *AcknowledgeExcessWeightRiskNotFound) WriteResponse(rw http.ResponseWrit
 // AcknowledgeExcessWeightRiskPreconditionFailedCode is the HTTP code returned for type AcknowledgeExcessWeightRiskPreconditionFailed
 const AcknowledgeExcessWeightRiskPreconditionFailedCode int = 412
 
-/*
-AcknowledgeExcessWeightRiskPreconditionFailed Precondition failed
+/*AcknowledgeExcessWeightRiskPreconditionFailed Precondition failed
 
 swagger:response acknowledgeExcessWeightRiskPreconditionFailed
 */
@@ -196,8 +192,7 @@ func (o *AcknowledgeExcessWeightRiskPreconditionFailed) WriteResponse(rw http.Re
 // AcknowledgeExcessWeightRiskUnprocessableEntityCode is the HTTP code returned for type AcknowledgeExcessWeightRiskUnprocessableEntity
 const AcknowledgeExcessWeightRiskUnprocessableEntityCode int = 422
 
-/*
-AcknowledgeExcessWeightRiskUnprocessableEntity The payload was unprocessable.
+/*AcknowledgeExcessWeightRiskUnprocessableEntity The payload was unprocessable.
 
 swagger:response acknowledgeExcessWeightRiskUnprocessableEntity
 */
@@ -241,8 +236,7 @@ func (o *AcknowledgeExcessWeightRiskUnprocessableEntity) WriteResponse(rw http.R
 // AcknowledgeExcessWeightRiskInternalServerErrorCode is the HTTP code returned for type AcknowledgeExcessWeightRiskInternalServerError
 const AcknowledgeExcessWeightRiskInternalServerErrorCode int = 500
 
-/*
-AcknowledgeExcessWeightRiskInternalServerError A server error occurred
+/*AcknowledgeExcessWeightRiskInternalServerError A server error occurred
 
 swagger:response acknowledgeExcessWeightRiskInternalServerError
 */

--- a/pkg/gen/ghcapi/ghcoperations/order/counseling_update_allowance.go
+++ b/pkg/gen/ghcapi/ghcoperations/order/counseling_update_allowance.go
@@ -29,12 +29,12 @@ func NewCounselingUpdateAllowance(ctx *middleware.Context, handler CounselingUpd
 	return &CounselingUpdateAllowance{Context: ctx, Handler: handler}
 }
 
-/*
-	CounselingUpdateAllowance swagger:route PATCH /counseling/orders/{orderID}/allowances order counselingUpdateAllowance
+/* CounselingUpdateAllowance swagger:route PATCH /counseling/orders/{orderID}/allowances order counselingUpdateAllowance
 
 Updates an allowance (Orders with Entitlements)
 
 All fields sent in this request will be set on the order referenced
+
 */
 type CounselingUpdateAllowance struct {
 	Context *middleware.Context

--- a/pkg/gen/ghcapi/ghcoperations/order/counseling_update_allowance_responses.go
+++ b/pkg/gen/ghcapi/ghcoperations/order/counseling_update_allowance_responses.go
@@ -16,8 +16,7 @@ import (
 // CounselingUpdateAllowanceOKCode is the HTTP code returned for type CounselingUpdateAllowanceOK
 const CounselingUpdateAllowanceOKCode int = 200
 
-/*
-CounselingUpdateAllowanceOK updated instance of allowance
+/*CounselingUpdateAllowanceOK updated instance of allowance
 
 swagger:response counselingUpdateAllowanceOK
 */
@@ -61,8 +60,7 @@ func (o *CounselingUpdateAllowanceOK) WriteResponse(rw http.ResponseWriter, prod
 // CounselingUpdateAllowanceForbiddenCode is the HTTP code returned for type CounselingUpdateAllowanceForbidden
 const CounselingUpdateAllowanceForbiddenCode int = 403
 
-/*
-CounselingUpdateAllowanceForbidden The request was denied
+/*CounselingUpdateAllowanceForbidden The request was denied
 
 swagger:response counselingUpdateAllowanceForbidden
 */
@@ -106,8 +104,7 @@ func (o *CounselingUpdateAllowanceForbidden) WriteResponse(rw http.ResponseWrite
 // CounselingUpdateAllowanceNotFoundCode is the HTTP code returned for type CounselingUpdateAllowanceNotFound
 const CounselingUpdateAllowanceNotFoundCode int = 404
 
-/*
-CounselingUpdateAllowanceNotFound The requested resource wasn't found
+/*CounselingUpdateAllowanceNotFound The requested resource wasn't found
 
 swagger:response counselingUpdateAllowanceNotFound
 */
@@ -151,8 +148,7 @@ func (o *CounselingUpdateAllowanceNotFound) WriteResponse(rw http.ResponseWriter
 // CounselingUpdateAllowancePreconditionFailedCode is the HTTP code returned for type CounselingUpdateAllowancePreconditionFailed
 const CounselingUpdateAllowancePreconditionFailedCode int = 412
 
-/*
-CounselingUpdateAllowancePreconditionFailed Precondition failed
+/*CounselingUpdateAllowancePreconditionFailed Precondition failed
 
 swagger:response counselingUpdateAllowancePreconditionFailed
 */
@@ -196,8 +192,7 @@ func (o *CounselingUpdateAllowancePreconditionFailed) WriteResponse(rw http.Resp
 // CounselingUpdateAllowanceUnprocessableEntityCode is the HTTP code returned for type CounselingUpdateAllowanceUnprocessableEntity
 const CounselingUpdateAllowanceUnprocessableEntityCode int = 422
 
-/*
-CounselingUpdateAllowanceUnprocessableEntity The payload was unprocessable.
+/*CounselingUpdateAllowanceUnprocessableEntity The payload was unprocessable.
 
 swagger:response counselingUpdateAllowanceUnprocessableEntity
 */
@@ -241,8 +236,7 @@ func (o *CounselingUpdateAllowanceUnprocessableEntity) WriteResponse(rw http.Res
 // CounselingUpdateAllowanceInternalServerErrorCode is the HTTP code returned for type CounselingUpdateAllowanceInternalServerError
 const CounselingUpdateAllowanceInternalServerErrorCode int = 500
 
-/*
-CounselingUpdateAllowanceInternalServerError A server error occurred
+/*CounselingUpdateAllowanceInternalServerError A server error occurred
 
 swagger:response counselingUpdateAllowanceInternalServerError
 */

--- a/pkg/gen/ghcapi/ghcoperations/order/counseling_update_order.go
+++ b/pkg/gen/ghcapi/ghcoperations/order/counseling_update_order.go
@@ -29,12 +29,12 @@ func NewCounselingUpdateOrder(ctx *middleware.Context, handler CounselingUpdateO
 	return &CounselingUpdateOrder{Context: ctx, Handler: handler}
 }
 
-/*
-	CounselingUpdateOrder swagger:route PATCH /counseling/orders/{orderID} order counselingUpdateOrder
+/* CounselingUpdateOrder swagger:route PATCH /counseling/orders/{orderID} order counselingUpdateOrder
 
 Updates an order (performed by a services counselor)
 
 All fields sent in this request will be set on the order referenced
+
 */
 type CounselingUpdateOrder struct {
 	Context *middleware.Context

--- a/pkg/gen/ghcapi/ghcoperations/order/counseling_update_order_responses.go
+++ b/pkg/gen/ghcapi/ghcoperations/order/counseling_update_order_responses.go
@@ -16,8 +16,7 @@ import (
 // CounselingUpdateOrderOKCode is the HTTP code returned for type CounselingUpdateOrderOK
 const CounselingUpdateOrderOKCode int = 200
 
-/*
-CounselingUpdateOrderOK updated instance of orders
+/*CounselingUpdateOrderOK updated instance of orders
 
 swagger:response counselingUpdateOrderOK
 */
@@ -61,8 +60,7 @@ func (o *CounselingUpdateOrderOK) WriteResponse(rw http.ResponseWriter, producer
 // CounselingUpdateOrderForbiddenCode is the HTTP code returned for type CounselingUpdateOrderForbidden
 const CounselingUpdateOrderForbiddenCode int = 403
 
-/*
-CounselingUpdateOrderForbidden The request was denied
+/*CounselingUpdateOrderForbidden The request was denied
 
 swagger:response counselingUpdateOrderForbidden
 */
@@ -106,8 +104,7 @@ func (o *CounselingUpdateOrderForbidden) WriteResponse(rw http.ResponseWriter, p
 // CounselingUpdateOrderNotFoundCode is the HTTP code returned for type CounselingUpdateOrderNotFound
 const CounselingUpdateOrderNotFoundCode int = 404
 
-/*
-CounselingUpdateOrderNotFound The requested resource wasn't found
+/*CounselingUpdateOrderNotFound The requested resource wasn't found
 
 swagger:response counselingUpdateOrderNotFound
 */
@@ -151,8 +148,7 @@ func (o *CounselingUpdateOrderNotFound) WriteResponse(rw http.ResponseWriter, pr
 // CounselingUpdateOrderPreconditionFailedCode is the HTTP code returned for type CounselingUpdateOrderPreconditionFailed
 const CounselingUpdateOrderPreconditionFailedCode int = 412
 
-/*
-CounselingUpdateOrderPreconditionFailed Precondition failed
+/*CounselingUpdateOrderPreconditionFailed Precondition failed
 
 swagger:response counselingUpdateOrderPreconditionFailed
 */
@@ -196,8 +192,7 @@ func (o *CounselingUpdateOrderPreconditionFailed) WriteResponse(rw http.Response
 // CounselingUpdateOrderUnprocessableEntityCode is the HTTP code returned for type CounselingUpdateOrderUnprocessableEntity
 const CounselingUpdateOrderUnprocessableEntityCode int = 422
 
-/*
-CounselingUpdateOrderUnprocessableEntity The payload was unprocessable.
+/*CounselingUpdateOrderUnprocessableEntity The payload was unprocessable.
 
 swagger:response counselingUpdateOrderUnprocessableEntity
 */
@@ -241,8 +236,7 @@ func (o *CounselingUpdateOrderUnprocessableEntity) WriteResponse(rw http.Respons
 // CounselingUpdateOrderInternalServerErrorCode is the HTTP code returned for type CounselingUpdateOrderInternalServerError
 const CounselingUpdateOrderInternalServerErrorCode int = 500
 
-/*
-CounselingUpdateOrderInternalServerError A server error occurred
+/*CounselingUpdateOrderInternalServerError A server error occurred
 
 swagger:response counselingUpdateOrderInternalServerError
 */

--- a/pkg/gen/ghcapi/ghcoperations/order/get_order.go
+++ b/pkg/gen/ghcapi/ghcoperations/order/get_order.go
@@ -29,12 +29,12 @@ func NewGetOrder(ctx *middleware.Context, handler GetOrderHandler) *GetOrder {
 	return &GetOrder{Context: ctx, Handler: handler}
 }
 
-/*
-	GetOrder swagger:route GET /orders/{orderID} order getOrder
+/* GetOrder swagger:route GET /orders/{orderID} order getOrder
 
-# Gets an order by ID
+Gets an order by ID
 
 Gets an order
+
 */
 type GetOrder struct {
 	Context *middleware.Context

--- a/pkg/gen/ghcapi/ghcoperations/order/get_order_responses.go
+++ b/pkg/gen/ghcapi/ghcoperations/order/get_order_responses.go
@@ -16,8 +16,7 @@ import (
 // GetOrderOKCode is the HTTP code returned for type GetOrderOK
 const GetOrderOKCode int = 200
 
-/*
-GetOrderOK Successfully retrieved order
+/*GetOrderOK Successfully retrieved order
 
 swagger:response getOrderOK
 */
@@ -61,8 +60,7 @@ func (o *GetOrderOK) WriteResponse(rw http.ResponseWriter, producer runtime.Prod
 // GetOrderBadRequestCode is the HTTP code returned for type GetOrderBadRequest
 const GetOrderBadRequestCode int = 400
 
-/*
-GetOrderBadRequest The request payload is invalid
+/*GetOrderBadRequest The request payload is invalid
 
 swagger:response getOrderBadRequest
 */
@@ -106,8 +104,7 @@ func (o *GetOrderBadRequest) WriteResponse(rw http.ResponseWriter, producer runt
 // GetOrderUnauthorizedCode is the HTTP code returned for type GetOrderUnauthorized
 const GetOrderUnauthorizedCode int = 401
 
-/*
-GetOrderUnauthorized The request was denied
+/*GetOrderUnauthorized The request was denied
 
 swagger:response getOrderUnauthorized
 */
@@ -151,8 +148,7 @@ func (o *GetOrderUnauthorized) WriteResponse(rw http.ResponseWriter, producer ru
 // GetOrderForbiddenCode is the HTTP code returned for type GetOrderForbidden
 const GetOrderForbiddenCode int = 403
 
-/*
-GetOrderForbidden The request was denied
+/*GetOrderForbidden The request was denied
 
 swagger:response getOrderForbidden
 */
@@ -196,8 +192,7 @@ func (o *GetOrderForbidden) WriteResponse(rw http.ResponseWriter, producer runti
 // GetOrderNotFoundCode is the HTTP code returned for type GetOrderNotFound
 const GetOrderNotFoundCode int = 404
 
-/*
-GetOrderNotFound The requested resource wasn't found
+/*GetOrderNotFound The requested resource wasn't found
 
 swagger:response getOrderNotFound
 */
@@ -241,8 +236,7 @@ func (o *GetOrderNotFound) WriteResponse(rw http.ResponseWriter, producer runtim
 // GetOrderInternalServerErrorCode is the HTTP code returned for type GetOrderInternalServerError
 const GetOrderInternalServerErrorCode int = 500
 
-/*
-GetOrderInternalServerError A server error occurred
+/*GetOrderInternalServerError A server error occurred
 
 swagger:response getOrderInternalServerError
 */

--- a/pkg/gen/ghcapi/ghcoperations/order/update_allowance.go
+++ b/pkg/gen/ghcapi/ghcoperations/order/update_allowance.go
@@ -29,12 +29,12 @@ func NewUpdateAllowance(ctx *middleware.Context, handler UpdateAllowanceHandler)
 	return &UpdateAllowance{Context: ctx, Handler: handler}
 }
 
-/*
-	UpdateAllowance swagger:route PATCH /orders/{orderID}/allowances order updateAllowance
+/* UpdateAllowance swagger:route PATCH /orders/{orderID}/allowances order updateAllowance
 
 Updates an allowance (Orders with Entitlements)
 
 All fields sent in this request will be set on the order referenced
+
 */
 type UpdateAllowance struct {
 	Context *middleware.Context

--- a/pkg/gen/ghcapi/ghcoperations/order/update_allowance_responses.go
+++ b/pkg/gen/ghcapi/ghcoperations/order/update_allowance_responses.go
@@ -16,8 +16,7 @@ import (
 // UpdateAllowanceOKCode is the HTTP code returned for type UpdateAllowanceOK
 const UpdateAllowanceOKCode int = 200
 
-/*
-UpdateAllowanceOK updated instance of allowance
+/*UpdateAllowanceOK updated instance of allowance
 
 swagger:response updateAllowanceOK
 */
@@ -61,8 +60,7 @@ func (o *UpdateAllowanceOK) WriteResponse(rw http.ResponseWriter, producer runti
 // UpdateAllowanceForbiddenCode is the HTTP code returned for type UpdateAllowanceForbidden
 const UpdateAllowanceForbiddenCode int = 403
 
-/*
-UpdateAllowanceForbidden The request was denied
+/*UpdateAllowanceForbidden The request was denied
 
 swagger:response updateAllowanceForbidden
 */
@@ -106,8 +104,7 @@ func (o *UpdateAllowanceForbidden) WriteResponse(rw http.ResponseWriter, produce
 // UpdateAllowanceNotFoundCode is the HTTP code returned for type UpdateAllowanceNotFound
 const UpdateAllowanceNotFoundCode int = 404
 
-/*
-UpdateAllowanceNotFound The requested resource wasn't found
+/*UpdateAllowanceNotFound The requested resource wasn't found
 
 swagger:response updateAllowanceNotFound
 */
@@ -151,8 +148,7 @@ func (o *UpdateAllowanceNotFound) WriteResponse(rw http.ResponseWriter, producer
 // UpdateAllowancePreconditionFailedCode is the HTTP code returned for type UpdateAllowancePreconditionFailed
 const UpdateAllowancePreconditionFailedCode int = 412
 
-/*
-UpdateAllowancePreconditionFailed Precondition failed
+/*UpdateAllowancePreconditionFailed Precondition failed
 
 swagger:response updateAllowancePreconditionFailed
 */
@@ -196,8 +192,7 @@ func (o *UpdateAllowancePreconditionFailed) WriteResponse(rw http.ResponseWriter
 // UpdateAllowanceUnprocessableEntityCode is the HTTP code returned for type UpdateAllowanceUnprocessableEntity
 const UpdateAllowanceUnprocessableEntityCode int = 422
 
-/*
-UpdateAllowanceUnprocessableEntity The payload was unprocessable.
+/*UpdateAllowanceUnprocessableEntity The payload was unprocessable.
 
 swagger:response updateAllowanceUnprocessableEntity
 */
@@ -241,8 +236,7 @@ func (o *UpdateAllowanceUnprocessableEntity) WriteResponse(rw http.ResponseWrite
 // UpdateAllowanceInternalServerErrorCode is the HTTP code returned for type UpdateAllowanceInternalServerError
 const UpdateAllowanceInternalServerErrorCode int = 500
 
-/*
-UpdateAllowanceInternalServerError A server error occurred
+/*UpdateAllowanceInternalServerError A server error occurred
 
 swagger:response updateAllowanceInternalServerError
 */

--- a/pkg/gen/ghcapi/ghcoperations/order/update_billable_weight.go
+++ b/pkg/gen/ghcapi/ghcoperations/order/update_billable_weight.go
@@ -29,12 +29,12 @@ func NewUpdateBillableWeight(ctx *middleware.Context, handler UpdateBillableWeig
 	return &UpdateBillableWeight{Context: ctx, Handler: handler}
 }
 
-/*
-	UpdateBillableWeight swagger:route PATCH /orders/{orderID}/update-billable-weight order updateBillableWeight
+/* UpdateBillableWeight swagger:route PATCH /orders/{orderID}/update-billable-weight order updateBillableWeight
 
-# Updates the max billable weight
+Updates the max billable weight
 
 Updates the DBAuthorizedWeight attribute for the Order Entitlements=
+
 */
 type UpdateBillableWeight struct {
 	Context *middleware.Context

--- a/pkg/gen/ghcapi/ghcoperations/order/update_billable_weight_responses.go
+++ b/pkg/gen/ghcapi/ghcoperations/order/update_billable_weight_responses.go
@@ -16,8 +16,7 @@ import (
 // UpdateBillableWeightOKCode is the HTTP code returned for type UpdateBillableWeightOK
 const UpdateBillableWeightOKCode int = 200
 
-/*
-UpdateBillableWeightOK updated Order
+/*UpdateBillableWeightOK updated Order
 
 swagger:response updateBillableWeightOK
 */
@@ -61,8 +60,7 @@ func (o *UpdateBillableWeightOK) WriteResponse(rw http.ResponseWriter, producer 
 // UpdateBillableWeightForbiddenCode is the HTTP code returned for type UpdateBillableWeightForbidden
 const UpdateBillableWeightForbiddenCode int = 403
 
-/*
-UpdateBillableWeightForbidden The request was denied
+/*UpdateBillableWeightForbidden The request was denied
 
 swagger:response updateBillableWeightForbidden
 */
@@ -106,8 +104,7 @@ func (o *UpdateBillableWeightForbidden) WriteResponse(rw http.ResponseWriter, pr
 // UpdateBillableWeightNotFoundCode is the HTTP code returned for type UpdateBillableWeightNotFound
 const UpdateBillableWeightNotFoundCode int = 404
 
-/*
-UpdateBillableWeightNotFound The requested resource wasn't found
+/*UpdateBillableWeightNotFound The requested resource wasn't found
 
 swagger:response updateBillableWeightNotFound
 */
@@ -151,8 +148,7 @@ func (o *UpdateBillableWeightNotFound) WriteResponse(rw http.ResponseWriter, pro
 // UpdateBillableWeightPreconditionFailedCode is the HTTP code returned for type UpdateBillableWeightPreconditionFailed
 const UpdateBillableWeightPreconditionFailedCode int = 412
 
-/*
-UpdateBillableWeightPreconditionFailed Precondition failed
+/*UpdateBillableWeightPreconditionFailed Precondition failed
 
 swagger:response updateBillableWeightPreconditionFailed
 */
@@ -196,8 +192,7 @@ func (o *UpdateBillableWeightPreconditionFailed) WriteResponse(rw http.ResponseW
 // UpdateBillableWeightUnprocessableEntityCode is the HTTP code returned for type UpdateBillableWeightUnprocessableEntity
 const UpdateBillableWeightUnprocessableEntityCode int = 422
 
-/*
-UpdateBillableWeightUnprocessableEntity The payload was unprocessable.
+/*UpdateBillableWeightUnprocessableEntity The payload was unprocessable.
 
 swagger:response updateBillableWeightUnprocessableEntity
 */
@@ -241,8 +236,7 @@ func (o *UpdateBillableWeightUnprocessableEntity) WriteResponse(rw http.Response
 // UpdateBillableWeightInternalServerErrorCode is the HTTP code returned for type UpdateBillableWeightInternalServerError
 const UpdateBillableWeightInternalServerErrorCode int = 500
 
-/*
-UpdateBillableWeightInternalServerError A server error occurred
+/*UpdateBillableWeightInternalServerError A server error occurred
 
 swagger:response updateBillableWeightInternalServerError
 */

--- a/pkg/gen/ghcapi/ghcoperations/order/update_max_billable_weight_as_t_i_o.go
+++ b/pkg/gen/ghcapi/ghcoperations/order/update_max_billable_weight_as_t_i_o.go
@@ -29,12 +29,12 @@ func NewUpdateMaxBillableWeightAsTIO(ctx *middleware.Context, handler UpdateMaxB
 	return &UpdateMaxBillableWeightAsTIO{Context: ctx, Handler: handler}
 }
 
-/*
-	UpdateMaxBillableWeightAsTIO swagger:route PATCH /orders/{orderID}/update-max-billable-weight/tio order updateMaxBillableWeightAsTIO
+/* UpdateMaxBillableWeightAsTIO swagger:route PATCH /orders/{orderID}/update-max-billable-weight/tio order updateMaxBillableWeightAsTIO
 
-# Updates the max billable weight with TIO remarks
+Updates the max billable weight with TIO remarks
 
 Updates the DBAuthorizedWeight attribute for the Order Entitlements and move TIO remarks
+
 */
 type UpdateMaxBillableWeightAsTIO struct {
 	Context *middleware.Context

--- a/pkg/gen/ghcapi/ghcoperations/order/update_max_billable_weight_as_t_i_o_responses.go
+++ b/pkg/gen/ghcapi/ghcoperations/order/update_max_billable_weight_as_t_i_o_responses.go
@@ -16,8 +16,7 @@ import (
 // UpdateMaxBillableWeightAsTIOOKCode is the HTTP code returned for type UpdateMaxBillableWeightAsTIOOK
 const UpdateMaxBillableWeightAsTIOOKCode int = 200
 
-/*
-UpdateMaxBillableWeightAsTIOOK updated Order
+/*UpdateMaxBillableWeightAsTIOOK updated Order
 
 swagger:response updateMaxBillableWeightAsTIOOK
 */
@@ -61,8 +60,7 @@ func (o *UpdateMaxBillableWeightAsTIOOK) WriteResponse(rw http.ResponseWriter, p
 // UpdateMaxBillableWeightAsTIOForbiddenCode is the HTTP code returned for type UpdateMaxBillableWeightAsTIOForbidden
 const UpdateMaxBillableWeightAsTIOForbiddenCode int = 403
 
-/*
-UpdateMaxBillableWeightAsTIOForbidden The request was denied
+/*UpdateMaxBillableWeightAsTIOForbidden The request was denied
 
 swagger:response updateMaxBillableWeightAsTIOForbidden
 */
@@ -106,8 +104,7 @@ func (o *UpdateMaxBillableWeightAsTIOForbidden) WriteResponse(rw http.ResponseWr
 // UpdateMaxBillableWeightAsTIONotFoundCode is the HTTP code returned for type UpdateMaxBillableWeightAsTIONotFound
 const UpdateMaxBillableWeightAsTIONotFoundCode int = 404
 
-/*
-UpdateMaxBillableWeightAsTIONotFound The requested resource wasn't found
+/*UpdateMaxBillableWeightAsTIONotFound The requested resource wasn't found
 
 swagger:response updateMaxBillableWeightAsTIONotFound
 */
@@ -151,8 +148,7 @@ func (o *UpdateMaxBillableWeightAsTIONotFound) WriteResponse(rw http.ResponseWri
 // UpdateMaxBillableWeightAsTIOPreconditionFailedCode is the HTTP code returned for type UpdateMaxBillableWeightAsTIOPreconditionFailed
 const UpdateMaxBillableWeightAsTIOPreconditionFailedCode int = 412
 
-/*
-UpdateMaxBillableWeightAsTIOPreconditionFailed Precondition failed
+/*UpdateMaxBillableWeightAsTIOPreconditionFailed Precondition failed
 
 swagger:response updateMaxBillableWeightAsTIOPreconditionFailed
 */
@@ -196,8 +192,7 @@ func (o *UpdateMaxBillableWeightAsTIOPreconditionFailed) WriteResponse(rw http.R
 // UpdateMaxBillableWeightAsTIOUnprocessableEntityCode is the HTTP code returned for type UpdateMaxBillableWeightAsTIOUnprocessableEntity
 const UpdateMaxBillableWeightAsTIOUnprocessableEntityCode int = 422
 
-/*
-UpdateMaxBillableWeightAsTIOUnprocessableEntity The payload was unprocessable.
+/*UpdateMaxBillableWeightAsTIOUnprocessableEntity The payload was unprocessable.
 
 swagger:response updateMaxBillableWeightAsTIOUnprocessableEntity
 */
@@ -241,8 +236,7 @@ func (o *UpdateMaxBillableWeightAsTIOUnprocessableEntity) WriteResponse(rw http.
 // UpdateMaxBillableWeightAsTIOInternalServerErrorCode is the HTTP code returned for type UpdateMaxBillableWeightAsTIOInternalServerError
 const UpdateMaxBillableWeightAsTIOInternalServerErrorCode int = 500
 
-/*
-UpdateMaxBillableWeightAsTIOInternalServerError A server error occurred
+/*UpdateMaxBillableWeightAsTIOInternalServerError A server error occurred
 
 swagger:response updateMaxBillableWeightAsTIOInternalServerError
 */

--- a/pkg/gen/ghcapi/ghcoperations/order/update_order.go
+++ b/pkg/gen/ghcapi/ghcoperations/order/update_order.go
@@ -29,12 +29,12 @@ func NewUpdateOrder(ctx *middleware.Context, handler UpdateOrderHandler) *Update
 	return &UpdateOrder{Context: ctx, Handler: handler}
 }
 
-/*
-	UpdateOrder swagger:route PATCH /orders/{orderID} order updateOrder
+/* UpdateOrder swagger:route PATCH /orders/{orderID} order updateOrder
 
-# Updates an order
+Updates an order
 
 All fields sent in this request will be set on the order referenced
+
 */
 type UpdateOrder struct {
 	Context *middleware.Context

--- a/pkg/gen/ghcapi/ghcoperations/order/update_order_responses.go
+++ b/pkg/gen/ghcapi/ghcoperations/order/update_order_responses.go
@@ -16,8 +16,7 @@ import (
 // UpdateOrderOKCode is the HTTP code returned for type UpdateOrderOK
 const UpdateOrderOKCode int = 200
 
-/*
-UpdateOrderOK updated instance of orders
+/*UpdateOrderOK updated instance of orders
 
 swagger:response updateOrderOK
 */
@@ -61,8 +60,7 @@ func (o *UpdateOrderOK) WriteResponse(rw http.ResponseWriter, producer runtime.P
 // UpdateOrderBadRequestCode is the HTTP code returned for type UpdateOrderBadRequest
 const UpdateOrderBadRequestCode int = 400
 
-/*
-UpdateOrderBadRequest The request payload is invalid
+/*UpdateOrderBadRequest The request payload is invalid
 
 swagger:response updateOrderBadRequest
 */
@@ -106,8 +104,7 @@ func (o *UpdateOrderBadRequest) WriteResponse(rw http.ResponseWriter, producer r
 // UpdateOrderForbiddenCode is the HTTP code returned for type UpdateOrderForbidden
 const UpdateOrderForbiddenCode int = 403
 
-/*
-UpdateOrderForbidden The request was denied
+/*UpdateOrderForbidden The request was denied
 
 swagger:response updateOrderForbidden
 */
@@ -151,8 +148,7 @@ func (o *UpdateOrderForbidden) WriteResponse(rw http.ResponseWriter, producer ru
 // UpdateOrderNotFoundCode is the HTTP code returned for type UpdateOrderNotFound
 const UpdateOrderNotFoundCode int = 404
 
-/*
-UpdateOrderNotFound The requested resource wasn't found
+/*UpdateOrderNotFound The requested resource wasn't found
 
 swagger:response updateOrderNotFound
 */
@@ -196,8 +192,7 @@ func (o *UpdateOrderNotFound) WriteResponse(rw http.ResponseWriter, producer run
 // UpdateOrderConflictCode is the HTTP code returned for type UpdateOrderConflict
 const UpdateOrderConflictCode int = 409
 
-/*
-UpdateOrderConflict Conflict error
+/*UpdateOrderConflict Conflict error
 
 swagger:response updateOrderConflict
 */
@@ -241,8 +236,7 @@ func (o *UpdateOrderConflict) WriteResponse(rw http.ResponseWriter, producer run
 // UpdateOrderPreconditionFailedCode is the HTTP code returned for type UpdateOrderPreconditionFailed
 const UpdateOrderPreconditionFailedCode int = 412
 
-/*
-UpdateOrderPreconditionFailed Precondition failed
+/*UpdateOrderPreconditionFailed Precondition failed
 
 swagger:response updateOrderPreconditionFailed
 */
@@ -286,8 +280,7 @@ func (o *UpdateOrderPreconditionFailed) WriteResponse(rw http.ResponseWriter, pr
 // UpdateOrderUnprocessableEntityCode is the HTTP code returned for type UpdateOrderUnprocessableEntity
 const UpdateOrderUnprocessableEntityCode int = 422
 
-/*
-UpdateOrderUnprocessableEntity The payload was unprocessable.
+/*UpdateOrderUnprocessableEntity The payload was unprocessable.
 
 swagger:response updateOrderUnprocessableEntity
 */
@@ -331,8 +324,7 @@ func (o *UpdateOrderUnprocessableEntity) WriteResponse(rw http.ResponseWriter, p
 // UpdateOrderInternalServerErrorCode is the HTTP code returned for type UpdateOrderInternalServerError
 const UpdateOrderInternalServerErrorCode int = 500
 
-/*
-UpdateOrderInternalServerError A server error occurred
+/*UpdateOrderInternalServerError A server error occurred
 
 swagger:response updateOrderInternalServerError
 */

--- a/pkg/gen/ghcapi/ghcoperations/payment_requests/get_payment_request.go
+++ b/pkg/gen/ghcapi/ghcoperations/payment_requests/get_payment_request.go
@@ -29,12 +29,12 @@ func NewGetPaymentRequest(ctx *middleware.Context, handler GetPaymentRequestHand
 	return &GetPaymentRequest{Context: ctx, Handler: handler}
 }
 
-/*
-	GetPaymentRequest swagger:route GET /payment-requests/{paymentRequestID} paymentRequests getPaymentRequest
+/* GetPaymentRequest swagger:route GET /payment-requests/{paymentRequestID} paymentRequests getPaymentRequest
 
-# Fetches a payment request by id
+Fetches a payment request by id
 
 Fetches an instance of a payment request by id
+
 */
 type GetPaymentRequest struct {
 	Context *middleware.Context

--- a/pkg/gen/ghcapi/ghcoperations/payment_requests/get_payment_request_responses.go
+++ b/pkg/gen/ghcapi/ghcoperations/payment_requests/get_payment_request_responses.go
@@ -16,8 +16,7 @@ import (
 // GetPaymentRequestOKCode is the HTTP code returned for type GetPaymentRequestOK
 const GetPaymentRequestOKCode int = 200
 
-/*
-GetPaymentRequestOK fetched instance of payment request
+/*GetPaymentRequestOK fetched instance of payment request
 
 swagger:response getPaymentRequestOK
 */
@@ -61,8 +60,7 @@ func (o *GetPaymentRequestOK) WriteResponse(rw http.ResponseWriter, producer run
 // GetPaymentRequestBadRequestCode is the HTTP code returned for type GetPaymentRequestBadRequest
 const GetPaymentRequestBadRequestCode int = 400
 
-/*
-GetPaymentRequestBadRequest The request payload is invalid
+/*GetPaymentRequestBadRequest The request payload is invalid
 
 swagger:response getPaymentRequestBadRequest
 */
@@ -106,8 +104,7 @@ func (o *GetPaymentRequestBadRequest) WriteResponse(rw http.ResponseWriter, prod
 // GetPaymentRequestUnauthorizedCode is the HTTP code returned for type GetPaymentRequestUnauthorized
 const GetPaymentRequestUnauthorizedCode int = 401
 
-/*
-GetPaymentRequestUnauthorized The request was denied
+/*GetPaymentRequestUnauthorized The request was denied
 
 swagger:response getPaymentRequestUnauthorized
 */
@@ -151,8 +148,7 @@ func (o *GetPaymentRequestUnauthorized) WriteResponse(rw http.ResponseWriter, pr
 // GetPaymentRequestForbiddenCode is the HTTP code returned for type GetPaymentRequestForbidden
 const GetPaymentRequestForbiddenCode int = 403
 
-/*
-GetPaymentRequestForbidden The request was denied
+/*GetPaymentRequestForbidden The request was denied
 
 swagger:response getPaymentRequestForbidden
 */
@@ -196,8 +192,7 @@ func (o *GetPaymentRequestForbidden) WriteResponse(rw http.ResponseWriter, produ
 // GetPaymentRequestNotFoundCode is the HTTP code returned for type GetPaymentRequestNotFound
 const GetPaymentRequestNotFoundCode int = 404
 
-/*
-GetPaymentRequestNotFound The requested resource wasn't found
+/*GetPaymentRequestNotFound The requested resource wasn't found
 
 swagger:response getPaymentRequestNotFound
 */
@@ -241,8 +236,7 @@ func (o *GetPaymentRequestNotFound) WriteResponse(rw http.ResponseWriter, produc
 // GetPaymentRequestInternalServerErrorCode is the HTTP code returned for type GetPaymentRequestInternalServerError
 const GetPaymentRequestInternalServerErrorCode int = 500
 
-/*
-GetPaymentRequestInternalServerError A server error occurred
+/*GetPaymentRequestInternalServerError A server error occurred
 
 swagger:response getPaymentRequestInternalServerError
 */

--- a/pkg/gen/ghcapi/ghcoperations/payment_requests/get_payment_requests_for_move.go
+++ b/pkg/gen/ghcapi/ghcoperations/payment_requests/get_payment_requests_for_move.go
@@ -29,12 +29,12 @@ func NewGetPaymentRequestsForMove(ctx *middleware.Context, handler GetPaymentReq
 	return &GetPaymentRequestsForMove{Context: ctx, Handler: handler}
 }
 
-/*
-	GetPaymentRequestsForMove swagger:route GET /moves/{locator}/payment-requests paymentRequests getPaymentRequestsForMove
+/* GetPaymentRequestsForMove swagger:route GET /moves/{locator}/payment-requests paymentRequests getPaymentRequestsForMove
 
 Fetches payment requests using the move code (locator).
 
 Fetches payment requests for a move
+
 */
 type GetPaymentRequestsForMove struct {
 	Context *middleware.Context

--- a/pkg/gen/ghcapi/ghcoperations/payment_requests/get_payment_requests_for_move_responses.go
+++ b/pkg/gen/ghcapi/ghcoperations/payment_requests/get_payment_requests_for_move_responses.go
@@ -16,8 +16,7 @@ import (
 // GetPaymentRequestsForMoveOKCode is the HTTP code returned for type GetPaymentRequestsForMoveOK
 const GetPaymentRequestsForMoveOKCode int = 200
 
-/*
-GetPaymentRequestsForMoveOK Successfully retrieved all line items for a move task order
+/*GetPaymentRequestsForMoveOK Successfully retrieved all line items for a move task order
 
 swagger:response getPaymentRequestsForMoveOK
 */
@@ -64,8 +63,7 @@ func (o *GetPaymentRequestsForMoveOK) WriteResponse(rw http.ResponseWriter, prod
 // GetPaymentRequestsForMoveForbiddenCode is the HTTP code returned for type GetPaymentRequestsForMoveForbidden
 const GetPaymentRequestsForMoveForbiddenCode int = 403
 
-/*
-GetPaymentRequestsForMoveForbidden The request was denied
+/*GetPaymentRequestsForMoveForbidden The request was denied
 
 swagger:response getPaymentRequestsForMoveForbidden
 */
@@ -109,8 +107,7 @@ func (o *GetPaymentRequestsForMoveForbidden) WriteResponse(rw http.ResponseWrite
 // GetPaymentRequestsForMoveNotFoundCode is the HTTP code returned for type GetPaymentRequestsForMoveNotFound
 const GetPaymentRequestsForMoveNotFoundCode int = 404
 
-/*
-GetPaymentRequestsForMoveNotFound The requested resource wasn't found
+/*GetPaymentRequestsForMoveNotFound The requested resource wasn't found
 
 swagger:response getPaymentRequestsForMoveNotFound
 */
@@ -154,8 +151,7 @@ func (o *GetPaymentRequestsForMoveNotFound) WriteResponse(rw http.ResponseWriter
 // GetPaymentRequestsForMoveUnprocessableEntityCode is the HTTP code returned for type GetPaymentRequestsForMoveUnprocessableEntity
 const GetPaymentRequestsForMoveUnprocessableEntityCode int = 422
 
-/*
-GetPaymentRequestsForMoveUnprocessableEntity The payload was unprocessable.
+/*GetPaymentRequestsForMoveUnprocessableEntity The payload was unprocessable.
 
 swagger:response getPaymentRequestsForMoveUnprocessableEntity
 */
@@ -199,8 +195,7 @@ func (o *GetPaymentRequestsForMoveUnprocessableEntity) WriteResponse(rw http.Res
 // GetPaymentRequestsForMoveInternalServerErrorCode is the HTTP code returned for type GetPaymentRequestsForMoveInternalServerError
 const GetPaymentRequestsForMoveInternalServerErrorCode int = 500
 
-/*
-GetPaymentRequestsForMoveInternalServerError A server error occurred
+/*GetPaymentRequestsForMoveInternalServerError A server error occurred
 
 swagger:response getPaymentRequestsForMoveInternalServerError
 */

--- a/pkg/gen/ghcapi/ghcoperations/payment_requests/get_shipments_payment_s_i_t_balance.go
+++ b/pkg/gen/ghcapi/ghcoperations/payment_requests/get_shipments_payment_s_i_t_balance.go
@@ -29,12 +29,12 @@ func NewGetShipmentsPaymentSITBalance(ctx *middleware.Context, handler GetShipme
 	return &GetShipmentsPaymentSITBalance{Context: ctx, Handler: handler}
 }
 
-/*
-	GetShipmentsPaymentSITBalance swagger:route GET /payment-requests/{paymentRequestID}/shipments-payment-sit-balance paymentRequests getShipmentsPaymentSITBalance
-
-# Returns all shipment payment request SIT usage to support partial SIT invoicing
+/* GetShipmentsPaymentSITBalance swagger:route GET /payment-requests/{paymentRequestID}/shipments-payment-sit-balance paymentRequests getShipmentsPaymentSITBalance
 
 Returns all shipment payment request SIT usage to support partial SIT invoicing
+
+Returns all shipment payment request SIT usage to support partial SIT invoicing
+
 */
 type GetShipmentsPaymentSITBalance struct {
 	Context *middleware.Context

--- a/pkg/gen/ghcapi/ghcoperations/payment_requests/get_shipments_payment_s_i_t_balance_responses.go
+++ b/pkg/gen/ghcapi/ghcoperations/payment_requests/get_shipments_payment_s_i_t_balance_responses.go
@@ -16,8 +16,7 @@ import (
 // GetShipmentsPaymentSITBalanceOKCode is the HTTP code returned for type GetShipmentsPaymentSITBalanceOK
 const GetShipmentsPaymentSITBalanceOKCode int = 200
 
-/*
-GetShipmentsPaymentSITBalanceOK Successfully retrieved shipments and their SIT days balance from all payment requests on the move
+/*GetShipmentsPaymentSITBalanceOK Successfully retrieved shipments and their SIT days balance from all payment requests on the move
 
 swagger:response getShipmentsPaymentSITBalanceOK
 */
@@ -64,8 +63,7 @@ func (o *GetShipmentsPaymentSITBalanceOK) WriteResponse(rw http.ResponseWriter, 
 // GetShipmentsPaymentSITBalanceForbiddenCode is the HTTP code returned for type GetShipmentsPaymentSITBalanceForbidden
 const GetShipmentsPaymentSITBalanceForbiddenCode int = 403
 
-/*
-GetShipmentsPaymentSITBalanceForbidden The request was denied
+/*GetShipmentsPaymentSITBalanceForbidden The request was denied
 
 swagger:response getShipmentsPaymentSITBalanceForbidden
 */
@@ -109,8 +107,7 @@ func (o *GetShipmentsPaymentSITBalanceForbidden) WriteResponse(rw http.ResponseW
 // GetShipmentsPaymentSITBalanceNotFoundCode is the HTTP code returned for type GetShipmentsPaymentSITBalanceNotFound
 const GetShipmentsPaymentSITBalanceNotFoundCode int = 404
 
-/*
-GetShipmentsPaymentSITBalanceNotFound The requested resource wasn't found
+/*GetShipmentsPaymentSITBalanceNotFound The requested resource wasn't found
 
 swagger:response getShipmentsPaymentSITBalanceNotFound
 */
@@ -154,8 +151,7 @@ func (o *GetShipmentsPaymentSITBalanceNotFound) WriteResponse(rw http.ResponseWr
 // GetShipmentsPaymentSITBalanceUnprocessableEntityCode is the HTTP code returned for type GetShipmentsPaymentSITBalanceUnprocessableEntity
 const GetShipmentsPaymentSITBalanceUnprocessableEntityCode int = 422
 
-/*
-GetShipmentsPaymentSITBalanceUnprocessableEntity The payload was unprocessable.
+/*GetShipmentsPaymentSITBalanceUnprocessableEntity The payload was unprocessable.
 
 swagger:response getShipmentsPaymentSITBalanceUnprocessableEntity
 */
@@ -199,8 +195,7 @@ func (o *GetShipmentsPaymentSITBalanceUnprocessableEntity) WriteResponse(rw http
 // GetShipmentsPaymentSITBalanceInternalServerErrorCode is the HTTP code returned for type GetShipmentsPaymentSITBalanceInternalServerError
 const GetShipmentsPaymentSITBalanceInternalServerErrorCode int = 500
 
-/*
-GetShipmentsPaymentSITBalanceInternalServerError A server error occurred
+/*GetShipmentsPaymentSITBalanceInternalServerError A server error occurred
 
 swagger:response getShipmentsPaymentSITBalanceInternalServerError
 */

--- a/pkg/gen/ghcapi/ghcoperations/payment_requests/update_payment_request_status.go
+++ b/pkg/gen/ghcapi/ghcoperations/payment_requests/update_payment_request_status.go
@@ -29,12 +29,12 @@ func NewUpdatePaymentRequestStatus(ctx *middleware.Context, handler UpdatePaymen
 	return &UpdatePaymentRequestStatus{Context: ctx, Handler: handler}
 }
 
-/*
-	UpdatePaymentRequestStatus swagger:route PATCH /payment-requests/{paymentRequestID}/status paymentRequests updatePaymentRequestStatus
-
-# Updates status of a payment request by id
+/* UpdatePaymentRequestStatus swagger:route PATCH /payment-requests/{paymentRequestID}/status paymentRequests updatePaymentRequestStatus
 
 Updates status of a payment request by id
+
+Updates status of a payment request by id
+
 */
 type UpdatePaymentRequestStatus struct {
 	Context *middleware.Context

--- a/pkg/gen/ghcapi/ghcoperations/payment_requests/update_payment_request_status_responses.go
+++ b/pkg/gen/ghcapi/ghcoperations/payment_requests/update_payment_request_status_responses.go
@@ -16,8 +16,7 @@ import (
 // UpdatePaymentRequestStatusOKCode is the HTTP code returned for type UpdatePaymentRequestStatusOK
 const UpdatePaymentRequestStatusOKCode int = 200
 
-/*
-UpdatePaymentRequestStatusOK updated payment request
+/*UpdatePaymentRequestStatusOK updated payment request
 
 swagger:response updatePaymentRequestStatusOK
 */
@@ -61,8 +60,7 @@ func (o *UpdatePaymentRequestStatusOK) WriteResponse(rw http.ResponseWriter, pro
 // UpdatePaymentRequestStatusBadRequestCode is the HTTP code returned for type UpdatePaymentRequestStatusBadRequest
 const UpdatePaymentRequestStatusBadRequestCode int = 400
 
-/*
-UpdatePaymentRequestStatusBadRequest The request payload is invalid
+/*UpdatePaymentRequestStatusBadRequest The request payload is invalid
 
 swagger:response updatePaymentRequestStatusBadRequest
 */
@@ -106,8 +104,7 @@ func (o *UpdatePaymentRequestStatusBadRequest) WriteResponse(rw http.ResponseWri
 // UpdatePaymentRequestStatusUnauthorizedCode is the HTTP code returned for type UpdatePaymentRequestStatusUnauthorized
 const UpdatePaymentRequestStatusUnauthorizedCode int = 401
 
-/*
-UpdatePaymentRequestStatusUnauthorized The request was denied
+/*UpdatePaymentRequestStatusUnauthorized The request was denied
 
 swagger:response updatePaymentRequestStatusUnauthorized
 */
@@ -151,8 +148,7 @@ func (o *UpdatePaymentRequestStatusUnauthorized) WriteResponse(rw http.ResponseW
 // UpdatePaymentRequestStatusForbiddenCode is the HTTP code returned for type UpdatePaymentRequestStatusForbidden
 const UpdatePaymentRequestStatusForbiddenCode int = 403
 
-/*
-UpdatePaymentRequestStatusForbidden The request was denied
+/*UpdatePaymentRequestStatusForbidden The request was denied
 
 swagger:response updatePaymentRequestStatusForbidden
 */
@@ -196,8 +192,7 @@ func (o *UpdatePaymentRequestStatusForbidden) WriteResponse(rw http.ResponseWrit
 // UpdatePaymentRequestStatusNotFoundCode is the HTTP code returned for type UpdatePaymentRequestStatusNotFound
 const UpdatePaymentRequestStatusNotFoundCode int = 404
 
-/*
-UpdatePaymentRequestStatusNotFound The requested resource wasn't found
+/*UpdatePaymentRequestStatusNotFound The requested resource wasn't found
 
 swagger:response updatePaymentRequestStatusNotFound
 */
@@ -241,8 +236,7 @@ func (o *UpdatePaymentRequestStatusNotFound) WriteResponse(rw http.ResponseWrite
 // UpdatePaymentRequestStatusPreconditionFailedCode is the HTTP code returned for type UpdatePaymentRequestStatusPreconditionFailed
 const UpdatePaymentRequestStatusPreconditionFailedCode int = 412
 
-/*
-UpdatePaymentRequestStatusPreconditionFailed Precondition failed
+/*UpdatePaymentRequestStatusPreconditionFailed Precondition failed
 
 swagger:response updatePaymentRequestStatusPreconditionFailed
 */
@@ -286,8 +280,7 @@ func (o *UpdatePaymentRequestStatusPreconditionFailed) WriteResponse(rw http.Res
 // UpdatePaymentRequestStatusUnprocessableEntityCode is the HTTP code returned for type UpdatePaymentRequestStatusUnprocessableEntity
 const UpdatePaymentRequestStatusUnprocessableEntityCode int = 422
 
-/*
-UpdatePaymentRequestStatusUnprocessableEntity The payload was unprocessable.
+/*UpdatePaymentRequestStatusUnprocessableEntity The payload was unprocessable.
 
 swagger:response updatePaymentRequestStatusUnprocessableEntity
 */
@@ -331,8 +324,7 @@ func (o *UpdatePaymentRequestStatusUnprocessableEntity) WriteResponse(rw http.Re
 // UpdatePaymentRequestStatusInternalServerErrorCode is the HTTP code returned for type UpdatePaymentRequestStatusInternalServerError
 const UpdatePaymentRequestStatusInternalServerErrorCode int = 500
 
-/*
-UpdatePaymentRequestStatusInternalServerError A server error occurred
+/*UpdatePaymentRequestStatusInternalServerError A server error occurred
 
 swagger:response updatePaymentRequestStatusInternalServerError
 */

--- a/pkg/gen/ghcapi/ghcoperations/payment_service_item/update_payment_service_item_status.go
+++ b/pkg/gen/ghcapi/ghcoperations/payment_service_item/update_payment_service_item_status.go
@@ -29,12 +29,12 @@ func NewUpdatePaymentServiceItemStatus(ctx *middleware.Context, handler UpdatePa
 	return &UpdatePaymentServiceItemStatus{Context: ctx, Handler: handler}
 }
 
-/*
-	UpdatePaymentServiceItemStatus swagger:route PATCH /move-task-orders/{moveTaskOrderID}/payment-service-items/{paymentServiceItemID}/status paymentServiceItem updatePaymentServiceItemStatus
+/* UpdatePaymentServiceItemStatus swagger:route PATCH /move-task-orders/{moveTaskOrderID}/payment-service-items/{paymentServiceItemID}/status paymentServiceItem updatePaymentServiceItemStatus
 
-# Change the status of a payment service item for a move by ID
+Change the status of a payment service item for a move by ID
 
 Changes the status of a line item for a move by ID
+
 */
 type UpdatePaymentServiceItemStatus struct {
 	Context *middleware.Context

--- a/pkg/gen/ghcapi/ghcoperations/payment_service_item/update_payment_service_item_status_responses.go
+++ b/pkg/gen/ghcapi/ghcoperations/payment_service_item/update_payment_service_item_status_responses.go
@@ -16,8 +16,7 @@ import (
 // UpdatePaymentServiceItemStatusOKCode is the HTTP code returned for type UpdatePaymentServiceItemStatusOK
 const UpdatePaymentServiceItemStatusOKCode int = 200
 
-/*
-UpdatePaymentServiceItemStatusOK Successfully updated status for a line item for a move task order by ID
+/*UpdatePaymentServiceItemStatusOK Successfully updated status for a line item for a move task order by ID
 
 swagger:response updatePaymentServiceItemStatusOK
 */
@@ -61,8 +60,7 @@ func (o *UpdatePaymentServiceItemStatusOK) WriteResponse(rw http.ResponseWriter,
 // UpdatePaymentServiceItemStatusBadRequestCode is the HTTP code returned for type UpdatePaymentServiceItemStatusBadRequest
 const UpdatePaymentServiceItemStatusBadRequestCode int = 400
 
-/*
-UpdatePaymentServiceItemStatusBadRequest The request payload is invalid
+/*UpdatePaymentServiceItemStatusBadRequest The request payload is invalid
 
 swagger:response updatePaymentServiceItemStatusBadRequest
 */
@@ -106,8 +104,7 @@ func (o *UpdatePaymentServiceItemStatusBadRequest) WriteResponse(rw http.Respons
 // UpdatePaymentServiceItemStatusUnauthorizedCode is the HTTP code returned for type UpdatePaymentServiceItemStatusUnauthorized
 const UpdatePaymentServiceItemStatusUnauthorizedCode int = 401
 
-/*
-UpdatePaymentServiceItemStatusUnauthorized The request was denied
+/*UpdatePaymentServiceItemStatusUnauthorized The request was denied
 
 swagger:response updatePaymentServiceItemStatusUnauthorized
 */
@@ -151,8 +148,7 @@ func (o *UpdatePaymentServiceItemStatusUnauthorized) WriteResponse(rw http.Respo
 // UpdatePaymentServiceItemStatusForbiddenCode is the HTTP code returned for type UpdatePaymentServiceItemStatusForbidden
 const UpdatePaymentServiceItemStatusForbiddenCode int = 403
 
-/*
-UpdatePaymentServiceItemStatusForbidden The request was denied
+/*UpdatePaymentServiceItemStatusForbidden The request was denied
 
 swagger:response updatePaymentServiceItemStatusForbidden
 */
@@ -196,8 +192,7 @@ func (o *UpdatePaymentServiceItemStatusForbidden) WriteResponse(rw http.Response
 // UpdatePaymentServiceItemStatusNotFoundCode is the HTTP code returned for type UpdatePaymentServiceItemStatusNotFound
 const UpdatePaymentServiceItemStatusNotFoundCode int = 404
 
-/*
-UpdatePaymentServiceItemStatusNotFound The requested resource wasn't found
+/*UpdatePaymentServiceItemStatusNotFound The requested resource wasn't found
 
 swagger:response updatePaymentServiceItemStatusNotFound
 */
@@ -241,8 +236,7 @@ func (o *UpdatePaymentServiceItemStatusNotFound) WriteResponse(rw http.ResponseW
 // UpdatePaymentServiceItemStatusPreconditionFailedCode is the HTTP code returned for type UpdatePaymentServiceItemStatusPreconditionFailed
 const UpdatePaymentServiceItemStatusPreconditionFailedCode int = 412
 
-/*
-UpdatePaymentServiceItemStatusPreconditionFailed Precondition failed
+/*UpdatePaymentServiceItemStatusPreconditionFailed Precondition failed
 
 swagger:response updatePaymentServiceItemStatusPreconditionFailed
 */
@@ -286,8 +280,7 @@ func (o *UpdatePaymentServiceItemStatusPreconditionFailed) WriteResponse(rw http
 // UpdatePaymentServiceItemStatusUnprocessableEntityCode is the HTTP code returned for type UpdatePaymentServiceItemStatusUnprocessableEntity
 const UpdatePaymentServiceItemStatusUnprocessableEntityCode int = 422
 
-/*
-UpdatePaymentServiceItemStatusUnprocessableEntity The payload was unprocessable.
+/*UpdatePaymentServiceItemStatusUnprocessableEntity The payload was unprocessable.
 
 swagger:response updatePaymentServiceItemStatusUnprocessableEntity
 */
@@ -331,8 +324,7 @@ func (o *UpdatePaymentServiceItemStatusUnprocessableEntity) WriteResponse(rw htt
 // UpdatePaymentServiceItemStatusInternalServerErrorCode is the HTTP code returned for type UpdatePaymentServiceItemStatusInternalServerError
 const UpdatePaymentServiceItemStatusInternalServerErrorCode int = 500
 
-/*
-UpdatePaymentServiceItemStatusInternalServerError A server error occurred
+/*UpdatePaymentServiceItemStatusInternalServerError A server error occurred
 
 swagger:response updatePaymentServiceItemStatusInternalServerError
 */

--- a/pkg/gen/ghcapi/ghcoperations/queues/get_moves_queue.go
+++ b/pkg/gen/ghcapi/ghcoperations/queues/get_moves_queue.go
@@ -29,12 +29,13 @@ func NewGetMovesQueue(ctx *middleware.Context, handler GetMovesQueueHandler) *Ge
 	return &GetMovesQueue{Context: ctx, Handler: handler}
 }
 
-/*
-	GetMovesQueue swagger:route GET /queues/moves queues getMovesQueue
+/* GetMovesQueue swagger:route GET /queues/moves queues getMovesQueue
 
-# Gets queued list of all customer moves by GBLOC origin
+Gets queued list of all customer moves by GBLOC origin
 
 An office TOO user will be assigned a transportation office that will determine which moves are displayed in their queue based on the origin duty location.  GHC moves will show up here onced they have reached the submitted status sent by the customer and have move task orders, shipments, and service items to approve.
+
+
 */
 type GetMovesQueue struct {
 	Context *middleware.Context

--- a/pkg/gen/ghcapi/ghcoperations/queues/get_moves_queue_responses.go
+++ b/pkg/gen/ghcapi/ghcoperations/queues/get_moves_queue_responses.go
@@ -16,8 +16,7 @@ import (
 // GetMovesQueueOKCode is the HTTP code returned for type GetMovesQueueOK
 const GetMovesQueueOKCode int = 200
 
-/*
-GetMovesQueueOK Successfully returned all moves matching the criteria
+/*GetMovesQueueOK Successfully returned all moves matching the criteria
 
 swagger:response getMovesQueueOK
 */
@@ -61,8 +60,7 @@ func (o *GetMovesQueueOK) WriteResponse(rw http.ResponseWriter, producer runtime
 // GetMovesQueueForbiddenCode is the HTTP code returned for type GetMovesQueueForbidden
 const GetMovesQueueForbiddenCode int = 403
 
-/*
-GetMovesQueueForbidden The request was denied
+/*GetMovesQueueForbidden The request was denied
 
 swagger:response getMovesQueueForbidden
 */
@@ -106,8 +104,7 @@ func (o *GetMovesQueueForbidden) WriteResponse(rw http.ResponseWriter, producer 
 // GetMovesQueueInternalServerErrorCode is the HTTP code returned for type GetMovesQueueInternalServerError
 const GetMovesQueueInternalServerErrorCode int = 500
 
-/*
-GetMovesQueueInternalServerError A server error occurred
+/*GetMovesQueueInternalServerError A server error occurred
 
 swagger:response getMovesQueueInternalServerError
 */

--- a/pkg/gen/ghcapi/ghcoperations/queues/get_payment_requests_queue.go
+++ b/pkg/gen/ghcapi/ghcoperations/queues/get_payment_requests_queue.go
@@ -29,12 +29,13 @@ func NewGetPaymentRequestsQueue(ctx *middleware.Context, handler GetPaymentReque
 	return &GetPaymentRequestsQueue{Context: ctx, Handler: handler}
 }
 
-/*
-	GetPaymentRequestsQueue swagger:route GET /queues/payment-requests queues getPaymentRequestsQueue
+/* GetPaymentRequestsQueue swagger:route GET /queues/payment-requests queues getPaymentRequestsQueue
 
-# Gets queued list of all payment requests by GBLOC origin
+Gets queued list of all payment requests by GBLOC origin
 
 An office TIO user will be assigned a transportation office that will determine which payment requests are displayed in their queue based on the origin duty location.
+
+
 */
 type GetPaymentRequestsQueue struct {
 	Context *middleware.Context

--- a/pkg/gen/ghcapi/ghcoperations/queues/get_payment_requests_queue_responses.go
+++ b/pkg/gen/ghcapi/ghcoperations/queues/get_payment_requests_queue_responses.go
@@ -16,8 +16,7 @@ import (
 // GetPaymentRequestsQueueOKCode is the HTTP code returned for type GetPaymentRequestsQueueOK
 const GetPaymentRequestsQueueOKCode int = 200
 
-/*
-GetPaymentRequestsQueueOK Successfully returned all moves matching the criteria
+/*GetPaymentRequestsQueueOK Successfully returned all moves matching the criteria
 
 swagger:response getPaymentRequestsQueueOK
 */
@@ -61,8 +60,7 @@ func (o *GetPaymentRequestsQueueOK) WriteResponse(rw http.ResponseWriter, produc
 // GetPaymentRequestsQueueForbiddenCode is the HTTP code returned for type GetPaymentRequestsQueueForbidden
 const GetPaymentRequestsQueueForbiddenCode int = 403
 
-/*
-GetPaymentRequestsQueueForbidden The request was denied
+/*GetPaymentRequestsQueueForbidden The request was denied
 
 swagger:response getPaymentRequestsQueueForbidden
 */
@@ -106,8 +104,7 @@ func (o *GetPaymentRequestsQueueForbidden) WriteResponse(rw http.ResponseWriter,
 // GetPaymentRequestsQueueInternalServerErrorCode is the HTTP code returned for type GetPaymentRequestsQueueInternalServerError
 const GetPaymentRequestsQueueInternalServerErrorCode int = 500
 
-/*
-GetPaymentRequestsQueueInternalServerError A server error occurred
+/*GetPaymentRequestsQueueInternalServerError A server error occurred
 
 swagger:response getPaymentRequestsQueueInternalServerError
 */

--- a/pkg/gen/ghcapi/ghcoperations/queues/get_services_counseling_queue.go
+++ b/pkg/gen/ghcapi/ghcoperations/queues/get_services_counseling_queue.go
@@ -29,12 +29,13 @@ func NewGetServicesCounselingQueue(ctx *middleware.Context, handler GetServicesC
 	return &GetServicesCounselingQueue{Context: ctx, Handler: handler}
 }
 
-/*
-	GetServicesCounselingQueue swagger:route GET /queues/counseling queues getServicesCounselingQueue
+/* GetServicesCounselingQueue swagger:route GET /queues/counseling queues getServicesCounselingQueue
 
-# Gets queued list of all customer moves needing services counseling by GBLOC origin
+Gets queued list of all customer moves needing services counseling by GBLOC origin
 
 An office services counselor user will be assigned a transportation office that will determine which moves are displayed in their queue based on the origin duty location.  GHC moves will show up here onced they have reached the NEEDS SERVICE COUNSELING status after submission from a customer or created on a customer's behalf.
+
+
 */
 type GetServicesCounselingQueue struct {
 	Context *middleware.Context

--- a/pkg/gen/ghcapi/ghcoperations/queues/get_services_counseling_queue_responses.go
+++ b/pkg/gen/ghcapi/ghcoperations/queues/get_services_counseling_queue_responses.go
@@ -16,8 +16,7 @@ import (
 // GetServicesCounselingQueueOKCode is the HTTP code returned for type GetServicesCounselingQueueOK
 const GetServicesCounselingQueueOKCode int = 200
 
-/*
-GetServicesCounselingQueueOK Successfully returned all moves matching the criteria
+/*GetServicesCounselingQueueOK Successfully returned all moves matching the criteria
 
 swagger:response getServicesCounselingQueueOK
 */
@@ -61,8 +60,7 @@ func (o *GetServicesCounselingQueueOK) WriteResponse(rw http.ResponseWriter, pro
 // GetServicesCounselingQueueForbiddenCode is the HTTP code returned for type GetServicesCounselingQueueForbidden
 const GetServicesCounselingQueueForbiddenCode int = 403
 
-/*
-GetServicesCounselingQueueForbidden The request was denied
+/*GetServicesCounselingQueueForbidden The request was denied
 
 swagger:response getServicesCounselingQueueForbidden
 */
@@ -106,8 +104,7 @@ func (o *GetServicesCounselingQueueForbidden) WriteResponse(rw http.ResponseWrit
 // GetServicesCounselingQueueInternalServerErrorCode is the HTTP code returned for type GetServicesCounselingQueueInternalServerError
 const GetServicesCounselingQueueInternalServerErrorCode int = 500
 
-/*
-GetServicesCounselingQueueInternalServerError A server error occurred
+/*GetServicesCounselingQueueInternalServerError A server error occurred
 
 swagger:response getServicesCounselingQueueInternalServerError
 */

--- a/pkg/gen/ghcapi/ghcoperations/report_violations/associate_report_violations.go
+++ b/pkg/gen/ghcapi/ghcoperations/report_violations/associate_report_violations.go
@@ -29,12 +29,12 @@ func NewAssociateReportViolations(ctx *middleware.Context, handler AssociateRepo
 	return &AssociateReportViolations{Context: ctx, Handler: handler}
 }
 
-/*
-	AssociateReportViolations swagger:route POST /report-violations/{reportID} reportViolations associateReportViolations
+/* AssociateReportViolations swagger:route POST /report-violations/{reportID} reportViolations associateReportViolations
 
-# Associate violations with an evaluation report
+Associate violations with an evaluation report
 
 Associate violations with an evaluation report. This will overwrite any existing report-violations associations for the report and replace them with the newly provided ones.  An empty array will remove all violation associations for a given report.
+
 */
 type AssociateReportViolations struct {
 	Context *middleware.Context

--- a/pkg/gen/ghcapi/ghcoperations/report_violations/associate_report_violations_responses.go
+++ b/pkg/gen/ghcapi/ghcoperations/report_violations/associate_report_violations_responses.go
@@ -16,8 +16,7 @@ import (
 // AssociateReportViolationsNoContentCode is the HTTP code returned for type AssociateReportViolationsNoContent
 const AssociateReportViolationsNoContentCode int = 204
 
-/*
-AssociateReportViolationsNoContent Successfully saved the report violations
+/*AssociateReportViolationsNoContent Successfully saved the report violations
 
 swagger:response associateReportViolationsNoContent
 */
@@ -41,8 +40,7 @@ func (o *AssociateReportViolationsNoContent) WriteResponse(rw http.ResponseWrite
 // AssociateReportViolationsBadRequestCode is the HTTP code returned for type AssociateReportViolationsBadRequest
 const AssociateReportViolationsBadRequestCode int = 400
 
-/*
-AssociateReportViolationsBadRequest The request payload is invalid
+/*AssociateReportViolationsBadRequest The request payload is invalid
 
 swagger:response associateReportViolationsBadRequest
 */
@@ -86,8 +84,7 @@ func (o *AssociateReportViolationsBadRequest) WriteResponse(rw http.ResponseWrit
 // AssociateReportViolationsForbiddenCode is the HTTP code returned for type AssociateReportViolationsForbidden
 const AssociateReportViolationsForbiddenCode int = 403
 
-/*
-AssociateReportViolationsForbidden The request was denied
+/*AssociateReportViolationsForbidden The request was denied
 
 swagger:response associateReportViolationsForbidden
 */
@@ -131,8 +128,7 @@ func (o *AssociateReportViolationsForbidden) WriteResponse(rw http.ResponseWrite
 // AssociateReportViolationsNotFoundCode is the HTTP code returned for type AssociateReportViolationsNotFound
 const AssociateReportViolationsNotFoundCode int = 404
 
-/*
-AssociateReportViolationsNotFound The requested resource wasn't found
+/*AssociateReportViolationsNotFound The requested resource wasn't found
 
 swagger:response associateReportViolationsNotFound
 */
@@ -176,8 +172,7 @@ func (o *AssociateReportViolationsNotFound) WriteResponse(rw http.ResponseWriter
 // AssociateReportViolationsConflictCode is the HTTP code returned for type AssociateReportViolationsConflict
 const AssociateReportViolationsConflictCode int = 409
 
-/*
-AssociateReportViolationsConflict Conflict error
+/*AssociateReportViolationsConflict Conflict error
 
 swagger:response associateReportViolationsConflict
 */
@@ -221,8 +216,7 @@ func (o *AssociateReportViolationsConflict) WriteResponse(rw http.ResponseWriter
 // AssociateReportViolationsUnprocessableEntityCode is the HTTP code returned for type AssociateReportViolationsUnprocessableEntity
 const AssociateReportViolationsUnprocessableEntityCode int = 422
 
-/*
-AssociateReportViolationsUnprocessableEntity The payload was unprocessable.
+/*AssociateReportViolationsUnprocessableEntity The payload was unprocessable.
 
 swagger:response associateReportViolationsUnprocessableEntity
 */
@@ -266,8 +260,7 @@ func (o *AssociateReportViolationsUnprocessableEntity) WriteResponse(rw http.Res
 // AssociateReportViolationsInternalServerErrorCode is the HTTP code returned for type AssociateReportViolationsInternalServerError
 const AssociateReportViolationsInternalServerErrorCode int = 500
 
-/*
-AssociateReportViolationsInternalServerError A server error occurred
+/*AssociateReportViolationsInternalServerError A server error occurred
 
 swagger:response associateReportViolationsInternalServerError
 */

--- a/pkg/gen/ghcapi/ghcoperations/report_violations/get_report_violations_by_report_id.go
+++ b/pkg/gen/ghcapi/ghcoperations/report_violations/get_report_violations_by_report_id.go
@@ -29,12 +29,12 @@ func NewGetReportViolationsByReportID(ctx *middleware.Context, handler GetReport
 	return &GetReportViolationsByReportID{Context: ctx, Handler: handler}
 }
 
-/*
-	GetReportViolationsByReportID swagger:route GET /report-violations/{reportID} reportViolations getReportViolationsByReportId
-
-# Fetch the report violations for an evaluation report
+/* GetReportViolationsByReportID swagger:route GET /report-violations/{reportID} reportViolations getReportViolationsByReportId
 
 Fetch the report violations for an evaluation report
+
+Fetch the report violations for an evaluation report
+
 */
 type GetReportViolationsByReportID struct {
 	Context *middleware.Context

--- a/pkg/gen/ghcapi/ghcoperations/report_violations/get_report_violations_by_report_id_responses.go
+++ b/pkg/gen/ghcapi/ghcoperations/report_violations/get_report_violations_by_report_id_responses.go
@@ -16,8 +16,7 @@ import (
 // GetReportViolationsByReportIDOKCode is the HTTP code returned for type GetReportViolationsByReportIDOK
 const GetReportViolationsByReportIDOKCode int = 200
 
-/*
-GetReportViolationsByReportIDOK Successfully retrieved the report violations
+/*GetReportViolationsByReportIDOK Successfully retrieved the report violations
 
 swagger:response getReportViolationsByReportIdOK
 */
@@ -64,8 +63,7 @@ func (o *GetReportViolationsByReportIDOK) WriteResponse(rw http.ResponseWriter, 
 // GetReportViolationsByReportIDBadRequestCode is the HTTP code returned for type GetReportViolationsByReportIDBadRequest
 const GetReportViolationsByReportIDBadRequestCode int = 400
 
-/*
-GetReportViolationsByReportIDBadRequest The request payload is invalid
+/*GetReportViolationsByReportIDBadRequest The request payload is invalid
 
 swagger:response getReportViolationsByReportIdBadRequest
 */
@@ -109,8 +107,7 @@ func (o *GetReportViolationsByReportIDBadRequest) WriteResponse(rw http.Response
 // GetReportViolationsByReportIDForbiddenCode is the HTTP code returned for type GetReportViolationsByReportIDForbidden
 const GetReportViolationsByReportIDForbiddenCode int = 403
 
-/*
-GetReportViolationsByReportIDForbidden The request was denied
+/*GetReportViolationsByReportIDForbidden The request was denied
 
 swagger:response getReportViolationsByReportIdForbidden
 */
@@ -154,8 +151,7 @@ func (o *GetReportViolationsByReportIDForbidden) WriteResponse(rw http.ResponseW
 // GetReportViolationsByReportIDNotFoundCode is the HTTP code returned for type GetReportViolationsByReportIDNotFound
 const GetReportViolationsByReportIDNotFoundCode int = 404
 
-/*
-GetReportViolationsByReportIDNotFound The requested resource wasn't found
+/*GetReportViolationsByReportIDNotFound The requested resource wasn't found
 
 swagger:response getReportViolationsByReportIdNotFound
 */
@@ -199,8 +195,7 @@ func (o *GetReportViolationsByReportIDNotFound) WriteResponse(rw http.ResponseWr
 // GetReportViolationsByReportIDInternalServerErrorCode is the HTTP code returned for type GetReportViolationsByReportIDInternalServerError
 const GetReportViolationsByReportIDInternalServerErrorCode int = 500
 
-/*
-GetReportViolationsByReportIDInternalServerError A server error occurred
+/*GetReportViolationsByReportIDInternalServerError A server error occurred
 
 swagger:response getReportViolationsByReportIdInternalServerError
 */

--- a/pkg/gen/ghcapi/ghcoperations/shipment/approve_s_i_t_extension.go
+++ b/pkg/gen/ghcapi/ghcoperations/shipment/approve_s_i_t_extension.go
@@ -29,12 +29,12 @@ func NewApproveSITExtension(ctx *middleware.Context, handler ApproveSITExtension
 	return &ApproveSITExtension{Context: ctx, Handler: handler}
 }
 
-/*
-	ApproveSITExtension swagger:route PATCH /shipments/{shipmentID}/sit-extensions/{sitExtensionID}/approve shipment sitExtension approveSITExtension
-
-# Approves a SIT extension
+/* ApproveSITExtension swagger:route PATCH /shipments/{shipmentID}/sit-extensions/{sitExtensionID}/approve shipment sitExtension approveSITExtension
 
 Approves a SIT extension
+
+Approves a SIT extension
+
 */
 type ApproveSITExtension struct {
 	Context *middleware.Context

--- a/pkg/gen/ghcapi/ghcoperations/shipment/approve_s_i_t_extension_responses.go
+++ b/pkg/gen/ghcapi/ghcoperations/shipment/approve_s_i_t_extension_responses.go
@@ -16,8 +16,7 @@ import (
 // ApproveSITExtensionOKCode is the HTTP code returned for type ApproveSITExtensionOK
 const ApproveSITExtensionOKCode int = 200
 
-/*
-ApproveSITExtensionOK Successfully approved a SIT extension
+/*ApproveSITExtensionOK Successfully approved a SIT extension
 
 swagger:response approveSITExtensionOK
 */
@@ -61,8 +60,7 @@ func (o *ApproveSITExtensionOK) WriteResponse(rw http.ResponseWriter, producer r
 // ApproveSITExtensionForbiddenCode is the HTTP code returned for type ApproveSITExtensionForbidden
 const ApproveSITExtensionForbiddenCode int = 403
 
-/*
-ApproveSITExtensionForbidden The request was denied
+/*ApproveSITExtensionForbidden The request was denied
 
 swagger:response approveSITExtensionForbidden
 */
@@ -106,8 +104,7 @@ func (o *ApproveSITExtensionForbidden) WriteResponse(rw http.ResponseWriter, pro
 // ApproveSITExtensionNotFoundCode is the HTTP code returned for type ApproveSITExtensionNotFound
 const ApproveSITExtensionNotFoundCode int = 404
 
-/*
-ApproveSITExtensionNotFound The requested resource wasn't found
+/*ApproveSITExtensionNotFound The requested resource wasn't found
 
 swagger:response approveSITExtensionNotFound
 */
@@ -151,8 +148,7 @@ func (o *ApproveSITExtensionNotFound) WriteResponse(rw http.ResponseWriter, prod
 // ApproveSITExtensionConflictCode is the HTTP code returned for type ApproveSITExtensionConflict
 const ApproveSITExtensionConflictCode int = 409
 
-/*
-ApproveSITExtensionConflict Conflict error
+/*ApproveSITExtensionConflict Conflict error
 
 swagger:response approveSITExtensionConflict
 */
@@ -196,8 +192,7 @@ func (o *ApproveSITExtensionConflict) WriteResponse(rw http.ResponseWriter, prod
 // ApproveSITExtensionPreconditionFailedCode is the HTTP code returned for type ApproveSITExtensionPreconditionFailed
 const ApproveSITExtensionPreconditionFailedCode int = 412
 
-/*
-ApproveSITExtensionPreconditionFailed Precondition failed
+/*ApproveSITExtensionPreconditionFailed Precondition failed
 
 swagger:response approveSITExtensionPreconditionFailed
 */
@@ -241,8 +236,7 @@ func (o *ApproveSITExtensionPreconditionFailed) WriteResponse(rw http.ResponseWr
 // ApproveSITExtensionUnprocessableEntityCode is the HTTP code returned for type ApproveSITExtensionUnprocessableEntity
 const ApproveSITExtensionUnprocessableEntityCode int = 422
 
-/*
-ApproveSITExtensionUnprocessableEntity The payload was unprocessable.
+/*ApproveSITExtensionUnprocessableEntity The payload was unprocessable.
 
 swagger:response approveSITExtensionUnprocessableEntity
 */
@@ -286,8 +280,7 @@ func (o *ApproveSITExtensionUnprocessableEntity) WriteResponse(rw http.ResponseW
 // ApproveSITExtensionInternalServerErrorCode is the HTTP code returned for type ApproveSITExtensionInternalServerError
 const ApproveSITExtensionInternalServerErrorCode int = 500
 
-/*
-ApproveSITExtensionInternalServerError A server error occurred
+/*ApproveSITExtensionInternalServerError A server error occurred
 
 swagger:response approveSITExtensionInternalServerError
 */

--- a/pkg/gen/ghcapi/ghcoperations/shipment/approve_shipment.go
+++ b/pkg/gen/ghcapi/ghcoperations/shipment/approve_shipment.go
@@ -29,12 +29,12 @@ func NewApproveShipment(ctx *middleware.Context, handler ApproveShipmentHandler)
 	return &ApproveShipment{Context: ctx, Handler: handler}
 }
 
-/*
-	ApproveShipment swagger:route POST /shipments/{shipmentID}/approve shipment approveShipment
-
-# Approves a shipment
+/* ApproveShipment swagger:route POST /shipments/{shipmentID}/approve shipment approveShipment
 
 Approves a shipment
+
+Approves a shipment
+
 */
 type ApproveShipment struct {
 	Context *middleware.Context

--- a/pkg/gen/ghcapi/ghcoperations/shipment/approve_shipment_diversion.go
+++ b/pkg/gen/ghcapi/ghcoperations/shipment/approve_shipment_diversion.go
@@ -29,12 +29,12 @@ func NewApproveShipmentDiversion(ctx *middleware.Context, handler ApproveShipmen
 	return &ApproveShipmentDiversion{Context: ctx, Handler: handler}
 }
 
-/*
-	ApproveShipmentDiversion swagger:route POST /shipments/{shipmentID}/approve-diversion shipment approveShipmentDiversion
-
-# Approves a shipment diversion
+/* ApproveShipmentDiversion swagger:route POST /shipments/{shipmentID}/approve-diversion shipment approveShipmentDiversion
 
 Approves a shipment diversion
+
+Approves a shipment diversion
+
 */
 type ApproveShipmentDiversion struct {
 	Context *middleware.Context

--- a/pkg/gen/ghcapi/ghcoperations/shipment/approve_shipment_diversion_responses.go
+++ b/pkg/gen/ghcapi/ghcoperations/shipment/approve_shipment_diversion_responses.go
@@ -16,8 +16,7 @@ import (
 // ApproveShipmentDiversionOKCode is the HTTP code returned for type ApproveShipmentDiversionOK
 const ApproveShipmentDiversionOKCode int = 200
 
-/*
-ApproveShipmentDiversionOK Successfully approved the shipment diversion
+/*ApproveShipmentDiversionOK Successfully approved the shipment diversion
 
 swagger:response approveShipmentDiversionOK
 */
@@ -61,8 +60,7 @@ func (o *ApproveShipmentDiversionOK) WriteResponse(rw http.ResponseWriter, produ
 // ApproveShipmentDiversionForbiddenCode is the HTTP code returned for type ApproveShipmentDiversionForbidden
 const ApproveShipmentDiversionForbiddenCode int = 403
 
-/*
-ApproveShipmentDiversionForbidden The request was denied
+/*ApproveShipmentDiversionForbidden The request was denied
 
 swagger:response approveShipmentDiversionForbidden
 */
@@ -106,8 +104,7 @@ func (o *ApproveShipmentDiversionForbidden) WriteResponse(rw http.ResponseWriter
 // ApproveShipmentDiversionNotFoundCode is the HTTP code returned for type ApproveShipmentDiversionNotFound
 const ApproveShipmentDiversionNotFoundCode int = 404
 
-/*
-ApproveShipmentDiversionNotFound The requested resource wasn't found
+/*ApproveShipmentDiversionNotFound The requested resource wasn't found
 
 swagger:response approveShipmentDiversionNotFound
 */
@@ -151,8 +148,7 @@ func (o *ApproveShipmentDiversionNotFound) WriteResponse(rw http.ResponseWriter,
 // ApproveShipmentDiversionConflictCode is the HTTP code returned for type ApproveShipmentDiversionConflict
 const ApproveShipmentDiversionConflictCode int = 409
 
-/*
-ApproveShipmentDiversionConflict Conflict error
+/*ApproveShipmentDiversionConflict Conflict error
 
 swagger:response approveShipmentDiversionConflict
 */
@@ -196,8 +192,7 @@ func (o *ApproveShipmentDiversionConflict) WriteResponse(rw http.ResponseWriter,
 // ApproveShipmentDiversionPreconditionFailedCode is the HTTP code returned for type ApproveShipmentDiversionPreconditionFailed
 const ApproveShipmentDiversionPreconditionFailedCode int = 412
 
-/*
-ApproveShipmentDiversionPreconditionFailed Precondition failed
+/*ApproveShipmentDiversionPreconditionFailed Precondition failed
 
 swagger:response approveShipmentDiversionPreconditionFailed
 */
@@ -241,8 +236,7 @@ func (o *ApproveShipmentDiversionPreconditionFailed) WriteResponse(rw http.Respo
 // ApproveShipmentDiversionUnprocessableEntityCode is the HTTP code returned for type ApproveShipmentDiversionUnprocessableEntity
 const ApproveShipmentDiversionUnprocessableEntityCode int = 422
 
-/*
-ApproveShipmentDiversionUnprocessableEntity The payload was unprocessable.
+/*ApproveShipmentDiversionUnprocessableEntity The payload was unprocessable.
 
 swagger:response approveShipmentDiversionUnprocessableEntity
 */
@@ -286,8 +280,7 @@ func (o *ApproveShipmentDiversionUnprocessableEntity) WriteResponse(rw http.Resp
 // ApproveShipmentDiversionInternalServerErrorCode is the HTTP code returned for type ApproveShipmentDiversionInternalServerError
 const ApproveShipmentDiversionInternalServerErrorCode int = 500
 
-/*
-ApproveShipmentDiversionInternalServerError A server error occurred
+/*ApproveShipmentDiversionInternalServerError A server error occurred
 
 swagger:response approveShipmentDiversionInternalServerError
 */

--- a/pkg/gen/ghcapi/ghcoperations/shipment/approve_shipment_responses.go
+++ b/pkg/gen/ghcapi/ghcoperations/shipment/approve_shipment_responses.go
@@ -16,8 +16,7 @@ import (
 // ApproveShipmentOKCode is the HTTP code returned for type ApproveShipmentOK
 const ApproveShipmentOKCode int = 200
 
-/*
-ApproveShipmentOK Successfully approved the shipment
+/*ApproveShipmentOK Successfully approved the shipment
 
 swagger:response approveShipmentOK
 */
@@ -61,8 +60,7 @@ func (o *ApproveShipmentOK) WriteResponse(rw http.ResponseWriter, producer runti
 // ApproveShipmentForbiddenCode is the HTTP code returned for type ApproveShipmentForbidden
 const ApproveShipmentForbiddenCode int = 403
 
-/*
-ApproveShipmentForbidden The request was denied
+/*ApproveShipmentForbidden The request was denied
 
 swagger:response approveShipmentForbidden
 */
@@ -106,8 +104,7 @@ func (o *ApproveShipmentForbidden) WriteResponse(rw http.ResponseWriter, produce
 // ApproveShipmentNotFoundCode is the HTTP code returned for type ApproveShipmentNotFound
 const ApproveShipmentNotFoundCode int = 404
 
-/*
-ApproveShipmentNotFound The requested resource wasn't found
+/*ApproveShipmentNotFound The requested resource wasn't found
 
 swagger:response approveShipmentNotFound
 */
@@ -151,8 +148,7 @@ func (o *ApproveShipmentNotFound) WriteResponse(rw http.ResponseWriter, producer
 // ApproveShipmentConflictCode is the HTTP code returned for type ApproveShipmentConflict
 const ApproveShipmentConflictCode int = 409
 
-/*
-ApproveShipmentConflict Conflict error
+/*ApproveShipmentConflict Conflict error
 
 swagger:response approveShipmentConflict
 */
@@ -196,8 +192,7 @@ func (o *ApproveShipmentConflict) WriteResponse(rw http.ResponseWriter, producer
 // ApproveShipmentPreconditionFailedCode is the HTTP code returned for type ApproveShipmentPreconditionFailed
 const ApproveShipmentPreconditionFailedCode int = 412
 
-/*
-ApproveShipmentPreconditionFailed Precondition failed
+/*ApproveShipmentPreconditionFailed Precondition failed
 
 swagger:response approveShipmentPreconditionFailed
 */
@@ -241,8 +236,7 @@ func (o *ApproveShipmentPreconditionFailed) WriteResponse(rw http.ResponseWriter
 // ApproveShipmentUnprocessableEntityCode is the HTTP code returned for type ApproveShipmentUnprocessableEntity
 const ApproveShipmentUnprocessableEntityCode int = 422
 
-/*
-ApproveShipmentUnprocessableEntity The payload was unprocessable.
+/*ApproveShipmentUnprocessableEntity The payload was unprocessable.
 
 swagger:response approveShipmentUnprocessableEntity
 */
@@ -286,8 +280,7 @@ func (o *ApproveShipmentUnprocessableEntity) WriteResponse(rw http.ResponseWrite
 // ApproveShipmentInternalServerErrorCode is the HTTP code returned for type ApproveShipmentInternalServerError
 const ApproveShipmentInternalServerErrorCode int = 500
 
-/*
-ApproveShipmentInternalServerError A server error occurred
+/*ApproveShipmentInternalServerError A server error occurred
 
 swagger:response approveShipmentInternalServerError
 */

--- a/pkg/gen/ghcapi/ghcoperations/shipment/create_s_i_t_extension_as_t_o_o.go
+++ b/pkg/gen/ghcapi/ghcoperations/shipment/create_s_i_t_extension_as_t_o_o.go
@@ -29,12 +29,12 @@ func NewCreateSITExtensionAsTOO(ctx *middleware.Context, handler CreateSITExtens
 	return &CreateSITExtensionAsTOO{Context: ctx, Handler: handler}
 }
 
-/*
-	CreateSITExtensionAsTOO swagger:route POST /shipments/{shipmentID}/sit-extensions/ shipment sitExtension createSITExtensionAsTOO
+/* CreateSITExtensionAsTOO swagger:route POST /shipments/{shipmentID}/sit-extensions/ shipment sitExtension createSITExtensionAsTOO
 
-# Create an approved SIT extension
+Create an approved SIT extension
 
 TOO can creates an already-approved SIT extension on behalf of a customer
+
 */
 type CreateSITExtensionAsTOO struct {
 	Context *middleware.Context

--- a/pkg/gen/ghcapi/ghcoperations/shipment/create_s_i_t_extension_as_t_o_o_responses.go
+++ b/pkg/gen/ghcapi/ghcoperations/shipment/create_s_i_t_extension_as_t_o_o_responses.go
@@ -16,8 +16,7 @@ import (
 // CreateSITExtensionAsTOOOKCode is the HTTP code returned for type CreateSITExtensionAsTOOOK
 const CreateSITExtensionAsTOOOKCode int = 200
 
-/*
-CreateSITExtensionAsTOOOK Successfully created a SIT Extension.
+/*CreateSITExtensionAsTOOOK Successfully created a SIT Extension.
 
 swagger:response createSITExtensionAsTOOOK
 */
@@ -61,8 +60,7 @@ func (o *CreateSITExtensionAsTOOOK) WriteResponse(rw http.ResponseWriter, produc
 // CreateSITExtensionAsTOOBadRequestCode is the HTTP code returned for type CreateSITExtensionAsTOOBadRequest
 const CreateSITExtensionAsTOOBadRequestCode int = 400
 
-/*
-CreateSITExtensionAsTOOBadRequest The request payload is invalid
+/*CreateSITExtensionAsTOOBadRequest The request payload is invalid
 
 swagger:response createSITExtensionAsTOOBadRequest
 */
@@ -106,8 +104,7 @@ func (o *CreateSITExtensionAsTOOBadRequest) WriteResponse(rw http.ResponseWriter
 // CreateSITExtensionAsTOOForbiddenCode is the HTTP code returned for type CreateSITExtensionAsTOOForbidden
 const CreateSITExtensionAsTOOForbiddenCode int = 403
 
-/*
-CreateSITExtensionAsTOOForbidden The request was denied
+/*CreateSITExtensionAsTOOForbidden The request was denied
 
 swagger:response createSITExtensionAsTOOForbidden
 */
@@ -151,8 +148,7 @@ func (o *CreateSITExtensionAsTOOForbidden) WriteResponse(rw http.ResponseWriter,
 // CreateSITExtensionAsTOONotFoundCode is the HTTP code returned for type CreateSITExtensionAsTOONotFound
 const CreateSITExtensionAsTOONotFoundCode int = 404
 
-/*
-CreateSITExtensionAsTOONotFound The requested resource wasn't found
+/*CreateSITExtensionAsTOONotFound The requested resource wasn't found
 
 swagger:response createSITExtensionAsTOONotFound
 */
@@ -196,8 +192,7 @@ func (o *CreateSITExtensionAsTOONotFound) WriteResponse(rw http.ResponseWriter, 
 // CreateSITExtensionAsTOOUnprocessableEntityCode is the HTTP code returned for type CreateSITExtensionAsTOOUnprocessableEntity
 const CreateSITExtensionAsTOOUnprocessableEntityCode int = 422
 
-/*
-CreateSITExtensionAsTOOUnprocessableEntity The payload was unprocessable.
+/*CreateSITExtensionAsTOOUnprocessableEntity The payload was unprocessable.
 
 swagger:response createSITExtensionAsTOOUnprocessableEntity
 */
@@ -241,8 +236,7 @@ func (o *CreateSITExtensionAsTOOUnprocessableEntity) WriteResponse(rw http.Respo
 // CreateSITExtensionAsTOOInternalServerErrorCode is the HTTP code returned for type CreateSITExtensionAsTOOInternalServerError
 const CreateSITExtensionAsTOOInternalServerErrorCode int = 500
 
-/*
-CreateSITExtensionAsTOOInternalServerError A server error occurred
+/*CreateSITExtensionAsTOOInternalServerError A server error occurred
 
 swagger:response createSITExtensionAsTOOInternalServerError
 */

--- a/pkg/gen/ghcapi/ghcoperations/shipment/delete_shipment.go
+++ b/pkg/gen/ghcapi/ghcoperations/shipment/delete_shipment.go
@@ -29,12 +29,12 @@ func NewDeleteShipment(ctx *middleware.Context, handler DeleteShipmentHandler) *
 	return &DeleteShipment{Context: ctx, Handler: handler}
 }
 
-/*
-	DeleteShipment swagger:route DELETE /shipments/{shipmentID} shipment deleteShipment
-
-# Soft deletes a shipment by ID
+/* DeleteShipment swagger:route DELETE /shipments/{shipmentID} shipment deleteShipment
 
 Soft deletes a shipment by ID
+
+Soft deletes a shipment by ID
+
 */
 type DeleteShipment struct {
 	Context *middleware.Context

--- a/pkg/gen/ghcapi/ghcoperations/shipment/delete_shipment_responses.go
+++ b/pkg/gen/ghcapi/ghcoperations/shipment/delete_shipment_responses.go
@@ -16,8 +16,7 @@ import (
 // DeleteShipmentNoContentCode is the HTTP code returned for type DeleteShipmentNoContent
 const DeleteShipmentNoContentCode int = 204
 
-/*
-DeleteShipmentNoContent Successfully soft deleted the shipment
+/*DeleteShipmentNoContent Successfully soft deleted the shipment
 
 swagger:response deleteShipmentNoContent
 */
@@ -41,8 +40,7 @@ func (o *DeleteShipmentNoContent) WriteResponse(rw http.ResponseWriter, producer
 // DeleteShipmentBadRequestCode is the HTTP code returned for type DeleteShipmentBadRequest
 const DeleteShipmentBadRequestCode int = 400
 
-/*
-DeleteShipmentBadRequest The request payload is invalid
+/*DeleteShipmentBadRequest The request payload is invalid
 
 swagger:response deleteShipmentBadRequest
 */
@@ -86,8 +84,7 @@ func (o *DeleteShipmentBadRequest) WriteResponse(rw http.ResponseWriter, produce
 // DeleteShipmentForbiddenCode is the HTTP code returned for type DeleteShipmentForbidden
 const DeleteShipmentForbiddenCode int = 403
 
-/*
-DeleteShipmentForbidden The request was denied
+/*DeleteShipmentForbidden The request was denied
 
 swagger:response deleteShipmentForbidden
 */
@@ -131,8 +128,7 @@ func (o *DeleteShipmentForbidden) WriteResponse(rw http.ResponseWriter, producer
 // DeleteShipmentNotFoundCode is the HTTP code returned for type DeleteShipmentNotFound
 const DeleteShipmentNotFoundCode int = 404
 
-/*
-DeleteShipmentNotFound The requested resource wasn't found
+/*DeleteShipmentNotFound The requested resource wasn't found
 
 swagger:response deleteShipmentNotFound
 */
@@ -176,8 +172,7 @@ func (o *DeleteShipmentNotFound) WriteResponse(rw http.ResponseWriter, producer 
 // DeleteShipmentConflictCode is the HTTP code returned for type DeleteShipmentConflict
 const DeleteShipmentConflictCode int = 409
 
-/*
-DeleteShipmentConflict Conflict error
+/*DeleteShipmentConflict Conflict error
 
 swagger:response deleteShipmentConflict
 */
@@ -221,8 +216,7 @@ func (o *DeleteShipmentConflict) WriteResponse(rw http.ResponseWriter, producer 
 // DeleteShipmentUnprocessableEntityCode is the HTTP code returned for type DeleteShipmentUnprocessableEntity
 const DeleteShipmentUnprocessableEntityCode int = 422
 
-/*
-DeleteShipmentUnprocessableEntity The payload was unprocessable.
+/*DeleteShipmentUnprocessableEntity The payload was unprocessable.
 
 swagger:response deleteShipmentUnprocessableEntity
 */
@@ -266,8 +260,7 @@ func (o *DeleteShipmentUnprocessableEntity) WriteResponse(rw http.ResponseWriter
 // DeleteShipmentInternalServerErrorCode is the HTTP code returned for type DeleteShipmentInternalServerError
 const DeleteShipmentInternalServerErrorCode int = 500
 
-/*
-DeleteShipmentInternalServerError A server error occurred
+/*DeleteShipmentInternalServerError A server error occurred
 
 swagger:response deleteShipmentInternalServerError
 */

--- a/pkg/gen/ghcapi/ghcoperations/shipment/deny_s_i_t_extension.go
+++ b/pkg/gen/ghcapi/ghcoperations/shipment/deny_s_i_t_extension.go
@@ -29,12 +29,12 @@ func NewDenySITExtension(ctx *middleware.Context, handler DenySITExtensionHandle
 	return &DenySITExtension{Context: ctx, Handler: handler}
 }
 
-/*
-	DenySITExtension swagger:route PATCH /shipments/{shipmentID}/sit-extensions/{sitExtensionID}/deny shipment sitExtension denySITExtension
-
-# Denies a SIT extension
+/* DenySITExtension swagger:route PATCH /shipments/{shipmentID}/sit-extensions/{sitExtensionID}/deny shipment sitExtension denySITExtension
 
 Denies a SIT extension
+
+Denies a SIT extension
+
 */
 type DenySITExtension struct {
 	Context *middleware.Context

--- a/pkg/gen/ghcapi/ghcoperations/shipment/deny_s_i_t_extension_responses.go
+++ b/pkg/gen/ghcapi/ghcoperations/shipment/deny_s_i_t_extension_responses.go
@@ -16,8 +16,7 @@ import (
 // DenySITExtensionOKCode is the HTTP code returned for type DenySITExtensionOK
 const DenySITExtensionOKCode int = 200
 
-/*
-DenySITExtensionOK Successfully denied a SIT extension
+/*DenySITExtensionOK Successfully denied a SIT extension
 
 swagger:response denySITExtensionOK
 */
@@ -61,8 +60,7 @@ func (o *DenySITExtensionOK) WriteResponse(rw http.ResponseWriter, producer runt
 // DenySITExtensionForbiddenCode is the HTTP code returned for type DenySITExtensionForbidden
 const DenySITExtensionForbiddenCode int = 403
 
-/*
-DenySITExtensionForbidden The request was denied
+/*DenySITExtensionForbidden The request was denied
 
 swagger:response denySITExtensionForbidden
 */
@@ -106,8 +104,7 @@ func (o *DenySITExtensionForbidden) WriteResponse(rw http.ResponseWriter, produc
 // DenySITExtensionNotFoundCode is the HTTP code returned for type DenySITExtensionNotFound
 const DenySITExtensionNotFoundCode int = 404
 
-/*
-DenySITExtensionNotFound The requested resource wasn't found
+/*DenySITExtensionNotFound The requested resource wasn't found
 
 swagger:response denySITExtensionNotFound
 */
@@ -151,8 +148,7 @@ func (o *DenySITExtensionNotFound) WriteResponse(rw http.ResponseWriter, produce
 // DenySITExtensionConflictCode is the HTTP code returned for type DenySITExtensionConflict
 const DenySITExtensionConflictCode int = 409
 
-/*
-DenySITExtensionConflict Conflict error
+/*DenySITExtensionConflict Conflict error
 
 swagger:response denySITExtensionConflict
 */
@@ -196,8 +192,7 @@ func (o *DenySITExtensionConflict) WriteResponse(rw http.ResponseWriter, produce
 // DenySITExtensionPreconditionFailedCode is the HTTP code returned for type DenySITExtensionPreconditionFailed
 const DenySITExtensionPreconditionFailedCode int = 412
 
-/*
-DenySITExtensionPreconditionFailed Precondition failed
+/*DenySITExtensionPreconditionFailed Precondition failed
 
 swagger:response denySITExtensionPreconditionFailed
 */
@@ -241,8 +236,7 @@ func (o *DenySITExtensionPreconditionFailed) WriteResponse(rw http.ResponseWrite
 // DenySITExtensionUnprocessableEntityCode is the HTTP code returned for type DenySITExtensionUnprocessableEntity
 const DenySITExtensionUnprocessableEntityCode int = 422
 
-/*
-DenySITExtensionUnprocessableEntity The payload was unprocessable.
+/*DenySITExtensionUnprocessableEntity The payload was unprocessable.
 
 swagger:response denySITExtensionUnprocessableEntity
 */
@@ -286,8 +280,7 @@ func (o *DenySITExtensionUnprocessableEntity) WriteResponse(rw http.ResponseWrit
 // DenySITExtensionInternalServerErrorCode is the HTTP code returned for type DenySITExtensionInternalServerError
 const DenySITExtensionInternalServerErrorCode int = 500
 
-/*
-DenySITExtensionInternalServerError A server error occurred
+/*DenySITExtensionInternalServerError A server error occurred
 
 swagger:response denySITExtensionInternalServerError
 */

--- a/pkg/gen/ghcapi/ghcoperations/shipment/reject_shipment.go
+++ b/pkg/gen/ghcapi/ghcoperations/shipment/reject_shipment.go
@@ -29,12 +29,12 @@ func NewRejectShipment(ctx *middleware.Context, handler RejectShipmentHandler) *
 	return &RejectShipment{Context: ctx, Handler: handler}
 }
 
-/*
-	RejectShipment swagger:route POST /shipments/{shipmentID}/reject shipment rejectShipment
+/* RejectShipment swagger:route POST /shipments/{shipmentID}/reject shipment rejectShipment
 
 rejects a shipment
 
 rejects a shipment
+
 */
 type RejectShipment struct {
 	Context *middleware.Context

--- a/pkg/gen/ghcapi/ghcoperations/shipment/reject_shipment_responses.go
+++ b/pkg/gen/ghcapi/ghcoperations/shipment/reject_shipment_responses.go
@@ -16,8 +16,7 @@ import (
 // RejectShipmentOKCode is the HTTP code returned for type RejectShipmentOK
 const RejectShipmentOKCode int = 200
 
-/*
-RejectShipmentOK Successfully rejected the shipment
+/*RejectShipmentOK Successfully rejected the shipment
 
 swagger:response rejectShipmentOK
 */
@@ -61,8 +60,7 @@ func (o *RejectShipmentOK) WriteResponse(rw http.ResponseWriter, producer runtim
 // RejectShipmentForbiddenCode is the HTTP code returned for type RejectShipmentForbidden
 const RejectShipmentForbiddenCode int = 403
 
-/*
-RejectShipmentForbidden The request was denied
+/*RejectShipmentForbidden The request was denied
 
 swagger:response rejectShipmentForbidden
 */
@@ -106,8 +104,7 @@ func (o *RejectShipmentForbidden) WriteResponse(rw http.ResponseWriter, producer
 // RejectShipmentNotFoundCode is the HTTP code returned for type RejectShipmentNotFound
 const RejectShipmentNotFoundCode int = 404
 
-/*
-RejectShipmentNotFound The requested resource wasn't found
+/*RejectShipmentNotFound The requested resource wasn't found
 
 swagger:response rejectShipmentNotFound
 */
@@ -151,8 +148,7 @@ func (o *RejectShipmentNotFound) WriteResponse(rw http.ResponseWriter, producer 
 // RejectShipmentConflictCode is the HTTP code returned for type RejectShipmentConflict
 const RejectShipmentConflictCode int = 409
 
-/*
-RejectShipmentConflict Conflict error
+/*RejectShipmentConflict Conflict error
 
 swagger:response rejectShipmentConflict
 */
@@ -196,8 +192,7 @@ func (o *RejectShipmentConflict) WriteResponse(rw http.ResponseWriter, producer 
 // RejectShipmentPreconditionFailedCode is the HTTP code returned for type RejectShipmentPreconditionFailed
 const RejectShipmentPreconditionFailedCode int = 412
 
-/*
-RejectShipmentPreconditionFailed Precondition failed
+/*RejectShipmentPreconditionFailed Precondition failed
 
 swagger:response rejectShipmentPreconditionFailed
 */
@@ -241,8 +236,7 @@ func (o *RejectShipmentPreconditionFailed) WriteResponse(rw http.ResponseWriter,
 // RejectShipmentUnprocessableEntityCode is the HTTP code returned for type RejectShipmentUnprocessableEntity
 const RejectShipmentUnprocessableEntityCode int = 422
 
-/*
-RejectShipmentUnprocessableEntity The payload was unprocessable.
+/*RejectShipmentUnprocessableEntity The payload was unprocessable.
 
 swagger:response rejectShipmentUnprocessableEntity
 */
@@ -286,8 +280,7 @@ func (o *RejectShipmentUnprocessableEntity) WriteResponse(rw http.ResponseWriter
 // RejectShipmentInternalServerErrorCode is the HTTP code returned for type RejectShipmentInternalServerError
 const RejectShipmentInternalServerErrorCode int = 500
 
-/*
-RejectShipmentInternalServerError A server error occurred
+/*RejectShipmentInternalServerError A server error occurred
 
 swagger:response rejectShipmentInternalServerError
 */

--- a/pkg/gen/ghcapi/ghcoperations/shipment/request_shipment_cancellation.go
+++ b/pkg/gen/ghcapi/ghcoperations/shipment/request_shipment_cancellation.go
@@ -29,12 +29,12 @@ func NewRequestShipmentCancellation(ctx *middleware.Context, handler RequestShip
 	return &RequestShipmentCancellation{Context: ctx, Handler: handler}
 }
 
-/*
-	RequestShipmentCancellation swagger:route POST /shipments/{shipmentID}/request-cancellation shipment requestShipmentCancellation
-
-# Requests a shipment cancellation
+/* RequestShipmentCancellation swagger:route POST /shipments/{shipmentID}/request-cancellation shipment requestShipmentCancellation
 
 Requests a shipment cancellation
+
+Requests a shipment cancellation
+
 */
 type RequestShipmentCancellation struct {
 	Context *middleware.Context

--- a/pkg/gen/ghcapi/ghcoperations/shipment/request_shipment_cancellation_responses.go
+++ b/pkg/gen/ghcapi/ghcoperations/shipment/request_shipment_cancellation_responses.go
@@ -16,8 +16,7 @@ import (
 // RequestShipmentCancellationOKCode is the HTTP code returned for type RequestShipmentCancellationOK
 const RequestShipmentCancellationOKCode int = 200
 
-/*
-RequestShipmentCancellationOK Successfully requested the shipment cancellation
+/*RequestShipmentCancellationOK Successfully requested the shipment cancellation
 
 swagger:response requestShipmentCancellationOK
 */
@@ -61,8 +60,7 @@ func (o *RequestShipmentCancellationOK) WriteResponse(rw http.ResponseWriter, pr
 // RequestShipmentCancellationForbiddenCode is the HTTP code returned for type RequestShipmentCancellationForbidden
 const RequestShipmentCancellationForbiddenCode int = 403
 
-/*
-RequestShipmentCancellationForbidden The request was denied
+/*RequestShipmentCancellationForbidden The request was denied
 
 swagger:response requestShipmentCancellationForbidden
 */
@@ -106,8 +104,7 @@ func (o *RequestShipmentCancellationForbidden) WriteResponse(rw http.ResponseWri
 // RequestShipmentCancellationNotFoundCode is the HTTP code returned for type RequestShipmentCancellationNotFound
 const RequestShipmentCancellationNotFoundCode int = 404
 
-/*
-RequestShipmentCancellationNotFound The requested resource wasn't found
+/*RequestShipmentCancellationNotFound The requested resource wasn't found
 
 swagger:response requestShipmentCancellationNotFound
 */
@@ -151,8 +148,7 @@ func (o *RequestShipmentCancellationNotFound) WriteResponse(rw http.ResponseWrit
 // RequestShipmentCancellationConflictCode is the HTTP code returned for type RequestShipmentCancellationConflict
 const RequestShipmentCancellationConflictCode int = 409
 
-/*
-RequestShipmentCancellationConflict Conflict error
+/*RequestShipmentCancellationConflict Conflict error
 
 swagger:response requestShipmentCancellationConflict
 */
@@ -196,8 +192,7 @@ func (o *RequestShipmentCancellationConflict) WriteResponse(rw http.ResponseWrit
 // RequestShipmentCancellationPreconditionFailedCode is the HTTP code returned for type RequestShipmentCancellationPreconditionFailed
 const RequestShipmentCancellationPreconditionFailedCode int = 412
 
-/*
-RequestShipmentCancellationPreconditionFailed Precondition failed
+/*RequestShipmentCancellationPreconditionFailed Precondition failed
 
 swagger:response requestShipmentCancellationPreconditionFailed
 */
@@ -241,8 +236,7 @@ func (o *RequestShipmentCancellationPreconditionFailed) WriteResponse(rw http.Re
 // RequestShipmentCancellationUnprocessableEntityCode is the HTTP code returned for type RequestShipmentCancellationUnprocessableEntity
 const RequestShipmentCancellationUnprocessableEntityCode int = 422
 
-/*
-RequestShipmentCancellationUnprocessableEntity The payload was unprocessable.
+/*RequestShipmentCancellationUnprocessableEntity The payload was unprocessable.
 
 swagger:response requestShipmentCancellationUnprocessableEntity
 */
@@ -286,8 +280,7 @@ func (o *RequestShipmentCancellationUnprocessableEntity) WriteResponse(rw http.R
 // RequestShipmentCancellationInternalServerErrorCode is the HTTP code returned for type RequestShipmentCancellationInternalServerError
 const RequestShipmentCancellationInternalServerErrorCode int = 500
 
-/*
-RequestShipmentCancellationInternalServerError A server error occurred
+/*RequestShipmentCancellationInternalServerError A server error occurred
 
 swagger:response requestShipmentCancellationInternalServerError
 */

--- a/pkg/gen/ghcapi/ghcoperations/shipment/request_shipment_diversion.go
+++ b/pkg/gen/ghcapi/ghcoperations/shipment/request_shipment_diversion.go
@@ -29,12 +29,12 @@ func NewRequestShipmentDiversion(ctx *middleware.Context, handler RequestShipmen
 	return &RequestShipmentDiversion{Context: ctx, Handler: handler}
 }
 
-/*
-	RequestShipmentDiversion swagger:route POST /shipments/{shipmentID}/request-diversion shipment requestShipmentDiversion
-
-# Requests a shipment diversion
+/* RequestShipmentDiversion swagger:route POST /shipments/{shipmentID}/request-diversion shipment requestShipmentDiversion
 
 Requests a shipment diversion
+
+Requests a shipment diversion
+
 */
 type RequestShipmentDiversion struct {
 	Context *middleware.Context

--- a/pkg/gen/ghcapi/ghcoperations/shipment/request_shipment_diversion_responses.go
+++ b/pkg/gen/ghcapi/ghcoperations/shipment/request_shipment_diversion_responses.go
@@ -16,8 +16,7 @@ import (
 // RequestShipmentDiversionOKCode is the HTTP code returned for type RequestShipmentDiversionOK
 const RequestShipmentDiversionOKCode int = 200
 
-/*
-RequestShipmentDiversionOK Successfully requested the shipment diversion
+/*RequestShipmentDiversionOK Successfully requested the shipment diversion
 
 swagger:response requestShipmentDiversionOK
 */
@@ -61,8 +60,7 @@ func (o *RequestShipmentDiversionOK) WriteResponse(rw http.ResponseWriter, produ
 // RequestShipmentDiversionForbiddenCode is the HTTP code returned for type RequestShipmentDiversionForbidden
 const RequestShipmentDiversionForbiddenCode int = 403
 
-/*
-RequestShipmentDiversionForbidden The request was denied
+/*RequestShipmentDiversionForbidden The request was denied
 
 swagger:response requestShipmentDiversionForbidden
 */
@@ -106,8 +104,7 @@ func (o *RequestShipmentDiversionForbidden) WriteResponse(rw http.ResponseWriter
 // RequestShipmentDiversionNotFoundCode is the HTTP code returned for type RequestShipmentDiversionNotFound
 const RequestShipmentDiversionNotFoundCode int = 404
 
-/*
-RequestShipmentDiversionNotFound The requested resource wasn't found
+/*RequestShipmentDiversionNotFound The requested resource wasn't found
 
 swagger:response requestShipmentDiversionNotFound
 */
@@ -151,8 +148,7 @@ func (o *RequestShipmentDiversionNotFound) WriteResponse(rw http.ResponseWriter,
 // RequestShipmentDiversionConflictCode is the HTTP code returned for type RequestShipmentDiversionConflict
 const RequestShipmentDiversionConflictCode int = 409
 
-/*
-RequestShipmentDiversionConflict Conflict error
+/*RequestShipmentDiversionConflict Conflict error
 
 swagger:response requestShipmentDiversionConflict
 */
@@ -196,8 +192,7 @@ func (o *RequestShipmentDiversionConflict) WriteResponse(rw http.ResponseWriter,
 // RequestShipmentDiversionPreconditionFailedCode is the HTTP code returned for type RequestShipmentDiversionPreconditionFailed
 const RequestShipmentDiversionPreconditionFailedCode int = 412
 
-/*
-RequestShipmentDiversionPreconditionFailed Precondition failed
+/*RequestShipmentDiversionPreconditionFailed Precondition failed
 
 swagger:response requestShipmentDiversionPreconditionFailed
 */
@@ -241,8 +236,7 @@ func (o *RequestShipmentDiversionPreconditionFailed) WriteResponse(rw http.Respo
 // RequestShipmentDiversionUnprocessableEntityCode is the HTTP code returned for type RequestShipmentDiversionUnprocessableEntity
 const RequestShipmentDiversionUnprocessableEntityCode int = 422
 
-/*
-RequestShipmentDiversionUnprocessableEntity The payload was unprocessable.
+/*RequestShipmentDiversionUnprocessableEntity The payload was unprocessable.
 
 swagger:response requestShipmentDiversionUnprocessableEntity
 */
@@ -286,8 +280,7 @@ func (o *RequestShipmentDiversionUnprocessableEntity) WriteResponse(rw http.Resp
 // RequestShipmentDiversionInternalServerErrorCode is the HTTP code returned for type RequestShipmentDiversionInternalServerError
 const RequestShipmentDiversionInternalServerErrorCode int = 500
 
-/*
-RequestShipmentDiversionInternalServerError A server error occurred
+/*RequestShipmentDiversionInternalServerError A server error occurred
 
 swagger:response requestShipmentDiversionInternalServerError
 */

--- a/pkg/gen/ghcapi/ghcoperations/shipment/request_shipment_reweigh.go
+++ b/pkg/gen/ghcapi/ghcoperations/shipment/request_shipment_reweigh.go
@@ -29,12 +29,12 @@ func NewRequestShipmentReweigh(ctx *middleware.Context, handler RequestShipmentR
 	return &RequestShipmentReweigh{Context: ctx, Handler: handler}
 }
 
-/*
-	RequestShipmentReweigh swagger:route POST /shipments/{shipmentID}/request-reweigh shipment reweigh requestShipmentReweigh
-
-# Requests a shipment reweigh
+/* RequestShipmentReweigh swagger:route POST /shipments/{shipmentID}/request-reweigh shipment reweigh requestShipmentReweigh
 
 Requests a shipment reweigh
+
+Requests a shipment reweigh
+
 */
 type RequestShipmentReweigh struct {
 	Context *middleware.Context

--- a/pkg/gen/ghcapi/ghcoperations/shipment/request_shipment_reweigh_responses.go
+++ b/pkg/gen/ghcapi/ghcoperations/shipment/request_shipment_reweigh_responses.go
@@ -16,8 +16,7 @@ import (
 // RequestShipmentReweighOKCode is the HTTP code returned for type RequestShipmentReweighOK
 const RequestShipmentReweighOKCode int = 200
 
-/*
-RequestShipmentReweighOK Successfully requested a reweigh of the shipment
+/*RequestShipmentReweighOK Successfully requested a reweigh of the shipment
 
 swagger:response requestShipmentReweighOK
 */
@@ -61,8 +60,7 @@ func (o *RequestShipmentReweighOK) WriteResponse(rw http.ResponseWriter, produce
 // RequestShipmentReweighForbiddenCode is the HTTP code returned for type RequestShipmentReweighForbidden
 const RequestShipmentReweighForbiddenCode int = 403
 
-/*
-RequestShipmentReweighForbidden The request was denied
+/*RequestShipmentReweighForbidden The request was denied
 
 swagger:response requestShipmentReweighForbidden
 */
@@ -106,8 +104,7 @@ func (o *RequestShipmentReweighForbidden) WriteResponse(rw http.ResponseWriter, 
 // RequestShipmentReweighNotFoundCode is the HTTP code returned for type RequestShipmentReweighNotFound
 const RequestShipmentReweighNotFoundCode int = 404
 
-/*
-RequestShipmentReweighNotFound The requested resource wasn't found
+/*RequestShipmentReweighNotFound The requested resource wasn't found
 
 swagger:response requestShipmentReweighNotFound
 */
@@ -151,8 +148,7 @@ func (o *RequestShipmentReweighNotFound) WriteResponse(rw http.ResponseWriter, p
 // RequestShipmentReweighConflictCode is the HTTP code returned for type RequestShipmentReweighConflict
 const RequestShipmentReweighConflictCode int = 409
 
-/*
-RequestShipmentReweighConflict Conflict error
+/*RequestShipmentReweighConflict Conflict error
 
 swagger:response requestShipmentReweighConflict
 */
@@ -196,8 +192,7 @@ func (o *RequestShipmentReweighConflict) WriteResponse(rw http.ResponseWriter, p
 // RequestShipmentReweighPreconditionFailedCode is the HTTP code returned for type RequestShipmentReweighPreconditionFailed
 const RequestShipmentReweighPreconditionFailedCode int = 412
 
-/*
-RequestShipmentReweighPreconditionFailed Precondition failed
+/*RequestShipmentReweighPreconditionFailed Precondition failed
 
 swagger:response requestShipmentReweighPreconditionFailed
 */
@@ -241,8 +236,7 @@ func (o *RequestShipmentReweighPreconditionFailed) WriteResponse(rw http.Respons
 // RequestShipmentReweighUnprocessableEntityCode is the HTTP code returned for type RequestShipmentReweighUnprocessableEntity
 const RequestShipmentReweighUnprocessableEntityCode int = 422
 
-/*
-RequestShipmentReweighUnprocessableEntity The payload was unprocessable.
+/*RequestShipmentReweighUnprocessableEntity The payload was unprocessable.
 
 swagger:response requestShipmentReweighUnprocessableEntity
 */
@@ -286,8 +280,7 @@ func (o *RequestShipmentReweighUnprocessableEntity) WriteResponse(rw http.Respon
 // RequestShipmentReweighInternalServerErrorCode is the HTTP code returned for type RequestShipmentReweighInternalServerError
 const RequestShipmentReweighInternalServerErrorCode int = 500
 
-/*
-RequestShipmentReweighInternalServerError A server error occurred
+/*RequestShipmentReweighInternalServerError A server error occurred
 
 swagger:response requestShipmentReweighInternalServerError
 */

--- a/pkg/gen/ghcapi/ghcoperations/tac/tac_validation.go
+++ b/pkg/gen/ghcapi/ghcoperations/tac/tac_validation.go
@@ -29,12 +29,12 @@ func NewTacValidation(ctx *middleware.Context, handler TacValidationHandler) *Ta
 	return &TacValidation{Context: ctx, Handler: handler}
 }
 
-/*
-	TacValidation swagger:route GET /tac/valid tac order tacValidation
+/* TacValidation swagger:route GET /tac/valid tac order tacValidation
 
-# Validation of a TAC value
+Validation of a TAC value
 
 Returns a boolean based on whether a tac value is valid or not
+
 */
 type TacValidation struct {
 	Context *middleware.Context

--- a/pkg/gen/ghcapi/ghcoperations/tac/tac_validation_responses.go
+++ b/pkg/gen/ghcapi/ghcoperations/tac/tac_validation_responses.go
@@ -16,8 +16,7 @@ import (
 // TacValidationOKCode is the HTTP code returned for type TacValidationOK
 const TacValidationOKCode int = 200
 
-/*
-TacValidationOK Successfully retrieved validation status
+/*TacValidationOK Successfully retrieved validation status
 
 swagger:response tacValidationOK
 */
@@ -61,8 +60,7 @@ func (o *TacValidationOK) WriteResponse(rw http.ResponseWriter, producer runtime
 // TacValidationBadRequestCode is the HTTP code returned for type TacValidationBadRequest
 const TacValidationBadRequestCode int = 400
 
-/*
-TacValidationBadRequest The request payload is invalid
+/*TacValidationBadRequest The request payload is invalid
 
 swagger:response tacValidationBadRequest
 */
@@ -106,8 +104,7 @@ func (o *TacValidationBadRequest) WriteResponse(rw http.ResponseWriter, producer
 // TacValidationUnauthorizedCode is the HTTP code returned for type TacValidationUnauthorized
 const TacValidationUnauthorizedCode int = 401
 
-/*
-TacValidationUnauthorized The request was denied
+/*TacValidationUnauthorized The request was denied
 
 swagger:response tacValidationUnauthorized
 */
@@ -151,8 +148,7 @@ func (o *TacValidationUnauthorized) WriteResponse(rw http.ResponseWriter, produc
 // TacValidationForbiddenCode is the HTTP code returned for type TacValidationForbidden
 const TacValidationForbiddenCode int = 403
 
-/*
-TacValidationForbidden The request was denied
+/*TacValidationForbidden The request was denied
 
 swagger:response tacValidationForbidden
 */
@@ -196,8 +192,7 @@ func (o *TacValidationForbidden) WriteResponse(rw http.ResponseWriter, producer 
 // TacValidationNotFoundCode is the HTTP code returned for type TacValidationNotFound
 const TacValidationNotFoundCode int = 404
 
-/*
-TacValidationNotFound The requested resource wasn't found
+/*TacValidationNotFound The requested resource wasn't found
 
 swagger:response tacValidationNotFound
 */
@@ -241,8 +236,7 @@ func (o *TacValidationNotFound) WriteResponse(rw http.ResponseWriter, producer r
 // TacValidationInternalServerErrorCode is the HTTP code returned for type TacValidationInternalServerError
 const TacValidationInternalServerErrorCode int = 500
 
-/*
-TacValidationInternalServerError A server error occurred
+/*TacValidationInternalServerError A server error occurred
 
 swagger:response tacValidationInternalServerError
 */

--- a/pkg/gen/ghcmessages/affiliation.go
+++ b/pkg/gen/ghcmessages/affiliation.go
@@ -16,7 +16,7 @@ import (
 
 // Affiliation Branch of service
 //
-// # Military branch of service
+// Military branch of service
 //
 // swagger:model Affiliation
 type Affiliation string

--- a/pkg/gen/ghcmessages/p_p_m_shipment_status.go
+++ b/pkg/gen/ghcmessages/p_p_m_shipment_status.go
@@ -15,12 +15,13 @@ import (
 )
 
 // PPMShipmentStatus Status of the PPM Shipment:
-//   - **DRAFT**: The customer has created the PPM shipment but has not yet submitted their move for counseling.
-//   - **SUBMITTED**: The shipment belongs to a move that has been submitted by the customer or has been created by a Service Counselor or Prime Contractor for a submitted move.
-//   - **WAITING_ON_CUSTOMER**: The PPM shipment has been approved and the customer may now provide their actual move closeout information and documentation required to get paid.
-//   - **NEEDS_ADVANCE_APPROVAL**: The shipment was counseled by the Prime Contractor and approved but an advance was requested so will need further financial approval from the government.
-//   - **NEEDS_PAYMENT_APPROVAL**: The customer has provided their closeout weight tickets, receipts, and expenses and certified it for the Service Counselor to approve, exclude or reject.
-//   - **PAYMENT_APPROVED**: The Service Counselor has reviewed all of the customer's PPM closeout documentation and authorizes the customer can download and submit their finalized SSW packet.
+//   * **DRAFT**: The customer has created the PPM shipment but has not yet submitted their move for counseling.
+//   * **SUBMITTED**: The shipment belongs to a move that has been submitted by the customer or has been created by a Service Counselor or Prime Contractor for a submitted move.
+//   * **WAITING_ON_CUSTOMER**: The PPM shipment has been approved and the customer may now provide their actual move closeout information and documentation required to get paid.
+//   * **NEEDS_ADVANCE_APPROVAL**: The shipment was counseled by the Prime Contractor and approved but an advance was requested so will need further financial approval from the government.
+//   * **NEEDS_PAYMENT_APPROVAL**: The customer has provided their closeout weight tickets, receipts, and expenses and certified it for the Service Counselor to approve, exclude or reject.
+//   * **PAYMENT_APPROVED**: The Service Counselor has reviewed all of the customer's PPM closeout documentation and authorizes the customer can download and submit their finalized SSW packet.
+//
 //
 // swagger:model PPMShipmentStatus
 type PPMShipmentStatus string

--- a/pkg/gen/internalapi/doc.go
+++ b/pkg/gen/internalapi/doc.go
@@ -2,26 +2,26 @@
 
 // Package internalapi MilMove Internal API
 //
-//	The Internal API is a RESTful API that enables the Customer application for
-//	MilMove.
+//  The Internal API is a RESTful API that enables the Customer application for
+//  MilMove.
 //
-//	All endpoints are located under `/internal`.
+//  All endpoints are located under `/internal`.
 //
-//	Schemes:
-//	  http
-//	Host: localhost
-//	BasePath: /internal
-//	Version: 0.0.1
-//	License: MIT https://opensource.org/licenses/MIT
-//	Contact: <ppp@truss.works>
+//  Schemes:
+//    http
+//  Host: localhost
+//  BasePath: /internal
+//  Version: 0.0.1
+//  License: MIT https://opensource.org/licenses/MIT
+//  Contact: <ppp@truss.works>
 //
-//	Consumes:
-//	  - application/json
-//	  - multipart/form-data
+//  Consumes:
+//    - application/json
+//    - multipart/form-data
 //
-//	Produces:
-//	  - application/pdf
-//	  - application/json
+//  Produces:
+//    - application/pdf
+//    - application/json
 //
 // swagger:meta
 package internalapi

--- a/pkg/gen/internalapi/internaloperations/addresses/show_address.go
+++ b/pkg/gen/internalapi/internaloperations/addresses/show_address.go
@@ -29,12 +29,12 @@ func NewShowAddress(ctx *middleware.Context, handler ShowAddressHandler) *ShowAd
 	return &ShowAddress{Context: ctx, Handler: handler}
 }
 
-/*
-	ShowAddress swagger:route GET /addresses/{addressId} addresses showAddress
-
-# Returns an address
+/* ShowAddress swagger:route GET /addresses/{addressId} addresses showAddress
 
 Returns an address
+
+Returns an address
+
 */
 type ShowAddress struct {
 	Context *middleware.Context

--- a/pkg/gen/internalapi/internaloperations/addresses/show_address_responses.go
+++ b/pkg/gen/internalapi/internaloperations/addresses/show_address_responses.go
@@ -16,8 +16,7 @@ import (
 // ShowAddressOKCode is the HTTP code returned for type ShowAddressOK
 const ShowAddressOKCode int = 200
 
-/*
-ShowAddressOK the requested address
+/*ShowAddressOK the requested address
 
 swagger:response showAddressOK
 */
@@ -61,8 +60,7 @@ func (o *ShowAddressOK) WriteResponse(rw http.ResponseWriter, producer runtime.P
 // ShowAddressBadRequestCode is the HTTP code returned for type ShowAddressBadRequest
 const ShowAddressBadRequestCode int = 400
 
-/*
-ShowAddressBadRequest invalid request
+/*ShowAddressBadRequest invalid request
 
 swagger:response showAddressBadRequest
 */
@@ -86,8 +84,7 @@ func (o *ShowAddressBadRequest) WriteResponse(rw http.ResponseWriter, producer r
 // ShowAddressForbiddenCode is the HTTP code returned for type ShowAddressForbidden
 const ShowAddressForbiddenCode int = 403
 
-/*
-ShowAddressForbidden not authorized
+/*ShowAddressForbidden not authorized
 
 swagger:response showAddressForbidden
 */
@@ -111,8 +108,7 @@ func (o *ShowAddressForbidden) WriteResponse(rw http.ResponseWriter, producer ru
 // ShowAddressNotFoundCode is the HTTP code returned for type ShowAddressNotFound
 const ShowAddressNotFoundCode int = 404
 
-/*
-ShowAddressNotFound not found
+/*ShowAddressNotFound not found
 
 swagger:response showAddressNotFound
 */
@@ -136,8 +132,7 @@ func (o *ShowAddressNotFound) WriteResponse(rw http.ResponseWriter, producer run
 // ShowAddressInternalServerErrorCode is the HTTP code returned for type ShowAddressInternalServerError
 const ShowAddressInternalServerErrorCode int = 500
 
-/*
-ShowAddressInternalServerError server error
+/*ShowAddressInternalServerError server error
 
 swagger:response showAddressInternalServerError
 */

--- a/pkg/gen/internalapi/internaloperations/backup_contacts/create_service_member_backup_contact.go
+++ b/pkg/gen/internalapi/internaloperations/backup_contacts/create_service_member_backup_contact.go
@@ -29,12 +29,12 @@ func NewCreateServiceMemberBackupContact(ctx *middleware.Context, handler Create
 	return &CreateServiceMemberBackupContact{Context: ctx, Handler: handler}
 }
 
-/*
-	CreateServiceMemberBackupContact swagger:route POST /service_members/{serviceMemberId}/backup_contacts backup_contacts createServiceMemberBackupContact
+/* CreateServiceMemberBackupContact swagger:route POST /service_members/{serviceMemberId}/backup_contacts backup_contacts createServiceMemberBackupContact
 
-# Submits backup contact for a logged-in user
+Submits backup contact for a logged-in user
 
 Creates an instance of a backup contact tied to a service member user
+
 */
 type CreateServiceMemberBackupContact struct {
 	Context *middleware.Context

--- a/pkg/gen/internalapi/internaloperations/backup_contacts/create_service_member_backup_contact_responses.go
+++ b/pkg/gen/internalapi/internaloperations/backup_contacts/create_service_member_backup_contact_responses.go
@@ -16,8 +16,7 @@ import (
 // CreateServiceMemberBackupContactCreatedCode is the HTTP code returned for type CreateServiceMemberBackupContactCreated
 const CreateServiceMemberBackupContactCreatedCode int = 201
 
-/*
-CreateServiceMemberBackupContactCreated created instance of service member backup contact
+/*CreateServiceMemberBackupContactCreated created instance of service member backup contact
 
 swagger:response createServiceMemberBackupContactCreated
 */
@@ -61,8 +60,7 @@ func (o *CreateServiceMemberBackupContactCreated) WriteResponse(rw http.Response
 // CreateServiceMemberBackupContactBadRequestCode is the HTTP code returned for type CreateServiceMemberBackupContactBadRequest
 const CreateServiceMemberBackupContactBadRequestCode int = 400
 
-/*
-CreateServiceMemberBackupContactBadRequest invalid request
+/*CreateServiceMemberBackupContactBadRequest invalid request
 
 swagger:response createServiceMemberBackupContactBadRequest
 */
@@ -86,8 +84,7 @@ func (o *CreateServiceMemberBackupContactBadRequest) WriteResponse(rw http.Respo
 // CreateServiceMemberBackupContactUnauthorizedCode is the HTTP code returned for type CreateServiceMemberBackupContactUnauthorized
 const CreateServiceMemberBackupContactUnauthorizedCode int = 401
 
-/*
-CreateServiceMemberBackupContactUnauthorized request requires user authentication
+/*CreateServiceMemberBackupContactUnauthorized request requires user authentication
 
 swagger:response createServiceMemberBackupContactUnauthorized
 */
@@ -111,8 +108,7 @@ func (o *CreateServiceMemberBackupContactUnauthorized) WriteResponse(rw http.Res
 // CreateServiceMemberBackupContactForbiddenCode is the HTTP code returned for type CreateServiceMemberBackupContactForbidden
 const CreateServiceMemberBackupContactForbiddenCode int = 403
 
-/*
-CreateServiceMemberBackupContactForbidden user is not authorized to create this backup contact
+/*CreateServiceMemberBackupContactForbidden user is not authorized to create this backup contact
 
 swagger:response createServiceMemberBackupContactForbidden
 */
@@ -136,8 +132,7 @@ func (o *CreateServiceMemberBackupContactForbidden) WriteResponse(rw http.Respon
 // CreateServiceMemberBackupContactNotFoundCode is the HTTP code returned for type CreateServiceMemberBackupContactNotFound
 const CreateServiceMemberBackupContactNotFoundCode int = 404
 
-/*
-CreateServiceMemberBackupContactNotFound contact not found
+/*CreateServiceMemberBackupContactNotFound contact not found
 
 swagger:response createServiceMemberBackupContactNotFound
 */
@@ -161,8 +156,7 @@ func (o *CreateServiceMemberBackupContactNotFound) WriteResponse(rw http.Respons
 // CreateServiceMemberBackupContactInternalServerErrorCode is the HTTP code returned for type CreateServiceMemberBackupContactInternalServerError
 const CreateServiceMemberBackupContactInternalServerErrorCode int = 500
 
-/*
-CreateServiceMemberBackupContactInternalServerError internal server error
+/*CreateServiceMemberBackupContactInternalServerError internal server error
 
 swagger:response createServiceMemberBackupContactInternalServerError
 */

--- a/pkg/gen/internalapi/internaloperations/backup_contacts/index_service_member_backup_contacts.go
+++ b/pkg/gen/internalapi/internaloperations/backup_contacts/index_service_member_backup_contacts.go
@@ -29,12 +29,12 @@ func NewIndexServiceMemberBackupContacts(ctx *middleware.Context, handler IndexS
 	return &IndexServiceMemberBackupContacts{Context: ctx, Handler: handler}
 }
 
-/*
-	IndexServiceMemberBackupContacts swagger:route GET /service_members/{serviceMemberId}/backup_contacts backup_contacts indexServiceMemberBackupContacts
-
-# List all service member backup contacts
+/* IndexServiceMemberBackupContacts swagger:route GET /service_members/{serviceMemberId}/backup_contacts backup_contacts indexServiceMemberBackupContacts
 
 List all service member backup contacts
+
+List all service member backup contacts
+
 */
 type IndexServiceMemberBackupContacts struct {
 	Context *middleware.Context

--- a/pkg/gen/internalapi/internaloperations/backup_contacts/index_service_member_backup_contacts_responses.go
+++ b/pkg/gen/internalapi/internaloperations/backup_contacts/index_service_member_backup_contacts_responses.go
@@ -16,8 +16,7 @@ import (
 // IndexServiceMemberBackupContactsOKCode is the HTTP code returned for type IndexServiceMemberBackupContactsOK
 const IndexServiceMemberBackupContactsOKCode int = 200
 
-/*
-IndexServiceMemberBackupContactsOK list of service member backup contacts
+/*IndexServiceMemberBackupContactsOK list of service member backup contacts
 
 swagger:response indexServiceMemberBackupContactsOK
 */
@@ -64,8 +63,7 @@ func (o *IndexServiceMemberBackupContactsOK) WriteResponse(rw http.ResponseWrite
 // IndexServiceMemberBackupContactsBadRequestCode is the HTTP code returned for type IndexServiceMemberBackupContactsBadRequest
 const IndexServiceMemberBackupContactsBadRequestCode int = 400
 
-/*
-IndexServiceMemberBackupContactsBadRequest invalid request
+/*IndexServiceMemberBackupContactsBadRequest invalid request
 
 swagger:response indexServiceMemberBackupContactsBadRequest
 */
@@ -89,8 +87,7 @@ func (o *IndexServiceMemberBackupContactsBadRequest) WriteResponse(rw http.Respo
 // IndexServiceMemberBackupContactsUnauthorizedCode is the HTTP code returned for type IndexServiceMemberBackupContactsUnauthorized
 const IndexServiceMemberBackupContactsUnauthorizedCode int = 401
 
-/*
-IndexServiceMemberBackupContactsUnauthorized request requires user authentication
+/*IndexServiceMemberBackupContactsUnauthorized request requires user authentication
 
 swagger:response indexServiceMemberBackupContactsUnauthorized
 */
@@ -114,8 +111,7 @@ func (o *IndexServiceMemberBackupContactsUnauthorized) WriteResponse(rw http.Res
 // IndexServiceMemberBackupContactsForbiddenCode is the HTTP code returned for type IndexServiceMemberBackupContactsForbidden
 const IndexServiceMemberBackupContactsForbiddenCode int = 403
 
-/*
-IndexServiceMemberBackupContactsForbidden user is not authorized to see this backup contact
+/*IndexServiceMemberBackupContactsForbidden user is not authorized to see this backup contact
 
 swagger:response indexServiceMemberBackupContactsForbidden
 */
@@ -139,8 +135,7 @@ func (o *IndexServiceMemberBackupContactsForbidden) WriteResponse(rw http.Respon
 // IndexServiceMemberBackupContactsNotFoundCode is the HTTP code returned for type IndexServiceMemberBackupContactsNotFound
 const IndexServiceMemberBackupContactsNotFoundCode int = 404
 
-/*
-IndexServiceMemberBackupContactsNotFound contact not found
+/*IndexServiceMemberBackupContactsNotFound contact not found
 
 swagger:response indexServiceMemberBackupContactsNotFound
 */
@@ -164,8 +159,7 @@ func (o *IndexServiceMemberBackupContactsNotFound) WriteResponse(rw http.Respons
 // IndexServiceMemberBackupContactsInternalServerErrorCode is the HTTP code returned for type IndexServiceMemberBackupContactsInternalServerError
 const IndexServiceMemberBackupContactsInternalServerErrorCode int = 500
 
-/*
-IndexServiceMemberBackupContactsInternalServerError internal server error
+/*IndexServiceMemberBackupContactsInternalServerError internal server error
 
 swagger:response indexServiceMemberBackupContactsInternalServerError
 */

--- a/pkg/gen/internalapi/internaloperations/backup_contacts/show_service_member_backup_contact.go
+++ b/pkg/gen/internalapi/internaloperations/backup_contacts/show_service_member_backup_contact.go
@@ -29,12 +29,12 @@ func NewShowServiceMemberBackupContact(ctx *middleware.Context, handler ShowServ
 	return &ShowServiceMemberBackupContact{Context: ctx, Handler: handler}
 }
 
-/*
-	ShowServiceMemberBackupContact swagger:route GET /backup_contacts/{backupContactId} backup_contacts showServiceMemberBackupContact
-
-# Returns the given service member backup contact
+/* ShowServiceMemberBackupContact swagger:route GET /backup_contacts/{backupContactId} backup_contacts showServiceMemberBackupContact
 
 Returns the given service member backup contact
+
+Returns the given service member backup contact
+
 */
 type ShowServiceMemberBackupContact struct {
 	Context *middleware.Context

--- a/pkg/gen/internalapi/internaloperations/backup_contacts/show_service_member_backup_contact_responses.go
+++ b/pkg/gen/internalapi/internaloperations/backup_contacts/show_service_member_backup_contact_responses.go
@@ -16,8 +16,7 @@ import (
 // ShowServiceMemberBackupContactOKCode is the HTTP code returned for type ShowServiceMemberBackupContactOK
 const ShowServiceMemberBackupContactOKCode int = 200
 
-/*
-ShowServiceMemberBackupContactOK the instance of the service member backup contact
+/*ShowServiceMemberBackupContactOK the instance of the service member backup contact
 
 swagger:response showServiceMemberBackupContactOK
 */
@@ -61,8 +60,7 @@ func (o *ShowServiceMemberBackupContactOK) WriteResponse(rw http.ResponseWriter,
 // ShowServiceMemberBackupContactBadRequestCode is the HTTP code returned for type ShowServiceMemberBackupContactBadRequest
 const ShowServiceMemberBackupContactBadRequestCode int = 400
 
-/*
-ShowServiceMemberBackupContactBadRequest invalid request
+/*ShowServiceMemberBackupContactBadRequest invalid request
 
 swagger:response showServiceMemberBackupContactBadRequest
 */
@@ -86,8 +84,7 @@ func (o *ShowServiceMemberBackupContactBadRequest) WriteResponse(rw http.Respons
 // ShowServiceMemberBackupContactUnauthorizedCode is the HTTP code returned for type ShowServiceMemberBackupContactUnauthorized
 const ShowServiceMemberBackupContactUnauthorizedCode int = 401
 
-/*
-ShowServiceMemberBackupContactUnauthorized request requires user authentication
+/*ShowServiceMemberBackupContactUnauthorized request requires user authentication
 
 swagger:response showServiceMemberBackupContactUnauthorized
 */
@@ -111,8 +108,7 @@ func (o *ShowServiceMemberBackupContactUnauthorized) WriteResponse(rw http.Respo
 // ShowServiceMemberBackupContactForbiddenCode is the HTTP code returned for type ShowServiceMemberBackupContactForbidden
 const ShowServiceMemberBackupContactForbiddenCode int = 403
 
-/*
-ShowServiceMemberBackupContactForbidden user is not authorized
+/*ShowServiceMemberBackupContactForbidden user is not authorized
 
 swagger:response showServiceMemberBackupContactForbidden
 */
@@ -136,8 +132,7 @@ func (o *ShowServiceMemberBackupContactForbidden) WriteResponse(rw http.Response
 // ShowServiceMemberBackupContactNotFoundCode is the HTTP code returned for type ShowServiceMemberBackupContactNotFound
 const ShowServiceMemberBackupContactNotFoundCode int = 404
 
-/*
-ShowServiceMemberBackupContactNotFound backup contact not found
+/*ShowServiceMemberBackupContactNotFound backup contact not found
 
 swagger:response showServiceMemberBackupContactNotFound
 */
@@ -161,8 +156,7 @@ func (o *ShowServiceMemberBackupContactNotFound) WriteResponse(rw http.ResponseW
 // ShowServiceMemberBackupContactInternalServerErrorCode is the HTTP code returned for type ShowServiceMemberBackupContactInternalServerError
 const ShowServiceMemberBackupContactInternalServerErrorCode int = 500
 
-/*
-ShowServiceMemberBackupContactInternalServerError internal server error
+/*ShowServiceMemberBackupContactInternalServerError internal server error
 
 swagger:response showServiceMemberBackupContactInternalServerError
 */

--- a/pkg/gen/internalapi/internaloperations/backup_contacts/update_service_member_backup_contact.go
+++ b/pkg/gen/internalapi/internaloperations/backup_contacts/update_service_member_backup_contact.go
@@ -29,12 +29,12 @@ func NewUpdateServiceMemberBackupContact(ctx *middleware.Context, handler Update
 	return &UpdateServiceMemberBackupContact{Context: ctx, Handler: handler}
 }
 
-/*
-	UpdateServiceMemberBackupContact swagger:route PUT /backup_contacts/{backupContactId} backup_contacts updateServiceMemberBackupContact
+/* UpdateServiceMemberBackupContact swagger:route PUT /backup_contacts/{backupContactId} backup_contacts updateServiceMemberBackupContact
 
-# Updates a service member backup contact
+Updates a service member backup contact
 
 Any fields sent in this request will be set on the backup contact referenced
+
 */
 type UpdateServiceMemberBackupContact struct {
 	Context *middleware.Context

--- a/pkg/gen/internalapi/internaloperations/backup_contacts/update_service_member_backup_contact_responses.go
+++ b/pkg/gen/internalapi/internaloperations/backup_contacts/update_service_member_backup_contact_responses.go
@@ -16,8 +16,7 @@ import (
 // UpdateServiceMemberBackupContactCreatedCode is the HTTP code returned for type UpdateServiceMemberBackupContactCreated
 const UpdateServiceMemberBackupContactCreatedCode int = 201
 
-/*
-UpdateServiceMemberBackupContactCreated updated instance of backup contact
+/*UpdateServiceMemberBackupContactCreated updated instance of backup contact
 
 swagger:response updateServiceMemberBackupContactCreated
 */
@@ -61,8 +60,7 @@ func (o *UpdateServiceMemberBackupContactCreated) WriteResponse(rw http.Response
 // UpdateServiceMemberBackupContactBadRequestCode is the HTTP code returned for type UpdateServiceMemberBackupContactBadRequest
 const UpdateServiceMemberBackupContactBadRequestCode int = 400
 
-/*
-UpdateServiceMemberBackupContactBadRequest invalid request
+/*UpdateServiceMemberBackupContactBadRequest invalid request
 
 swagger:response updateServiceMemberBackupContactBadRequest
 */
@@ -86,8 +84,7 @@ func (o *UpdateServiceMemberBackupContactBadRequest) WriteResponse(rw http.Respo
 // UpdateServiceMemberBackupContactUnauthorizedCode is the HTTP code returned for type UpdateServiceMemberBackupContactUnauthorized
 const UpdateServiceMemberBackupContactUnauthorizedCode int = 401
 
-/*
-UpdateServiceMemberBackupContactUnauthorized request requires user authentication
+/*UpdateServiceMemberBackupContactUnauthorized request requires user authentication
 
 swagger:response updateServiceMemberBackupContactUnauthorized
 */
@@ -111,8 +108,7 @@ func (o *UpdateServiceMemberBackupContactUnauthorized) WriteResponse(rw http.Res
 // UpdateServiceMemberBackupContactForbiddenCode is the HTTP code returned for type UpdateServiceMemberBackupContactForbidden
 const UpdateServiceMemberBackupContactForbiddenCode int = 403
 
-/*
-UpdateServiceMemberBackupContactForbidden user is not authorized
+/*UpdateServiceMemberBackupContactForbidden user is not authorized
 
 swagger:response updateServiceMemberBackupContactForbidden
 */
@@ -136,8 +132,7 @@ func (o *UpdateServiceMemberBackupContactForbidden) WriteResponse(rw http.Respon
 // UpdateServiceMemberBackupContactNotFoundCode is the HTTP code returned for type UpdateServiceMemberBackupContactNotFound
 const UpdateServiceMemberBackupContactNotFoundCode int = 404
 
-/*
-UpdateServiceMemberBackupContactNotFound backup contact not found
+/*UpdateServiceMemberBackupContactNotFound backup contact not found
 
 swagger:response updateServiceMemberBackupContactNotFound
 */
@@ -161,8 +156,7 @@ func (o *UpdateServiceMemberBackupContactNotFound) WriteResponse(rw http.Respons
 // UpdateServiceMemberBackupContactInternalServerErrorCode is the HTTP code returned for type UpdateServiceMemberBackupContactInternalServerError
 const UpdateServiceMemberBackupContactInternalServerErrorCode int = 500
 
-/*
-UpdateServiceMemberBackupContactInternalServerError internal server error
+/*UpdateServiceMemberBackupContactInternalServerError internal server error
 
 swagger:response updateServiceMemberBackupContactInternalServerError
 */

--- a/pkg/gen/internalapi/internaloperations/calendar/show_available_move_dates.go
+++ b/pkg/gen/internalapi/internaloperations/calendar/show_available_move_dates.go
@@ -29,12 +29,12 @@ func NewShowAvailableMoveDates(ctx *middleware.Context, handler ShowAvailableMov
 	return &ShowAvailableMoveDates{Context: ctx, Handler: handler}
 }
 
-/*
-	ShowAvailableMoveDates swagger:route GET /calendar/available_move_dates calendar showAvailableMoveDates
-
-# Returns available dates for the move calendar
+/* ShowAvailableMoveDates swagger:route GET /calendar/available_move_dates calendar showAvailableMoveDates
 
 Returns available dates for the move calendar
+
+Returns available dates for the move calendar
+
 */
 type ShowAvailableMoveDates struct {
 	Context *middleware.Context

--- a/pkg/gen/internalapi/internaloperations/calendar/show_available_move_dates_responses.go
+++ b/pkg/gen/internalapi/internaloperations/calendar/show_available_move_dates_responses.go
@@ -16,8 +16,7 @@ import (
 // ShowAvailableMoveDatesOKCode is the HTTP code returned for type ShowAvailableMoveDatesOK
 const ShowAvailableMoveDatesOKCode int = 200
 
-/*
-ShowAvailableMoveDatesOK List of available dates
+/*ShowAvailableMoveDatesOK List of available dates
 
 swagger:response showAvailableMoveDatesOK
 */
@@ -61,8 +60,7 @@ func (o *ShowAvailableMoveDatesOK) WriteResponse(rw http.ResponseWriter, produce
 // ShowAvailableMoveDatesBadRequestCode is the HTTP code returned for type ShowAvailableMoveDatesBadRequest
 const ShowAvailableMoveDatesBadRequestCode int = 400
 
-/*
-ShowAvailableMoveDatesBadRequest invalid request
+/*ShowAvailableMoveDatesBadRequest invalid request
 
 swagger:response showAvailableMoveDatesBadRequest
 */
@@ -86,8 +84,7 @@ func (o *ShowAvailableMoveDatesBadRequest) WriteResponse(rw http.ResponseWriter,
 // ShowAvailableMoveDatesUnauthorizedCode is the HTTP code returned for type ShowAvailableMoveDatesUnauthorized
 const ShowAvailableMoveDatesUnauthorizedCode int = 401
 
-/*
-ShowAvailableMoveDatesUnauthorized request requires user authentication
+/*ShowAvailableMoveDatesUnauthorized request requires user authentication
 
 swagger:response showAvailableMoveDatesUnauthorized
 */
@@ -111,8 +108,7 @@ func (o *ShowAvailableMoveDatesUnauthorized) WriteResponse(rw http.ResponseWrite
 // ShowAvailableMoveDatesForbiddenCode is the HTTP code returned for type ShowAvailableMoveDatesForbidden
 const ShowAvailableMoveDatesForbiddenCode int = 403
 
-/*
-ShowAvailableMoveDatesForbidden user is not authorized
+/*ShowAvailableMoveDatesForbidden user is not authorized
 
 swagger:response showAvailableMoveDatesForbidden
 */
@@ -136,8 +132,7 @@ func (o *ShowAvailableMoveDatesForbidden) WriteResponse(rw http.ResponseWriter, 
 // ShowAvailableMoveDatesInternalServerErrorCode is the HTTP code returned for type ShowAvailableMoveDatesInternalServerError
 const ShowAvailableMoveDatesInternalServerErrorCode int = 500
 
-/*
-ShowAvailableMoveDatesInternalServerError internal server error
+/*ShowAvailableMoveDatesInternalServerError internal server error
 
 swagger:response showAvailableMoveDatesInternalServerError
 */

--- a/pkg/gen/internalapi/internaloperations/certification/create_signed_certification.go
+++ b/pkg/gen/internalapi/internaloperations/certification/create_signed_certification.go
@@ -29,12 +29,12 @@ func NewCreateSignedCertification(ctx *middleware.Context, handler CreateSignedC
 	return &CreateSignedCertification{Context: ctx, Handler: handler}
 }
 
-/*
-	CreateSignedCertification swagger:route POST /moves/{moveId}/signed_certifications certification createSignedCertification
+/* CreateSignedCertification swagger:route POST /moves/{moveId}/signed_certifications certification createSignedCertification
 
-# Submits signed certification for the given move ID
+Submits signed certification for the given move ID
 
 Create an instance of signed_certification tied to the move ID
+
 */
 type CreateSignedCertification struct {
 	Context *middleware.Context

--- a/pkg/gen/internalapi/internaloperations/certification/create_signed_certification_responses.go
+++ b/pkg/gen/internalapi/internaloperations/certification/create_signed_certification_responses.go
@@ -16,8 +16,7 @@ import (
 // CreateSignedCertificationCreatedCode is the HTTP code returned for type CreateSignedCertificationCreated
 const CreateSignedCertificationCreatedCode int = 201
 
-/*
-CreateSignedCertificationCreated created instance of signed_certification
+/*CreateSignedCertificationCreated created instance of signed_certification
 
 swagger:response createSignedCertificationCreated
 */
@@ -61,8 +60,7 @@ func (o *CreateSignedCertificationCreated) WriteResponse(rw http.ResponseWriter,
 // CreateSignedCertificationBadRequestCode is the HTTP code returned for type CreateSignedCertificationBadRequest
 const CreateSignedCertificationBadRequestCode int = 400
 
-/*
-CreateSignedCertificationBadRequest invalid request
+/*CreateSignedCertificationBadRequest invalid request
 
 swagger:response createSignedCertificationBadRequest
 */
@@ -86,8 +84,7 @@ func (o *CreateSignedCertificationBadRequest) WriteResponse(rw http.ResponseWrit
 // CreateSignedCertificationUnauthorizedCode is the HTTP code returned for type CreateSignedCertificationUnauthorized
 const CreateSignedCertificationUnauthorizedCode int = 401
 
-/*
-CreateSignedCertificationUnauthorized request requires user authentication
+/*CreateSignedCertificationUnauthorized request requires user authentication
 
 swagger:response createSignedCertificationUnauthorized
 */
@@ -111,8 +108,7 @@ func (o *CreateSignedCertificationUnauthorized) WriteResponse(rw http.ResponseWr
 // CreateSignedCertificationForbiddenCode is the HTTP code returned for type CreateSignedCertificationForbidden
 const CreateSignedCertificationForbiddenCode int = 403
 
-/*
-CreateSignedCertificationForbidden user is not authorized to sign for this move
+/*CreateSignedCertificationForbidden user is not authorized to sign for this move
 
 swagger:response createSignedCertificationForbidden
 */
@@ -136,8 +132,7 @@ func (o *CreateSignedCertificationForbidden) WriteResponse(rw http.ResponseWrite
 // CreateSignedCertificationNotFoundCode is the HTTP code returned for type CreateSignedCertificationNotFound
 const CreateSignedCertificationNotFoundCode int = 404
 
-/*
-CreateSignedCertificationNotFound move not found
+/*CreateSignedCertificationNotFound move not found
 
 swagger:response createSignedCertificationNotFound
 */
@@ -161,8 +156,7 @@ func (o *CreateSignedCertificationNotFound) WriteResponse(rw http.ResponseWriter
 // CreateSignedCertificationInternalServerErrorCode is the HTTP code returned for type CreateSignedCertificationInternalServerError
 const CreateSignedCertificationInternalServerErrorCode int = 500
 
-/*
-CreateSignedCertificationInternalServerError internal server error
+/*CreateSignedCertificationInternalServerError internal server error
 
 swagger:response createSignedCertificationInternalServerError
 */

--- a/pkg/gen/internalapi/internaloperations/certification/index_signed_certification.go
+++ b/pkg/gen/internalapi/internaloperations/certification/index_signed_certification.go
@@ -29,12 +29,12 @@ func NewIndexSignedCertification(ctx *middleware.Context, handler IndexSignedCer
 	return &IndexSignedCertification{Context: ctx, Handler: handler}
 }
 
-/*
-	IndexSignedCertification swagger:route GET /moves/{moveId}/signed_certifications certification indexSignedCertification
+/* IndexSignedCertification swagger:route GET /moves/{moveId}/signed_certifications certification indexSignedCertification
 
 gets the signed certifications for the given move ID
 
 returns a list of all signed_certifications associated with the move ID
+
 */
 type IndexSignedCertification struct {
 	Context *middleware.Context

--- a/pkg/gen/internalapi/internaloperations/certification/index_signed_certification_responses.go
+++ b/pkg/gen/internalapi/internaloperations/certification/index_signed_certification_responses.go
@@ -16,8 +16,7 @@ import (
 // IndexSignedCertificationOKCode is the HTTP code returned for type IndexSignedCertificationOK
 const IndexSignedCertificationOKCode int = 200
 
-/*
-IndexSignedCertificationOK returns a list of signed certifications
+/*IndexSignedCertificationOK returns a list of signed certifications
 
 swagger:response indexSignedCertificationOK
 */
@@ -64,8 +63,7 @@ func (o *IndexSignedCertificationOK) WriteResponse(rw http.ResponseWriter, produ
 // IndexSignedCertificationBadRequestCode is the HTTP code returned for type IndexSignedCertificationBadRequest
 const IndexSignedCertificationBadRequestCode int = 400
 
-/*
-IndexSignedCertificationBadRequest invalid request
+/*IndexSignedCertificationBadRequest invalid request
 
 swagger:response indexSignedCertificationBadRequest
 */
@@ -89,8 +87,7 @@ func (o *IndexSignedCertificationBadRequest) WriteResponse(rw http.ResponseWrite
 // IndexSignedCertificationUnauthorizedCode is the HTTP code returned for type IndexSignedCertificationUnauthorized
 const IndexSignedCertificationUnauthorizedCode int = 401
 
-/*
-IndexSignedCertificationUnauthorized request requires user authentication
+/*IndexSignedCertificationUnauthorized request requires user authentication
 
 swagger:response indexSignedCertificationUnauthorized
 */
@@ -114,8 +111,7 @@ func (o *IndexSignedCertificationUnauthorized) WriteResponse(rw http.ResponseWri
 // IndexSignedCertificationForbiddenCode is the HTTP code returned for type IndexSignedCertificationForbidden
 const IndexSignedCertificationForbiddenCode int = 403
 
-/*
-IndexSignedCertificationForbidden user is not authorized
+/*IndexSignedCertificationForbidden user is not authorized
 
 swagger:response indexSignedCertificationForbidden
 */
@@ -139,8 +135,7 @@ func (o *IndexSignedCertificationForbidden) WriteResponse(rw http.ResponseWriter
 // IndexSignedCertificationNotFoundCode is the HTTP code returned for type IndexSignedCertificationNotFound
 const IndexSignedCertificationNotFoundCode int = 404
 
-/*
-IndexSignedCertificationNotFound move not found
+/*IndexSignedCertificationNotFound move not found
 
 swagger:response indexSignedCertificationNotFound
 */
@@ -164,8 +159,7 @@ func (o *IndexSignedCertificationNotFound) WriteResponse(rw http.ResponseWriter,
 // IndexSignedCertificationInternalServerErrorCode is the HTTP code returned for type IndexSignedCertificationInternalServerError
 const IndexSignedCertificationInternalServerErrorCode int = 500
 
-/*
-IndexSignedCertificationInternalServerError internal server error
+/*IndexSignedCertificationInternalServerError internal server error
 
 swagger:response indexSignedCertificationInternalServerError
 */

--- a/pkg/gen/internalapi/internaloperations/documents/create_document.go
+++ b/pkg/gen/internalapi/internaloperations/documents/create_document.go
@@ -29,12 +29,12 @@ func NewCreateDocument(ctx *middleware.Context, handler CreateDocumentHandler) *
 	return &CreateDocument{Context: ctx, Handler: handler}
 }
 
-/*
-	CreateDocument swagger:route POST /documents documents createDocument
+/* CreateDocument swagger:route POST /documents documents createDocument
 
-# Create a new document
+Create a new document
 
 Documents represent a physical artifact such as a scanned document or a PDF file
+
 */
 type CreateDocument struct {
 	Context *middleware.Context

--- a/pkg/gen/internalapi/internaloperations/documents/create_document_responses.go
+++ b/pkg/gen/internalapi/internaloperations/documents/create_document_responses.go
@@ -16,8 +16,7 @@ import (
 // CreateDocumentCreatedCode is the HTTP code returned for type CreateDocumentCreated
 const CreateDocumentCreatedCode int = 201
 
-/*
-CreateDocumentCreated created document
+/*CreateDocumentCreated created document
 
 swagger:response createDocumentCreated
 */
@@ -61,8 +60,7 @@ func (o *CreateDocumentCreated) WriteResponse(rw http.ResponseWriter, producer r
 // CreateDocumentBadRequestCode is the HTTP code returned for type CreateDocumentBadRequest
 const CreateDocumentBadRequestCode int = 400
 
-/*
-CreateDocumentBadRequest invalid request
+/*CreateDocumentBadRequest invalid request
 
 swagger:response createDocumentBadRequest
 */
@@ -86,8 +84,7 @@ func (o *CreateDocumentBadRequest) WriteResponse(rw http.ResponseWriter, produce
 // CreateDocumentInternalServerErrorCode is the HTTP code returned for type CreateDocumentInternalServerError
 const CreateDocumentInternalServerErrorCode int = 500
 
-/*
-CreateDocumentInternalServerError server error
+/*CreateDocumentInternalServerError server error
 
 swagger:response createDocumentInternalServerError
 */

--- a/pkg/gen/internalapi/internaloperations/documents/show_document.go
+++ b/pkg/gen/internalapi/internaloperations/documents/show_document.go
@@ -29,12 +29,12 @@ func NewShowDocument(ctx *middleware.Context, handler ShowDocumentHandler) *Show
 	return &ShowDocument{Context: ctx, Handler: handler}
 }
 
-/*
-	ShowDocument swagger:route GET /documents/{documentId} documents showDocument
+/* ShowDocument swagger:route GET /documents/{documentId} documents showDocument
 
-# Returns a document
+Returns a document
 
 Returns a document and its uploads
+
 */
 type ShowDocument struct {
 	Context *middleware.Context

--- a/pkg/gen/internalapi/internaloperations/documents/show_document_responses.go
+++ b/pkg/gen/internalapi/internaloperations/documents/show_document_responses.go
@@ -16,8 +16,7 @@ import (
 // ShowDocumentOKCode is the HTTP code returned for type ShowDocumentOK
 const ShowDocumentOKCode int = 200
 
-/*
-ShowDocumentOK the requested document
+/*ShowDocumentOK the requested document
 
 swagger:response showDocumentOK
 */
@@ -61,8 +60,7 @@ func (o *ShowDocumentOK) WriteResponse(rw http.ResponseWriter, producer runtime.
 // ShowDocumentBadRequestCode is the HTTP code returned for type ShowDocumentBadRequest
 const ShowDocumentBadRequestCode int = 400
 
-/*
-ShowDocumentBadRequest invalid request
+/*ShowDocumentBadRequest invalid request
 
 swagger:response showDocumentBadRequest
 */
@@ -106,8 +104,7 @@ func (o *ShowDocumentBadRequest) WriteResponse(rw http.ResponseWriter, producer 
 // ShowDocumentForbiddenCode is the HTTP code returned for type ShowDocumentForbidden
 const ShowDocumentForbiddenCode int = 403
 
-/*
-ShowDocumentForbidden not authorized
+/*ShowDocumentForbidden not authorized
 
 swagger:response showDocumentForbidden
 */
@@ -131,8 +128,7 @@ func (o *ShowDocumentForbidden) WriteResponse(rw http.ResponseWriter, producer r
 // ShowDocumentNotFoundCode is the HTTP code returned for type ShowDocumentNotFound
 const ShowDocumentNotFoundCode int = 404
 
-/*
-ShowDocumentNotFound not found
+/*ShowDocumentNotFound not found
 
 swagger:response showDocumentNotFound
 */
@@ -156,8 +152,7 @@ func (o *ShowDocumentNotFound) WriteResponse(rw http.ResponseWriter, producer ru
 // ShowDocumentInternalServerErrorCode is the HTTP code returned for type ShowDocumentInternalServerError
 const ShowDocumentInternalServerErrorCode int = 500
 
-/*
-ShowDocumentInternalServerError server error
+/*ShowDocumentInternalServerError server error
 
 swagger:response showDocumentInternalServerError
 */

--- a/pkg/gen/internalapi/internaloperations/duty_locations/search_duty_locations.go
+++ b/pkg/gen/internalapi/internaloperations/duty_locations/search_duty_locations.go
@@ -29,12 +29,12 @@ func NewSearchDutyLocations(ctx *middleware.Context, handler SearchDutyLocations
 	return &SearchDutyLocations{Context: ctx, Handler: handler}
 }
 
-/*
-	SearchDutyLocations swagger:route GET /duty_locations duty_locations searchDutyLocations
-
-# Returns the duty locations matching the search query
+/* SearchDutyLocations swagger:route GET /duty_locations duty_locations searchDutyLocations
 
 Returns the duty locations matching the search query
+
+Returns the duty locations matching the search query
+
 */
 type SearchDutyLocations struct {
 	Context *middleware.Context

--- a/pkg/gen/internalapi/internaloperations/duty_locations/search_duty_locations_responses.go
+++ b/pkg/gen/internalapi/internaloperations/duty_locations/search_duty_locations_responses.go
@@ -16,8 +16,7 @@ import (
 // SearchDutyLocationsOKCode is the HTTP code returned for type SearchDutyLocationsOK
 const SearchDutyLocationsOKCode int = 200
 
-/*
-SearchDutyLocationsOK the instance of the duty location
+/*SearchDutyLocationsOK the instance of the duty location
 
 swagger:response searchDutyLocationsOK
 */
@@ -64,8 +63,7 @@ func (o *SearchDutyLocationsOK) WriteResponse(rw http.ResponseWriter, producer r
 // SearchDutyLocationsBadRequestCode is the HTTP code returned for type SearchDutyLocationsBadRequest
 const SearchDutyLocationsBadRequestCode int = 400
 
-/*
-SearchDutyLocationsBadRequest invalid request
+/*SearchDutyLocationsBadRequest invalid request
 
 swagger:response searchDutyLocationsBadRequest
 */
@@ -89,8 +87,7 @@ func (o *SearchDutyLocationsBadRequest) WriteResponse(rw http.ResponseWriter, pr
 // SearchDutyLocationsUnauthorizedCode is the HTTP code returned for type SearchDutyLocationsUnauthorized
 const SearchDutyLocationsUnauthorizedCode int = 401
 
-/*
-SearchDutyLocationsUnauthorized request requires user authentication
+/*SearchDutyLocationsUnauthorized request requires user authentication
 
 swagger:response searchDutyLocationsUnauthorized
 */
@@ -114,8 +111,7 @@ func (o *SearchDutyLocationsUnauthorized) WriteResponse(rw http.ResponseWriter, 
 // SearchDutyLocationsForbiddenCode is the HTTP code returned for type SearchDutyLocationsForbidden
 const SearchDutyLocationsForbiddenCode int = 403
 
-/*
-SearchDutyLocationsForbidden user is not authorized
+/*SearchDutyLocationsForbidden user is not authorized
 
 swagger:response searchDutyLocationsForbidden
 */
@@ -139,8 +135,7 @@ func (o *SearchDutyLocationsForbidden) WriteResponse(rw http.ResponseWriter, pro
 // SearchDutyLocationsNotFoundCode is the HTTP code returned for type SearchDutyLocationsNotFound
 const SearchDutyLocationsNotFoundCode int = 404
 
-/*
-SearchDutyLocationsNotFound matching duty location not found
+/*SearchDutyLocationsNotFound matching duty location not found
 
 swagger:response searchDutyLocationsNotFound
 */
@@ -164,8 +159,7 @@ func (o *SearchDutyLocationsNotFound) WriteResponse(rw http.ResponseWriter, prod
 // SearchDutyLocationsInternalServerErrorCode is the HTTP code returned for type SearchDutyLocationsInternalServerError
 const SearchDutyLocationsInternalServerErrorCode int = 500
 
-/*
-SearchDutyLocationsInternalServerError internal server error
+/*SearchDutyLocationsInternalServerError internal server error
 
 swagger:response searchDutyLocationsInternalServerError
 */

--- a/pkg/gen/internalapi/internaloperations/entitlements/index_entitlements.go
+++ b/pkg/gen/internalapi/internaloperations/entitlements/index_entitlements.go
@@ -29,12 +29,12 @@ func NewIndexEntitlements(ctx *middleware.Context, handler IndexEntitlementsHand
 	return &IndexEntitlements{Context: ctx, Handler: handler}
 }
 
-/*
-	IndexEntitlements swagger:route GET /entitlements entitlements indexEntitlements
-
-# List weight weights allotted by entitlement
+/* IndexEntitlements swagger:route GET /entitlements entitlements indexEntitlements
 
 List weight weights allotted by entitlement
+
+List weight weights allotted by entitlement
+
 */
 type IndexEntitlements struct {
 	Context *middleware.Context

--- a/pkg/gen/internalapi/internaloperations/entitlements/index_entitlements_responses.go
+++ b/pkg/gen/internalapi/internaloperations/entitlements/index_entitlements_responses.go
@@ -16,8 +16,7 @@ import (
 // IndexEntitlementsOKCode is the HTTP code returned for type IndexEntitlementsOK
 const IndexEntitlementsOKCode int = 200
 
-/*
-IndexEntitlementsOK List of weights allotted entitlement
+/*IndexEntitlementsOK List of weights allotted entitlement
 
 swagger:response indexEntitlementsOK
 */

--- a/pkg/gen/internalapi/internaloperations/move_docs/create_generic_move_document.go
+++ b/pkg/gen/internalapi/internaloperations/move_docs/create_generic_move_document.go
@@ -29,12 +29,12 @@ func NewCreateGenericMoveDocument(ctx *middleware.Context, handler CreateGeneric
 	return &CreateGenericMoveDocument{Context: ctx, Handler: handler}
 }
 
-/*
-	CreateGenericMoveDocument swagger:route POST /moves/{moveId}/move_documents move_docs createGenericMoveDocument
+/* CreateGenericMoveDocument swagger:route POST /moves/{moveId}/move_documents move_docs createGenericMoveDocument
 
-# Creates a move document
+Creates a move document
 
 Created a move document with the given information
+
 */
 type CreateGenericMoveDocument struct {
 	Context *middleware.Context

--- a/pkg/gen/internalapi/internaloperations/move_docs/create_generic_move_document_responses.go
+++ b/pkg/gen/internalapi/internaloperations/move_docs/create_generic_move_document_responses.go
@@ -16,8 +16,7 @@ import (
 // CreateGenericMoveDocumentOKCode is the HTTP code returned for type CreateGenericMoveDocumentOK
 const CreateGenericMoveDocumentOKCode int = 200
 
-/*
-CreateGenericMoveDocumentOK returns new move document object
+/*CreateGenericMoveDocumentOK returns new move document object
 
 swagger:response createGenericMoveDocumentOK
 */
@@ -61,8 +60,7 @@ func (o *CreateGenericMoveDocumentOK) WriteResponse(rw http.ResponseWriter, prod
 // CreateGenericMoveDocumentBadRequestCode is the HTTP code returned for type CreateGenericMoveDocumentBadRequest
 const CreateGenericMoveDocumentBadRequestCode int = 400
 
-/*
-CreateGenericMoveDocumentBadRequest invalid request
+/*CreateGenericMoveDocumentBadRequest invalid request
 
 swagger:response createGenericMoveDocumentBadRequest
 */
@@ -86,8 +84,7 @@ func (o *CreateGenericMoveDocumentBadRequest) WriteResponse(rw http.ResponseWrit
 // CreateGenericMoveDocumentUnauthorizedCode is the HTTP code returned for type CreateGenericMoveDocumentUnauthorized
 const CreateGenericMoveDocumentUnauthorizedCode int = 401
 
-/*
-CreateGenericMoveDocumentUnauthorized must be authenticated to use this endpoint
+/*CreateGenericMoveDocumentUnauthorized must be authenticated to use this endpoint
 
 swagger:response createGenericMoveDocumentUnauthorized
 */
@@ -111,8 +108,7 @@ func (o *CreateGenericMoveDocumentUnauthorized) WriteResponse(rw http.ResponseWr
 // CreateGenericMoveDocumentForbiddenCode is the HTTP code returned for type CreateGenericMoveDocumentForbidden
 const CreateGenericMoveDocumentForbiddenCode int = 403
 
-/*
-CreateGenericMoveDocumentForbidden not authorized to modify this move
+/*CreateGenericMoveDocumentForbidden not authorized to modify this move
 
 swagger:response createGenericMoveDocumentForbidden
 */
@@ -136,8 +132,7 @@ func (o *CreateGenericMoveDocumentForbidden) WriteResponse(rw http.ResponseWrite
 // CreateGenericMoveDocumentInternalServerErrorCode is the HTTP code returned for type CreateGenericMoveDocumentInternalServerError
 const CreateGenericMoveDocumentInternalServerErrorCode int = 500
 
-/*
-CreateGenericMoveDocumentInternalServerError server error
+/*CreateGenericMoveDocumentInternalServerError server error
 
 swagger:response createGenericMoveDocumentInternalServerError
 */

--- a/pkg/gen/internalapi/internaloperations/move_docs/create_weight_ticket_document.go
+++ b/pkg/gen/internalapi/internaloperations/move_docs/create_weight_ticket_document.go
@@ -29,12 +29,12 @@ func NewCreateWeightTicketDocument(ctx *middleware.Context, handler CreateWeight
 	return &CreateWeightTicketDocument{Context: ctx, Handler: handler}
 }
 
-/*
-	CreateWeightTicketDocument swagger:route POST /moves/{moveId}/weight_ticket move_docs createWeightTicketDocument
+/* CreateWeightTicketDocument swagger:route POST /moves/{moveId}/weight_ticket move_docs createWeightTicketDocument
 
-# Creates a weight ticket document
+Creates a weight ticket document
 
 Created a weight ticket document with the given information
+
 */
 type CreateWeightTicketDocument struct {
 	Context *middleware.Context

--- a/pkg/gen/internalapi/internaloperations/move_docs/create_weight_ticket_document_responses.go
+++ b/pkg/gen/internalapi/internaloperations/move_docs/create_weight_ticket_document_responses.go
@@ -16,8 +16,7 @@ import (
 // CreateWeightTicketDocumentOKCode is the HTTP code returned for type CreateWeightTicketDocumentOK
 const CreateWeightTicketDocumentOKCode int = 200
 
-/*
-CreateWeightTicketDocumentOK returns new weight ticket document object
+/*CreateWeightTicketDocumentOK returns new weight ticket document object
 
 swagger:response createWeightTicketDocumentOK
 */
@@ -61,8 +60,7 @@ func (o *CreateWeightTicketDocumentOK) WriteResponse(rw http.ResponseWriter, pro
 // CreateWeightTicketDocumentBadRequestCode is the HTTP code returned for type CreateWeightTicketDocumentBadRequest
 const CreateWeightTicketDocumentBadRequestCode int = 400
 
-/*
-CreateWeightTicketDocumentBadRequest invalid request
+/*CreateWeightTicketDocumentBadRequest invalid request
 
 swagger:response createWeightTicketDocumentBadRequest
 */
@@ -86,8 +84,7 @@ func (o *CreateWeightTicketDocumentBadRequest) WriteResponse(rw http.ResponseWri
 // CreateWeightTicketDocumentUnauthorizedCode is the HTTP code returned for type CreateWeightTicketDocumentUnauthorized
 const CreateWeightTicketDocumentUnauthorizedCode int = 401
 
-/*
-CreateWeightTicketDocumentUnauthorized must be authenticated to use this endpoint
+/*CreateWeightTicketDocumentUnauthorized must be authenticated to use this endpoint
 
 swagger:response createWeightTicketDocumentUnauthorized
 */
@@ -111,8 +108,7 @@ func (o *CreateWeightTicketDocumentUnauthorized) WriteResponse(rw http.ResponseW
 // CreateWeightTicketDocumentForbiddenCode is the HTTP code returned for type CreateWeightTicketDocumentForbidden
 const CreateWeightTicketDocumentForbiddenCode int = 403
 
-/*
-CreateWeightTicketDocumentForbidden not authorized to modify this move
+/*CreateWeightTicketDocumentForbidden not authorized to modify this move
 
 swagger:response createWeightTicketDocumentForbidden
 */
@@ -136,8 +132,7 @@ func (o *CreateWeightTicketDocumentForbidden) WriteResponse(rw http.ResponseWrit
 // CreateWeightTicketDocumentInternalServerErrorCode is the HTTP code returned for type CreateWeightTicketDocumentInternalServerError
 const CreateWeightTicketDocumentInternalServerErrorCode int = 500
 
-/*
-CreateWeightTicketDocumentInternalServerError server error
+/*CreateWeightTicketDocumentInternalServerError server error
 
 swagger:response createWeightTicketDocumentInternalServerError
 */

--- a/pkg/gen/internalapi/internaloperations/move_docs/delete_move_document.go
+++ b/pkg/gen/internalapi/internaloperations/move_docs/delete_move_document.go
@@ -29,12 +29,12 @@ func NewDeleteMoveDocument(ctx *middleware.Context, handler DeleteMoveDocumentHa
 	return &DeleteMoveDocument{Context: ctx, Handler: handler}
 }
 
-/*
-	DeleteMoveDocument swagger:route DELETE /move_documents/{moveDocumentId} move_docs deleteMoveDocument
+/* DeleteMoveDocument swagger:route DELETE /move_documents/{moveDocumentId} move_docs deleteMoveDocument
 
-# Deletes a move document
+Deletes a move document
 
 Deletes a move document with the given information
+
 */
 type DeleteMoveDocument struct {
 	Context *middleware.Context

--- a/pkg/gen/internalapi/internaloperations/move_docs/delete_move_document_responses.go
+++ b/pkg/gen/internalapi/internaloperations/move_docs/delete_move_document_responses.go
@@ -16,8 +16,7 @@ import (
 // DeleteMoveDocumentNoContentCode is the HTTP code returned for type DeleteMoveDocumentNoContent
 const DeleteMoveDocumentNoContentCode int = 204
 
-/*
-DeleteMoveDocumentNoContent deleted
+/*DeleteMoveDocumentNoContent deleted
 
 swagger:response deleteMoveDocumentNoContent
 */
@@ -41,8 +40,7 @@ func (o *DeleteMoveDocumentNoContent) WriteResponse(rw http.ResponseWriter, prod
 // DeleteMoveDocumentBadRequestCode is the HTTP code returned for type DeleteMoveDocumentBadRequest
 const DeleteMoveDocumentBadRequestCode int = 400
 
-/*
-DeleteMoveDocumentBadRequest invalid request
+/*DeleteMoveDocumentBadRequest invalid request
 
 swagger:response deleteMoveDocumentBadRequest
 */
@@ -86,8 +84,7 @@ func (o *DeleteMoveDocumentBadRequest) WriteResponse(rw http.ResponseWriter, pro
 // DeleteMoveDocumentForbiddenCode is the HTTP code returned for type DeleteMoveDocumentForbidden
 const DeleteMoveDocumentForbiddenCode int = 403
 
-/*
-DeleteMoveDocumentForbidden not authorized
+/*DeleteMoveDocumentForbidden not authorized
 
 swagger:response deleteMoveDocumentForbidden
 */
@@ -111,8 +108,7 @@ func (o *DeleteMoveDocumentForbidden) WriteResponse(rw http.ResponseWriter, prod
 // DeleteMoveDocumentNotFoundCode is the HTTP code returned for type DeleteMoveDocumentNotFound
 const DeleteMoveDocumentNotFoundCode int = 404
 
-/*
-DeleteMoveDocumentNotFound not found
+/*DeleteMoveDocumentNotFound not found
 
 swagger:response deleteMoveDocumentNotFound
 */
@@ -136,8 +132,7 @@ func (o *DeleteMoveDocumentNotFound) WriteResponse(rw http.ResponseWriter, produ
 // DeleteMoveDocumentInternalServerErrorCode is the HTTP code returned for type DeleteMoveDocumentInternalServerError
 const DeleteMoveDocumentInternalServerErrorCode int = 500
 
-/*
-DeleteMoveDocumentInternalServerError server error
+/*DeleteMoveDocumentInternalServerError server error
 
 swagger:response deleteMoveDocumentInternalServerError
 */

--- a/pkg/gen/internalapi/internaloperations/move_docs/index_move_documents.go
+++ b/pkg/gen/internalapi/internaloperations/move_docs/index_move_documents.go
@@ -29,12 +29,12 @@ func NewIndexMoveDocuments(ctx *middleware.Context, handler IndexMoveDocumentsHa
 	return &IndexMoveDocuments{Context: ctx, Handler: handler}
 }
 
-/*
-	IndexMoveDocuments swagger:route GET /moves/{moveId}/move_documents move_docs indexMoveDocuments
-
-# Returns a list of all Move Documents associated with this move
+/* IndexMoveDocuments swagger:route GET /moves/{moveId}/move_documents move_docs indexMoveDocuments
 
 Returns a list of all Move Documents associated with this move
+
+Returns a list of all Move Documents associated with this move
+
 */
 type IndexMoveDocuments struct {
 	Context *middleware.Context

--- a/pkg/gen/internalapi/internaloperations/move_docs/index_move_documents_responses.go
+++ b/pkg/gen/internalapi/internaloperations/move_docs/index_move_documents_responses.go
@@ -16,8 +16,7 @@ import (
 // IndexMoveDocumentsOKCode is the HTTP code returned for type IndexMoveDocumentsOK
 const IndexMoveDocumentsOKCode int = 200
 
-/*
-IndexMoveDocumentsOK returns list of move douments
+/*IndexMoveDocumentsOK returns list of move douments
 
 swagger:response indexMoveDocumentsOK
 */
@@ -64,8 +63,7 @@ func (o *IndexMoveDocumentsOK) WriteResponse(rw http.ResponseWriter, producer ru
 // IndexMoveDocumentsBadRequestCode is the HTTP code returned for type IndexMoveDocumentsBadRequest
 const IndexMoveDocumentsBadRequestCode int = 400
 
-/*
-IndexMoveDocumentsBadRequest invalid request
+/*IndexMoveDocumentsBadRequest invalid request
 
 swagger:response indexMoveDocumentsBadRequest
 */
@@ -89,8 +87,7 @@ func (o *IndexMoveDocumentsBadRequest) WriteResponse(rw http.ResponseWriter, pro
 // IndexMoveDocumentsUnauthorizedCode is the HTTP code returned for type IndexMoveDocumentsUnauthorized
 const IndexMoveDocumentsUnauthorizedCode int = 401
 
-/*
-IndexMoveDocumentsUnauthorized request requires user authentication
+/*IndexMoveDocumentsUnauthorized request requires user authentication
 
 swagger:response indexMoveDocumentsUnauthorized
 */
@@ -114,8 +111,7 @@ func (o *IndexMoveDocumentsUnauthorized) WriteResponse(rw http.ResponseWriter, p
 // IndexMoveDocumentsForbiddenCode is the HTTP code returned for type IndexMoveDocumentsForbidden
 const IndexMoveDocumentsForbiddenCode int = 403
 
-/*
-IndexMoveDocumentsForbidden user is not authorized
+/*IndexMoveDocumentsForbidden user is not authorized
 
 swagger:response indexMoveDocumentsForbidden
 */

--- a/pkg/gen/internalapi/internaloperations/move_docs/update_move_document.go
+++ b/pkg/gen/internalapi/internaloperations/move_docs/update_move_document.go
@@ -29,12 +29,12 @@ func NewUpdateMoveDocument(ctx *middleware.Context, handler UpdateMoveDocumentHa
 	return &UpdateMoveDocument{Context: ctx, Handler: handler}
 }
 
-/*
-	UpdateMoveDocument swagger:route PUT /move_documents/{moveDocumentId} move_docs updateMoveDocument
+/* UpdateMoveDocument swagger:route PUT /move_documents/{moveDocumentId} move_docs updateMoveDocument
 
-# Updates a move document
+Updates a move document
 
 Update a move document with the given information
+
 */
 type UpdateMoveDocument struct {
 	Context *middleware.Context

--- a/pkg/gen/internalapi/internaloperations/move_docs/update_move_document_responses.go
+++ b/pkg/gen/internalapi/internaloperations/move_docs/update_move_document_responses.go
@@ -16,8 +16,7 @@ import (
 // UpdateMoveDocumentOKCode is the HTTP code returned for type UpdateMoveDocumentOK
 const UpdateMoveDocumentOKCode int = 200
 
-/*
-UpdateMoveDocumentOK updated instance of move document
+/*UpdateMoveDocumentOK updated instance of move document
 
 swagger:response updateMoveDocumentOK
 */
@@ -61,8 +60,7 @@ func (o *UpdateMoveDocumentOK) WriteResponse(rw http.ResponseWriter, producer ru
 // UpdateMoveDocumentBadRequestCode is the HTTP code returned for type UpdateMoveDocumentBadRequest
 const UpdateMoveDocumentBadRequestCode int = 400
 
-/*
-UpdateMoveDocumentBadRequest invalid request
+/*UpdateMoveDocumentBadRequest invalid request
 
 swagger:response updateMoveDocumentBadRequest
 */
@@ -86,8 +84,7 @@ func (o *UpdateMoveDocumentBadRequest) WriteResponse(rw http.ResponseWriter, pro
 // UpdateMoveDocumentUnauthorizedCode is the HTTP code returned for type UpdateMoveDocumentUnauthorized
 const UpdateMoveDocumentUnauthorizedCode int = 401
 
-/*
-UpdateMoveDocumentUnauthorized request requires user authentication
+/*UpdateMoveDocumentUnauthorized request requires user authentication
 
 swagger:response updateMoveDocumentUnauthorized
 */
@@ -111,8 +108,7 @@ func (o *UpdateMoveDocumentUnauthorized) WriteResponse(rw http.ResponseWriter, p
 // UpdateMoveDocumentForbiddenCode is the HTTP code returned for type UpdateMoveDocumentForbidden
 const UpdateMoveDocumentForbiddenCode int = 403
 
-/*
-UpdateMoveDocumentForbidden user is not authorized
+/*UpdateMoveDocumentForbidden user is not authorized
 
 swagger:response updateMoveDocumentForbidden
 */
@@ -136,8 +132,7 @@ func (o *UpdateMoveDocumentForbidden) WriteResponse(rw http.ResponseWriter, prod
 // UpdateMoveDocumentNotFoundCode is the HTTP code returned for type UpdateMoveDocumentNotFound
 const UpdateMoveDocumentNotFoundCode int = 404
 
-/*
-UpdateMoveDocumentNotFound move document not found
+/*UpdateMoveDocumentNotFound move document not found
 
 swagger:response updateMoveDocumentNotFound
 */
@@ -161,8 +156,7 @@ func (o *UpdateMoveDocumentNotFound) WriteResponse(rw http.ResponseWriter, produ
 // UpdateMoveDocumentInternalServerErrorCode is the HTTP code returned for type UpdateMoveDocumentInternalServerError
 const UpdateMoveDocumentInternalServerErrorCode int = 500
 
-/*
-UpdateMoveDocumentInternalServerError internal server error
+/*UpdateMoveDocumentInternalServerError internal server error
 
 swagger:response updateMoveDocumentInternalServerError
 */

--- a/pkg/gen/internalapi/internaloperations/moves/patch_move.go
+++ b/pkg/gen/internalapi/internaloperations/moves/patch_move.go
@@ -29,12 +29,12 @@ func NewPatchMove(ctx *middleware.Context, handler PatchMoveHandler) *PatchMove 
 	return &PatchMove{Context: ctx, Handler: handler}
 }
 
-/*
-	PatchMove swagger:route PATCH /moves/{moveId} moves patchMove
+/* PatchMove swagger:route PATCH /moves/{moveId} moves patchMove
 
-# Patches the move
+Patches the move
 
 Any fields sent in this request will be set on the move referenced
+
 */
 type PatchMove struct {
 	Context *middleware.Context

--- a/pkg/gen/internalapi/internaloperations/moves/patch_move_responses.go
+++ b/pkg/gen/internalapi/internaloperations/moves/patch_move_responses.go
@@ -16,8 +16,7 @@ import (
 // PatchMoveCreatedCode is the HTTP code returned for type PatchMoveCreated
 const PatchMoveCreatedCode int = 201
 
-/*
-PatchMoveCreated updated instance of move
+/*PatchMoveCreated updated instance of move
 
 swagger:response patchMoveCreated
 */
@@ -61,8 +60,7 @@ func (o *PatchMoveCreated) WriteResponse(rw http.ResponseWriter, producer runtim
 // PatchMoveBadRequestCode is the HTTP code returned for type PatchMoveBadRequest
 const PatchMoveBadRequestCode int = 400
 
-/*
-PatchMoveBadRequest invalid request
+/*PatchMoveBadRequest invalid request
 
 swagger:response patchMoveBadRequest
 */
@@ -86,8 +84,7 @@ func (o *PatchMoveBadRequest) WriteResponse(rw http.ResponseWriter, producer run
 // PatchMoveUnauthorizedCode is the HTTP code returned for type PatchMoveUnauthorized
 const PatchMoveUnauthorizedCode int = 401
 
-/*
-PatchMoveUnauthorized request requires user authentication
+/*PatchMoveUnauthorized request requires user authentication
 
 swagger:response patchMoveUnauthorized
 */
@@ -111,8 +108,7 @@ func (o *PatchMoveUnauthorized) WriteResponse(rw http.ResponseWriter, producer r
 // PatchMoveForbiddenCode is the HTTP code returned for type PatchMoveForbidden
 const PatchMoveForbiddenCode int = 403
 
-/*
-PatchMoveForbidden user is not authorized
+/*PatchMoveForbidden user is not authorized
 
 swagger:response patchMoveForbidden
 */
@@ -136,8 +132,7 @@ func (o *PatchMoveForbidden) WriteResponse(rw http.ResponseWriter, producer runt
 // PatchMoveNotFoundCode is the HTTP code returned for type PatchMoveNotFound
 const PatchMoveNotFoundCode int = 404
 
-/*
-PatchMoveNotFound move is not found
+/*PatchMoveNotFound move is not found
 
 swagger:response patchMoveNotFound
 */
@@ -161,8 +156,7 @@ func (o *PatchMoveNotFound) WriteResponse(rw http.ResponseWriter, producer runti
 // PatchMoveInternalServerErrorCode is the HTTP code returned for type PatchMoveInternalServerError
 const PatchMoveInternalServerErrorCode int = 500
 
-/*
-PatchMoveInternalServerError internal server error
+/*PatchMoveInternalServerError internal server error
 
 swagger:response patchMoveInternalServerError
 */

--- a/pkg/gen/internalapi/internaloperations/moves/show_move.go
+++ b/pkg/gen/internalapi/internaloperations/moves/show_move.go
@@ -29,12 +29,12 @@ func NewShowMove(ctx *middleware.Context, handler ShowMoveHandler) *ShowMove {
 	return &ShowMove{Context: ctx, Handler: handler}
 }
 
-/*
-	ShowMove swagger:route GET /moves/{moveId} moves showMove
-
-# Returns the given move
+/* ShowMove swagger:route GET /moves/{moveId} moves showMove
 
 Returns the given move
+
+Returns the given move
+
 */
 type ShowMove struct {
 	Context *middleware.Context

--- a/pkg/gen/internalapi/internaloperations/moves/show_move_dates_summary.go
+++ b/pkg/gen/internalapi/internaloperations/moves/show_move_dates_summary.go
@@ -29,12 +29,12 @@ func NewShowMoveDatesSummary(ctx *middleware.Context, handler ShowMoveDatesSumma
 	return &ShowMoveDatesSummary{Context: ctx, Handler: handler}
 }
 
-/*
-	ShowMoveDatesSummary swagger:route GET /moves/{moveId}/move_dates_summary moves showMoveDatesSummary
-
-# Returns projected move-related dates for a given move date
+/* ShowMoveDatesSummary swagger:route GET /moves/{moveId}/move_dates_summary moves showMoveDatesSummary
 
 Returns projected move-related dates for a given move date
+
+Returns projected move-related dates for a given move date
+
 */
 type ShowMoveDatesSummary struct {
 	Context *middleware.Context

--- a/pkg/gen/internalapi/internaloperations/moves/show_move_dates_summary_responses.go
+++ b/pkg/gen/internalapi/internaloperations/moves/show_move_dates_summary_responses.go
@@ -16,8 +16,7 @@ import (
 // ShowMoveDatesSummaryOKCode is the HTTP code returned for type ShowMoveDatesSummaryOK
 const ShowMoveDatesSummaryOKCode int = 200
 
-/*
-ShowMoveDatesSummaryOK List of projected move-related dates
+/*ShowMoveDatesSummaryOK List of projected move-related dates
 
 swagger:response showMoveDatesSummaryOK
 */
@@ -61,8 +60,7 @@ func (o *ShowMoveDatesSummaryOK) WriteResponse(rw http.ResponseWriter, producer 
 // ShowMoveDatesSummaryBadRequestCode is the HTTP code returned for type ShowMoveDatesSummaryBadRequest
 const ShowMoveDatesSummaryBadRequestCode int = 400
 
-/*
-ShowMoveDatesSummaryBadRequest invalid request
+/*ShowMoveDatesSummaryBadRequest invalid request
 
 swagger:response showMoveDatesSummaryBadRequest
 */
@@ -86,8 +84,7 @@ func (o *ShowMoveDatesSummaryBadRequest) WriteResponse(rw http.ResponseWriter, p
 // ShowMoveDatesSummaryUnauthorizedCode is the HTTP code returned for type ShowMoveDatesSummaryUnauthorized
 const ShowMoveDatesSummaryUnauthorizedCode int = 401
 
-/*
-ShowMoveDatesSummaryUnauthorized request requires user authentication
+/*ShowMoveDatesSummaryUnauthorized request requires user authentication
 
 swagger:response showMoveDatesSummaryUnauthorized
 */
@@ -111,8 +108,7 @@ func (o *ShowMoveDatesSummaryUnauthorized) WriteResponse(rw http.ResponseWriter,
 // ShowMoveDatesSummaryForbiddenCode is the HTTP code returned for type ShowMoveDatesSummaryForbidden
 const ShowMoveDatesSummaryForbiddenCode int = 403
 
-/*
-ShowMoveDatesSummaryForbidden user is not authorized
+/*ShowMoveDatesSummaryForbidden user is not authorized
 
 swagger:response showMoveDatesSummaryForbidden
 */
@@ -136,8 +132,7 @@ func (o *ShowMoveDatesSummaryForbidden) WriteResponse(rw http.ResponseWriter, pr
 // ShowMoveDatesSummaryInternalServerErrorCode is the HTTP code returned for type ShowMoveDatesSummaryInternalServerError
 const ShowMoveDatesSummaryInternalServerErrorCode int = 500
 
-/*
-ShowMoveDatesSummaryInternalServerError internal server error
+/*ShowMoveDatesSummaryInternalServerError internal server error
 
 swagger:response showMoveDatesSummaryInternalServerError
 */

--- a/pkg/gen/internalapi/internaloperations/moves/show_move_responses.go
+++ b/pkg/gen/internalapi/internaloperations/moves/show_move_responses.go
@@ -16,8 +16,7 @@ import (
 // ShowMoveOKCode is the HTTP code returned for type ShowMoveOK
 const ShowMoveOKCode int = 200
 
-/*
-ShowMoveOK the instance of the move
+/*ShowMoveOK the instance of the move
 
 swagger:response showMoveOK
 */
@@ -61,8 +60,7 @@ func (o *ShowMoveOK) WriteResponse(rw http.ResponseWriter, producer runtime.Prod
 // ShowMoveBadRequestCode is the HTTP code returned for type ShowMoveBadRequest
 const ShowMoveBadRequestCode int = 400
 
-/*
-ShowMoveBadRequest invalid request
+/*ShowMoveBadRequest invalid request
 
 swagger:response showMoveBadRequest
 */
@@ -86,8 +84,7 @@ func (o *ShowMoveBadRequest) WriteResponse(rw http.ResponseWriter, producer runt
 // ShowMoveUnauthorizedCode is the HTTP code returned for type ShowMoveUnauthorized
 const ShowMoveUnauthorizedCode int = 401
 
-/*
-ShowMoveUnauthorized request requires user authentication
+/*ShowMoveUnauthorized request requires user authentication
 
 swagger:response showMoveUnauthorized
 */
@@ -111,8 +108,7 @@ func (o *ShowMoveUnauthorized) WriteResponse(rw http.ResponseWriter, producer ru
 // ShowMoveForbiddenCode is the HTTP code returned for type ShowMoveForbidden
 const ShowMoveForbiddenCode int = 403
 
-/*
-ShowMoveForbidden user is not authorized
+/*ShowMoveForbidden user is not authorized
 
 swagger:response showMoveForbidden
 */
@@ -136,8 +132,7 @@ func (o *ShowMoveForbidden) WriteResponse(rw http.ResponseWriter, producer runti
 // ShowMoveNotFoundCode is the HTTP code returned for type ShowMoveNotFound
 const ShowMoveNotFoundCode int = 404
 
-/*
-ShowMoveNotFound move is not found
+/*ShowMoveNotFound move is not found
 
 swagger:response showMoveNotFound
 */
@@ -161,8 +156,7 @@ func (o *ShowMoveNotFound) WriteResponse(rw http.ResponseWriter, producer runtim
 // ShowMoveInternalServerErrorCode is the HTTP code returned for type ShowMoveInternalServerError
 const ShowMoveInternalServerErrorCode int = 500
 
-/*
-ShowMoveInternalServerError internal server error
+/*ShowMoveInternalServerError internal server error
 
 swagger:response showMoveInternalServerError
 */

--- a/pkg/gen/internalapi/internaloperations/moves/show_shipment_summary_worksheet.go
+++ b/pkg/gen/internalapi/internaloperations/moves/show_shipment_summary_worksheet.go
@@ -29,12 +29,12 @@ func NewShowShipmentSummaryWorksheet(ctx *middleware.Context, handler ShowShipme
 	return &ShowShipmentSummaryWorksheet{Context: ctx, Handler: handler}
 }
 
-/*
-	ShowShipmentSummaryWorksheet swagger:route GET /moves/{moveId}/shipment_summary_worksheet moves showShipmentSummaryWorksheet
+/* ShowShipmentSummaryWorksheet swagger:route GET /moves/{moveId}/shipment_summary_worksheet moves showShipmentSummaryWorksheet
 
-# Returns Shipment Summary Worksheet
+Returns Shipment Summary Worksheet
 
 Generates pre-filled PDF using data already collected
+
 */
 type ShowShipmentSummaryWorksheet struct {
 	Context *middleware.Context

--- a/pkg/gen/internalapi/internaloperations/moves/show_shipment_summary_worksheet_responses.go
+++ b/pkg/gen/internalapi/internaloperations/moves/show_shipment_summary_worksheet_responses.go
@@ -15,8 +15,7 @@ import (
 // ShowShipmentSummaryWorksheetOKCode is the HTTP code returned for type ShowShipmentSummaryWorksheetOK
 const ShowShipmentSummaryWorksheetOKCode int = 200
 
-/*
-ShowShipmentSummaryWorksheetOK Pre-filled worksheet PDF
+/*ShowShipmentSummaryWorksheetOK Pre-filled worksheet PDF
 
 swagger:response showShipmentSummaryWorksheetOK
 */
@@ -80,8 +79,7 @@ func (o *ShowShipmentSummaryWorksheetOK) WriteResponse(rw http.ResponseWriter, p
 // ShowShipmentSummaryWorksheetBadRequestCode is the HTTP code returned for type ShowShipmentSummaryWorksheetBadRequest
 const ShowShipmentSummaryWorksheetBadRequestCode int = 400
 
-/*
-ShowShipmentSummaryWorksheetBadRequest invalid request
+/*ShowShipmentSummaryWorksheetBadRequest invalid request
 
 swagger:response showShipmentSummaryWorksheetBadRequest
 */
@@ -105,8 +103,7 @@ func (o *ShowShipmentSummaryWorksheetBadRequest) WriteResponse(rw http.ResponseW
 // ShowShipmentSummaryWorksheetUnauthorizedCode is the HTTP code returned for type ShowShipmentSummaryWorksheetUnauthorized
 const ShowShipmentSummaryWorksheetUnauthorizedCode int = 401
 
-/*
-ShowShipmentSummaryWorksheetUnauthorized request requires user authentication
+/*ShowShipmentSummaryWorksheetUnauthorized request requires user authentication
 
 swagger:response showShipmentSummaryWorksheetUnauthorized
 */
@@ -130,8 +127,7 @@ func (o *ShowShipmentSummaryWorksheetUnauthorized) WriteResponse(rw http.Respons
 // ShowShipmentSummaryWorksheetForbiddenCode is the HTTP code returned for type ShowShipmentSummaryWorksheetForbidden
 const ShowShipmentSummaryWorksheetForbiddenCode int = 403
 
-/*
-ShowShipmentSummaryWorksheetForbidden user is not authorized
+/*ShowShipmentSummaryWorksheetForbidden user is not authorized
 
 swagger:response showShipmentSummaryWorksheetForbidden
 */
@@ -155,8 +151,7 @@ func (o *ShowShipmentSummaryWorksheetForbidden) WriteResponse(rw http.ResponseWr
 // ShowShipmentSummaryWorksheetInternalServerErrorCode is the HTTP code returned for type ShowShipmentSummaryWorksheetInternalServerError
 const ShowShipmentSummaryWorksheetInternalServerErrorCode int = 500
 
-/*
-ShowShipmentSummaryWorksheetInternalServerError internal server error
+/*ShowShipmentSummaryWorksheetInternalServerError internal server error
 
 swagger:response showShipmentSummaryWorksheetInternalServerError
 */

--- a/pkg/gen/internalapi/internaloperations/moves/submit_amended_orders.go
+++ b/pkg/gen/internalapi/internaloperations/moves/submit_amended_orders.go
@@ -29,12 +29,12 @@ func NewSubmitAmendedOrders(ctx *middleware.Context, handler SubmitAmendedOrders
 	return &SubmitAmendedOrders{Context: ctx, Handler: handler}
 }
 
-/*
-	SubmitAmendedOrders swagger:route POST /moves/{moveId}/submit_amended_orders moves submitAmendedOrders
+/* SubmitAmendedOrders swagger:route POST /moves/{moveId}/submit_amended_orders moves submitAmendedOrders
 
-# Submits amended orders for review
+Submits amended orders for review
 
 Submits amended orders for review by the office. The status of the move will be updated to an appropriate status depending on whether it needs services counseling or not.
+
 */
 type SubmitAmendedOrders struct {
 	Context *middleware.Context

--- a/pkg/gen/internalapi/internaloperations/moves/submit_amended_orders_responses.go
+++ b/pkg/gen/internalapi/internaloperations/moves/submit_amended_orders_responses.go
@@ -16,8 +16,7 @@ import (
 // SubmitAmendedOrdersOKCode is the HTTP code returned for type SubmitAmendedOrdersOK
 const SubmitAmendedOrdersOKCode int = 200
 
-/*
-SubmitAmendedOrdersOK returns updated (submitted) move object
+/*SubmitAmendedOrdersOK returns updated (submitted) move object
 
 swagger:response submitAmendedOrdersOK
 */
@@ -61,8 +60,7 @@ func (o *SubmitAmendedOrdersOK) WriteResponse(rw http.ResponseWriter, producer r
 // SubmitAmendedOrdersBadRequestCode is the HTTP code returned for type SubmitAmendedOrdersBadRequest
 const SubmitAmendedOrdersBadRequestCode int = 400
 
-/*
-SubmitAmendedOrdersBadRequest invalid request
+/*SubmitAmendedOrdersBadRequest invalid request
 
 swagger:response submitAmendedOrdersBadRequest
 */
@@ -86,8 +84,7 @@ func (o *SubmitAmendedOrdersBadRequest) WriteResponse(rw http.ResponseWriter, pr
 // SubmitAmendedOrdersUnauthorizedCode is the HTTP code returned for type SubmitAmendedOrdersUnauthorized
 const SubmitAmendedOrdersUnauthorizedCode int = 401
 
-/*
-SubmitAmendedOrdersUnauthorized must be authenticated to use this endpoint
+/*SubmitAmendedOrdersUnauthorized must be authenticated to use this endpoint
 
 swagger:response submitAmendedOrdersUnauthorized
 */
@@ -111,8 +108,7 @@ func (o *SubmitAmendedOrdersUnauthorized) WriteResponse(rw http.ResponseWriter, 
 // SubmitAmendedOrdersForbiddenCode is the HTTP code returned for type SubmitAmendedOrdersForbidden
 const SubmitAmendedOrdersForbiddenCode int = 403
 
-/*
-SubmitAmendedOrdersForbidden not authorized to approve this move
+/*SubmitAmendedOrdersForbidden not authorized to approve this move
 
 swagger:response submitAmendedOrdersForbidden
 */
@@ -136,8 +132,7 @@ func (o *SubmitAmendedOrdersForbidden) WriteResponse(rw http.ResponseWriter, pro
 // SubmitAmendedOrdersConflictCode is the HTTP code returned for type SubmitAmendedOrdersConflict
 const SubmitAmendedOrdersConflictCode int = 409
 
-/*
-SubmitAmendedOrdersConflict the move is not in a state to be approved
+/*SubmitAmendedOrdersConflict the move is not in a state to be approved
 
 swagger:response submitAmendedOrdersConflict
 */
@@ -181,8 +176,7 @@ func (o *SubmitAmendedOrdersConflict) WriteResponse(rw http.ResponseWriter, prod
 // SubmitAmendedOrdersInternalServerErrorCode is the HTTP code returned for type SubmitAmendedOrdersInternalServerError
 const SubmitAmendedOrdersInternalServerErrorCode int = 500
 
-/*
-SubmitAmendedOrdersInternalServerError server error
+/*SubmitAmendedOrdersInternalServerError server error
 
 swagger:response submitAmendedOrdersInternalServerError
 */

--- a/pkg/gen/internalapi/internaloperations/moves/submit_move_for_approval.go
+++ b/pkg/gen/internalapi/internaloperations/moves/submit_move_for_approval.go
@@ -29,12 +29,12 @@ func NewSubmitMoveForApproval(ctx *middleware.Context, handler SubmitMoveForAppr
 	return &SubmitMoveForApproval{Context: ctx, Handler: handler}
 }
 
-/*
-	SubmitMoveForApproval swagger:route POST /moves/{moveId}/submit moves submitMoveForApproval
+/* SubmitMoveForApproval swagger:route POST /moves/{moveId}/submit moves submitMoveForApproval
 
-# Submits a move for approval
+Submits a move for approval
 
 Submits a move for approval by the office. The status of the move will be updated to SUBMITTED
+
 */
 type SubmitMoveForApproval struct {
 	Context *middleware.Context

--- a/pkg/gen/internalapi/internaloperations/moves/submit_move_for_approval_responses.go
+++ b/pkg/gen/internalapi/internaloperations/moves/submit_move_for_approval_responses.go
@@ -16,8 +16,7 @@ import (
 // SubmitMoveForApprovalOKCode is the HTTP code returned for type SubmitMoveForApprovalOK
 const SubmitMoveForApprovalOKCode int = 200
 
-/*
-SubmitMoveForApprovalOK returns updated (submitted) move object
+/*SubmitMoveForApprovalOK returns updated (submitted) move object
 
 swagger:response submitMoveForApprovalOK
 */
@@ -61,8 +60,7 @@ func (o *SubmitMoveForApprovalOK) WriteResponse(rw http.ResponseWriter, producer
 // SubmitMoveForApprovalBadRequestCode is the HTTP code returned for type SubmitMoveForApprovalBadRequest
 const SubmitMoveForApprovalBadRequestCode int = 400
 
-/*
-SubmitMoveForApprovalBadRequest invalid request
+/*SubmitMoveForApprovalBadRequest invalid request
 
 swagger:response submitMoveForApprovalBadRequest
 */
@@ -86,8 +84,7 @@ func (o *SubmitMoveForApprovalBadRequest) WriteResponse(rw http.ResponseWriter, 
 // SubmitMoveForApprovalUnauthorizedCode is the HTTP code returned for type SubmitMoveForApprovalUnauthorized
 const SubmitMoveForApprovalUnauthorizedCode int = 401
 
-/*
-SubmitMoveForApprovalUnauthorized must be authenticated to use this endpoint
+/*SubmitMoveForApprovalUnauthorized must be authenticated to use this endpoint
 
 swagger:response submitMoveForApprovalUnauthorized
 */
@@ -111,8 +108,7 @@ func (o *SubmitMoveForApprovalUnauthorized) WriteResponse(rw http.ResponseWriter
 // SubmitMoveForApprovalForbiddenCode is the HTTP code returned for type SubmitMoveForApprovalForbidden
 const SubmitMoveForApprovalForbiddenCode int = 403
 
-/*
-SubmitMoveForApprovalForbidden not authorized to approve this move
+/*SubmitMoveForApprovalForbidden not authorized to approve this move
 
 swagger:response submitMoveForApprovalForbidden
 */
@@ -136,8 +132,7 @@ func (o *SubmitMoveForApprovalForbidden) WriteResponse(rw http.ResponseWriter, p
 // SubmitMoveForApprovalConflictCode is the HTTP code returned for type SubmitMoveForApprovalConflict
 const SubmitMoveForApprovalConflictCode int = 409
 
-/*
-SubmitMoveForApprovalConflict the move is not in a state to be approved
+/*SubmitMoveForApprovalConflict the move is not in a state to be approved
 
 swagger:response submitMoveForApprovalConflict
 */
@@ -181,8 +176,7 @@ func (o *SubmitMoveForApprovalConflict) WriteResponse(rw http.ResponseWriter, pr
 // SubmitMoveForApprovalInternalServerErrorCode is the HTTP code returned for type SubmitMoveForApprovalInternalServerError
 const SubmitMoveForApprovalInternalServerErrorCode int = 500
 
-/*
-SubmitMoveForApprovalInternalServerError server error
+/*SubmitMoveForApprovalInternalServerError server error
 
 swagger:response submitMoveForApprovalInternalServerError
 */

--- a/pkg/gen/internalapi/internaloperations/mto_shipment/create_m_t_o_shipment.go
+++ b/pkg/gen/internalapi/internaloperations/mto_shipment/create_m_t_o_shipment.go
@@ -29,8 +29,7 @@ func NewCreateMTOShipment(ctx *middleware.Context, handler CreateMTOShipmentHand
 	return &CreateMTOShipment{Context: ctx, Handler: handler}
 }
 
-/*
-	CreateMTOShipment swagger:route POST /mto_shipments mtoShipment createMTOShipment
+/* CreateMTOShipment swagger:route POST /mto_shipments mtoShipment createMTOShipment
 
 createMTOShipment
 
@@ -44,6 +43,8 @@ Required fields include:
 Optional fields include:
 * Customer Remarks
 * Releasing / Receiving agents
+
+
 */
 type CreateMTOShipment struct {
 	Context *middleware.Context

--- a/pkg/gen/internalapi/internaloperations/mto_shipment/create_m_t_o_shipment_responses.go
+++ b/pkg/gen/internalapi/internaloperations/mto_shipment/create_m_t_o_shipment_responses.go
@@ -16,8 +16,7 @@ import (
 // CreateMTOShipmentOKCode is the HTTP code returned for type CreateMTOShipmentOK
 const CreateMTOShipmentOKCode int = 200
 
-/*
-CreateMTOShipmentOK Successfully created a MTO shipment.
+/*CreateMTOShipmentOK Successfully created a MTO shipment.
 
 swagger:response createMTOShipmentOK
 */
@@ -61,8 +60,7 @@ func (o *CreateMTOShipmentOK) WriteResponse(rw http.ResponseWriter, producer run
 // CreateMTOShipmentBadRequestCode is the HTTP code returned for type CreateMTOShipmentBadRequest
 const CreateMTOShipmentBadRequestCode int = 400
 
-/*
-CreateMTOShipmentBadRequest The request payload is invalid.
+/*CreateMTOShipmentBadRequest The request payload is invalid.
 
 swagger:response createMTOShipmentBadRequest
 */
@@ -106,8 +104,7 @@ func (o *CreateMTOShipmentBadRequest) WriteResponse(rw http.ResponseWriter, prod
 // CreateMTOShipmentUnauthorizedCode is the HTTP code returned for type CreateMTOShipmentUnauthorized
 const CreateMTOShipmentUnauthorizedCode int = 401
 
-/*
-CreateMTOShipmentUnauthorized The request was denied.
+/*CreateMTOShipmentUnauthorized The request was denied.
 
 swagger:response createMTOShipmentUnauthorized
 */
@@ -151,8 +148,7 @@ func (o *CreateMTOShipmentUnauthorized) WriteResponse(rw http.ResponseWriter, pr
 // CreateMTOShipmentForbiddenCode is the HTTP code returned for type CreateMTOShipmentForbidden
 const CreateMTOShipmentForbiddenCode int = 403
 
-/*
-CreateMTOShipmentForbidden The request was denied.
+/*CreateMTOShipmentForbidden The request was denied.
 
 swagger:response createMTOShipmentForbidden
 */
@@ -196,8 +192,7 @@ func (o *CreateMTOShipmentForbidden) WriteResponse(rw http.ResponseWriter, produ
 // CreateMTOShipmentNotFoundCode is the HTTP code returned for type CreateMTOShipmentNotFound
 const CreateMTOShipmentNotFoundCode int = 404
 
-/*
-CreateMTOShipmentNotFound The requested resource wasn't found.
+/*CreateMTOShipmentNotFound The requested resource wasn't found.
 
 swagger:response createMTOShipmentNotFound
 */
@@ -241,8 +236,7 @@ func (o *CreateMTOShipmentNotFound) WriteResponse(rw http.ResponseWriter, produc
 // CreateMTOShipmentUnprocessableEntityCode is the HTTP code returned for type CreateMTOShipmentUnprocessableEntity
 const CreateMTOShipmentUnprocessableEntityCode int = 422
 
-/*
-CreateMTOShipmentUnprocessableEntity The payload was unprocessable.
+/*CreateMTOShipmentUnprocessableEntity The payload was unprocessable.
 
 swagger:response createMTOShipmentUnprocessableEntity
 */
@@ -286,8 +280,7 @@ func (o *CreateMTOShipmentUnprocessableEntity) WriteResponse(rw http.ResponseWri
 // CreateMTOShipmentInternalServerErrorCode is the HTTP code returned for type CreateMTOShipmentInternalServerError
 const CreateMTOShipmentInternalServerErrorCode int = 500
 
-/*
-CreateMTOShipmentInternalServerError A server error occurred.
+/*CreateMTOShipmentInternalServerError A server error occurred.
 
 swagger:response createMTOShipmentInternalServerError
 */

--- a/pkg/gen/internalapi/internaloperations/mto_shipment/delete_shipment.go
+++ b/pkg/gen/internalapi/internaloperations/mto_shipment/delete_shipment.go
@@ -29,12 +29,12 @@ func NewDeleteShipment(ctx *middleware.Context, handler DeleteShipmentHandler) *
 	return &DeleteShipment{Context: ctx, Handler: handler}
 }
 
-/*
-	DeleteShipment swagger:route DELETE /mto-shipments/{mtoShipmentId} mtoShipment deleteShipment
-
-# Soft deletes a shipment by ID
+/* DeleteShipment swagger:route DELETE /mto-shipments/{mtoShipmentId} mtoShipment deleteShipment
 
 Soft deletes a shipment by ID
+
+Soft deletes a shipment by ID
+
 */
 type DeleteShipment struct {
 	Context *middleware.Context

--- a/pkg/gen/internalapi/internaloperations/mto_shipment/delete_shipment_responses.go
+++ b/pkg/gen/internalapi/internaloperations/mto_shipment/delete_shipment_responses.go
@@ -16,8 +16,7 @@ import (
 // DeleteShipmentNoContentCode is the HTTP code returned for type DeleteShipmentNoContent
 const DeleteShipmentNoContentCode int = 204
 
-/*
-DeleteShipmentNoContent Successfully soft deleted the shipment
+/*DeleteShipmentNoContent Successfully soft deleted the shipment
 
 swagger:response deleteShipmentNoContent
 */
@@ -41,8 +40,7 @@ func (o *DeleteShipmentNoContent) WriteResponse(rw http.ResponseWriter, producer
 // DeleteShipmentBadRequestCode is the HTTP code returned for type DeleteShipmentBadRequest
 const DeleteShipmentBadRequestCode int = 400
 
-/*
-DeleteShipmentBadRequest The request payload is invalid.
+/*DeleteShipmentBadRequest The request payload is invalid.
 
 swagger:response deleteShipmentBadRequest
 */
@@ -86,8 +84,7 @@ func (o *DeleteShipmentBadRequest) WriteResponse(rw http.ResponseWriter, produce
 // DeleteShipmentForbiddenCode is the HTTP code returned for type DeleteShipmentForbidden
 const DeleteShipmentForbiddenCode int = 403
 
-/*
-DeleteShipmentForbidden The request was denied.
+/*DeleteShipmentForbidden The request was denied.
 
 swagger:response deleteShipmentForbidden
 */
@@ -131,8 +128,7 @@ func (o *DeleteShipmentForbidden) WriteResponse(rw http.ResponseWriter, producer
 // DeleteShipmentNotFoundCode is the HTTP code returned for type DeleteShipmentNotFound
 const DeleteShipmentNotFoundCode int = 404
 
-/*
-DeleteShipmentNotFound The requested resource wasn't found.
+/*DeleteShipmentNotFound The requested resource wasn't found.
 
 swagger:response deleteShipmentNotFound
 */
@@ -176,8 +172,7 @@ func (o *DeleteShipmentNotFound) WriteResponse(rw http.ResponseWriter, producer 
 // DeleteShipmentConflictCode is the HTTP code returned for type DeleteShipmentConflict
 const DeleteShipmentConflictCode int = 409
 
-/*
-DeleteShipmentConflict The request could not be processed because of conflict in the current state of the resource.
+/*DeleteShipmentConflict The request could not be processed because of conflict in the current state of the resource.
 
 swagger:response deleteShipmentConflict
 */
@@ -221,8 +216,7 @@ func (o *DeleteShipmentConflict) WriteResponse(rw http.ResponseWriter, producer 
 // DeleteShipmentUnprocessableEntityCode is the HTTP code returned for type DeleteShipmentUnprocessableEntity
 const DeleteShipmentUnprocessableEntityCode int = 422
 
-/*
-DeleteShipmentUnprocessableEntity The payload was unprocessable.
+/*DeleteShipmentUnprocessableEntity The payload was unprocessable.
 
 swagger:response deleteShipmentUnprocessableEntity
 */
@@ -266,8 +260,7 @@ func (o *DeleteShipmentUnprocessableEntity) WriteResponse(rw http.ResponseWriter
 // DeleteShipmentInternalServerErrorCode is the HTTP code returned for type DeleteShipmentInternalServerError
 const DeleteShipmentInternalServerErrorCode int = 500
 
-/*
-DeleteShipmentInternalServerError A server error occurred.
+/*DeleteShipmentInternalServerError A server error occurred.
 
 swagger:response deleteShipmentInternalServerError
 */

--- a/pkg/gen/internalapi/internaloperations/mto_shipment/list_m_t_o_shipments.go
+++ b/pkg/gen/internalapi/internaloperations/mto_shipment/list_m_t_o_shipments.go
@@ -29,12 +29,13 @@ func NewListMTOShipments(ctx *middleware.Context, handler ListMTOShipmentsHandle
 	return &ListMTOShipments{Context: ctx, Handler: handler}
 }
 
-/*
-	ListMTOShipments swagger:route GET /moves/{moveTaskOrderID}/mto_shipments mtoShipment listMTOShipments
+/* ListMTOShipments swagger:route GET /moves/{moveTaskOrderID}/mto_shipments mtoShipment listMTOShipments
 
-# Gets all shipments for a move task order
+Gets all shipments for a move task order
 
 Gets all MTO shipments for the specified Move Task Order.
+
+
 */
 type ListMTOShipments struct {
 	Context *middleware.Context

--- a/pkg/gen/internalapi/internaloperations/mto_shipment/list_m_t_o_shipments_responses.go
+++ b/pkg/gen/internalapi/internaloperations/mto_shipment/list_m_t_o_shipments_responses.go
@@ -16,8 +16,7 @@ import (
 // ListMTOShipmentsOKCode is the HTTP code returned for type ListMTOShipmentsOK
 const ListMTOShipmentsOKCode int = 200
 
-/*
-ListMTOShipmentsOK Successfully retrieved all mto shipments for a move task order.
+/*ListMTOShipmentsOK Successfully retrieved all mto shipments for a move task order.
 
 swagger:response listMTOShipmentsOK
 */
@@ -64,8 +63,7 @@ func (o *ListMTOShipmentsOK) WriteResponse(rw http.ResponseWriter, producer runt
 // ListMTOShipmentsBadRequestCode is the HTTP code returned for type ListMTOShipmentsBadRequest
 const ListMTOShipmentsBadRequestCode int = 400
 
-/*
-ListMTOShipmentsBadRequest The request payload is invalid.
+/*ListMTOShipmentsBadRequest The request payload is invalid.
 
 swagger:response listMTOShipmentsBadRequest
 */
@@ -109,8 +107,7 @@ func (o *ListMTOShipmentsBadRequest) WriteResponse(rw http.ResponseWriter, produ
 // ListMTOShipmentsUnauthorizedCode is the HTTP code returned for type ListMTOShipmentsUnauthorized
 const ListMTOShipmentsUnauthorizedCode int = 401
 
-/*
-ListMTOShipmentsUnauthorized The request was denied.
+/*ListMTOShipmentsUnauthorized The request was denied.
 
 swagger:response listMTOShipmentsUnauthorized
 */
@@ -154,8 +151,7 @@ func (o *ListMTOShipmentsUnauthorized) WriteResponse(rw http.ResponseWriter, pro
 // ListMTOShipmentsInternalServerErrorCode is the HTTP code returned for type ListMTOShipmentsInternalServerError
 const ListMTOShipmentsInternalServerErrorCode int = 500
 
-/*
-ListMTOShipmentsInternalServerError A server error occurred.
+/*ListMTOShipmentsInternalServerError A server error occurred.
 
 swagger:response listMTOShipmentsInternalServerError
 */

--- a/pkg/gen/internalapi/internaloperations/mto_shipment/update_m_t_o_shipment.go
+++ b/pkg/gen/internalapi/internaloperations/mto_shipment/update_m_t_o_shipment.go
@@ -29,8 +29,7 @@ func NewUpdateMTOShipment(ctx *middleware.Context, handler UpdateMTOShipmentHand
 	return &UpdateMTOShipment{Context: ctx, Handler: handler}
 }
 
-/*
-	UpdateMTOShipment swagger:route PATCH /mto-shipments/{mtoShipmentId} mtoShipment updateMTOShipment
+/* UpdateMTOShipment swagger:route PATCH /mto-shipments/{mtoShipmentId} mtoShipment updateMTOShipment
 
 updateMTOShipment
 
@@ -49,6 +48,8 @@ Optional fields include:
 * Delivery Address
 * Customer Remarks
 * Releasing / Receiving agents
+
+
 */
 type UpdateMTOShipment struct {
 	Context *middleware.Context

--- a/pkg/gen/internalapi/internaloperations/mto_shipment/update_m_t_o_shipment_responses.go
+++ b/pkg/gen/internalapi/internaloperations/mto_shipment/update_m_t_o_shipment_responses.go
@@ -16,8 +16,7 @@ import (
 // UpdateMTOShipmentOKCode is the HTTP code returned for type UpdateMTOShipmentOK
 const UpdateMTOShipmentOKCode int = 200
 
-/*
-UpdateMTOShipmentOK Successfully updated the specified MTO shipment.
+/*UpdateMTOShipmentOK Successfully updated the specified MTO shipment.
 
 swagger:response updateMTOShipmentOK
 */
@@ -61,8 +60,7 @@ func (o *UpdateMTOShipmentOK) WriteResponse(rw http.ResponseWriter, producer run
 // UpdateMTOShipmentBadRequestCode is the HTTP code returned for type UpdateMTOShipmentBadRequest
 const UpdateMTOShipmentBadRequestCode int = 400
 
-/*
-UpdateMTOShipmentBadRequest The request payload is invalid.
+/*UpdateMTOShipmentBadRequest The request payload is invalid.
 
 swagger:response updateMTOShipmentBadRequest
 */
@@ -106,8 +104,7 @@ func (o *UpdateMTOShipmentBadRequest) WriteResponse(rw http.ResponseWriter, prod
 // UpdateMTOShipmentUnauthorizedCode is the HTTP code returned for type UpdateMTOShipmentUnauthorized
 const UpdateMTOShipmentUnauthorizedCode int = 401
 
-/*
-UpdateMTOShipmentUnauthorized The request was denied.
+/*UpdateMTOShipmentUnauthorized The request was denied.
 
 swagger:response updateMTOShipmentUnauthorized
 */
@@ -151,8 +148,7 @@ func (o *UpdateMTOShipmentUnauthorized) WriteResponse(rw http.ResponseWriter, pr
 // UpdateMTOShipmentForbiddenCode is the HTTP code returned for type UpdateMTOShipmentForbidden
 const UpdateMTOShipmentForbiddenCode int = 403
 
-/*
-UpdateMTOShipmentForbidden The request was denied.
+/*UpdateMTOShipmentForbidden The request was denied.
 
 swagger:response updateMTOShipmentForbidden
 */
@@ -196,8 +192,7 @@ func (o *UpdateMTOShipmentForbidden) WriteResponse(rw http.ResponseWriter, produ
 // UpdateMTOShipmentNotFoundCode is the HTTP code returned for type UpdateMTOShipmentNotFound
 const UpdateMTOShipmentNotFoundCode int = 404
 
-/*
-UpdateMTOShipmentNotFound The requested resource wasn't found.
+/*UpdateMTOShipmentNotFound The requested resource wasn't found.
 
 swagger:response updateMTOShipmentNotFound
 */
@@ -241,8 +236,7 @@ func (o *UpdateMTOShipmentNotFound) WriteResponse(rw http.ResponseWriter, produc
 // UpdateMTOShipmentPreconditionFailedCode is the HTTP code returned for type UpdateMTOShipmentPreconditionFailed
 const UpdateMTOShipmentPreconditionFailedCode int = 412
 
-/*
-UpdateMTOShipmentPreconditionFailed Precondition failed, likely due to a stale eTag (If-Match). Fetch the request again to get the updated eTag value.
+/*UpdateMTOShipmentPreconditionFailed Precondition failed, likely due to a stale eTag (If-Match). Fetch the request again to get the updated eTag value.
 
 swagger:response updateMTOShipmentPreconditionFailed
 */
@@ -286,8 +280,7 @@ func (o *UpdateMTOShipmentPreconditionFailed) WriteResponse(rw http.ResponseWrit
 // UpdateMTOShipmentUnprocessableEntityCode is the HTTP code returned for type UpdateMTOShipmentUnprocessableEntity
 const UpdateMTOShipmentUnprocessableEntityCode int = 422
 
-/*
-UpdateMTOShipmentUnprocessableEntity The payload was unprocessable.
+/*UpdateMTOShipmentUnprocessableEntity The payload was unprocessable.
 
 swagger:response updateMTOShipmentUnprocessableEntity
 */
@@ -331,8 +324,7 @@ func (o *UpdateMTOShipmentUnprocessableEntity) WriteResponse(rw http.ResponseWri
 // UpdateMTOShipmentInternalServerErrorCode is the HTTP code returned for type UpdateMTOShipmentInternalServerError
 const UpdateMTOShipmentInternalServerErrorCode int = 500
 
-/*
-UpdateMTOShipmentInternalServerError A server error occurred.
+/*UpdateMTOShipmentInternalServerError A server error occurred.
 
 swagger:response updateMTOShipmentInternalServerError
 */

--- a/pkg/gen/internalapi/internaloperations/mymove_api.go
+++ b/pkg/gen/internalapi/internaloperations/mymove_api.go
@@ -259,8 +259,7 @@ func NewMymoveAPI(spec *loads.Document) *MymoveAPI {
 	}
 }
 
-/*
-MymoveAPI The Internal API is a RESTful API that enables the Customer application for
+/*MymoveAPI The Internal API is a RESTful API that enables the Customer application for
 MilMove.
 
 All endpoints are located under `/internal`.

--- a/pkg/gen/internalapi/internaloperations/office/approve_move.go
+++ b/pkg/gen/internalapi/internaloperations/office/approve_move.go
@@ -29,12 +29,12 @@ func NewApproveMove(ctx *middleware.Context, handler ApproveMoveHandler) *Approv
 	return &ApproveMove{Context: ctx, Handler: handler}
 }
 
-/*
-	ApproveMove swagger:route POST /moves/{moveId}/approve office approveMove
+/* ApproveMove swagger:route POST /moves/{moveId}/approve office approveMove
 
-# Approves a move to proceed
+Approves a move to proceed
 
 Approves the basic details of a move. The status of the move will be updated to APPROVED
+
 */
 type ApproveMove struct {
 	Context *middleware.Context

--- a/pkg/gen/internalapi/internaloperations/office/approve_move_responses.go
+++ b/pkg/gen/internalapi/internaloperations/office/approve_move_responses.go
@@ -16,8 +16,7 @@ import (
 // ApproveMoveOKCode is the HTTP code returned for type ApproveMoveOK
 const ApproveMoveOKCode int = 200
 
-/*
-ApproveMoveOK returns updated (approved) move object
+/*ApproveMoveOK returns updated (approved) move object
 
 swagger:response approveMoveOK
 */
@@ -61,8 +60,7 @@ func (o *ApproveMoveOK) WriteResponse(rw http.ResponseWriter, producer runtime.P
 // ApproveMoveBadRequestCode is the HTTP code returned for type ApproveMoveBadRequest
 const ApproveMoveBadRequestCode int = 400
 
-/*
-ApproveMoveBadRequest invalid request
+/*ApproveMoveBadRequest invalid request
 
 swagger:response approveMoveBadRequest
 */
@@ -86,8 +84,7 @@ func (o *ApproveMoveBadRequest) WriteResponse(rw http.ResponseWriter, producer r
 // ApproveMoveUnauthorizedCode is the HTTP code returned for type ApproveMoveUnauthorized
 const ApproveMoveUnauthorizedCode int = 401
 
-/*
-ApproveMoveUnauthorized must be authenticated to use this endpoint
+/*ApproveMoveUnauthorized must be authenticated to use this endpoint
 
 swagger:response approveMoveUnauthorized
 */
@@ -111,8 +108,7 @@ func (o *ApproveMoveUnauthorized) WriteResponse(rw http.ResponseWriter, producer
 // ApproveMoveForbiddenCode is the HTTP code returned for type ApproveMoveForbidden
 const ApproveMoveForbiddenCode int = 403
 
-/*
-ApproveMoveForbidden not authorized to approve this move
+/*ApproveMoveForbidden not authorized to approve this move
 
 swagger:response approveMoveForbidden
 */
@@ -136,8 +132,7 @@ func (o *ApproveMoveForbidden) WriteResponse(rw http.ResponseWriter, producer ru
 // ApproveMoveConflictCode is the HTTP code returned for type ApproveMoveConflict
 const ApproveMoveConflictCode int = 409
 
-/*
-ApproveMoveConflict the move is not in a state to be approved
+/*ApproveMoveConflict the move is not in a state to be approved
 
 swagger:response approveMoveConflict
 */
@@ -181,8 +176,7 @@ func (o *ApproveMoveConflict) WriteResponse(rw http.ResponseWriter, producer run
 // ApproveMoveInternalServerErrorCode is the HTTP code returned for type ApproveMoveInternalServerError
 const ApproveMoveInternalServerErrorCode int = 500
 
-/*
-ApproveMoveInternalServerError server error
+/*ApproveMoveInternalServerError server error
 
 swagger:response approveMoveInternalServerError
 */

--- a/pkg/gen/internalapi/internaloperations/office/approve_p_p_m.go
+++ b/pkg/gen/internalapi/internaloperations/office/approve_p_p_m.go
@@ -29,12 +29,12 @@ func NewApprovePPM(ctx *middleware.Context, handler ApprovePPMHandler) *ApproveP
 	return &ApprovePPM{Context: ctx, Handler: handler}
 }
 
-/*
-	ApprovePPM swagger:route POST /personally_procured_moves/{personallyProcuredMoveId}/approve office approvePPM
+/* ApprovePPM swagger:route POST /personally_procured_moves/{personallyProcuredMoveId}/approve office approvePPM
 
-# Approves the PPM
+Approves the PPM
 
 Sets the status of the PPM to APPROVED.
+
 */
 type ApprovePPM struct {
 	Context *middleware.Context

--- a/pkg/gen/internalapi/internaloperations/office/approve_p_p_m_responses.go
+++ b/pkg/gen/internalapi/internaloperations/office/approve_p_p_m_responses.go
@@ -16,8 +16,7 @@ import (
 // ApprovePPMOKCode is the HTTP code returned for type ApprovePPMOK
 const ApprovePPMOKCode int = 200
 
-/*
-ApprovePPMOK updated instance of personally_procured_move
+/*ApprovePPMOK updated instance of personally_procured_move
 
 swagger:response approvePPMOK
 */
@@ -61,8 +60,7 @@ func (o *ApprovePPMOK) WriteResponse(rw http.ResponseWriter, producer runtime.Pr
 // ApprovePPMBadRequestCode is the HTTP code returned for type ApprovePPMBadRequest
 const ApprovePPMBadRequestCode int = 400
 
-/*
-ApprovePPMBadRequest invalid request
+/*ApprovePPMBadRequest invalid request
 
 swagger:response approvePPMBadRequest
 */
@@ -86,8 +84,7 @@ func (o *ApprovePPMBadRequest) WriteResponse(rw http.ResponseWriter, producer ru
 // ApprovePPMUnauthorizedCode is the HTTP code returned for type ApprovePPMUnauthorized
 const ApprovePPMUnauthorizedCode int = 401
 
-/*
-ApprovePPMUnauthorized request requires user authentication
+/*ApprovePPMUnauthorized request requires user authentication
 
 swagger:response approvePPMUnauthorized
 */
@@ -111,8 +108,7 @@ func (o *ApprovePPMUnauthorized) WriteResponse(rw http.ResponseWriter, producer 
 // ApprovePPMForbiddenCode is the HTTP code returned for type ApprovePPMForbidden
 const ApprovePPMForbiddenCode int = 403
 
-/*
-ApprovePPMForbidden user is not authorized
+/*ApprovePPMForbidden user is not authorized
 
 swagger:response approvePPMForbidden
 */
@@ -136,8 +132,7 @@ func (o *ApprovePPMForbidden) WriteResponse(rw http.ResponseWriter, producer run
 // ApprovePPMInternalServerErrorCode is the HTTP code returned for type ApprovePPMInternalServerError
 const ApprovePPMInternalServerErrorCode int = 500
 
-/*
-ApprovePPMInternalServerError internal server error
+/*ApprovePPMInternalServerError internal server error
 
 swagger:response approvePPMInternalServerError
 */

--- a/pkg/gen/internalapi/internaloperations/office/approve_reimbursement.go
+++ b/pkg/gen/internalapi/internaloperations/office/approve_reimbursement.go
@@ -29,12 +29,12 @@ func NewApproveReimbursement(ctx *middleware.Context, handler ApproveReimburseme
 	return &ApproveReimbursement{Context: ctx, Handler: handler}
 }
 
-/*
-	ApproveReimbursement swagger:route POST /reimbursement/{reimbursementId}/approve office approveReimbursement
+/* ApproveReimbursement swagger:route POST /reimbursement/{reimbursementId}/approve office approveReimbursement
 
-# Approves the reimbursement
+Approves the reimbursement
 
 Sets the status of the reimbursement to APPROVED.
+
 */
 type ApproveReimbursement struct {
 	Context *middleware.Context

--- a/pkg/gen/internalapi/internaloperations/office/approve_reimbursement_responses.go
+++ b/pkg/gen/internalapi/internaloperations/office/approve_reimbursement_responses.go
@@ -16,8 +16,7 @@ import (
 // ApproveReimbursementOKCode is the HTTP code returned for type ApproveReimbursementOK
 const ApproveReimbursementOKCode int = 200
 
-/*
-ApproveReimbursementOK updated instance of reimbursement
+/*ApproveReimbursementOK updated instance of reimbursement
 
 swagger:response approveReimbursementOK
 */
@@ -61,8 +60,7 @@ func (o *ApproveReimbursementOK) WriteResponse(rw http.ResponseWriter, producer 
 // ApproveReimbursementBadRequestCode is the HTTP code returned for type ApproveReimbursementBadRequest
 const ApproveReimbursementBadRequestCode int = 400
 
-/*
-ApproveReimbursementBadRequest invalid request
+/*ApproveReimbursementBadRequest invalid request
 
 swagger:response approveReimbursementBadRequest
 */
@@ -86,8 +84,7 @@ func (o *ApproveReimbursementBadRequest) WriteResponse(rw http.ResponseWriter, p
 // ApproveReimbursementUnauthorizedCode is the HTTP code returned for type ApproveReimbursementUnauthorized
 const ApproveReimbursementUnauthorizedCode int = 401
 
-/*
-ApproveReimbursementUnauthorized request requires user authentication
+/*ApproveReimbursementUnauthorized request requires user authentication
 
 swagger:response approveReimbursementUnauthorized
 */
@@ -111,8 +108,7 @@ func (o *ApproveReimbursementUnauthorized) WriteResponse(rw http.ResponseWriter,
 // ApproveReimbursementForbiddenCode is the HTTP code returned for type ApproveReimbursementForbidden
 const ApproveReimbursementForbiddenCode int = 403
 
-/*
-ApproveReimbursementForbidden user is not authorized
+/*ApproveReimbursementForbidden user is not authorized
 
 swagger:response approveReimbursementForbidden
 */
@@ -136,8 +132,7 @@ func (o *ApproveReimbursementForbidden) WriteResponse(rw http.ResponseWriter, pr
 // ApproveReimbursementInternalServerErrorCode is the HTTP code returned for type ApproveReimbursementInternalServerError
 const ApproveReimbursementInternalServerErrorCode int = 500
 
-/*
-ApproveReimbursementInternalServerError internal server error
+/*ApproveReimbursementInternalServerError internal server error
 
 swagger:response approveReimbursementInternalServerError
 */

--- a/pkg/gen/internalapi/internaloperations/office/cancel_move.go
+++ b/pkg/gen/internalapi/internaloperations/office/cancel_move.go
@@ -29,12 +29,12 @@ func NewCancelMove(ctx *middleware.Context, handler CancelMoveHandler) *CancelMo
 	return &CancelMove{Context: ctx, Handler: handler}
 }
 
-/*
-	CancelMove swagger:route POST /moves/{moveId}/cancel office cancelMove
+/* CancelMove swagger:route POST /moves/{moveId}/cancel office cancelMove
 
-# Cancels a move
+Cancels a move
 
 Cancels the basic details of a move. The status of the move will be updated to CANCELED
+
 */
 type CancelMove struct {
 	Context *middleware.Context

--- a/pkg/gen/internalapi/internaloperations/office/cancel_move_responses.go
+++ b/pkg/gen/internalapi/internaloperations/office/cancel_move_responses.go
@@ -16,8 +16,7 @@ import (
 // CancelMoveOKCode is the HTTP code returned for type CancelMoveOK
 const CancelMoveOKCode int = 200
 
-/*
-CancelMoveOK returns updated (canceled) move object
+/*CancelMoveOK returns updated (canceled) move object
 
 swagger:response cancelMoveOK
 */
@@ -61,8 +60,7 @@ func (o *CancelMoveOK) WriteResponse(rw http.ResponseWriter, producer runtime.Pr
 // CancelMoveBadRequestCode is the HTTP code returned for type CancelMoveBadRequest
 const CancelMoveBadRequestCode int = 400
 
-/*
-CancelMoveBadRequest invalid request
+/*CancelMoveBadRequest invalid request
 
 swagger:response cancelMoveBadRequest
 */
@@ -86,8 +84,7 @@ func (o *CancelMoveBadRequest) WriteResponse(rw http.ResponseWriter, producer ru
 // CancelMoveUnauthorizedCode is the HTTP code returned for type CancelMoveUnauthorized
 const CancelMoveUnauthorizedCode int = 401
 
-/*
-CancelMoveUnauthorized must be authenticated to use this endpoint
+/*CancelMoveUnauthorized must be authenticated to use this endpoint
 
 swagger:response cancelMoveUnauthorized
 */
@@ -111,8 +108,7 @@ func (o *CancelMoveUnauthorized) WriteResponse(rw http.ResponseWriter, producer 
 // CancelMoveForbiddenCode is the HTTP code returned for type CancelMoveForbidden
 const CancelMoveForbiddenCode int = 403
 
-/*
-CancelMoveForbidden not authorized to cancel this move
+/*CancelMoveForbidden not authorized to cancel this move
 
 swagger:response cancelMoveForbidden
 */
@@ -136,8 +132,7 @@ func (o *CancelMoveForbidden) WriteResponse(rw http.ResponseWriter, producer run
 // CancelMoveConflictCode is the HTTP code returned for type CancelMoveConflict
 const CancelMoveConflictCode int = 409
 
-/*
-CancelMoveConflict the move is not in a state to be canceled
+/*CancelMoveConflict the move is not in a state to be canceled
 
 swagger:response cancelMoveConflict
 */
@@ -181,8 +176,7 @@ func (o *CancelMoveConflict) WriteResponse(rw http.ResponseWriter, producer runt
 // CancelMoveInternalServerErrorCode is the HTTP code returned for type CancelMoveInternalServerError
 const CancelMoveInternalServerErrorCode int = 500
 
-/*
-CancelMoveInternalServerError server error
+/*CancelMoveInternalServerError server error
 
 swagger:response cancelMoveInternalServerError
 */

--- a/pkg/gen/internalapi/internaloperations/office/show_office_orders.go
+++ b/pkg/gen/internalapi/internaloperations/office/show_office_orders.go
@@ -29,12 +29,12 @@ func NewShowOfficeOrders(ctx *middleware.Context, handler ShowOfficeOrdersHandle
 	return &ShowOfficeOrders{Context: ctx, Handler: handler}
 }
 
-/*
-	ShowOfficeOrders swagger:route GET /moves/{moveId}/orders office showOfficeOrders
-
-# Returns orders information for a move for office use
+/* ShowOfficeOrders swagger:route GET /moves/{moveId}/orders office showOfficeOrders
 
 Returns orders information for a move for office use
+
+Returns orders information for a move for office use
+
 */
 type ShowOfficeOrders struct {
 	Context *middleware.Context

--- a/pkg/gen/internalapi/internaloperations/office/show_office_orders_responses.go
+++ b/pkg/gen/internalapi/internaloperations/office/show_office_orders_responses.go
@@ -16,8 +16,7 @@ import (
 // ShowOfficeOrdersOKCode is the HTTP code returned for type ShowOfficeOrdersOK
 const ShowOfficeOrdersOKCode int = 200
 
-/*
-ShowOfficeOrdersOK the orders information for a move for office use
+/*ShowOfficeOrdersOK the orders information for a move for office use
 
 swagger:response showOfficeOrdersOK
 */
@@ -61,8 +60,7 @@ func (o *ShowOfficeOrdersOK) WriteResponse(rw http.ResponseWriter, producer runt
 // ShowOfficeOrdersBadRequestCode is the HTTP code returned for type ShowOfficeOrdersBadRequest
 const ShowOfficeOrdersBadRequestCode int = 400
 
-/*
-ShowOfficeOrdersBadRequest invalid request
+/*ShowOfficeOrdersBadRequest invalid request
 
 swagger:response showOfficeOrdersBadRequest
 */
@@ -86,8 +84,7 @@ func (o *ShowOfficeOrdersBadRequest) WriteResponse(rw http.ResponseWriter, produ
 // ShowOfficeOrdersUnauthorizedCode is the HTTP code returned for type ShowOfficeOrdersUnauthorized
 const ShowOfficeOrdersUnauthorizedCode int = 401
 
-/*
-ShowOfficeOrdersUnauthorized request requires user authentication
+/*ShowOfficeOrdersUnauthorized request requires user authentication
 
 swagger:response showOfficeOrdersUnauthorized
 */
@@ -111,8 +108,7 @@ func (o *ShowOfficeOrdersUnauthorized) WriteResponse(rw http.ResponseWriter, pro
 // ShowOfficeOrdersForbiddenCode is the HTTP code returned for type ShowOfficeOrdersForbidden
 const ShowOfficeOrdersForbiddenCode int = 403
 
-/*
-ShowOfficeOrdersForbidden user is not authorized
+/*ShowOfficeOrdersForbidden user is not authorized
 
 swagger:response showOfficeOrdersForbidden
 */
@@ -136,8 +132,7 @@ func (o *ShowOfficeOrdersForbidden) WriteResponse(rw http.ResponseWriter, produc
 // ShowOfficeOrdersNotFoundCode is the HTTP code returned for type ShowOfficeOrdersNotFound
 const ShowOfficeOrdersNotFoundCode int = 404
 
-/*
-ShowOfficeOrdersNotFound move not found
+/*ShowOfficeOrdersNotFound move not found
 
 swagger:response showOfficeOrdersNotFound
 */
@@ -161,8 +156,7 @@ func (o *ShowOfficeOrdersNotFound) WriteResponse(rw http.ResponseWriter, produce
 // ShowOfficeOrdersInternalServerErrorCode is the HTTP code returned for type ShowOfficeOrdersInternalServerError
 const ShowOfficeOrdersInternalServerErrorCode int = 500
 
-/*
-ShowOfficeOrdersInternalServerError internal server error
+/*ShowOfficeOrdersInternalServerError internal server error
 
 swagger:response showOfficeOrdersInternalServerError
 */

--- a/pkg/gen/internalapi/internaloperations/orders/create_orders.go
+++ b/pkg/gen/internalapi/internaloperations/orders/create_orders.go
@@ -29,12 +29,12 @@ func NewCreateOrders(ctx *middleware.Context, handler CreateOrdersHandler) *Crea
 	return &CreateOrders{Context: ctx, Handler: handler}
 }
 
-/*
-	CreateOrders swagger:route POST /orders orders createOrders
+/* CreateOrders swagger:route POST /orders orders createOrders
 
-# Creates an orders model for a logged-in user
+Creates an orders model for a logged-in user
 
 Creates an instance of orders tied to a service member
+
 */
 type CreateOrders struct {
 	Context *middleware.Context

--- a/pkg/gen/internalapi/internaloperations/orders/create_orders_responses.go
+++ b/pkg/gen/internalapi/internaloperations/orders/create_orders_responses.go
@@ -16,8 +16,7 @@ import (
 // CreateOrdersCreatedCode is the HTTP code returned for type CreateOrdersCreated
 const CreateOrdersCreatedCode int = 201
 
-/*
-CreateOrdersCreated created instance of orders
+/*CreateOrdersCreated created instance of orders
 
 swagger:response createOrdersCreated
 */
@@ -61,8 +60,7 @@ func (o *CreateOrdersCreated) WriteResponse(rw http.ResponseWriter, producer run
 // CreateOrdersBadRequestCode is the HTTP code returned for type CreateOrdersBadRequest
 const CreateOrdersBadRequestCode int = 400
 
-/*
-CreateOrdersBadRequest invalid request
+/*CreateOrdersBadRequest invalid request
 
 swagger:response createOrdersBadRequest
 */
@@ -86,8 +84,7 @@ func (o *CreateOrdersBadRequest) WriteResponse(rw http.ResponseWriter, producer 
 // CreateOrdersUnauthorizedCode is the HTTP code returned for type CreateOrdersUnauthorized
 const CreateOrdersUnauthorizedCode int = 401
 
-/*
-CreateOrdersUnauthorized request requires user authentication
+/*CreateOrdersUnauthorized request requires user authentication
 
 swagger:response createOrdersUnauthorized
 */
@@ -111,8 +108,7 @@ func (o *CreateOrdersUnauthorized) WriteResponse(rw http.ResponseWriter, produce
 // CreateOrdersForbiddenCode is the HTTP code returned for type CreateOrdersForbidden
 const CreateOrdersForbiddenCode int = 403
 
-/*
-CreateOrdersForbidden user is not authorized
+/*CreateOrdersForbidden user is not authorized
 
 swagger:response createOrdersForbidden
 */
@@ -136,8 +132,7 @@ func (o *CreateOrdersForbidden) WriteResponse(rw http.ResponseWriter, producer r
 // CreateOrdersInternalServerErrorCode is the HTTP code returned for type CreateOrdersInternalServerError
 const CreateOrdersInternalServerErrorCode int = 500
 
-/*
-CreateOrdersInternalServerError internal server error
+/*CreateOrdersInternalServerError internal server error
 
 swagger:response createOrdersInternalServerError
 */

--- a/pkg/gen/internalapi/internaloperations/orders/show_orders.go
+++ b/pkg/gen/internalapi/internaloperations/orders/show_orders.go
@@ -29,12 +29,12 @@ func NewShowOrders(ctx *middleware.Context, handler ShowOrdersHandler) *ShowOrde
 	return &ShowOrders{Context: ctx, Handler: handler}
 }
 
-/*
-	ShowOrders swagger:route GET /orders/{ordersId} orders showOrders
-
-# Returns the given order
+/* ShowOrders swagger:route GET /orders/{ordersId} orders showOrders
 
 Returns the given order
+
+Returns the given order
+
 */
 type ShowOrders struct {
 	Context *middleware.Context

--- a/pkg/gen/internalapi/internaloperations/orders/show_orders_responses.go
+++ b/pkg/gen/internalapi/internaloperations/orders/show_orders_responses.go
@@ -16,8 +16,7 @@ import (
 // ShowOrdersOKCode is the HTTP code returned for type ShowOrdersOK
 const ShowOrdersOKCode int = 200
 
-/*
-ShowOrdersOK the instance of the order
+/*ShowOrdersOK the instance of the order
 
 swagger:response showOrdersOK
 */
@@ -61,8 +60,7 @@ func (o *ShowOrdersOK) WriteResponse(rw http.ResponseWriter, producer runtime.Pr
 // ShowOrdersBadRequestCode is the HTTP code returned for type ShowOrdersBadRequest
 const ShowOrdersBadRequestCode int = 400
 
-/*
-ShowOrdersBadRequest invalid request
+/*ShowOrdersBadRequest invalid request
 
 swagger:response showOrdersBadRequest
 */
@@ -86,8 +84,7 @@ func (o *ShowOrdersBadRequest) WriteResponse(rw http.ResponseWriter, producer ru
 // ShowOrdersUnauthorizedCode is the HTTP code returned for type ShowOrdersUnauthorized
 const ShowOrdersUnauthorizedCode int = 401
 
-/*
-ShowOrdersUnauthorized request requires user authentication
+/*ShowOrdersUnauthorized request requires user authentication
 
 swagger:response showOrdersUnauthorized
 */
@@ -111,8 +108,7 @@ func (o *ShowOrdersUnauthorized) WriteResponse(rw http.ResponseWriter, producer 
 // ShowOrdersForbiddenCode is the HTTP code returned for type ShowOrdersForbidden
 const ShowOrdersForbiddenCode int = 403
 
-/*
-ShowOrdersForbidden user is not authorized
+/*ShowOrdersForbidden user is not authorized
 
 swagger:response showOrdersForbidden
 */
@@ -136,8 +132,7 @@ func (o *ShowOrdersForbidden) WriteResponse(rw http.ResponseWriter, producer run
 // ShowOrdersNotFoundCode is the HTTP code returned for type ShowOrdersNotFound
 const ShowOrdersNotFoundCode int = 404
 
-/*
-ShowOrdersNotFound order is not found
+/*ShowOrdersNotFound order is not found
 
 swagger:response showOrdersNotFound
 */
@@ -161,8 +156,7 @@ func (o *ShowOrdersNotFound) WriteResponse(rw http.ResponseWriter, producer runt
 // ShowOrdersInternalServerErrorCode is the HTTP code returned for type ShowOrdersInternalServerError
 const ShowOrdersInternalServerErrorCode int = 500
 
-/*
-ShowOrdersInternalServerError internal server error
+/*ShowOrdersInternalServerError internal server error
 
 swagger:response showOrdersInternalServerError
 */

--- a/pkg/gen/internalapi/internaloperations/orders/update_orders.go
+++ b/pkg/gen/internalapi/internaloperations/orders/update_orders.go
@@ -29,12 +29,12 @@ func NewUpdateOrders(ctx *middleware.Context, handler UpdateOrdersHandler) *Upda
 	return &UpdateOrders{Context: ctx, Handler: handler}
 }
 
-/*
-	UpdateOrders swagger:route PUT /orders/{ordersId} orders updateOrders
+/* UpdateOrders swagger:route PUT /orders/{ordersId} orders updateOrders
 
-# Updates orders
+Updates orders
 
 All fields sent in this request will be set on the orders referenced
+
 */
 type UpdateOrders struct {
 	Context *middleware.Context

--- a/pkg/gen/internalapi/internaloperations/orders/update_orders_responses.go
+++ b/pkg/gen/internalapi/internaloperations/orders/update_orders_responses.go
@@ -16,8 +16,7 @@ import (
 // UpdateOrdersOKCode is the HTTP code returned for type UpdateOrdersOK
 const UpdateOrdersOKCode int = 200
 
-/*
-UpdateOrdersOK updated instance of orders
+/*UpdateOrdersOK updated instance of orders
 
 swagger:response updateOrdersOK
 */
@@ -61,8 +60,7 @@ func (o *UpdateOrdersOK) WriteResponse(rw http.ResponseWriter, producer runtime.
 // UpdateOrdersBadRequestCode is the HTTP code returned for type UpdateOrdersBadRequest
 const UpdateOrdersBadRequestCode int = 400
 
-/*
-UpdateOrdersBadRequest invalid request
+/*UpdateOrdersBadRequest invalid request
 
 swagger:response updateOrdersBadRequest
 */
@@ -86,8 +84,7 @@ func (o *UpdateOrdersBadRequest) WriteResponse(rw http.ResponseWriter, producer 
 // UpdateOrdersUnauthorizedCode is the HTTP code returned for type UpdateOrdersUnauthorized
 const UpdateOrdersUnauthorizedCode int = 401
 
-/*
-UpdateOrdersUnauthorized request requires user authentication
+/*UpdateOrdersUnauthorized request requires user authentication
 
 swagger:response updateOrdersUnauthorized
 */
@@ -111,8 +108,7 @@ func (o *UpdateOrdersUnauthorized) WriteResponse(rw http.ResponseWriter, produce
 // UpdateOrdersForbiddenCode is the HTTP code returned for type UpdateOrdersForbidden
 const UpdateOrdersForbiddenCode int = 403
 
-/*
-UpdateOrdersForbidden user is not authorized
+/*UpdateOrdersForbidden user is not authorized
 
 swagger:response updateOrdersForbidden
 */
@@ -136,8 +132,7 @@ func (o *UpdateOrdersForbidden) WriteResponse(rw http.ResponseWriter, producer r
 // UpdateOrdersNotFoundCode is the HTTP code returned for type UpdateOrdersNotFound
 const UpdateOrdersNotFoundCode int = 404
 
-/*
-UpdateOrdersNotFound orders not found
+/*UpdateOrdersNotFound orders not found
 
 swagger:response updateOrdersNotFound
 */
@@ -161,8 +156,7 @@ func (o *UpdateOrdersNotFound) WriteResponse(rw http.ResponseWriter, producer ru
 // UpdateOrdersInternalServerErrorCode is the HTTP code returned for type UpdateOrdersInternalServerError
 const UpdateOrdersInternalServerErrorCode int = 500
 
-/*
-UpdateOrdersInternalServerError internal server error
+/*UpdateOrdersInternalServerError internal server error
 
 swagger:response updateOrdersInternalServerError
 */

--- a/pkg/gen/internalapi/internaloperations/orders/upload_amended_orders.go
+++ b/pkg/gen/internalapi/internaloperations/orders/upload_amended_orders.go
@@ -29,12 +29,12 @@ func NewUploadAmendedOrders(ctx *middleware.Context, handler UploadAmendedOrders
 	return &UploadAmendedOrders{Context: ctx, Handler: handler}
 }
 
-/*
-	UploadAmendedOrders swagger:route PATCH /orders/{ordersId}/upload_amended_orders orders uploadAmendedOrders
-
-# Patch the amended orders for a given order
+/* UploadAmendedOrders swagger:route PATCH /orders/{ordersId}/upload_amended_orders orders uploadAmendedOrders
 
 Patch the amended orders for a given order
+
+Patch the amended orders for a given order
+
 */
 type UploadAmendedOrders struct {
 	Context *middleware.Context

--- a/pkg/gen/internalapi/internaloperations/orders/upload_amended_orders_responses.go
+++ b/pkg/gen/internalapi/internaloperations/orders/upload_amended_orders_responses.go
@@ -16,8 +16,7 @@ import (
 // UploadAmendedOrdersCreatedCode is the HTTP code returned for type UploadAmendedOrdersCreated
 const UploadAmendedOrdersCreatedCode int = 201
 
-/*
-UploadAmendedOrdersCreated created upload
+/*UploadAmendedOrdersCreated created upload
 
 swagger:response uploadAmendedOrdersCreated
 */
@@ -61,8 +60,7 @@ func (o *UploadAmendedOrdersCreated) WriteResponse(rw http.ResponseWriter, produ
 // UploadAmendedOrdersBadRequestCode is the HTTP code returned for type UploadAmendedOrdersBadRequest
 const UploadAmendedOrdersBadRequestCode int = 400
 
-/*
-UploadAmendedOrdersBadRequest invalid request
+/*UploadAmendedOrdersBadRequest invalid request
 
 swagger:response uploadAmendedOrdersBadRequest
 */
@@ -106,8 +104,7 @@ func (o *UploadAmendedOrdersBadRequest) WriteResponse(rw http.ResponseWriter, pr
 // UploadAmendedOrdersForbiddenCode is the HTTP code returned for type UploadAmendedOrdersForbidden
 const UploadAmendedOrdersForbiddenCode int = 403
 
-/*
-UploadAmendedOrdersForbidden not authorized
+/*UploadAmendedOrdersForbidden not authorized
 
 swagger:response uploadAmendedOrdersForbidden
 */
@@ -131,8 +128,7 @@ func (o *UploadAmendedOrdersForbidden) WriteResponse(rw http.ResponseWriter, pro
 // UploadAmendedOrdersNotFoundCode is the HTTP code returned for type UploadAmendedOrdersNotFound
 const UploadAmendedOrdersNotFoundCode int = 404
 
-/*
-UploadAmendedOrdersNotFound not found
+/*UploadAmendedOrdersNotFound not found
 
 swagger:response uploadAmendedOrdersNotFound
 */
@@ -156,8 +152,7 @@ func (o *UploadAmendedOrdersNotFound) WriteResponse(rw http.ResponseWriter, prod
 // UploadAmendedOrdersRequestEntityTooLargeCode is the HTTP code returned for type UploadAmendedOrdersRequestEntityTooLarge
 const UploadAmendedOrdersRequestEntityTooLargeCode int = 413
 
-/*
-UploadAmendedOrdersRequestEntityTooLarge payload is too large
+/*UploadAmendedOrdersRequestEntityTooLarge payload is too large
 
 swagger:response uploadAmendedOrdersRequestEntityTooLarge
 */
@@ -181,8 +176,7 @@ func (o *UploadAmendedOrdersRequestEntityTooLarge) WriteResponse(rw http.Respons
 // UploadAmendedOrdersInternalServerErrorCode is the HTTP code returned for type UploadAmendedOrdersInternalServerError
 const UploadAmendedOrdersInternalServerErrorCode int = 500
 
-/*
-UploadAmendedOrdersInternalServerError server error
+/*UploadAmendedOrdersInternalServerError server error
 
 swagger:response uploadAmendedOrdersInternalServerError
 */

--- a/pkg/gen/internalapi/internaloperations/postal_codes/validate_postal_code_with_rate_data.go
+++ b/pkg/gen/internalapi/internaloperations/postal_codes/validate_postal_code_with_rate_data.go
@@ -29,12 +29,12 @@ func NewValidatePostalCodeWithRateData(ctx *middleware.Context, handler Validate
 	return &ValidatePostalCodeWithRateData{Context: ctx, Handler: handler}
 }
 
-/*
-	ValidatePostalCodeWithRateData swagger:route GET /rate_engine_postal_codes/{postal_code} postal_codes validatePostalCodeWithRateData
+/* ValidatePostalCodeWithRateData swagger:route GET /rate_engine_postal_codes/{postal_code} postal_codes validatePostalCodeWithRateData
 
 Validate if a zipcode is valid for origin or destination location for a move.
 
 Verifies if a zipcode is valid for origin or destination location for a move.
+
 */
 type ValidatePostalCodeWithRateData struct {
 	Context *middleware.Context

--- a/pkg/gen/internalapi/internaloperations/postal_codes/validate_postal_code_with_rate_data_responses.go
+++ b/pkg/gen/internalapi/internaloperations/postal_codes/validate_postal_code_with_rate_data_responses.go
@@ -16,8 +16,7 @@ import (
 // ValidatePostalCodeWithRateDataOKCode is the HTTP code returned for type ValidatePostalCodeWithRateDataOK
 const ValidatePostalCodeWithRateDataOKCode int = 200
 
-/*
-ValidatePostalCodeWithRateDataOK postal_code is valid or invalid
+/*ValidatePostalCodeWithRateDataOK postal_code is valid or invalid
 
 swagger:response validatePostalCodeWithRateDataOK
 */
@@ -61,8 +60,7 @@ func (o *ValidatePostalCodeWithRateDataOK) WriteResponse(rw http.ResponseWriter,
 // ValidatePostalCodeWithRateDataBadRequestCode is the HTTP code returned for type ValidatePostalCodeWithRateDataBadRequest
 const ValidatePostalCodeWithRateDataBadRequestCode int = 400
 
-/*
-ValidatePostalCodeWithRateDataBadRequest invalid request
+/*ValidatePostalCodeWithRateDataBadRequest invalid request
 
 swagger:response validatePostalCodeWithRateDataBadRequest
 */
@@ -86,8 +84,7 @@ func (o *ValidatePostalCodeWithRateDataBadRequest) WriteResponse(rw http.Respons
 // ValidatePostalCodeWithRateDataUnauthorizedCode is the HTTP code returned for type ValidatePostalCodeWithRateDataUnauthorized
 const ValidatePostalCodeWithRateDataUnauthorizedCode int = 401
 
-/*
-ValidatePostalCodeWithRateDataUnauthorized must be authenticated to use this endpoint
+/*ValidatePostalCodeWithRateDataUnauthorized must be authenticated to use this endpoint
 
 swagger:response validatePostalCodeWithRateDataUnauthorized
 */
@@ -111,8 +108,7 @@ func (o *ValidatePostalCodeWithRateDataUnauthorized) WriteResponse(rw http.Respo
 // ValidatePostalCodeWithRateDataForbiddenCode is the HTTP code returned for type ValidatePostalCodeWithRateDataForbidden
 const ValidatePostalCodeWithRateDataForbiddenCode int = 403
 
-/*
-ValidatePostalCodeWithRateDataForbidden user is not authorized
+/*ValidatePostalCodeWithRateDataForbidden user is not authorized
 
 swagger:response validatePostalCodeWithRateDataForbidden
 */
@@ -136,8 +132,7 @@ func (o *ValidatePostalCodeWithRateDataForbidden) WriteResponse(rw http.Response
 // ValidatePostalCodeWithRateDataInternalServerErrorCode is the HTTP code returned for type ValidatePostalCodeWithRateDataInternalServerError
 const ValidatePostalCodeWithRateDataInternalServerErrorCode int = 500
 
-/*
-ValidatePostalCodeWithRateDataInternalServerError server error
+/*ValidatePostalCodeWithRateDataInternalServerError server error
 
 swagger:response validatePostalCodeWithRateDataInternalServerError
 */

--- a/pkg/gen/internalapi/internaloperations/ppm/create_moving_expense.go
+++ b/pkg/gen/internalapi/internaloperations/ppm/create_moving_expense.go
@@ -29,12 +29,12 @@ func NewCreateMovingExpense(ctx *middleware.Context, handler CreateMovingExpense
 	return &CreateMovingExpense{Context: ctx, Handler: handler}
 }
 
-/*
-	CreateMovingExpense swagger:route POST /ppm-shipments/{ppmShipmentId}/moving-expenses ppm createMovingExpense
+/* CreateMovingExpense swagger:route POST /ppm-shipments/{ppmShipmentId}/moving-expenses ppm createMovingExpense
 
-# Creates moving expense document
+Creates moving expense document
 
 Creates a moving expense document for the PPM shipment
+
 */
 type CreateMovingExpense struct {
 	Context *middleware.Context

--- a/pkg/gen/internalapi/internaloperations/ppm/create_moving_expense_responses.go
+++ b/pkg/gen/internalapi/internaloperations/ppm/create_moving_expense_responses.go
@@ -16,8 +16,7 @@ import (
 // CreateMovingExpenseOKCode is the HTTP code returned for type CreateMovingExpenseOK
 const CreateMovingExpenseOKCode int = 200
 
-/*
-CreateMovingExpenseOK returns new moving expense object
+/*CreateMovingExpenseOK returns new moving expense object
 
 swagger:response createMovingExpenseOK
 */
@@ -61,8 +60,7 @@ func (o *CreateMovingExpenseOK) WriteResponse(rw http.ResponseWriter, producer r
 // CreateMovingExpenseBadRequestCode is the HTTP code returned for type CreateMovingExpenseBadRequest
 const CreateMovingExpenseBadRequestCode int = 400
 
-/*
-CreateMovingExpenseBadRequest The request payload is invalid.
+/*CreateMovingExpenseBadRequest The request payload is invalid.
 
 swagger:response createMovingExpenseBadRequest
 */
@@ -106,8 +104,7 @@ func (o *CreateMovingExpenseBadRequest) WriteResponse(rw http.ResponseWriter, pr
 // CreateMovingExpenseUnauthorizedCode is the HTTP code returned for type CreateMovingExpenseUnauthorized
 const CreateMovingExpenseUnauthorizedCode int = 401
 
-/*
-CreateMovingExpenseUnauthorized The request was denied.
+/*CreateMovingExpenseUnauthorized The request was denied.
 
 swagger:response createMovingExpenseUnauthorized
 */
@@ -151,8 +148,7 @@ func (o *CreateMovingExpenseUnauthorized) WriteResponse(rw http.ResponseWriter, 
 // CreateMovingExpenseForbiddenCode is the HTTP code returned for type CreateMovingExpenseForbidden
 const CreateMovingExpenseForbiddenCode int = 403
 
-/*
-CreateMovingExpenseForbidden The request was denied.
+/*CreateMovingExpenseForbidden The request was denied.
 
 swagger:response createMovingExpenseForbidden
 */
@@ -196,8 +192,7 @@ func (o *CreateMovingExpenseForbidden) WriteResponse(rw http.ResponseWriter, pro
 // CreateMovingExpenseNotFoundCode is the HTTP code returned for type CreateMovingExpenseNotFound
 const CreateMovingExpenseNotFoundCode int = 404
 
-/*
-CreateMovingExpenseNotFound The requested resource wasn't found.
+/*CreateMovingExpenseNotFound The requested resource wasn't found.
 
 swagger:response createMovingExpenseNotFound
 */
@@ -241,8 +236,7 @@ func (o *CreateMovingExpenseNotFound) WriteResponse(rw http.ResponseWriter, prod
 // CreateMovingExpenseUnprocessableEntityCode is the HTTP code returned for type CreateMovingExpenseUnprocessableEntity
 const CreateMovingExpenseUnprocessableEntityCode int = 422
 
-/*
-CreateMovingExpenseUnprocessableEntity The payload was unprocessable.
+/*CreateMovingExpenseUnprocessableEntity The payload was unprocessable.
 
 swagger:response createMovingExpenseUnprocessableEntity
 */
@@ -286,8 +280,7 @@ func (o *CreateMovingExpenseUnprocessableEntity) WriteResponse(rw http.ResponseW
 // CreateMovingExpenseInternalServerErrorCode is the HTTP code returned for type CreateMovingExpenseInternalServerError
 const CreateMovingExpenseInternalServerErrorCode int = 500
 
-/*
-CreateMovingExpenseInternalServerError A server error occurred.
+/*CreateMovingExpenseInternalServerError A server error occurred.
 
 swagger:response createMovingExpenseInternalServerError
 */

--- a/pkg/gen/internalapi/internaloperations/ppm/create_p_p_m_attachments.go
+++ b/pkg/gen/internalapi/internaloperations/ppm/create_p_p_m_attachments.go
@@ -29,12 +29,12 @@ func NewCreatePPMAttachments(ctx *middleware.Context, handler CreatePPMAttachmen
 	return &CreatePPMAttachments{Context: ctx, Handler: handler}
 }
 
-/*
-	CreatePPMAttachments swagger:route POST /personally_procured_moves/{personallyProcuredMoveId}/create_ppm_attachments ppm createPPMAttachments
+/* CreatePPMAttachments swagger:route POST /personally_procured_moves/{personallyProcuredMoveId}/create_ppm_attachments ppm createPPMAttachments
 
-# Creates PPM attachments PDF
+Creates PPM attachments PDF
 
 Creates a PPM attachments PDF
+
 */
 type CreatePPMAttachments struct {
 	Context *middleware.Context

--- a/pkg/gen/internalapi/internaloperations/ppm/create_p_p_m_attachments_responses.go
+++ b/pkg/gen/internalapi/internaloperations/ppm/create_p_p_m_attachments_responses.go
@@ -16,8 +16,7 @@ import (
 // CreatePPMAttachmentsOKCode is the HTTP code returned for type CreatePPMAttachmentsOK
 const CreatePPMAttachmentsOKCode int = 200
 
-/*
-CreatePPMAttachmentsOK returns a PPM attachments upload
+/*CreatePPMAttachmentsOK returns a PPM attachments upload
 
 swagger:response createPPMAttachmentsOK
 */
@@ -61,8 +60,7 @@ func (o *CreatePPMAttachmentsOK) WriteResponse(rw http.ResponseWriter, producer 
 // CreatePPMAttachmentsBadRequestCode is the HTTP code returned for type CreatePPMAttachmentsBadRequest
 const CreatePPMAttachmentsBadRequestCode int = 400
 
-/*
-CreatePPMAttachmentsBadRequest invalid request
+/*CreatePPMAttachmentsBadRequest invalid request
 
 swagger:response createPPMAttachmentsBadRequest
 */
@@ -86,8 +84,7 @@ func (o *CreatePPMAttachmentsBadRequest) WriteResponse(rw http.ResponseWriter, p
 // CreatePPMAttachmentsUnauthorizedCode is the HTTP code returned for type CreatePPMAttachmentsUnauthorized
 const CreatePPMAttachmentsUnauthorizedCode int = 401
 
-/*
-CreatePPMAttachmentsUnauthorized must be authenticated to use this endpoint
+/*CreatePPMAttachmentsUnauthorized must be authenticated to use this endpoint
 
 swagger:response createPPMAttachmentsUnauthorized
 */
@@ -111,8 +108,7 @@ func (o *CreatePPMAttachmentsUnauthorized) WriteResponse(rw http.ResponseWriter,
 // CreatePPMAttachmentsForbiddenCode is the HTTP code returned for type CreatePPMAttachmentsForbidden
 const CreatePPMAttachmentsForbiddenCode int = 403
 
-/*
-CreatePPMAttachmentsForbidden not authorized to perform this action
+/*CreatePPMAttachmentsForbidden not authorized to perform this action
 
 swagger:response createPPMAttachmentsForbidden
 */
@@ -136,8 +132,7 @@ func (o *CreatePPMAttachmentsForbidden) WriteResponse(rw http.ResponseWriter, pr
 // CreatePPMAttachmentsRequestEntityTooLargeCode is the HTTP code returned for type CreatePPMAttachmentsRequestEntityTooLarge
 const CreatePPMAttachmentsRequestEntityTooLargeCode int = 413
 
-/*
-CreatePPMAttachmentsRequestEntityTooLarge payload is too large
+/*CreatePPMAttachmentsRequestEntityTooLarge payload is too large
 
 swagger:response createPPMAttachmentsRequestEntityTooLarge
 */
@@ -161,8 +156,7 @@ func (o *CreatePPMAttachmentsRequestEntityTooLarge) WriteResponse(rw http.Respon
 // CreatePPMAttachmentsUnprocessableEntityCode is the HTTP code returned for type CreatePPMAttachmentsUnprocessableEntity
 const CreatePPMAttachmentsUnprocessableEntityCode int = 422
 
-/*
-CreatePPMAttachmentsUnprocessableEntity malformed PDF contained in uploads
+/*CreatePPMAttachmentsUnprocessableEntity malformed PDF contained in uploads
 
 swagger:response createPPMAttachmentsUnprocessableEntity
 */
@@ -186,8 +180,7 @@ func (o *CreatePPMAttachmentsUnprocessableEntity) WriteResponse(rw http.Response
 // CreatePPMAttachmentsFailedDependencyCode is the HTTP code returned for type CreatePPMAttachmentsFailedDependency
 const CreatePPMAttachmentsFailedDependencyCode int = 424
 
-/*
-CreatePPMAttachmentsFailedDependency no files to be processed into attachments PDF
+/*CreatePPMAttachmentsFailedDependency no files to be processed into attachments PDF
 
 swagger:response createPPMAttachmentsFailedDependency
 */
@@ -211,8 +204,7 @@ func (o *CreatePPMAttachmentsFailedDependency) WriteResponse(rw http.ResponseWri
 // CreatePPMAttachmentsInternalServerErrorCode is the HTTP code returned for type CreatePPMAttachmentsInternalServerError
 const CreatePPMAttachmentsInternalServerErrorCode int = 500
 
-/*
-CreatePPMAttachmentsInternalServerError server error
+/*CreatePPMAttachmentsInternalServerError server error
 
 swagger:response createPPMAttachmentsInternalServerError
 */

--- a/pkg/gen/internalapi/internaloperations/ppm/create_personally_procured_move.go
+++ b/pkg/gen/internalapi/internaloperations/ppm/create_personally_procured_move.go
@@ -29,12 +29,12 @@ func NewCreatePersonallyProcuredMove(ctx *middleware.Context, handler CreatePers
 	return &CreatePersonallyProcuredMove{Context: ctx, Handler: handler}
 }
 
-/*
-	CreatePersonallyProcuredMove swagger:route POST /moves/{moveId}/personally_procured_move ppm createPersonallyProcuredMove
+/* CreatePersonallyProcuredMove swagger:route POST /moves/{moveId}/personally_procured_move ppm createPersonallyProcuredMove
 
-# Creates a new PPM for the given move
+Creates a new PPM for the given move
 
 Create an instance of personally_procured_move tied to the move ID
+
 */
 type CreatePersonallyProcuredMove struct {
 	Context *middleware.Context

--- a/pkg/gen/internalapi/internaloperations/ppm/create_personally_procured_move_responses.go
+++ b/pkg/gen/internalapi/internaloperations/ppm/create_personally_procured_move_responses.go
@@ -16,8 +16,7 @@ import (
 // CreatePersonallyProcuredMoveCreatedCode is the HTTP code returned for type CreatePersonallyProcuredMoveCreated
 const CreatePersonallyProcuredMoveCreatedCode int = 201
 
-/*
-CreatePersonallyProcuredMoveCreated created instance of personally_procured_move
+/*CreatePersonallyProcuredMoveCreated created instance of personally_procured_move
 
 swagger:response createPersonallyProcuredMoveCreated
 */
@@ -61,8 +60,7 @@ func (o *CreatePersonallyProcuredMoveCreated) WriteResponse(rw http.ResponseWrit
 // CreatePersonallyProcuredMoveBadRequestCode is the HTTP code returned for type CreatePersonallyProcuredMoveBadRequest
 const CreatePersonallyProcuredMoveBadRequestCode int = 400
 
-/*
-CreatePersonallyProcuredMoveBadRequest invalid request
+/*CreatePersonallyProcuredMoveBadRequest invalid request
 
 swagger:response createPersonallyProcuredMoveBadRequest
 */
@@ -86,8 +84,7 @@ func (o *CreatePersonallyProcuredMoveBadRequest) WriteResponse(rw http.ResponseW
 // CreatePersonallyProcuredMoveUnauthorizedCode is the HTTP code returned for type CreatePersonallyProcuredMoveUnauthorized
 const CreatePersonallyProcuredMoveUnauthorizedCode int = 401
 
-/*
-CreatePersonallyProcuredMoveUnauthorized request requires user authentication
+/*CreatePersonallyProcuredMoveUnauthorized request requires user authentication
 
 swagger:response createPersonallyProcuredMoveUnauthorized
 */
@@ -111,8 +108,7 @@ func (o *CreatePersonallyProcuredMoveUnauthorized) WriteResponse(rw http.Respons
 // CreatePersonallyProcuredMoveForbiddenCode is the HTTP code returned for type CreatePersonallyProcuredMoveForbidden
 const CreatePersonallyProcuredMoveForbiddenCode int = 403
 
-/*
-CreatePersonallyProcuredMoveForbidden user is not authorized
+/*CreatePersonallyProcuredMoveForbidden user is not authorized
 
 swagger:response createPersonallyProcuredMoveForbidden
 */
@@ -136,8 +132,7 @@ func (o *CreatePersonallyProcuredMoveForbidden) WriteResponse(rw http.ResponseWr
 // CreatePersonallyProcuredMoveNotFoundCode is the HTTP code returned for type CreatePersonallyProcuredMoveNotFound
 const CreatePersonallyProcuredMoveNotFoundCode int = 404
 
-/*
-CreatePersonallyProcuredMoveNotFound move not found
+/*CreatePersonallyProcuredMoveNotFound move not found
 
 swagger:response createPersonallyProcuredMoveNotFound
 */
@@ -161,8 +156,7 @@ func (o *CreatePersonallyProcuredMoveNotFound) WriteResponse(rw http.ResponseWri
 // CreatePersonallyProcuredMoveInternalServerErrorCode is the HTTP code returned for type CreatePersonallyProcuredMoveInternalServerError
 const CreatePersonallyProcuredMoveInternalServerErrorCode int = 500
 
-/*
-CreatePersonallyProcuredMoveInternalServerError server error
+/*CreatePersonallyProcuredMoveInternalServerError server error
 
 swagger:response createPersonallyProcuredMoveInternalServerError
 */

--- a/pkg/gen/internalapi/internaloperations/ppm/create_weight_ticket.go
+++ b/pkg/gen/internalapi/internaloperations/ppm/create_weight_ticket.go
@@ -29,12 +29,12 @@ func NewCreateWeightTicket(ctx *middleware.Context, handler CreateWeightTicketHa
 	return &CreateWeightTicket{Context: ctx, Handler: handler}
 }
 
-/*
-	CreateWeightTicket swagger:route POST /ppm-shipments/{ppmShipmentId}/weight-ticket ppm createWeightTicket
+/* CreateWeightTicket swagger:route POST /ppm-shipments/{ppmShipmentId}/weight-ticket ppm createWeightTicket
 
-# Creates a weight ticket document
+Creates a weight ticket document
 
 Created a weight ticket document with the given information
+
 */
 type CreateWeightTicket struct {
 	Context *middleware.Context

--- a/pkg/gen/internalapi/internaloperations/ppm/create_weight_ticket_responses.go
+++ b/pkg/gen/internalapi/internaloperations/ppm/create_weight_ticket_responses.go
@@ -16,8 +16,7 @@ import (
 // CreateWeightTicketOKCode is the HTTP code returned for type CreateWeightTicketOK
 const CreateWeightTicketOKCode int = 200
 
-/*
-CreateWeightTicketOK returns new weight ticket object
+/*CreateWeightTicketOK returns new weight ticket object
 
 swagger:response createWeightTicketOK
 */
@@ -61,8 +60,7 @@ func (o *CreateWeightTicketOK) WriteResponse(rw http.ResponseWriter, producer ru
 // CreateWeightTicketBadRequestCode is the HTTP code returned for type CreateWeightTicketBadRequest
 const CreateWeightTicketBadRequestCode int = 400
 
-/*
-CreateWeightTicketBadRequest The request payload is invalid.
+/*CreateWeightTicketBadRequest The request payload is invalid.
 
 swagger:response createWeightTicketBadRequest
 */
@@ -106,8 +104,7 @@ func (o *CreateWeightTicketBadRequest) WriteResponse(rw http.ResponseWriter, pro
 // CreateWeightTicketUnauthorizedCode is the HTTP code returned for type CreateWeightTicketUnauthorized
 const CreateWeightTicketUnauthorizedCode int = 401
 
-/*
-CreateWeightTicketUnauthorized The request was denied.
+/*CreateWeightTicketUnauthorized The request was denied.
 
 swagger:response createWeightTicketUnauthorized
 */
@@ -151,8 +148,7 @@ func (o *CreateWeightTicketUnauthorized) WriteResponse(rw http.ResponseWriter, p
 // CreateWeightTicketForbiddenCode is the HTTP code returned for type CreateWeightTicketForbidden
 const CreateWeightTicketForbiddenCode int = 403
 
-/*
-CreateWeightTicketForbidden The request was denied.
+/*CreateWeightTicketForbidden The request was denied.
 
 swagger:response createWeightTicketForbidden
 */
@@ -196,8 +192,7 @@ func (o *CreateWeightTicketForbidden) WriteResponse(rw http.ResponseWriter, prod
 // CreateWeightTicketNotFoundCode is the HTTP code returned for type CreateWeightTicketNotFound
 const CreateWeightTicketNotFoundCode int = 404
 
-/*
-CreateWeightTicketNotFound The requested resource wasn't found.
+/*CreateWeightTicketNotFound The requested resource wasn't found.
 
 swagger:response createWeightTicketNotFound
 */
@@ -241,8 +236,7 @@ func (o *CreateWeightTicketNotFound) WriteResponse(rw http.ResponseWriter, produ
 // CreateWeightTicketUnprocessableEntityCode is the HTTP code returned for type CreateWeightTicketUnprocessableEntity
 const CreateWeightTicketUnprocessableEntityCode int = 422
 
-/*
-CreateWeightTicketUnprocessableEntity The payload was unprocessable.
+/*CreateWeightTicketUnprocessableEntity The payload was unprocessable.
 
 swagger:response createWeightTicketUnprocessableEntity
 */
@@ -286,8 +280,7 @@ func (o *CreateWeightTicketUnprocessableEntity) WriteResponse(rw http.ResponseWr
 // CreateWeightTicketInternalServerErrorCode is the HTTP code returned for type CreateWeightTicketInternalServerError
 const CreateWeightTicketInternalServerErrorCode int = 500
 
-/*
-CreateWeightTicketInternalServerError A server error occurred.
+/*CreateWeightTicketInternalServerError A server error occurred.
 
 swagger:response createWeightTicketInternalServerError
 */

--- a/pkg/gen/internalapi/internaloperations/ppm/index_personally_procured_moves.go
+++ b/pkg/gen/internalapi/internaloperations/ppm/index_personally_procured_moves.go
@@ -29,12 +29,12 @@ func NewIndexPersonallyProcuredMoves(ctx *middleware.Context, handler IndexPerso
 	return &IndexPersonallyProcuredMoves{Context: ctx, Handler: handler}
 }
 
-/*
-	IndexPersonallyProcuredMoves swagger:route GET /moves/{moveId}/personally_procured_move ppm indexPersonallyProcuredMoves
-
-# Returns a list of all PPMs associated with this move
+/* IndexPersonallyProcuredMoves swagger:route GET /moves/{moveId}/personally_procured_move ppm indexPersonallyProcuredMoves
 
 Returns a list of all PPMs associated with this move
+
+Returns a list of all PPMs associated with this move
+
 */
 type IndexPersonallyProcuredMoves struct {
 	Context *middleware.Context

--- a/pkg/gen/internalapi/internaloperations/ppm/index_personally_procured_moves_responses.go
+++ b/pkg/gen/internalapi/internaloperations/ppm/index_personally_procured_moves_responses.go
@@ -16,8 +16,7 @@ import (
 // IndexPersonallyProcuredMovesOKCode is the HTTP code returned for type IndexPersonallyProcuredMovesOK
 const IndexPersonallyProcuredMovesOKCode int = 200
 
-/*
-IndexPersonallyProcuredMovesOK returns list of personally_procured_move
+/*IndexPersonallyProcuredMovesOK returns list of personally_procured_move
 
 swagger:response indexPersonallyProcuredMovesOK
 */
@@ -64,8 +63,7 @@ func (o *IndexPersonallyProcuredMovesOK) WriteResponse(rw http.ResponseWriter, p
 // IndexPersonallyProcuredMovesBadRequestCode is the HTTP code returned for type IndexPersonallyProcuredMovesBadRequest
 const IndexPersonallyProcuredMovesBadRequestCode int = 400
 
-/*
-IndexPersonallyProcuredMovesBadRequest invalid request
+/*IndexPersonallyProcuredMovesBadRequest invalid request
 
 swagger:response indexPersonallyProcuredMovesBadRequest
 */
@@ -89,8 +87,7 @@ func (o *IndexPersonallyProcuredMovesBadRequest) WriteResponse(rw http.ResponseW
 // IndexPersonallyProcuredMovesUnauthorizedCode is the HTTP code returned for type IndexPersonallyProcuredMovesUnauthorized
 const IndexPersonallyProcuredMovesUnauthorizedCode int = 401
 
-/*
-IndexPersonallyProcuredMovesUnauthorized request requires user authentication
+/*IndexPersonallyProcuredMovesUnauthorized request requires user authentication
 
 swagger:response indexPersonallyProcuredMovesUnauthorized
 */
@@ -114,8 +111,7 @@ func (o *IndexPersonallyProcuredMovesUnauthorized) WriteResponse(rw http.Respons
 // IndexPersonallyProcuredMovesForbiddenCode is the HTTP code returned for type IndexPersonallyProcuredMovesForbidden
 const IndexPersonallyProcuredMovesForbiddenCode int = 403
 
-/*
-IndexPersonallyProcuredMovesForbidden user is not authorized
+/*IndexPersonallyProcuredMovesForbidden user is not authorized
 
 swagger:response indexPersonallyProcuredMovesForbidden
 */

--- a/pkg/gen/internalapi/internaloperations/ppm/patch_personally_procured_move.go
+++ b/pkg/gen/internalapi/internaloperations/ppm/patch_personally_procured_move.go
@@ -29,12 +29,12 @@ func NewPatchPersonallyProcuredMove(ctx *middleware.Context, handler PatchPerson
 	return &PatchPersonallyProcuredMove{Context: ctx, Handler: handler}
 }
 
-/*
-	PatchPersonallyProcuredMove swagger:route PATCH /moves/{moveId}/personally_procured_move/{personallyProcuredMoveId} ppm patchPersonallyProcuredMove
+/* PatchPersonallyProcuredMove swagger:route PATCH /moves/{moveId}/personally_procured_move/{personallyProcuredMoveId} ppm patchPersonallyProcuredMove
 
-# Patches the PPM
+Patches the PPM
 
 Any fields sent in this request will be set on the PPM referenced
+
 */
 type PatchPersonallyProcuredMove struct {
 	Context *middleware.Context

--- a/pkg/gen/internalapi/internaloperations/ppm/patch_personally_procured_move_responses.go
+++ b/pkg/gen/internalapi/internaloperations/ppm/patch_personally_procured_move_responses.go
@@ -16,8 +16,7 @@ import (
 // PatchPersonallyProcuredMoveOKCode is the HTTP code returned for type PatchPersonallyProcuredMoveOK
 const PatchPersonallyProcuredMoveOKCode int = 200
 
-/*
-PatchPersonallyProcuredMoveOK updated instance of personally_procured_move
+/*PatchPersonallyProcuredMoveOK updated instance of personally_procured_move
 
 swagger:response patchPersonallyProcuredMoveOK
 */
@@ -61,8 +60,7 @@ func (o *PatchPersonallyProcuredMoveOK) WriteResponse(rw http.ResponseWriter, pr
 // PatchPersonallyProcuredMoveBadRequestCode is the HTTP code returned for type PatchPersonallyProcuredMoveBadRequest
 const PatchPersonallyProcuredMoveBadRequestCode int = 400
 
-/*
-PatchPersonallyProcuredMoveBadRequest invalid request
+/*PatchPersonallyProcuredMoveBadRequest invalid request
 
 swagger:response patchPersonallyProcuredMoveBadRequest
 */
@@ -86,8 +84,7 @@ func (o *PatchPersonallyProcuredMoveBadRequest) WriteResponse(rw http.ResponseWr
 // PatchPersonallyProcuredMoveUnauthorizedCode is the HTTP code returned for type PatchPersonallyProcuredMoveUnauthorized
 const PatchPersonallyProcuredMoveUnauthorizedCode int = 401
 
-/*
-PatchPersonallyProcuredMoveUnauthorized request requires user authentication
+/*PatchPersonallyProcuredMoveUnauthorized request requires user authentication
 
 swagger:response patchPersonallyProcuredMoveUnauthorized
 */
@@ -111,8 +108,7 @@ func (o *PatchPersonallyProcuredMoveUnauthorized) WriteResponse(rw http.Response
 // PatchPersonallyProcuredMoveForbiddenCode is the HTTP code returned for type PatchPersonallyProcuredMoveForbidden
 const PatchPersonallyProcuredMoveForbiddenCode int = 403
 
-/*
-PatchPersonallyProcuredMoveForbidden user is not authorized
+/*PatchPersonallyProcuredMoveForbidden user is not authorized
 
 swagger:response patchPersonallyProcuredMoveForbidden
 */
@@ -136,8 +132,7 @@ func (o *PatchPersonallyProcuredMoveForbidden) WriteResponse(rw http.ResponseWri
 // PatchPersonallyProcuredMoveNotFoundCode is the HTTP code returned for type PatchPersonallyProcuredMoveNotFound
 const PatchPersonallyProcuredMoveNotFoundCode int = 404
 
-/*
-PatchPersonallyProcuredMoveNotFound ppm is not found or ppm discount not found for provided postal codes and original move date
+/*PatchPersonallyProcuredMoveNotFound ppm is not found or ppm discount not found for provided postal codes and original move date
 
 swagger:response patchPersonallyProcuredMoveNotFound
 */
@@ -161,8 +156,7 @@ func (o *PatchPersonallyProcuredMoveNotFound) WriteResponse(rw http.ResponseWrit
 // PatchPersonallyProcuredMoveUnprocessableEntityCode is the HTTP code returned for type PatchPersonallyProcuredMoveUnprocessableEntity
 const PatchPersonallyProcuredMoveUnprocessableEntityCode int = 422
 
-/*
-PatchPersonallyProcuredMoveUnprocessableEntity cannot process request with given information
+/*PatchPersonallyProcuredMoveUnprocessableEntity cannot process request with given information
 
 swagger:response patchPersonallyProcuredMoveUnprocessableEntity
 */
@@ -186,8 +180,7 @@ func (o *PatchPersonallyProcuredMoveUnprocessableEntity) WriteResponse(rw http.R
 // PatchPersonallyProcuredMoveInternalServerErrorCode is the HTTP code returned for type PatchPersonallyProcuredMoveInternalServerError
 const PatchPersonallyProcuredMoveInternalServerErrorCode int = 500
 
-/*
-PatchPersonallyProcuredMoveInternalServerError internal server error
+/*PatchPersonallyProcuredMoveInternalServerError internal server error
 
 swagger:response patchPersonallyProcuredMoveInternalServerError
 */

--- a/pkg/gen/internalapi/internaloperations/ppm/request_p_p_m_expense_summary.go
+++ b/pkg/gen/internalapi/internaloperations/ppm/request_p_p_m_expense_summary.go
@@ -29,12 +29,12 @@ func NewRequestPPMExpenseSummary(ctx *middleware.Context, handler RequestPPMExpe
 	return &RequestPPMExpenseSummary{Context: ctx, Handler: handler}
 }
 
-/*
-	RequestPPMExpenseSummary swagger:route GET /personally_procured_move/{personallyProcuredMoveId}/expense_summary ppm requestPPMExpenseSummary
+/* RequestPPMExpenseSummary swagger:route GET /personally_procured_move/{personallyProcuredMoveId}/expense_summary ppm requestPPMExpenseSummary
 
-# Returns an expense summary organized by expense type
+Returns an expense summary organized by expense type
 
 Calculates and returns an expense summary organized by expense type
+
 */
 type RequestPPMExpenseSummary struct {
 	Context *middleware.Context

--- a/pkg/gen/internalapi/internaloperations/ppm/request_p_p_m_expense_summary_responses.go
+++ b/pkg/gen/internalapi/internaloperations/ppm/request_p_p_m_expense_summary_responses.go
@@ -16,8 +16,7 @@ import (
 // RequestPPMExpenseSummaryOKCode is the HTTP code returned for type RequestPPMExpenseSummaryOK
 const RequestPPMExpenseSummaryOKCode int = 200
 
-/*
-RequestPPMExpenseSummaryOK Successfully calculated expense summary
+/*RequestPPMExpenseSummaryOK Successfully calculated expense summary
 
 swagger:response requestPPMExpenseSummaryOK
 */
@@ -61,8 +60,7 @@ func (o *RequestPPMExpenseSummaryOK) WriteResponse(rw http.ResponseWriter, produ
 // RequestPPMExpenseSummaryBadRequestCode is the HTTP code returned for type RequestPPMExpenseSummaryBadRequest
 const RequestPPMExpenseSummaryBadRequestCode int = 400
 
-/*
-RequestPPMExpenseSummaryBadRequest invalid request
+/*RequestPPMExpenseSummaryBadRequest invalid request
 
 swagger:response requestPPMExpenseSummaryBadRequest
 */
@@ -86,8 +84,7 @@ func (o *RequestPPMExpenseSummaryBadRequest) WriteResponse(rw http.ResponseWrite
 // RequestPPMExpenseSummaryUnauthorizedCode is the HTTP code returned for type RequestPPMExpenseSummaryUnauthorized
 const RequestPPMExpenseSummaryUnauthorizedCode int = 401
 
-/*
-RequestPPMExpenseSummaryUnauthorized request requires user authentication
+/*RequestPPMExpenseSummaryUnauthorized request requires user authentication
 
 swagger:response requestPPMExpenseSummaryUnauthorized
 */
@@ -111,8 +108,7 @@ func (o *RequestPPMExpenseSummaryUnauthorized) WriteResponse(rw http.ResponseWri
 // RequestPPMExpenseSummaryForbiddenCode is the HTTP code returned for type RequestPPMExpenseSummaryForbidden
 const RequestPPMExpenseSummaryForbiddenCode int = 403
 
-/*
-RequestPPMExpenseSummaryForbidden user is not authorized
+/*RequestPPMExpenseSummaryForbidden user is not authorized
 
 swagger:response requestPPMExpenseSummaryForbidden
 */
@@ -136,8 +132,7 @@ func (o *RequestPPMExpenseSummaryForbidden) WriteResponse(rw http.ResponseWriter
 // RequestPPMExpenseSummaryNotFoundCode is the HTTP code returned for type RequestPPMExpenseSummaryNotFound
 const RequestPPMExpenseSummaryNotFoundCode int = 404
 
-/*
-RequestPPMExpenseSummaryNotFound personally procured move not found
+/*RequestPPMExpenseSummaryNotFound personally procured move not found
 
 swagger:response requestPPMExpenseSummaryNotFound
 */
@@ -161,8 +156,7 @@ func (o *RequestPPMExpenseSummaryNotFound) WriteResponse(rw http.ResponseWriter,
 // RequestPPMExpenseSummaryInternalServerErrorCode is the HTTP code returned for type RequestPPMExpenseSummaryInternalServerError
 const RequestPPMExpenseSummaryInternalServerErrorCode int = 500
 
-/*
-RequestPPMExpenseSummaryInternalServerError server error
+/*RequestPPMExpenseSummaryInternalServerError server error
 
 swagger:response requestPPMExpenseSummaryInternalServerError
 */

--- a/pkg/gen/internalapi/internaloperations/ppm/request_p_p_m_payment.go
+++ b/pkg/gen/internalapi/internaloperations/ppm/request_p_p_m_payment.go
@@ -29,12 +29,12 @@ func NewRequestPPMPayment(ctx *middleware.Context, handler RequestPPMPaymentHand
 	return &RequestPPMPayment{Context: ctx, Handler: handler}
 }
 
-/*
-	RequestPPMPayment swagger:route POST /personally_procured_move/{personallyProcuredMoveId}/request_payment ppm requestPPMPayment
+/* RequestPPMPayment swagger:route POST /personally_procured_move/{personallyProcuredMoveId}/request_payment ppm requestPPMPayment
 
 Moves the PPM and the move into the PAYMENT_REQUESTED state
 
 Moves the PPM and the move into the PAYMENT_REQUESTED state
+
 */
 type RequestPPMPayment struct {
 	Context *middleware.Context

--- a/pkg/gen/internalapi/internaloperations/ppm/request_p_p_m_payment_responses.go
+++ b/pkg/gen/internalapi/internaloperations/ppm/request_p_p_m_payment_responses.go
@@ -16,8 +16,7 @@ import (
 // RequestPPMPaymentOKCode is the HTTP code returned for type RequestPPMPaymentOK
 const RequestPPMPaymentOKCode int = 200
 
-/*
-RequestPPMPaymentOK Sucesssfully requested payment
+/*RequestPPMPaymentOK Sucesssfully requested payment
 
 swagger:response requestPPMPaymentOK
 */
@@ -61,8 +60,7 @@ func (o *RequestPPMPaymentOK) WriteResponse(rw http.ResponseWriter, producer run
 // RequestPPMPaymentBadRequestCode is the HTTP code returned for type RequestPPMPaymentBadRequest
 const RequestPPMPaymentBadRequestCode int = 400
 
-/*
-RequestPPMPaymentBadRequest invalid request
+/*RequestPPMPaymentBadRequest invalid request
 
 swagger:response requestPPMPaymentBadRequest
 */
@@ -86,8 +84,7 @@ func (o *RequestPPMPaymentBadRequest) WriteResponse(rw http.ResponseWriter, prod
 // RequestPPMPaymentUnauthorizedCode is the HTTP code returned for type RequestPPMPaymentUnauthorized
 const RequestPPMPaymentUnauthorizedCode int = 401
 
-/*
-RequestPPMPaymentUnauthorized request requires user authentication
+/*RequestPPMPaymentUnauthorized request requires user authentication
 
 swagger:response requestPPMPaymentUnauthorized
 */
@@ -111,8 +108,7 @@ func (o *RequestPPMPaymentUnauthorized) WriteResponse(rw http.ResponseWriter, pr
 // RequestPPMPaymentForbiddenCode is the HTTP code returned for type RequestPPMPaymentForbidden
 const RequestPPMPaymentForbiddenCode int = 403
 
-/*
-RequestPPMPaymentForbidden user is not authorized
+/*RequestPPMPaymentForbidden user is not authorized
 
 swagger:response requestPPMPaymentForbidden
 */
@@ -136,8 +132,7 @@ func (o *RequestPPMPaymentForbidden) WriteResponse(rw http.ResponseWriter, produ
 // RequestPPMPaymentNotFoundCode is the HTTP code returned for type RequestPPMPaymentNotFound
 const RequestPPMPaymentNotFoundCode int = 404
 
-/*
-RequestPPMPaymentNotFound move not found
+/*RequestPPMPaymentNotFound move not found
 
 swagger:response requestPPMPaymentNotFound
 */
@@ -161,8 +156,7 @@ func (o *RequestPPMPaymentNotFound) WriteResponse(rw http.ResponseWriter, produc
 // RequestPPMPaymentInternalServerErrorCode is the HTTP code returned for type RequestPPMPaymentInternalServerError
 const RequestPPMPaymentInternalServerErrorCode int = 500
 
-/*
-RequestPPMPaymentInternalServerError server error
+/*RequestPPMPaymentInternalServerError server error
 
 swagger:response requestPPMPaymentInternalServerError
 */

--- a/pkg/gen/internalapi/internaloperations/ppm/show_p_p_m_estimate.go
+++ b/pkg/gen/internalapi/internaloperations/ppm/show_p_p_m_estimate.go
@@ -29,12 +29,12 @@ func NewShowPPMEstimate(ctx *middleware.Context, handler ShowPPMEstimateHandler)
 	return &ShowPPMEstimate{Context: ctx, Handler: handler}
 }
 
-/*
-	ShowPPMEstimate swagger:route GET /estimates/ppm ppm showPPMEstimate
+/* ShowPPMEstimate swagger:route GET /estimates/ppm ppm showPPMEstimate
 
-# Return a PPM cost estimate
+Return a PPM cost estimate
 
 Calculates a reimbursement range for a PPM move (excluding SIT)
+
 */
 type ShowPPMEstimate struct {
 	Context *middleware.Context

--- a/pkg/gen/internalapi/internaloperations/ppm/show_p_p_m_estimate_responses.go
+++ b/pkg/gen/internalapi/internaloperations/ppm/show_p_p_m_estimate_responses.go
@@ -16,8 +16,7 @@ import (
 // ShowPPMEstimateOKCode is the HTTP code returned for type ShowPPMEstimateOK
 const ShowPPMEstimateOKCode int = 200
 
-/*
-ShowPPMEstimateOK Made estimate of PPM cost range
+/*ShowPPMEstimateOK Made estimate of PPM cost range
 
 swagger:response showPPMEstimateOK
 */
@@ -61,8 +60,7 @@ func (o *ShowPPMEstimateOK) WriteResponse(rw http.ResponseWriter, producer runti
 // ShowPPMEstimateBadRequestCode is the HTTP code returned for type ShowPPMEstimateBadRequest
 const ShowPPMEstimateBadRequestCode int = 400
 
-/*
-ShowPPMEstimateBadRequest invalid request
+/*ShowPPMEstimateBadRequest invalid request
 
 swagger:response showPPMEstimateBadRequest
 */
@@ -86,8 +84,7 @@ func (o *ShowPPMEstimateBadRequest) WriteResponse(rw http.ResponseWriter, produc
 // ShowPPMEstimateUnauthorizedCode is the HTTP code returned for type ShowPPMEstimateUnauthorized
 const ShowPPMEstimateUnauthorizedCode int = 401
 
-/*
-ShowPPMEstimateUnauthorized request requires user authentication
+/*ShowPPMEstimateUnauthorized request requires user authentication
 
 swagger:response showPPMEstimateUnauthorized
 */
@@ -111,8 +108,7 @@ func (o *ShowPPMEstimateUnauthorized) WriteResponse(rw http.ResponseWriter, prod
 // ShowPPMEstimateForbiddenCode is the HTTP code returned for type ShowPPMEstimateForbidden
 const ShowPPMEstimateForbiddenCode int = 403
 
-/*
-ShowPPMEstimateForbidden user is not authorized
+/*ShowPPMEstimateForbidden user is not authorized
 
 swagger:response showPPMEstimateForbidden
 */
@@ -136,8 +132,7 @@ func (o *ShowPPMEstimateForbidden) WriteResponse(rw http.ResponseWriter, produce
 // ShowPPMEstimateNotFoundCode is the HTTP code returned for type ShowPPMEstimateNotFound
 const ShowPPMEstimateNotFoundCode int = 404
 
-/*
-ShowPPMEstimateNotFound ppm discount not found for provided postal codes and original move date
+/*ShowPPMEstimateNotFound ppm discount not found for provided postal codes and original move date
 
 swagger:response showPPMEstimateNotFound
 */
@@ -161,8 +156,7 @@ func (o *ShowPPMEstimateNotFound) WriteResponse(rw http.ResponseWriter, producer
 // ShowPPMEstimateConflictCode is the HTTP code returned for type ShowPPMEstimateConflict
 const ShowPPMEstimateConflictCode int = 409
 
-/*
-ShowPPMEstimateConflict distance is less than 50 miles (no short haul moves)
+/*ShowPPMEstimateConflict distance is less than 50 miles (no short haul moves)
 
 swagger:response showPPMEstimateConflict
 */
@@ -186,8 +180,7 @@ func (o *ShowPPMEstimateConflict) WriteResponse(rw http.ResponseWriter, producer
 // ShowPPMEstimateUnprocessableEntityCode is the HTTP code returned for type ShowPPMEstimateUnprocessableEntity
 const ShowPPMEstimateUnprocessableEntityCode int = 422
 
-/*
-ShowPPMEstimateUnprocessableEntity cannot process request with given information
+/*ShowPPMEstimateUnprocessableEntity cannot process request with given information
 
 swagger:response showPPMEstimateUnprocessableEntity
 */
@@ -211,8 +204,7 @@ func (o *ShowPPMEstimateUnprocessableEntity) WriteResponse(rw http.ResponseWrite
 // ShowPPMEstimateInternalServerErrorCode is the HTTP code returned for type ShowPPMEstimateInternalServerError
 const ShowPPMEstimateInternalServerErrorCode int = 500
 
-/*
-ShowPPMEstimateInternalServerError internal server error
+/*ShowPPMEstimateInternalServerError internal server error
 
 swagger:response showPPMEstimateInternalServerError
 */

--- a/pkg/gen/internalapi/internaloperations/ppm/show_p_p_m_incentive.go
+++ b/pkg/gen/internalapi/internaloperations/ppm/show_p_p_m_incentive.go
@@ -29,12 +29,12 @@ func NewShowPPMIncentive(ctx *middleware.Context, handler ShowPPMIncentiveHandle
 	return &ShowPPMIncentive{Context: ctx, Handler: handler}
 }
 
-/*
-	ShowPPMIncentive swagger:route GET /personally_procured_moves/incentive ppm showPPMIncentive
+/* ShowPPMIncentive swagger:route GET /personally_procured_moves/incentive ppm showPPMIncentive
 
-# Return a PPM incentive value
+Return a PPM incentive value
 
 Calculates incentive for a PPM move (excluding SIT)
+
 */
 type ShowPPMIncentive struct {
 	Context *middleware.Context

--- a/pkg/gen/internalapi/internaloperations/ppm/show_p_p_m_incentive_responses.go
+++ b/pkg/gen/internalapi/internaloperations/ppm/show_p_p_m_incentive_responses.go
@@ -16,8 +16,7 @@ import (
 // ShowPPMIncentiveOKCode is the HTTP code returned for type ShowPPMIncentiveOK
 const ShowPPMIncentiveOKCode int = 200
 
-/*
-ShowPPMIncentiveOK Made calculation of PPM incentive
+/*ShowPPMIncentiveOK Made calculation of PPM incentive
 
 swagger:response showPPMIncentiveOK
 */
@@ -61,8 +60,7 @@ func (o *ShowPPMIncentiveOK) WriteResponse(rw http.ResponseWriter, producer runt
 // ShowPPMIncentiveBadRequestCode is the HTTP code returned for type ShowPPMIncentiveBadRequest
 const ShowPPMIncentiveBadRequestCode int = 400
 
-/*
-ShowPPMIncentiveBadRequest invalid request
+/*ShowPPMIncentiveBadRequest invalid request
 
 swagger:response showPPMIncentiveBadRequest
 */
@@ -86,8 +84,7 @@ func (o *ShowPPMIncentiveBadRequest) WriteResponse(rw http.ResponseWriter, produ
 // ShowPPMIncentiveUnauthorizedCode is the HTTP code returned for type ShowPPMIncentiveUnauthorized
 const ShowPPMIncentiveUnauthorizedCode int = 401
 
-/*
-ShowPPMIncentiveUnauthorized request requires user authentication
+/*ShowPPMIncentiveUnauthorized request requires user authentication
 
 swagger:response showPPMIncentiveUnauthorized
 */
@@ -111,8 +108,7 @@ func (o *ShowPPMIncentiveUnauthorized) WriteResponse(rw http.ResponseWriter, pro
 // ShowPPMIncentiveForbiddenCode is the HTTP code returned for type ShowPPMIncentiveForbidden
 const ShowPPMIncentiveForbiddenCode int = 403
 
-/*
-ShowPPMIncentiveForbidden user is not authorized
+/*ShowPPMIncentiveForbidden user is not authorized
 
 swagger:response showPPMIncentiveForbidden
 */
@@ -136,8 +132,7 @@ func (o *ShowPPMIncentiveForbidden) WriteResponse(rw http.ResponseWriter, produc
 // ShowPPMIncentiveConflictCode is the HTTP code returned for type ShowPPMIncentiveConflict
 const ShowPPMIncentiveConflictCode int = 409
 
-/*
-ShowPPMIncentiveConflict distance is less than 50 miles (no short haul moves)
+/*ShowPPMIncentiveConflict distance is less than 50 miles (no short haul moves)
 
 swagger:response showPPMIncentiveConflict
 */
@@ -161,8 +156,7 @@ func (o *ShowPPMIncentiveConflict) WriteResponse(rw http.ResponseWriter, produce
 // ShowPPMIncentiveInternalServerErrorCode is the HTTP code returned for type ShowPPMIncentiveInternalServerError
 const ShowPPMIncentiveInternalServerErrorCode int = 500
 
-/*
-ShowPPMIncentiveInternalServerError internal server error
+/*ShowPPMIncentiveInternalServerError internal server error
 
 swagger:response showPPMIncentiveInternalServerError
 */

--- a/pkg/gen/internalapi/internaloperations/ppm/show_p_p_m_sit_estimate.go
+++ b/pkg/gen/internalapi/internaloperations/ppm/show_p_p_m_sit_estimate.go
@@ -29,12 +29,12 @@ func NewShowPPMSitEstimate(ctx *middleware.Context, handler ShowPPMSitEstimateHa
 	return &ShowPPMSitEstimate{Context: ctx, Handler: handler}
 }
 
-/*
-	ShowPPMSitEstimate swagger:route GET /estimates/ppm_sit ppm showPPMSitEstimate
+/* ShowPPMSitEstimate swagger:route GET /estimates/ppm_sit ppm showPPMSitEstimate
 
-# Return a PPM move's SIT cost estimate
+Return a PPM move's SIT cost estimate
 
 Calculates a reimbursment for a PPM move's SIT
+
 */
 type ShowPPMSitEstimate struct {
 	Context *middleware.Context

--- a/pkg/gen/internalapi/internaloperations/ppm/show_p_p_m_sit_estimate_responses.go
+++ b/pkg/gen/internalapi/internaloperations/ppm/show_p_p_m_sit_estimate_responses.go
@@ -16,8 +16,7 @@ import (
 // ShowPPMSitEstimateOKCode is the HTTP code returned for type ShowPPMSitEstimateOK
 const ShowPPMSitEstimateOKCode int = 200
 
-/*
-ShowPPMSitEstimateOK show PPM SIT estimate
+/*ShowPPMSitEstimateOK show PPM SIT estimate
 
 swagger:response showPPMSitEstimateOK
 */
@@ -61,8 +60,7 @@ func (o *ShowPPMSitEstimateOK) WriteResponse(rw http.ResponseWriter, producer ru
 // ShowPPMSitEstimateBadRequestCode is the HTTP code returned for type ShowPPMSitEstimateBadRequest
 const ShowPPMSitEstimateBadRequestCode int = 400
 
-/*
-ShowPPMSitEstimateBadRequest invalid request
+/*ShowPPMSitEstimateBadRequest invalid request
 
 swagger:response showPPMSitEstimateBadRequest
 */
@@ -86,8 +84,7 @@ func (o *ShowPPMSitEstimateBadRequest) WriteResponse(rw http.ResponseWriter, pro
 // ShowPPMSitEstimateUnauthorizedCode is the HTTP code returned for type ShowPPMSitEstimateUnauthorized
 const ShowPPMSitEstimateUnauthorizedCode int = 401
 
-/*
-ShowPPMSitEstimateUnauthorized request requires user authentication
+/*ShowPPMSitEstimateUnauthorized request requires user authentication
 
 swagger:response showPPMSitEstimateUnauthorized
 */
@@ -111,8 +108,7 @@ func (o *ShowPPMSitEstimateUnauthorized) WriteResponse(rw http.ResponseWriter, p
 // ShowPPMSitEstimateForbiddenCode is the HTTP code returned for type ShowPPMSitEstimateForbidden
 const ShowPPMSitEstimateForbiddenCode int = 403
 
-/*
-ShowPPMSitEstimateForbidden user is not authorized
+/*ShowPPMSitEstimateForbidden user is not authorized
 
 swagger:response showPPMSitEstimateForbidden
 */
@@ -136,8 +132,7 @@ func (o *ShowPPMSitEstimateForbidden) WriteResponse(rw http.ResponseWriter, prod
 // ShowPPMSitEstimateConflictCode is the HTTP code returned for type ShowPPMSitEstimateConflict
 const ShowPPMSitEstimateConflictCode int = 409
 
-/*
-ShowPPMSitEstimateConflict distance is less than 50 miles (no short haul moves)
+/*ShowPPMSitEstimateConflict distance is less than 50 miles (no short haul moves)
 
 swagger:response showPPMSitEstimateConflict
 */
@@ -161,8 +156,7 @@ func (o *ShowPPMSitEstimateConflict) WriteResponse(rw http.ResponseWriter, produ
 // ShowPPMSitEstimateUnprocessableEntityCode is the HTTP code returned for type ShowPPMSitEstimateUnprocessableEntity
 const ShowPPMSitEstimateUnprocessableEntityCode int = 422
 
-/*
-ShowPPMSitEstimateUnprocessableEntity the payload was unprocessable
+/*ShowPPMSitEstimateUnprocessableEntity the payload was unprocessable
 
 swagger:response showPPMSitEstimateUnprocessableEntity
 */
@@ -186,8 +180,7 @@ func (o *ShowPPMSitEstimateUnprocessableEntity) WriteResponse(rw http.ResponseWr
 // ShowPPMSitEstimateInternalServerErrorCode is the HTTP code returned for type ShowPPMSitEstimateInternalServerError
 const ShowPPMSitEstimateInternalServerErrorCode int = 500
 
-/*
-ShowPPMSitEstimateInternalServerError internal server error
+/*ShowPPMSitEstimateInternalServerError internal server error
 
 swagger:response showPPMSitEstimateInternalServerError
 */

--- a/pkg/gen/internalapi/internaloperations/ppm/show_personally_procured_move.go
+++ b/pkg/gen/internalapi/internaloperations/ppm/show_personally_procured_move.go
@@ -29,12 +29,12 @@ func NewShowPersonallyProcuredMove(ctx *middleware.Context, handler ShowPersonal
 	return &ShowPersonallyProcuredMove{Context: ctx, Handler: handler}
 }
 
-/*
-	ShowPersonallyProcuredMove swagger:route GET /moves/{moveId}/personally_procured_move/{personallyProcuredMoveId} ppm showPersonallyProcuredMove
-
-# Returns the given PPM
+/* ShowPersonallyProcuredMove swagger:route GET /moves/{moveId}/personally_procured_move/{personallyProcuredMoveId} ppm showPersonallyProcuredMove
 
 Returns the given PPM
+
+Returns the given PPM
+
 */
 type ShowPersonallyProcuredMove struct {
 	Context *middleware.Context

--- a/pkg/gen/internalapi/internaloperations/ppm/show_personally_procured_move_responses.go
+++ b/pkg/gen/internalapi/internaloperations/ppm/show_personally_procured_move_responses.go
@@ -16,8 +16,7 @@ import (
 // ShowPersonallyProcuredMoveOKCode is the HTTP code returned for type ShowPersonallyProcuredMoveOK
 const ShowPersonallyProcuredMoveOKCode int = 200
 
-/*
-ShowPersonallyProcuredMoveOK the instance of personally_procured_move
+/*ShowPersonallyProcuredMoveOK the instance of personally_procured_move
 
 swagger:response showPersonallyProcuredMoveOK
 */
@@ -64,8 +63,7 @@ func (o *ShowPersonallyProcuredMoveOK) WriteResponse(rw http.ResponseWriter, pro
 // ShowPersonallyProcuredMoveBadRequestCode is the HTTP code returned for type ShowPersonallyProcuredMoveBadRequest
 const ShowPersonallyProcuredMoveBadRequestCode int = 400
 
-/*
-ShowPersonallyProcuredMoveBadRequest invalid request
+/*ShowPersonallyProcuredMoveBadRequest invalid request
 
 swagger:response showPersonallyProcuredMoveBadRequest
 */
@@ -89,8 +87,7 @@ func (o *ShowPersonallyProcuredMoveBadRequest) WriteResponse(rw http.ResponseWri
 // ShowPersonallyProcuredMoveUnauthorizedCode is the HTTP code returned for type ShowPersonallyProcuredMoveUnauthorized
 const ShowPersonallyProcuredMoveUnauthorizedCode int = 401
 
-/*
-ShowPersonallyProcuredMoveUnauthorized request requires user authentication
+/*ShowPersonallyProcuredMoveUnauthorized request requires user authentication
 
 swagger:response showPersonallyProcuredMoveUnauthorized
 */
@@ -114,8 +111,7 @@ func (o *ShowPersonallyProcuredMoveUnauthorized) WriteResponse(rw http.ResponseW
 // ShowPersonallyProcuredMoveForbiddenCode is the HTTP code returned for type ShowPersonallyProcuredMoveForbidden
 const ShowPersonallyProcuredMoveForbiddenCode int = 403
 
-/*
-ShowPersonallyProcuredMoveForbidden user is not authorized
+/*ShowPersonallyProcuredMoveForbidden user is not authorized
 
 swagger:response showPersonallyProcuredMoveForbidden
 */

--- a/pkg/gen/internalapi/internaloperations/ppm/submit_personally_procured_move.go
+++ b/pkg/gen/internalapi/internaloperations/ppm/submit_personally_procured_move.go
@@ -29,12 +29,12 @@ func NewSubmitPersonallyProcuredMove(ctx *middleware.Context, handler SubmitPers
 	return &SubmitPersonallyProcuredMove{Context: ctx, Handler: handler}
 }
 
-/*
-	SubmitPersonallyProcuredMove swagger:route POST /personally_procured_move/{personallyProcuredMoveId}/submit ppm submitPersonallyProcuredMove
+/* SubmitPersonallyProcuredMove swagger:route POST /personally_procured_move/{personallyProcuredMoveId}/submit ppm submitPersonallyProcuredMove
 
-# Submits a PPM for approval
+Submits a PPM for approval
 
 Submits a PPM for approval by the office. The status of the PPM will be updated to SUBMITTED
+
 */
 type SubmitPersonallyProcuredMove struct {
 	Context *middleware.Context

--- a/pkg/gen/internalapi/internaloperations/ppm/submit_personally_procured_move_responses.go
+++ b/pkg/gen/internalapi/internaloperations/ppm/submit_personally_procured_move_responses.go
@@ -16,8 +16,7 @@ import (
 // SubmitPersonallyProcuredMoveOKCode is the HTTP code returned for type SubmitPersonallyProcuredMoveOK
 const SubmitPersonallyProcuredMoveOKCode int = 200
 
-/*
-SubmitPersonallyProcuredMoveOK updated instance of personally_procured_move
+/*SubmitPersonallyProcuredMoveOK updated instance of personally_procured_move
 
 swagger:response submitPersonallyProcuredMoveOK
 */
@@ -61,8 +60,7 @@ func (o *SubmitPersonallyProcuredMoveOK) WriteResponse(rw http.ResponseWriter, p
 // SubmitPersonallyProcuredMoveBadRequestCode is the HTTP code returned for type SubmitPersonallyProcuredMoveBadRequest
 const SubmitPersonallyProcuredMoveBadRequestCode int = 400
 
-/*
-SubmitPersonallyProcuredMoveBadRequest invalid request
+/*SubmitPersonallyProcuredMoveBadRequest invalid request
 
 swagger:response submitPersonallyProcuredMoveBadRequest
 */
@@ -86,8 +84,7 @@ func (o *SubmitPersonallyProcuredMoveBadRequest) WriteResponse(rw http.ResponseW
 // SubmitPersonallyProcuredMoveUnauthorizedCode is the HTTP code returned for type SubmitPersonallyProcuredMoveUnauthorized
 const SubmitPersonallyProcuredMoveUnauthorizedCode int = 401
 
-/*
-SubmitPersonallyProcuredMoveUnauthorized request requires user authentication
+/*SubmitPersonallyProcuredMoveUnauthorized request requires user authentication
 
 swagger:response submitPersonallyProcuredMoveUnauthorized
 */
@@ -111,8 +108,7 @@ func (o *SubmitPersonallyProcuredMoveUnauthorized) WriteResponse(rw http.Respons
 // SubmitPersonallyProcuredMoveForbiddenCode is the HTTP code returned for type SubmitPersonallyProcuredMoveForbidden
 const SubmitPersonallyProcuredMoveForbiddenCode int = 403
 
-/*
-SubmitPersonallyProcuredMoveForbidden user is not authorized
+/*SubmitPersonallyProcuredMoveForbidden user is not authorized
 
 swagger:response submitPersonallyProcuredMoveForbidden
 */
@@ -136,8 +132,7 @@ func (o *SubmitPersonallyProcuredMoveForbidden) WriteResponse(rw http.ResponseWr
 // SubmitPersonallyProcuredMoveNotFoundCode is the HTTP code returned for type SubmitPersonallyProcuredMoveNotFound
 const SubmitPersonallyProcuredMoveNotFoundCode int = 404
 
-/*
-SubmitPersonallyProcuredMoveNotFound ppm is not found
+/*SubmitPersonallyProcuredMoveNotFound ppm is not found
 
 swagger:response submitPersonallyProcuredMoveNotFound
 */
@@ -161,8 +156,7 @@ func (o *SubmitPersonallyProcuredMoveNotFound) WriteResponse(rw http.ResponseWri
 // SubmitPersonallyProcuredMoveInternalServerErrorCode is the HTTP code returned for type SubmitPersonallyProcuredMoveInternalServerError
 const SubmitPersonallyProcuredMoveInternalServerErrorCode int = 500
 
-/*
-SubmitPersonallyProcuredMoveInternalServerError internal server error
+/*SubmitPersonallyProcuredMoveInternalServerError internal server error
 
 swagger:response submitPersonallyProcuredMoveInternalServerError
 */

--- a/pkg/gen/internalapi/internaloperations/ppm/update_moving_expense.go
+++ b/pkg/gen/internalapi/internaloperations/ppm/update_moving_expense.go
@@ -29,12 +29,12 @@ func NewUpdateMovingExpense(ctx *middleware.Context, handler UpdateMovingExpense
 	return &UpdateMovingExpense{Context: ctx, Handler: handler}
 }
 
-/*
-	UpdateMovingExpense swagger:route PATCH /ppm-shipments/{ppmShipmentId}/moving-expenses/{movingExpenseId} ppm updateMovingExpense
+/* UpdateMovingExpense swagger:route PATCH /ppm-shipments/{ppmShipmentId}/moving-expenses/{movingExpenseId} ppm updateMovingExpense
 
-# Updates the moving expense
+Updates the moving expense
 
 Any fields sent in this request will be set on the moving expense referenced
+
 */
 type UpdateMovingExpense struct {
 	Context *middleware.Context

--- a/pkg/gen/internalapi/internaloperations/ppm/update_moving_expense_responses.go
+++ b/pkg/gen/internalapi/internaloperations/ppm/update_moving_expense_responses.go
@@ -16,8 +16,7 @@ import (
 // UpdateMovingExpenseOKCode is the HTTP code returned for type UpdateMovingExpenseOK
 const UpdateMovingExpenseOKCode int = 200
 
-/*
-UpdateMovingExpenseOK returns an updated moving expense object
+/*UpdateMovingExpenseOK returns an updated moving expense object
 
 swagger:response updateMovingExpenseOK
 */
@@ -61,8 +60,7 @@ func (o *UpdateMovingExpenseOK) WriteResponse(rw http.ResponseWriter, producer r
 // UpdateMovingExpenseBadRequestCode is the HTTP code returned for type UpdateMovingExpenseBadRequest
 const UpdateMovingExpenseBadRequestCode int = 400
 
-/*
-UpdateMovingExpenseBadRequest The request payload is invalid.
+/*UpdateMovingExpenseBadRequest The request payload is invalid.
 
 swagger:response updateMovingExpenseBadRequest
 */
@@ -106,8 +104,7 @@ func (o *UpdateMovingExpenseBadRequest) WriteResponse(rw http.ResponseWriter, pr
 // UpdateMovingExpenseUnauthorizedCode is the HTTP code returned for type UpdateMovingExpenseUnauthorized
 const UpdateMovingExpenseUnauthorizedCode int = 401
 
-/*
-UpdateMovingExpenseUnauthorized The request was denied.
+/*UpdateMovingExpenseUnauthorized The request was denied.
 
 swagger:response updateMovingExpenseUnauthorized
 */
@@ -151,8 +148,7 @@ func (o *UpdateMovingExpenseUnauthorized) WriteResponse(rw http.ResponseWriter, 
 // UpdateMovingExpenseForbiddenCode is the HTTP code returned for type UpdateMovingExpenseForbidden
 const UpdateMovingExpenseForbiddenCode int = 403
 
-/*
-UpdateMovingExpenseForbidden The request was denied.
+/*UpdateMovingExpenseForbidden The request was denied.
 
 swagger:response updateMovingExpenseForbidden
 */
@@ -196,8 +192,7 @@ func (o *UpdateMovingExpenseForbidden) WriteResponse(rw http.ResponseWriter, pro
 // UpdateMovingExpenseNotFoundCode is the HTTP code returned for type UpdateMovingExpenseNotFound
 const UpdateMovingExpenseNotFoundCode int = 404
 
-/*
-UpdateMovingExpenseNotFound The requested resource wasn't found.
+/*UpdateMovingExpenseNotFound The requested resource wasn't found.
 
 swagger:response updateMovingExpenseNotFound
 */
@@ -241,8 +236,7 @@ func (o *UpdateMovingExpenseNotFound) WriteResponse(rw http.ResponseWriter, prod
 // UpdateMovingExpensePreconditionFailedCode is the HTTP code returned for type UpdateMovingExpensePreconditionFailed
 const UpdateMovingExpensePreconditionFailedCode int = 412
 
-/*
-UpdateMovingExpensePreconditionFailed Precondition failed, likely due to a stale eTag (If-Match). Fetch the request again to get the updated eTag value.
+/*UpdateMovingExpensePreconditionFailed Precondition failed, likely due to a stale eTag (If-Match). Fetch the request again to get the updated eTag value.
 
 swagger:response updateMovingExpensePreconditionFailed
 */
@@ -286,8 +280,7 @@ func (o *UpdateMovingExpensePreconditionFailed) WriteResponse(rw http.ResponseWr
 // UpdateMovingExpenseUnprocessableEntityCode is the HTTP code returned for type UpdateMovingExpenseUnprocessableEntity
 const UpdateMovingExpenseUnprocessableEntityCode int = 422
 
-/*
-UpdateMovingExpenseUnprocessableEntity The payload was unprocessable.
+/*UpdateMovingExpenseUnprocessableEntity The payload was unprocessable.
 
 swagger:response updateMovingExpenseUnprocessableEntity
 */
@@ -331,8 +324,7 @@ func (o *UpdateMovingExpenseUnprocessableEntity) WriteResponse(rw http.ResponseW
 // UpdateMovingExpenseInternalServerErrorCode is the HTTP code returned for type UpdateMovingExpenseInternalServerError
 const UpdateMovingExpenseInternalServerErrorCode int = 500
 
-/*
-UpdateMovingExpenseInternalServerError A server error occurred.
+/*UpdateMovingExpenseInternalServerError A server error occurred.
 
 swagger:response updateMovingExpenseInternalServerError
 */

--- a/pkg/gen/internalapi/internaloperations/ppm/update_personally_procured_move.go
+++ b/pkg/gen/internalapi/internaloperations/ppm/update_personally_procured_move.go
@@ -29,12 +29,12 @@ func NewUpdatePersonallyProcuredMove(ctx *middleware.Context, handler UpdatePers
 	return &UpdatePersonallyProcuredMove{Context: ctx, Handler: handler}
 }
 
-/*
-	UpdatePersonallyProcuredMove swagger:route PUT /moves/{moveId}/personally_procured_move/{personallyProcuredMoveId} ppm updatePersonallyProcuredMove
+/* UpdatePersonallyProcuredMove swagger:route PUT /moves/{moveId}/personally_procured_move/{personallyProcuredMoveId} ppm updatePersonallyProcuredMove
 
-# Updates the PPM
+Updates the PPM
 
 This replaces the current version of the PPM with the version sent.
+
 */
 type UpdatePersonallyProcuredMove struct {
 	Context *middleware.Context

--- a/pkg/gen/internalapi/internaloperations/ppm/update_personally_procured_move_responses.go
+++ b/pkg/gen/internalapi/internaloperations/ppm/update_personally_procured_move_responses.go
@@ -16,8 +16,7 @@ import (
 // UpdatePersonallyProcuredMoveOKCode is the HTTP code returned for type UpdatePersonallyProcuredMoveOK
 const UpdatePersonallyProcuredMoveOKCode int = 200
 
-/*
-UpdatePersonallyProcuredMoveOK updated instance of personally_procured_move
+/*UpdatePersonallyProcuredMoveOK updated instance of personally_procured_move
 
 swagger:response updatePersonallyProcuredMoveOK
 */
@@ -61,8 +60,7 @@ func (o *UpdatePersonallyProcuredMoveOK) WriteResponse(rw http.ResponseWriter, p
 // UpdatePersonallyProcuredMoveBadRequestCode is the HTTP code returned for type UpdatePersonallyProcuredMoveBadRequest
 const UpdatePersonallyProcuredMoveBadRequestCode int = 400
 
-/*
-UpdatePersonallyProcuredMoveBadRequest invalid request
+/*UpdatePersonallyProcuredMoveBadRequest invalid request
 
 swagger:response updatePersonallyProcuredMoveBadRequest
 */
@@ -86,8 +84,7 @@ func (o *UpdatePersonallyProcuredMoveBadRequest) WriteResponse(rw http.ResponseW
 // UpdatePersonallyProcuredMoveUnauthorizedCode is the HTTP code returned for type UpdatePersonallyProcuredMoveUnauthorized
 const UpdatePersonallyProcuredMoveUnauthorizedCode int = 401
 
-/*
-UpdatePersonallyProcuredMoveUnauthorized request requires user authentication
+/*UpdatePersonallyProcuredMoveUnauthorized request requires user authentication
 
 swagger:response updatePersonallyProcuredMoveUnauthorized
 */
@@ -111,8 +108,7 @@ func (o *UpdatePersonallyProcuredMoveUnauthorized) WriteResponse(rw http.Respons
 // UpdatePersonallyProcuredMoveForbiddenCode is the HTTP code returned for type UpdatePersonallyProcuredMoveForbidden
 const UpdatePersonallyProcuredMoveForbiddenCode int = 403
 
-/*
-UpdatePersonallyProcuredMoveForbidden user is not authorized
+/*UpdatePersonallyProcuredMoveForbidden user is not authorized
 
 swagger:response updatePersonallyProcuredMoveForbidden
 */
@@ -136,8 +132,7 @@ func (o *UpdatePersonallyProcuredMoveForbidden) WriteResponse(rw http.ResponseWr
 // UpdatePersonallyProcuredMoveInternalServerErrorCode is the HTTP code returned for type UpdatePersonallyProcuredMoveInternalServerError
 const UpdatePersonallyProcuredMoveInternalServerErrorCode int = 500
 
-/*
-UpdatePersonallyProcuredMoveInternalServerError internal server error
+/*UpdatePersonallyProcuredMoveInternalServerError internal server error
 
 swagger:response updatePersonallyProcuredMoveInternalServerError
 */

--- a/pkg/gen/internalapi/internaloperations/ppm/update_weight_ticket.go
+++ b/pkg/gen/internalapi/internaloperations/ppm/update_weight_ticket.go
@@ -29,12 +29,12 @@ func NewUpdateWeightTicket(ctx *middleware.Context, handler UpdateWeightTicketHa
 	return &UpdateWeightTicket{Context: ctx, Handler: handler}
 }
 
-/*
-	UpdateWeightTicket swagger:route PATCH /ppm-shipments/{ppmShipmentId}/weight-ticket/{weightTicketId} ppm updateWeightTicket
+/* UpdateWeightTicket swagger:route PATCH /ppm-shipments/{ppmShipmentId}/weight-ticket/{weightTicketId} ppm updateWeightTicket
 
-# Updates a weight ticket document
+Updates a weight ticket document
 
 Updates a weight ticket document with the new information
+
 */
 type UpdateWeightTicket struct {
 	Context *middleware.Context

--- a/pkg/gen/internalapi/internaloperations/ppm/update_weight_ticket_responses.go
+++ b/pkg/gen/internalapi/internaloperations/ppm/update_weight_ticket_responses.go
@@ -16,8 +16,7 @@ import (
 // UpdateWeightTicketOKCode is the HTTP code returned for type UpdateWeightTicketOK
 const UpdateWeightTicketOKCode int = 200
 
-/*
-UpdateWeightTicketOK returns an updated weight ticket object
+/*UpdateWeightTicketOK returns an updated weight ticket object
 
 swagger:response updateWeightTicketOK
 */
@@ -61,8 +60,7 @@ func (o *UpdateWeightTicketOK) WriteResponse(rw http.ResponseWriter, producer ru
 // UpdateWeightTicketBadRequestCode is the HTTP code returned for type UpdateWeightTicketBadRequest
 const UpdateWeightTicketBadRequestCode int = 400
 
-/*
-UpdateWeightTicketBadRequest The request payload is invalid.
+/*UpdateWeightTicketBadRequest The request payload is invalid.
 
 swagger:response updateWeightTicketBadRequest
 */
@@ -106,8 +104,7 @@ func (o *UpdateWeightTicketBadRequest) WriteResponse(rw http.ResponseWriter, pro
 // UpdateWeightTicketUnauthorizedCode is the HTTP code returned for type UpdateWeightTicketUnauthorized
 const UpdateWeightTicketUnauthorizedCode int = 401
 
-/*
-UpdateWeightTicketUnauthorized The request was denied.
+/*UpdateWeightTicketUnauthorized The request was denied.
 
 swagger:response updateWeightTicketUnauthorized
 */
@@ -151,8 +148,7 @@ func (o *UpdateWeightTicketUnauthorized) WriteResponse(rw http.ResponseWriter, p
 // UpdateWeightTicketForbiddenCode is the HTTP code returned for type UpdateWeightTicketForbidden
 const UpdateWeightTicketForbiddenCode int = 403
 
-/*
-UpdateWeightTicketForbidden The request was denied.
+/*UpdateWeightTicketForbidden The request was denied.
 
 swagger:response updateWeightTicketForbidden
 */
@@ -196,8 +192,7 @@ func (o *UpdateWeightTicketForbidden) WriteResponse(rw http.ResponseWriter, prod
 // UpdateWeightTicketNotFoundCode is the HTTP code returned for type UpdateWeightTicketNotFound
 const UpdateWeightTicketNotFoundCode int = 404
 
-/*
-UpdateWeightTicketNotFound The requested resource wasn't found.
+/*UpdateWeightTicketNotFound The requested resource wasn't found.
 
 swagger:response updateWeightTicketNotFound
 */
@@ -241,8 +236,7 @@ func (o *UpdateWeightTicketNotFound) WriteResponse(rw http.ResponseWriter, produ
 // UpdateWeightTicketPreconditionFailedCode is the HTTP code returned for type UpdateWeightTicketPreconditionFailed
 const UpdateWeightTicketPreconditionFailedCode int = 412
 
-/*
-UpdateWeightTicketPreconditionFailed Precondition failed, likely due to a stale eTag (If-Match). Fetch the request again to get the updated eTag value.
+/*UpdateWeightTicketPreconditionFailed Precondition failed, likely due to a stale eTag (If-Match). Fetch the request again to get the updated eTag value.
 
 swagger:response updateWeightTicketPreconditionFailed
 */
@@ -286,8 +280,7 @@ func (o *UpdateWeightTicketPreconditionFailed) WriteResponse(rw http.ResponseWri
 // UpdateWeightTicketUnprocessableEntityCode is the HTTP code returned for type UpdateWeightTicketUnprocessableEntity
 const UpdateWeightTicketUnprocessableEntityCode int = 422
 
-/*
-UpdateWeightTicketUnprocessableEntity The payload was unprocessable.
+/*UpdateWeightTicketUnprocessableEntity The payload was unprocessable.
 
 swagger:response updateWeightTicketUnprocessableEntity
 */
@@ -331,8 +324,7 @@ func (o *UpdateWeightTicketUnprocessableEntity) WriteResponse(rw http.ResponseWr
 // UpdateWeightTicketInternalServerErrorCode is the HTTP code returned for type UpdateWeightTicketInternalServerError
 const UpdateWeightTicketInternalServerErrorCode int = 500
 
-/*
-UpdateWeightTicketInternalServerError A server error occurred.
+/*UpdateWeightTicketInternalServerError A server error occurred.
 
 swagger:response updateWeightTicketInternalServerError
 */

--- a/pkg/gen/internalapi/internaloperations/queues/show_queue.go
+++ b/pkg/gen/internalapi/internaloperations/queues/show_queue.go
@@ -29,12 +29,12 @@ func NewShowQueue(ctx *middleware.Context, handler ShowQueueHandler) *ShowQueue 
 	return &ShowQueue{Context: ctx, Handler: handler}
 }
 
-/*
-	ShowQueue swagger:route GET /queues/{queueType} queues showQueue
-
-# Show all moves in a queue
+/* ShowQueue swagger:route GET /queues/{queueType} queues showQueue
 
 Show all moves in a queue
+
+Show all moves in a queue
+
 */
 type ShowQueue struct {
 	Context *middleware.Context

--- a/pkg/gen/internalapi/internaloperations/queues/show_queue_responses.go
+++ b/pkg/gen/internalapi/internaloperations/queues/show_queue_responses.go
@@ -16,8 +16,7 @@ import (
 // ShowQueueOKCode is the HTTP code returned for type ShowQueueOK
 const ShowQueueOKCode int = 200
 
-/*
-ShowQueueOK list all moves in the specified queue
+/*ShowQueueOK list all moves in the specified queue
 
 swagger:response showQueueOK
 */
@@ -64,8 +63,7 @@ func (o *ShowQueueOK) WriteResponse(rw http.ResponseWriter, producer runtime.Pro
 // ShowQueueBadRequestCode is the HTTP code returned for type ShowQueueBadRequest
 const ShowQueueBadRequestCode int = 400
 
-/*
-ShowQueueBadRequest invalid request
+/*ShowQueueBadRequest invalid request
 
 swagger:response showQueueBadRequest
 */
@@ -89,8 +87,7 @@ func (o *ShowQueueBadRequest) WriteResponse(rw http.ResponseWriter, producer run
 // ShowQueueUnauthorizedCode is the HTTP code returned for type ShowQueueUnauthorized
 const ShowQueueUnauthorizedCode int = 401
 
-/*
-ShowQueueUnauthorized request requires user authentication
+/*ShowQueueUnauthorized request requires user authentication
 
 swagger:response showQueueUnauthorized
 */
@@ -114,8 +111,7 @@ func (o *ShowQueueUnauthorized) WriteResponse(rw http.ResponseWriter, producer r
 // ShowQueueForbiddenCode is the HTTP code returned for type ShowQueueForbidden
 const ShowQueueForbiddenCode int = 403
 
-/*
-ShowQueueForbidden user is not authorized to access this queue
+/*ShowQueueForbidden user is not authorized to access this queue
 
 swagger:response showQueueForbidden
 */
@@ -139,8 +135,7 @@ func (o *ShowQueueForbidden) WriteResponse(rw http.ResponseWriter, producer runt
 // ShowQueueNotFoundCode is the HTTP code returned for type ShowQueueNotFound
 const ShowQueueNotFoundCode int = 404
 
-/*
-ShowQueueNotFound move queue item is not found
+/*ShowQueueNotFound move queue item is not found
 
 swagger:response showQueueNotFound
 */

--- a/pkg/gen/internalapi/internaloperations/service_members/create_service_member.go
+++ b/pkg/gen/internalapi/internaloperations/service_members/create_service_member.go
@@ -29,12 +29,12 @@ func NewCreateServiceMember(ctx *middleware.Context, handler CreateServiceMember
 	return &CreateServiceMember{Context: ctx, Handler: handler}
 }
 
-/*
-	CreateServiceMember swagger:route POST /service_members service_members createServiceMember
+/* CreateServiceMember swagger:route POST /service_members service_members createServiceMember
 
-# Creates service member for a logged-in user
+Creates service member for a logged-in user
 
 Creates an instance of a service member tied to a user
+
 */
 type CreateServiceMember struct {
 	Context *middleware.Context

--- a/pkg/gen/internalapi/internaloperations/service_members/create_service_member_responses.go
+++ b/pkg/gen/internalapi/internaloperations/service_members/create_service_member_responses.go
@@ -16,8 +16,7 @@ import (
 // CreateServiceMemberCreatedCode is the HTTP code returned for type CreateServiceMemberCreated
 const CreateServiceMemberCreatedCode int = 201
 
-/*
-CreateServiceMemberCreated created instance of service member
+/*CreateServiceMemberCreated created instance of service member
 
 swagger:response createServiceMemberCreated
 */
@@ -61,8 +60,7 @@ func (o *CreateServiceMemberCreated) WriteResponse(rw http.ResponseWriter, produ
 // CreateServiceMemberBadRequestCode is the HTTP code returned for type CreateServiceMemberBadRequest
 const CreateServiceMemberBadRequestCode int = 400
 
-/*
-CreateServiceMemberBadRequest invalid request
+/*CreateServiceMemberBadRequest invalid request
 
 swagger:response createServiceMemberBadRequest
 */
@@ -86,8 +84,7 @@ func (o *CreateServiceMemberBadRequest) WriteResponse(rw http.ResponseWriter, pr
 // CreateServiceMemberUnauthorizedCode is the HTTP code returned for type CreateServiceMemberUnauthorized
 const CreateServiceMemberUnauthorizedCode int = 401
 
-/*
-CreateServiceMemberUnauthorized request requires user authentication
+/*CreateServiceMemberUnauthorized request requires user authentication
 
 swagger:response createServiceMemberUnauthorized
 */
@@ -111,8 +108,7 @@ func (o *CreateServiceMemberUnauthorized) WriteResponse(rw http.ResponseWriter, 
 // CreateServiceMemberForbiddenCode is the HTTP code returned for type CreateServiceMemberForbidden
 const CreateServiceMemberForbiddenCode int = 403
 
-/*
-CreateServiceMemberForbidden user is not authorized
+/*CreateServiceMemberForbidden user is not authorized
 
 swagger:response createServiceMemberForbidden
 */
@@ -136,8 +132,7 @@ func (o *CreateServiceMemberForbidden) WriteResponse(rw http.ResponseWriter, pro
 // CreateServiceMemberNotFoundCode is the HTTP code returned for type CreateServiceMemberNotFound
 const CreateServiceMemberNotFoundCode int = 404
 
-/*
-CreateServiceMemberNotFound service member not found
+/*CreateServiceMemberNotFound service member not found
 
 swagger:response createServiceMemberNotFound
 */
@@ -161,8 +156,7 @@ func (o *CreateServiceMemberNotFound) WriteResponse(rw http.ResponseWriter, prod
 // CreateServiceMemberInternalServerErrorCode is the HTTP code returned for type CreateServiceMemberInternalServerError
 const CreateServiceMemberInternalServerErrorCode int = 500
 
-/*
-CreateServiceMemberInternalServerError internal server error
+/*CreateServiceMemberInternalServerError internal server error
 
 swagger:response createServiceMemberInternalServerError
 */

--- a/pkg/gen/internalapi/internaloperations/service_members/patch_service_member.go
+++ b/pkg/gen/internalapi/internaloperations/service_members/patch_service_member.go
@@ -29,12 +29,12 @@ func NewPatchServiceMember(ctx *middleware.Context, handler PatchServiceMemberHa
 	return &PatchServiceMember{Context: ctx, Handler: handler}
 }
 
-/*
-	PatchServiceMember swagger:route PATCH /service_members/{serviceMemberId} service_members patchServiceMember
+/* PatchServiceMember swagger:route PATCH /service_members/{serviceMemberId} service_members patchServiceMember
 
-# Patches the service member
+Patches the service member
 
 Any fields sent in this request will be set on the service member referenced
+
 */
 type PatchServiceMember struct {
 	Context *middleware.Context

--- a/pkg/gen/internalapi/internaloperations/service_members/patch_service_member_responses.go
+++ b/pkg/gen/internalapi/internaloperations/service_members/patch_service_member_responses.go
@@ -16,8 +16,7 @@ import (
 // PatchServiceMemberOKCode is the HTTP code returned for type PatchServiceMemberOK
 const PatchServiceMemberOKCode int = 200
 
-/*
-PatchServiceMemberOK updated instance of service member
+/*PatchServiceMemberOK updated instance of service member
 
 swagger:response patchServiceMemberOK
 */
@@ -61,8 +60,7 @@ func (o *PatchServiceMemberOK) WriteResponse(rw http.ResponseWriter, producer ru
 // PatchServiceMemberBadRequestCode is the HTTP code returned for type PatchServiceMemberBadRequest
 const PatchServiceMemberBadRequestCode int = 400
 
-/*
-PatchServiceMemberBadRequest invalid request
+/*PatchServiceMemberBadRequest invalid request
 
 swagger:response patchServiceMemberBadRequest
 */
@@ -86,8 +84,7 @@ func (o *PatchServiceMemberBadRequest) WriteResponse(rw http.ResponseWriter, pro
 // PatchServiceMemberUnauthorizedCode is the HTTP code returned for type PatchServiceMemberUnauthorized
 const PatchServiceMemberUnauthorizedCode int = 401
 
-/*
-PatchServiceMemberUnauthorized request requires user authentication
+/*PatchServiceMemberUnauthorized request requires user authentication
 
 swagger:response patchServiceMemberUnauthorized
 */
@@ -111,8 +108,7 @@ func (o *PatchServiceMemberUnauthorized) WriteResponse(rw http.ResponseWriter, p
 // PatchServiceMemberForbiddenCode is the HTTP code returned for type PatchServiceMemberForbidden
 const PatchServiceMemberForbiddenCode int = 403
 
-/*
-PatchServiceMemberForbidden user is not authorized
+/*PatchServiceMemberForbidden user is not authorized
 
 swagger:response patchServiceMemberForbidden
 */
@@ -136,8 +132,7 @@ func (o *PatchServiceMemberForbidden) WriteResponse(rw http.ResponseWriter, prod
 // PatchServiceMemberNotFoundCode is the HTTP code returned for type PatchServiceMemberNotFound
 const PatchServiceMemberNotFoundCode int = 404
 
-/*
-PatchServiceMemberNotFound service member not found
+/*PatchServiceMemberNotFound service member not found
 
 swagger:response patchServiceMemberNotFound
 */
@@ -161,8 +156,7 @@ func (o *PatchServiceMemberNotFound) WriteResponse(rw http.ResponseWriter, produ
 // PatchServiceMemberInternalServerErrorCode is the HTTP code returned for type PatchServiceMemberInternalServerError
 const PatchServiceMemberInternalServerErrorCode int = 500
 
-/*
-PatchServiceMemberInternalServerError internal server error
+/*PatchServiceMemberInternalServerError internal server error
 
 swagger:response patchServiceMemberInternalServerError
 */

--- a/pkg/gen/internalapi/internaloperations/service_members/show_service_member.go
+++ b/pkg/gen/internalapi/internaloperations/service_members/show_service_member.go
@@ -29,12 +29,12 @@ func NewShowServiceMember(ctx *middleware.Context, handler ShowServiceMemberHand
 	return &ShowServiceMember{Context: ctx, Handler: handler}
 }
 
-/*
-	ShowServiceMember swagger:route GET /service_members/{serviceMemberId} service_members showServiceMember
-
-# Returns the given service member
+/* ShowServiceMember swagger:route GET /service_members/{serviceMemberId} service_members showServiceMember
 
 Returns the given service member
+
+Returns the given service member
+
 */
 type ShowServiceMember struct {
 	Context *middleware.Context

--- a/pkg/gen/internalapi/internaloperations/service_members/show_service_member_orders.go
+++ b/pkg/gen/internalapi/internaloperations/service_members/show_service_member_orders.go
@@ -29,12 +29,12 @@ func NewShowServiceMemberOrders(ctx *middleware.Context, handler ShowServiceMemb
 	return &ShowServiceMemberOrders{Context: ctx, Handler: handler}
 }
 
-/*
-	ShowServiceMemberOrders swagger:route GET /service_members/{serviceMemberId}/current_orders service_members showServiceMemberOrders
+/* ShowServiceMemberOrders swagger:route GET /service_members/{serviceMemberId}/current_orders service_members showServiceMemberOrders
 
-# Returns the latest orders for a given service member
+Returns the latest orders for a given service member
 
 Returns orders
+
 */
 type ShowServiceMemberOrders struct {
 	Context *middleware.Context

--- a/pkg/gen/internalapi/internaloperations/service_members/show_service_member_orders_responses.go
+++ b/pkg/gen/internalapi/internaloperations/service_members/show_service_member_orders_responses.go
@@ -16,8 +16,7 @@ import (
 // ShowServiceMemberOrdersOKCode is the HTTP code returned for type ShowServiceMemberOrdersOK
 const ShowServiceMemberOrdersOKCode int = 200
 
-/*
-ShowServiceMemberOrdersOK the instance of the service member
+/*ShowServiceMemberOrdersOK the instance of the service member
 
 swagger:response showServiceMemberOrdersOK
 */
@@ -61,8 +60,7 @@ func (o *ShowServiceMemberOrdersOK) WriteResponse(rw http.ResponseWriter, produc
 // ShowServiceMemberOrdersBadRequestCode is the HTTP code returned for type ShowServiceMemberOrdersBadRequest
 const ShowServiceMemberOrdersBadRequestCode int = 400
 
-/*
-ShowServiceMemberOrdersBadRequest invalid request
+/*ShowServiceMemberOrdersBadRequest invalid request
 
 swagger:response showServiceMemberOrdersBadRequest
 */
@@ -86,8 +84,7 @@ func (o *ShowServiceMemberOrdersBadRequest) WriteResponse(rw http.ResponseWriter
 // ShowServiceMemberOrdersUnauthorizedCode is the HTTP code returned for type ShowServiceMemberOrdersUnauthorized
 const ShowServiceMemberOrdersUnauthorizedCode int = 401
 
-/*
-ShowServiceMemberOrdersUnauthorized request requires user authentication
+/*ShowServiceMemberOrdersUnauthorized request requires user authentication
 
 swagger:response showServiceMemberOrdersUnauthorized
 */
@@ -111,8 +108,7 @@ func (o *ShowServiceMemberOrdersUnauthorized) WriteResponse(rw http.ResponseWrit
 // ShowServiceMemberOrdersForbiddenCode is the HTTP code returned for type ShowServiceMemberOrdersForbidden
 const ShowServiceMemberOrdersForbiddenCode int = 403
 
-/*
-ShowServiceMemberOrdersForbidden user is not authorized
+/*ShowServiceMemberOrdersForbidden user is not authorized
 
 swagger:response showServiceMemberOrdersForbidden
 */
@@ -136,8 +132,7 @@ func (o *ShowServiceMemberOrdersForbidden) WriteResponse(rw http.ResponseWriter,
 // ShowServiceMemberOrdersNotFoundCode is the HTTP code returned for type ShowServiceMemberOrdersNotFound
 const ShowServiceMemberOrdersNotFoundCode int = 404
 
-/*
-ShowServiceMemberOrdersNotFound service member not found
+/*ShowServiceMemberOrdersNotFound service member not found
 
 swagger:response showServiceMemberOrdersNotFound
 */
@@ -161,8 +156,7 @@ func (o *ShowServiceMemberOrdersNotFound) WriteResponse(rw http.ResponseWriter, 
 // ShowServiceMemberOrdersInternalServerErrorCode is the HTTP code returned for type ShowServiceMemberOrdersInternalServerError
 const ShowServiceMemberOrdersInternalServerErrorCode int = 500
 
-/*
-ShowServiceMemberOrdersInternalServerError internal server error
+/*ShowServiceMemberOrdersInternalServerError internal server error
 
 swagger:response showServiceMemberOrdersInternalServerError
 */

--- a/pkg/gen/internalapi/internaloperations/service_members/show_service_member_responses.go
+++ b/pkg/gen/internalapi/internaloperations/service_members/show_service_member_responses.go
@@ -16,8 +16,7 @@ import (
 // ShowServiceMemberOKCode is the HTTP code returned for type ShowServiceMemberOK
 const ShowServiceMemberOKCode int = 200
 
-/*
-ShowServiceMemberOK the instance of the service member
+/*ShowServiceMemberOK the instance of the service member
 
 swagger:response showServiceMemberOK
 */
@@ -61,8 +60,7 @@ func (o *ShowServiceMemberOK) WriteResponse(rw http.ResponseWriter, producer run
 // ShowServiceMemberBadRequestCode is the HTTP code returned for type ShowServiceMemberBadRequest
 const ShowServiceMemberBadRequestCode int = 400
 
-/*
-ShowServiceMemberBadRequest invalid request
+/*ShowServiceMemberBadRequest invalid request
 
 swagger:response showServiceMemberBadRequest
 */
@@ -86,8 +84,7 @@ func (o *ShowServiceMemberBadRequest) WriteResponse(rw http.ResponseWriter, prod
 // ShowServiceMemberUnauthorizedCode is the HTTP code returned for type ShowServiceMemberUnauthorized
 const ShowServiceMemberUnauthorizedCode int = 401
 
-/*
-ShowServiceMemberUnauthorized request requires user authentication
+/*ShowServiceMemberUnauthorized request requires user authentication
 
 swagger:response showServiceMemberUnauthorized
 */
@@ -111,8 +108,7 @@ func (o *ShowServiceMemberUnauthorized) WriteResponse(rw http.ResponseWriter, pr
 // ShowServiceMemberForbiddenCode is the HTTP code returned for type ShowServiceMemberForbidden
 const ShowServiceMemberForbiddenCode int = 403
 
-/*
-ShowServiceMemberForbidden user is not authorized
+/*ShowServiceMemberForbidden user is not authorized
 
 swagger:response showServiceMemberForbidden
 */
@@ -136,8 +132,7 @@ func (o *ShowServiceMemberForbidden) WriteResponse(rw http.ResponseWriter, produ
 // ShowServiceMemberNotFoundCode is the HTTP code returned for type ShowServiceMemberNotFound
 const ShowServiceMemberNotFoundCode int = 404
 
-/*
-ShowServiceMemberNotFound service member not found
+/*ShowServiceMemberNotFound service member not found
 
 swagger:response showServiceMemberNotFound
 */
@@ -161,8 +156,7 @@ func (o *ShowServiceMemberNotFound) WriteResponse(rw http.ResponseWriter, produc
 // ShowServiceMemberInternalServerErrorCode is the HTTP code returned for type ShowServiceMemberInternalServerError
 const ShowServiceMemberInternalServerErrorCode int = 500
 
-/*
-ShowServiceMemberInternalServerError internal server error
+/*ShowServiceMemberInternalServerError internal server error
 
 swagger:response showServiceMemberInternalServerError
 */

--- a/pkg/gen/internalapi/internaloperations/transportation_offices/show_duty_location_transportation_office.go
+++ b/pkg/gen/internalapi/internaloperations/transportation_offices/show_duty_location_transportation_office.go
@@ -29,12 +29,12 @@ func NewShowDutyLocationTransportationOffice(ctx *middleware.Context, handler Sh
 	return &ShowDutyLocationTransportationOffice{Context: ctx, Handler: handler}
 }
 
-/*
-	ShowDutyLocationTransportationOffice swagger:route GET /duty_locations/{dutyLocationId}/transportation_office transportation_offices showDutyLocationTransportationOffice
+/* ShowDutyLocationTransportationOffice swagger:route GET /duty_locations/{dutyLocationId}/transportation_office transportation_offices showDutyLocationTransportationOffice
 
-# Returns the transportation office for a given duty location
+Returns the transportation office for a given duty location
 
 Returns the given duty location's transportation office
+
 */
 type ShowDutyLocationTransportationOffice struct {
 	Context *middleware.Context

--- a/pkg/gen/internalapi/internaloperations/transportation_offices/show_duty_location_transportation_office_responses.go
+++ b/pkg/gen/internalapi/internaloperations/transportation_offices/show_duty_location_transportation_office_responses.go
@@ -16,8 +16,7 @@ import (
 // ShowDutyLocationTransportationOfficeOKCode is the HTTP code returned for type ShowDutyLocationTransportationOfficeOK
 const ShowDutyLocationTransportationOfficeOKCode int = 200
 
-/*
-ShowDutyLocationTransportationOfficeOK the instance of the transportation office for a duty location
+/*ShowDutyLocationTransportationOfficeOK the instance of the transportation office for a duty location
 
 swagger:response showDutyLocationTransportationOfficeOK
 */
@@ -61,8 +60,7 @@ func (o *ShowDutyLocationTransportationOfficeOK) WriteResponse(rw http.ResponseW
 // ShowDutyLocationTransportationOfficeBadRequestCode is the HTTP code returned for type ShowDutyLocationTransportationOfficeBadRequest
 const ShowDutyLocationTransportationOfficeBadRequestCode int = 400
 
-/*
-ShowDutyLocationTransportationOfficeBadRequest invalid request
+/*ShowDutyLocationTransportationOfficeBadRequest invalid request
 
 swagger:response showDutyLocationTransportationOfficeBadRequest
 */
@@ -86,8 +84,7 @@ func (o *ShowDutyLocationTransportationOfficeBadRequest) WriteResponse(rw http.R
 // ShowDutyLocationTransportationOfficeUnauthorizedCode is the HTTP code returned for type ShowDutyLocationTransportationOfficeUnauthorized
 const ShowDutyLocationTransportationOfficeUnauthorizedCode int = 401
 
-/*
-ShowDutyLocationTransportationOfficeUnauthorized request requires user authentication
+/*ShowDutyLocationTransportationOfficeUnauthorized request requires user authentication
 
 swagger:response showDutyLocationTransportationOfficeUnauthorized
 */
@@ -111,8 +108,7 @@ func (o *ShowDutyLocationTransportationOfficeUnauthorized) WriteResponse(rw http
 // ShowDutyLocationTransportationOfficeForbiddenCode is the HTTP code returned for type ShowDutyLocationTransportationOfficeForbidden
 const ShowDutyLocationTransportationOfficeForbiddenCode int = 403
 
-/*
-ShowDutyLocationTransportationOfficeForbidden user is not authorized
+/*ShowDutyLocationTransportationOfficeForbidden user is not authorized
 
 swagger:response showDutyLocationTransportationOfficeForbidden
 */
@@ -136,8 +132,7 @@ func (o *ShowDutyLocationTransportationOfficeForbidden) WriteResponse(rw http.Re
 // ShowDutyLocationTransportationOfficeNotFoundCode is the HTTP code returned for type ShowDutyLocationTransportationOfficeNotFound
 const ShowDutyLocationTransportationOfficeNotFoundCode int = 404
 
-/*
-ShowDutyLocationTransportationOfficeNotFound transportation office not found
+/*ShowDutyLocationTransportationOfficeNotFound transportation office not found
 
 swagger:response showDutyLocationTransportationOfficeNotFound
 */
@@ -161,8 +156,7 @@ func (o *ShowDutyLocationTransportationOfficeNotFound) WriteResponse(rw http.Res
 // ShowDutyLocationTransportationOfficeInternalServerErrorCode is the HTTP code returned for type ShowDutyLocationTransportationOfficeInternalServerError
 const ShowDutyLocationTransportationOfficeInternalServerErrorCode int = 500
 
-/*
-ShowDutyLocationTransportationOfficeInternalServerError internal server error
+/*ShowDutyLocationTransportationOfficeInternalServerError internal server error
 
 swagger:response showDutyLocationTransportationOfficeInternalServerError
 */

--- a/pkg/gen/internalapi/internaloperations/uploads/create_upload.go
+++ b/pkg/gen/internalapi/internaloperations/uploads/create_upload.go
@@ -29,12 +29,12 @@ func NewCreateUpload(ctx *middleware.Context, handler CreateUploadHandler) *Crea
 	return &CreateUpload{Context: ctx, Handler: handler}
 }
 
-/*
-	CreateUpload swagger:route POST /uploads uploads createUpload
+/* CreateUpload swagger:route POST /uploads uploads createUpload
 
-# Create a new upload
+Create a new upload
 
 Uploads represent a single digital file, such as a JPEG or PDF.
+
 */
 type CreateUpload struct {
 	Context *middleware.Context

--- a/pkg/gen/internalapi/internaloperations/uploads/create_upload_responses.go
+++ b/pkg/gen/internalapi/internaloperations/uploads/create_upload_responses.go
@@ -16,8 +16,7 @@ import (
 // CreateUploadCreatedCode is the HTTP code returned for type CreateUploadCreated
 const CreateUploadCreatedCode int = 201
 
-/*
-CreateUploadCreated created upload
+/*CreateUploadCreated created upload
 
 swagger:response createUploadCreated
 */
@@ -61,8 +60,7 @@ func (o *CreateUploadCreated) WriteResponse(rw http.ResponseWriter, producer run
 // CreateUploadBadRequestCode is the HTTP code returned for type CreateUploadBadRequest
 const CreateUploadBadRequestCode int = 400
 
-/*
-CreateUploadBadRequest invalid request
+/*CreateUploadBadRequest invalid request
 
 swagger:response createUploadBadRequest
 */
@@ -106,8 +104,7 @@ func (o *CreateUploadBadRequest) WriteResponse(rw http.ResponseWriter, producer 
 // CreateUploadForbiddenCode is the HTTP code returned for type CreateUploadForbidden
 const CreateUploadForbiddenCode int = 403
 
-/*
-CreateUploadForbidden not authorized
+/*CreateUploadForbidden not authorized
 
 swagger:response createUploadForbidden
 */
@@ -131,8 +128,7 @@ func (o *CreateUploadForbidden) WriteResponse(rw http.ResponseWriter, producer r
 // CreateUploadNotFoundCode is the HTTP code returned for type CreateUploadNotFound
 const CreateUploadNotFoundCode int = 404
 
-/*
-CreateUploadNotFound not found
+/*CreateUploadNotFound not found
 
 swagger:response createUploadNotFound
 */
@@ -156,8 +152,7 @@ func (o *CreateUploadNotFound) WriteResponse(rw http.ResponseWriter, producer ru
 // CreateUploadRequestEntityTooLargeCode is the HTTP code returned for type CreateUploadRequestEntityTooLarge
 const CreateUploadRequestEntityTooLargeCode int = 413
 
-/*
-CreateUploadRequestEntityTooLarge payload is too large
+/*CreateUploadRequestEntityTooLarge payload is too large
 
 swagger:response createUploadRequestEntityTooLarge
 */
@@ -181,8 +176,7 @@ func (o *CreateUploadRequestEntityTooLarge) WriteResponse(rw http.ResponseWriter
 // CreateUploadInternalServerErrorCode is the HTTP code returned for type CreateUploadInternalServerError
 const CreateUploadInternalServerErrorCode int = 500
 
-/*
-CreateUploadInternalServerError server error
+/*CreateUploadInternalServerError server error
 
 swagger:response createUploadInternalServerError
 */

--- a/pkg/gen/internalapi/internaloperations/uploads/delete_upload.go
+++ b/pkg/gen/internalapi/internaloperations/uploads/delete_upload.go
@@ -29,12 +29,12 @@ func NewDeleteUpload(ctx *middleware.Context, handler DeleteUploadHandler) *Dele
 	return &DeleteUpload{Context: ctx, Handler: handler}
 }
 
-/*
-	DeleteUpload swagger:route DELETE /uploads/{uploadId} uploads deleteUpload
+/* DeleteUpload swagger:route DELETE /uploads/{uploadId} uploads deleteUpload
 
-# Deletes an upload
+Deletes an upload
 
 Uploads represent a single digital file, such as a JPEG or PDF.
+
 */
 type DeleteUpload struct {
 	Context *middleware.Context

--- a/pkg/gen/internalapi/internaloperations/uploads/delete_upload_responses.go
+++ b/pkg/gen/internalapi/internaloperations/uploads/delete_upload_responses.go
@@ -16,8 +16,7 @@ import (
 // DeleteUploadNoContentCode is the HTTP code returned for type DeleteUploadNoContent
 const DeleteUploadNoContentCode int = 204
 
-/*
-DeleteUploadNoContent deleted
+/*DeleteUploadNoContent deleted
 
 swagger:response deleteUploadNoContent
 */
@@ -41,8 +40,7 @@ func (o *DeleteUploadNoContent) WriteResponse(rw http.ResponseWriter, producer r
 // DeleteUploadBadRequestCode is the HTTP code returned for type DeleteUploadBadRequest
 const DeleteUploadBadRequestCode int = 400
 
-/*
-DeleteUploadBadRequest invalid request
+/*DeleteUploadBadRequest invalid request
 
 swagger:response deleteUploadBadRequest
 */
@@ -86,8 +84,7 @@ func (o *DeleteUploadBadRequest) WriteResponse(rw http.ResponseWriter, producer 
 // DeleteUploadForbiddenCode is the HTTP code returned for type DeleteUploadForbidden
 const DeleteUploadForbiddenCode int = 403
 
-/*
-DeleteUploadForbidden not authorized
+/*DeleteUploadForbidden not authorized
 
 swagger:response deleteUploadForbidden
 */
@@ -111,8 +108,7 @@ func (o *DeleteUploadForbidden) WriteResponse(rw http.ResponseWriter, producer r
 // DeleteUploadNotFoundCode is the HTTP code returned for type DeleteUploadNotFound
 const DeleteUploadNotFoundCode int = 404
 
-/*
-DeleteUploadNotFound not found
+/*DeleteUploadNotFound not found
 
 swagger:response deleteUploadNotFound
 */
@@ -136,8 +132,7 @@ func (o *DeleteUploadNotFound) WriteResponse(rw http.ResponseWriter, producer ru
 // DeleteUploadInternalServerErrorCode is the HTTP code returned for type DeleteUploadInternalServerError
 const DeleteUploadInternalServerErrorCode int = 500
 
-/*
-DeleteUploadInternalServerError server error
+/*DeleteUploadInternalServerError server error
 
 swagger:response deleteUploadInternalServerError
 */

--- a/pkg/gen/internalapi/internaloperations/uploads/delete_uploads.go
+++ b/pkg/gen/internalapi/internaloperations/uploads/delete_uploads.go
@@ -29,12 +29,12 @@ func NewDeleteUploads(ctx *middleware.Context, handler DeleteUploadsHandler) *De
 	return &DeleteUploads{Context: ctx, Handler: handler}
 }
 
-/*
-	DeleteUploads swagger:route DELETE /uploads uploads deleteUploads
+/* DeleteUploads swagger:route DELETE /uploads uploads deleteUploads
 
-# Deletes a collection of uploads
+Deletes a collection of uploads
 
 Uploads represent a single digital file, such as a JPEG or PDF.
+
 */
 type DeleteUploads struct {
 	Context *middleware.Context

--- a/pkg/gen/internalapi/internaloperations/uploads/delete_uploads_responses.go
+++ b/pkg/gen/internalapi/internaloperations/uploads/delete_uploads_responses.go
@@ -16,8 +16,7 @@ import (
 // DeleteUploadsNoContentCode is the HTTP code returned for type DeleteUploadsNoContent
 const DeleteUploadsNoContentCode int = 204
 
-/*
-DeleteUploadsNoContent deleted
+/*DeleteUploadsNoContent deleted
 
 swagger:response deleteUploadsNoContent
 */
@@ -41,8 +40,7 @@ func (o *DeleteUploadsNoContent) WriteResponse(rw http.ResponseWriter, producer 
 // DeleteUploadsBadRequestCode is the HTTP code returned for type DeleteUploadsBadRequest
 const DeleteUploadsBadRequestCode int = 400
 
-/*
-DeleteUploadsBadRequest invalid request
+/*DeleteUploadsBadRequest invalid request
 
 swagger:response deleteUploadsBadRequest
 */
@@ -86,8 +84,7 @@ func (o *DeleteUploadsBadRequest) WriteResponse(rw http.ResponseWriter, producer
 // DeleteUploadsForbiddenCode is the HTTP code returned for type DeleteUploadsForbidden
 const DeleteUploadsForbiddenCode int = 403
 
-/*
-DeleteUploadsForbidden not authorized
+/*DeleteUploadsForbidden not authorized
 
 swagger:response deleteUploadsForbidden
 */
@@ -111,8 +108,7 @@ func (o *DeleteUploadsForbidden) WriteResponse(rw http.ResponseWriter, producer 
 // DeleteUploadsNotFoundCode is the HTTP code returned for type DeleteUploadsNotFound
 const DeleteUploadsNotFoundCode int = 404
 
-/*
-DeleteUploadsNotFound not found
+/*DeleteUploadsNotFound not found
 
 swagger:response deleteUploadsNotFound
 */
@@ -136,8 +132,7 @@ func (o *DeleteUploadsNotFound) WriteResponse(rw http.ResponseWriter, producer r
 // DeleteUploadsInternalServerErrorCode is the HTTP code returned for type DeleteUploadsInternalServerError
 const DeleteUploadsInternalServerErrorCode int = 500
 
-/*
-DeleteUploadsInternalServerError server error
+/*DeleteUploadsInternalServerError server error
 
 swagger:response deleteUploadsInternalServerError
 */

--- a/pkg/gen/internalapi/internaloperations/users/is_logged_in_user.go
+++ b/pkg/gen/internalapi/internaloperations/users/is_logged_in_user.go
@@ -34,12 +34,12 @@ func NewIsLoggedInUser(ctx *middleware.Context, handler IsLoggedInUserHandler) *
 	return &IsLoggedInUser{Context: ctx, Handler: handler}
 }
 
-/*
-	IsLoggedInUser swagger:route GET /users/is_logged_in users isLoggedInUser
-
-# Returns boolean as to whether the user is logged in
+/* IsLoggedInUser swagger:route GET /users/is_logged_in users isLoggedInUser
 
 Returns boolean as to whether the user is logged in
+
+Returns boolean as to whether the user is logged in
+
 */
 type IsLoggedInUser struct {
 	Context *middleware.Context

--- a/pkg/gen/internalapi/internaloperations/users/is_logged_in_user_responses.go
+++ b/pkg/gen/internalapi/internaloperations/users/is_logged_in_user_responses.go
@@ -14,8 +14,7 @@ import (
 // IsLoggedInUserOKCode is the HTTP code returned for type IsLoggedInUserOK
 const IsLoggedInUserOKCode int = 200
 
-/*
-IsLoggedInUserOK Currently logged in user
+/*IsLoggedInUserOK Currently logged in user
 
 swagger:response isLoggedInUserOK
 */
@@ -59,8 +58,7 @@ func (o *IsLoggedInUserOK) WriteResponse(rw http.ResponseWriter, producer runtim
 // IsLoggedInUserBadRequestCode is the HTTP code returned for type IsLoggedInUserBadRequest
 const IsLoggedInUserBadRequestCode int = 400
 
-/*
-IsLoggedInUserBadRequest invalid request
+/*IsLoggedInUserBadRequest invalid request
 
 swagger:response isLoggedInUserBadRequest
 */
@@ -84,8 +82,7 @@ func (o *IsLoggedInUserBadRequest) WriteResponse(rw http.ResponseWriter, produce
 // IsLoggedInUserInternalServerErrorCode is the HTTP code returned for type IsLoggedInUserInternalServerError
 const IsLoggedInUserInternalServerErrorCode int = 500
 
-/*
-IsLoggedInUserInternalServerError server error
+/*IsLoggedInUserInternalServerError server error
 
 swagger:response isLoggedInUserInternalServerError
 */

--- a/pkg/gen/internalapi/internaloperations/users/show_logged_in_user.go
+++ b/pkg/gen/internalapi/internaloperations/users/show_logged_in_user.go
@@ -29,12 +29,12 @@ func NewShowLoggedInUser(ctx *middleware.Context, handler ShowLoggedInUserHandle
 	return &ShowLoggedInUser{Context: ctx, Handler: handler}
 }
 
-/*
-	ShowLoggedInUser swagger:route GET /users/logged_in users showLoggedInUser
-
-# Returns the user info for the currently logged in user
+/* ShowLoggedInUser swagger:route GET /users/logged_in users showLoggedInUser
 
 Returns the user info for the currently logged in user
+
+Returns the user info for the currently logged in user
+
 */
 type ShowLoggedInUser struct {
 	Context *middleware.Context

--- a/pkg/gen/internalapi/internaloperations/users/show_logged_in_user_responses.go
+++ b/pkg/gen/internalapi/internaloperations/users/show_logged_in_user_responses.go
@@ -16,8 +16,7 @@ import (
 // ShowLoggedInUserOKCode is the HTTP code returned for type ShowLoggedInUserOK
 const ShowLoggedInUserOKCode int = 200
 
-/*
-ShowLoggedInUserOK Currently logged in user
+/*ShowLoggedInUserOK Currently logged in user
 
 swagger:response showLoggedInUserOK
 */
@@ -61,8 +60,7 @@ func (o *ShowLoggedInUserOK) WriteResponse(rw http.ResponseWriter, producer runt
 // ShowLoggedInUserBadRequestCode is the HTTP code returned for type ShowLoggedInUserBadRequest
 const ShowLoggedInUserBadRequestCode int = 400
 
-/*
-ShowLoggedInUserBadRequest invalid request
+/*ShowLoggedInUserBadRequest invalid request
 
 swagger:response showLoggedInUserBadRequest
 */
@@ -86,8 +84,7 @@ func (o *ShowLoggedInUserBadRequest) WriteResponse(rw http.ResponseWriter, produ
 // ShowLoggedInUserUnauthorizedCode is the HTTP code returned for type ShowLoggedInUserUnauthorized
 const ShowLoggedInUserUnauthorizedCode int = 401
 
-/*
-ShowLoggedInUserUnauthorized request requires user authentication
+/*ShowLoggedInUserUnauthorized request requires user authentication
 
 swagger:response showLoggedInUserUnauthorized
 */
@@ -111,8 +108,7 @@ func (o *ShowLoggedInUserUnauthorized) WriteResponse(rw http.ResponseWriter, pro
 // ShowLoggedInUserInternalServerErrorCode is the HTTP code returned for type ShowLoggedInUserInternalServerError
 const ShowLoggedInUserInternalServerErrorCode int = 500
 
-/*
-ShowLoggedInUserInternalServerError server error
+/*ShowLoggedInUserInternalServerError server error
 
 swagger:response showLoggedInUserInternalServerError
 */

--- a/pkg/gen/internalmessages/affiliation.go
+++ b/pkg/gen/internalmessages/affiliation.go
@@ -16,7 +16,7 @@ import (
 
 // Affiliation Branch of service
 //
-// # Military branch of service
+// Military branch of service
 //
 // swagger:model Affiliation
 type Affiliation string

--- a/pkg/gen/internalmessages/p_p_m_shipment_status.go
+++ b/pkg/gen/internalmessages/p_p_m_shipment_status.go
@@ -15,12 +15,13 @@ import (
 )
 
 // PPMShipmentStatus Status of the PPM Shipment:
-//   - **DRAFT**: The customer has created the PPM shipment but has not yet submitted their move for counseling.
-//   - **SUBMITTED**: The shipment belongs to a move that has been submitted by the customer or has been created by a Service Counselor or Prime Contractor for a submitted move.
-//   - **WAITING_ON_CUSTOMER**: The PPM shipment has been approved and the customer may now provide their actual move closeout information and documentation required to get paid.
-//   - **NEEDS_ADVANCE_APPROVAL**: The shipment was counseled by the Prime Contractor and approved but an advance was requested so will need further financial approval from the government.
-//   - **NEEDS_PAYMENT_APPROVAL**: The customer has provided their closeout weight tickets, receipts, and expenses and certified it for the Service Counselor to approve, exclude or reject.
-//   - **PAYMENT_APPROVED**: The Service Counselor has reviewed all of the customer's PPM closeout documentation and authorizes the customer can download and submit their finalized SSW packet.
+//   * **DRAFT**: The customer has created the PPM shipment but has not yet submitted their move for counseling.
+//   * **SUBMITTED**: The shipment belongs to a move that has been submitted by the customer or has been created by a Service Counselor or Prime Contractor for a submitted move.
+//   * **WAITING_ON_CUSTOMER**: The PPM shipment has been approved and the customer may now provide their actual move closeout information and documentation required to get paid.
+//   * **NEEDS_ADVANCE_APPROVAL**: The shipment was counseled by the Prime Contractor and approved but an advance was requested so will need further financial approval from the government.
+//   * **NEEDS_PAYMENT_APPROVAL**: The customer has provided their closeout weight tickets, receipts, and expenses and certified it for the Service Counselor to approve, exclude or reject.
+//   * **PAYMENT_APPROVED**: The Service Counselor has reviewed all of the customer's PPM closeout documentation and authorizes the customer can download and submit their finalized SSW packet.
+//
 //
 // swagger:model PPMShipmentStatus
 type PPMShipmentStatus string

--- a/pkg/gen/ordersapi/doc.go
+++ b/pkg/gen/ordersapi/doc.go
@@ -2,23 +2,23 @@
 
 // Package ordersapi MilMove Orders API
 //
-//	The Orders API is a RESTful API that enables to submit, amend, and
-//	cancel orders for MilMove.
+//  The Orders API is a RESTful API that enables to submit, amend, and
+//  cancel orders for MilMove.
 //
-//	All endpoints are located under `/orders/v1`.
+//  All endpoints are located under `/orders/v1`.
 //
-//	Schemes:
-//	  http
-//	Host: localhost
-//	BasePath: /orders/v1
-//	Version: 1.0.0
-//	License: MIT https://github.com/transcom/mymove/blob/master/LICENSE.md
+//  Schemes:
+//    http
+//  Host: localhost
+//  BasePath: /orders/v1
+//  Version: 1.0.0
+//  License: MIT https://github.com/transcom/mymove/blob/master/LICENSE.md
 //
-//	Consumes:
-//	  - application/json
+//  Consumes:
+//    - application/json
 //
-//	Produces:
-//	  - application/json
+//  Produces:
+//    - application/json
 //
 // swagger:meta
 package ordersapi

--- a/pkg/gen/ordersapi/ordersoperations/get_orders.go
+++ b/pkg/gen/ordersapi/ordersoperations/get_orders.go
@@ -29,15 +29,15 @@ func NewGetOrders(ctx *middleware.Context, handler GetOrdersHandler) *GetOrders 
 	return &GetOrders{Context: ctx, Handler: handler}
 }
 
-/*
-	GetOrders swagger:route GET /orders/{uuid} getOrders
+/* GetOrders swagger:route GET /orders/{uuid} getOrders
 
-# Retrieve a set of Orders and all of its Revisions by UUID
+Retrieve a set of Orders and all of its Revisions by UUID
 
 Gets Orders with the supplied UUID.
 ## Errors
 Users of this endpoint must have permission to read Orders for the `issuer` associated with the Orders. If not, this endpoint will return `403 Forbidden`.
 The UUID must match an existing set of Orders. Otherwise, this endpoint will return `404 Not Found`.
+
 */
 type GetOrders struct {
 	Context *middleware.Context

--- a/pkg/gen/ordersapi/ordersoperations/get_orders_by_issuer_and_orders_num.go
+++ b/pkg/gen/ordersapi/ordersoperations/get_orders_by_issuer_and_orders_num.go
@@ -29,15 +29,15 @@ func NewGetOrdersByIssuerAndOrdersNum(ctx *middleware.Context, handler GetOrders
 	return &GetOrdersByIssuerAndOrdersNum{Context: ctx, Handler: handler}
 }
 
-/*
-	GetOrdersByIssuerAndOrdersNum swagger:route GET /issuers/{issuer}/orders/{ordersNum} getOrdersByIssuerAndOrdersNum
+/* GetOrdersByIssuerAndOrdersNum swagger:route GET /issuers/{issuer}/orders/{ordersNum} getOrdersByIssuerAndOrdersNum
 
-# Retrieve orders by issuer and orders number
+Retrieve orders by issuer and orders number
 
 Return Orders with the provided issuer and orders number.
 # Errors
 Users of this endpoint must have permission to read Orders for the specified issuer. Otherwise, this endpoint will return `403 Forbidden`.
 If there are no Orders with the specified orders number from the specified issuer, then this endpoint will return `404 Not Found`.
+
 */
 type GetOrdersByIssuerAndOrdersNum struct {
 	Context *middleware.Context

--- a/pkg/gen/ordersapi/ordersoperations/get_orders_by_issuer_and_orders_num_responses.go
+++ b/pkg/gen/ordersapi/ordersoperations/get_orders_by_issuer_and_orders_num_responses.go
@@ -16,8 +16,7 @@ import (
 // GetOrdersByIssuerAndOrdersNumOKCode is the HTTP code returned for type GetOrdersByIssuerAndOrdersNumOK
 const GetOrdersByIssuerAndOrdersNumOKCode int = 200
 
-/*
-GetOrdersByIssuerAndOrdersNumOK Successful
+/*GetOrdersByIssuerAndOrdersNumOK Successful
 
 swagger:response getOrdersByIssuerAndOrdersNumOK
 */
@@ -61,8 +60,7 @@ func (o *GetOrdersByIssuerAndOrdersNumOK) WriteResponse(rw http.ResponseWriter, 
 // GetOrdersByIssuerAndOrdersNumBadRequestCode is the HTTP code returned for type GetOrdersByIssuerAndOrdersNumBadRequest
 const GetOrdersByIssuerAndOrdersNumBadRequestCode int = 400
 
-/*
-GetOrdersByIssuerAndOrdersNumBadRequest Invalid
+/*GetOrdersByIssuerAndOrdersNumBadRequest Invalid
 
 swagger:response getOrdersByIssuerAndOrdersNumBadRequest
 */
@@ -86,8 +84,7 @@ func (o *GetOrdersByIssuerAndOrdersNumBadRequest) WriteResponse(rw http.Response
 // GetOrdersByIssuerAndOrdersNumUnauthorizedCode is the HTTP code returned for type GetOrdersByIssuerAndOrdersNumUnauthorized
 const GetOrdersByIssuerAndOrdersNumUnauthorizedCode int = 401
 
-/*
-GetOrdersByIssuerAndOrdersNumUnauthorized must be authenticated to use this endpoint
+/*GetOrdersByIssuerAndOrdersNumUnauthorized must be authenticated to use this endpoint
 
 swagger:response getOrdersByIssuerAndOrdersNumUnauthorized
 */
@@ -111,8 +108,7 @@ func (o *GetOrdersByIssuerAndOrdersNumUnauthorized) WriteResponse(rw http.Respon
 // GetOrdersByIssuerAndOrdersNumForbiddenCode is the HTTP code returned for type GetOrdersByIssuerAndOrdersNumForbidden
 const GetOrdersByIssuerAndOrdersNumForbiddenCode int = 403
 
-/*
-GetOrdersByIssuerAndOrdersNumForbidden Forbidden
+/*GetOrdersByIssuerAndOrdersNumForbidden Forbidden
 
 swagger:response getOrdersByIssuerAndOrdersNumForbidden
 */
@@ -136,8 +132,7 @@ func (o *GetOrdersByIssuerAndOrdersNumForbidden) WriteResponse(rw http.ResponseW
 // GetOrdersByIssuerAndOrdersNumNotFoundCode is the HTTP code returned for type GetOrdersByIssuerAndOrdersNumNotFound
 const GetOrdersByIssuerAndOrdersNumNotFoundCode int = 404
 
-/*
-GetOrdersByIssuerAndOrdersNumNotFound Orders not found
+/*GetOrdersByIssuerAndOrdersNumNotFound Orders not found
 
 swagger:response getOrdersByIssuerAndOrdersNumNotFound
 */
@@ -161,8 +156,7 @@ func (o *GetOrdersByIssuerAndOrdersNumNotFound) WriteResponse(rw http.ResponseWr
 // GetOrdersByIssuerAndOrdersNumInternalServerErrorCode is the HTTP code returned for type GetOrdersByIssuerAndOrdersNumInternalServerError
 const GetOrdersByIssuerAndOrdersNumInternalServerErrorCode int = 500
 
-/*
-GetOrdersByIssuerAndOrdersNumInternalServerError Server error
+/*GetOrdersByIssuerAndOrdersNumInternalServerError Server error
 
 swagger:response getOrdersByIssuerAndOrdersNumInternalServerError
 */

--- a/pkg/gen/ordersapi/ordersoperations/get_orders_responses.go
+++ b/pkg/gen/ordersapi/ordersoperations/get_orders_responses.go
@@ -16,8 +16,7 @@ import (
 // GetOrdersOKCode is the HTTP code returned for type GetOrdersOK
 const GetOrdersOKCode int = 200
 
-/*
-GetOrdersOK Successful
+/*GetOrdersOK Successful
 
 swagger:response getOrdersOK
 */
@@ -61,8 +60,7 @@ func (o *GetOrdersOK) WriteResponse(rw http.ResponseWriter, producer runtime.Pro
 // GetOrdersBadRequestCode is the HTTP code returned for type GetOrdersBadRequest
 const GetOrdersBadRequestCode int = 400
 
-/*
-GetOrdersBadRequest Invalid
+/*GetOrdersBadRequest Invalid
 
 swagger:response getOrdersBadRequest
 */
@@ -86,8 +84,7 @@ func (o *GetOrdersBadRequest) WriteResponse(rw http.ResponseWriter, producer run
 // GetOrdersUnauthorizedCode is the HTTP code returned for type GetOrdersUnauthorized
 const GetOrdersUnauthorizedCode int = 401
 
-/*
-GetOrdersUnauthorized must be authenticated to use this endpoint
+/*GetOrdersUnauthorized must be authenticated to use this endpoint
 
 swagger:response getOrdersUnauthorized
 */
@@ -111,8 +108,7 @@ func (o *GetOrdersUnauthorized) WriteResponse(rw http.ResponseWriter, producer r
 // GetOrdersForbiddenCode is the HTTP code returned for type GetOrdersForbidden
 const GetOrdersForbiddenCode int = 403
 
-/*
-GetOrdersForbidden Forbidden
+/*GetOrdersForbidden Forbidden
 
 swagger:response getOrdersForbidden
 */
@@ -136,8 +132,7 @@ func (o *GetOrdersForbidden) WriteResponse(rw http.ResponseWriter, producer runt
 // GetOrdersNotFoundCode is the HTTP code returned for type GetOrdersNotFound
 const GetOrdersNotFoundCode int = 404
 
-/*
-GetOrdersNotFound Orders not found
+/*GetOrdersNotFound Orders not found
 
 swagger:response getOrdersNotFound
 */
@@ -161,8 +156,7 @@ func (o *GetOrdersNotFound) WriteResponse(rw http.ResponseWriter, producer runti
 // GetOrdersInternalServerErrorCode is the HTTP code returned for type GetOrdersInternalServerError
 const GetOrdersInternalServerErrorCode int = 500
 
-/*
-GetOrdersInternalServerError Server error
+/*GetOrdersInternalServerError Server error
 
 swagger:response getOrdersInternalServerError
 */

--- a/pkg/gen/ordersapi/ordersoperations/index_orders_for_member.go
+++ b/pkg/gen/ordersapi/ordersoperations/index_orders_for_member.go
@@ -29,12 +29,13 @@ func NewIndexOrdersForMember(ctx *middleware.Context, handler IndexOrdersForMemb
 	return &IndexOrdersForMember{Context: ctx, Handler: handler}
 }
 
-/*
-	IndexOrdersForMember swagger:route GET /edipis/{edipi}/orders indexOrdersForMember
+/* IndexOrdersForMember swagger:route GET /edipis/{edipi}/orders indexOrdersForMember
 
-# Retrieve orders for a particular member
+Retrieve orders for a particular member
 
 Returns all Orders for the specified service member. This endpoint will only return Orders cut by issuers to which the user has read permission.
+
+
 */
 type IndexOrdersForMember struct {
 	Context *middleware.Context

--- a/pkg/gen/ordersapi/ordersoperations/index_orders_for_member_responses.go
+++ b/pkg/gen/ordersapi/ordersoperations/index_orders_for_member_responses.go
@@ -16,8 +16,7 @@ import (
 // IndexOrdersForMemberOKCode is the HTTP code returned for type IndexOrdersForMemberOK
 const IndexOrdersForMemberOKCode int = 200
 
-/*
-IndexOrdersForMemberOK Successful
+/*IndexOrdersForMemberOK Successful
 
 swagger:response indexOrdersForMemberOK
 */
@@ -64,8 +63,7 @@ func (o *IndexOrdersForMemberOK) WriteResponse(rw http.ResponseWriter, producer 
 // IndexOrdersForMemberBadRequestCode is the HTTP code returned for type IndexOrdersForMemberBadRequest
 const IndexOrdersForMemberBadRequestCode int = 400
 
-/*
-IndexOrdersForMemberBadRequest Bad request
+/*IndexOrdersForMemberBadRequest Bad request
 
 swagger:response indexOrdersForMemberBadRequest
 */
@@ -89,8 +87,7 @@ func (o *IndexOrdersForMemberBadRequest) WriteResponse(rw http.ResponseWriter, p
 // IndexOrdersForMemberUnauthorizedCode is the HTTP code returned for type IndexOrdersForMemberUnauthorized
 const IndexOrdersForMemberUnauthorizedCode int = 401
 
-/*
-IndexOrdersForMemberUnauthorized must be authenticated to use this endpoint
+/*IndexOrdersForMemberUnauthorized must be authenticated to use this endpoint
 
 swagger:response indexOrdersForMemberUnauthorized
 */
@@ -114,8 +111,7 @@ func (o *IndexOrdersForMemberUnauthorized) WriteResponse(rw http.ResponseWriter,
 // IndexOrdersForMemberForbiddenCode is the HTTP code returned for type IndexOrdersForMemberForbidden
 const IndexOrdersForMemberForbiddenCode int = 403
 
-/*
-IndexOrdersForMemberForbidden Forbidden
+/*IndexOrdersForMemberForbidden Forbidden
 
 swagger:response indexOrdersForMemberForbidden
 */
@@ -139,8 +135,7 @@ func (o *IndexOrdersForMemberForbidden) WriteResponse(rw http.ResponseWriter, pr
 // IndexOrdersForMemberNotFoundCode is the HTTP code returned for type IndexOrdersForMemberNotFound
 const IndexOrdersForMemberNotFoundCode int = 404
 
-/*
-IndexOrdersForMemberNotFound No orders found
+/*IndexOrdersForMemberNotFound No orders found
 
 swagger:response indexOrdersForMemberNotFound
 */
@@ -164,8 +159,7 @@ func (o *IndexOrdersForMemberNotFound) WriteResponse(rw http.ResponseWriter, pro
 // IndexOrdersForMemberInternalServerErrorCode is the HTTP code returned for type IndexOrdersForMemberInternalServerError
 const IndexOrdersForMemberInternalServerErrorCode int = 500
 
-/*
-IndexOrdersForMemberInternalServerError Server error
+/*IndexOrdersForMemberInternalServerError Server error
 
 swagger:response indexOrdersForMemberInternalServerError
 */

--- a/pkg/gen/ordersapi/ordersoperations/mymove_api.go
+++ b/pkg/gen/ordersapi/ordersoperations/mymove_api.go
@@ -60,8 +60,7 @@ func NewMymoveAPI(spec *loads.Document) *MymoveAPI {
 	}
 }
 
-/*
-MymoveAPI The Orders API is a RESTful API that enables to submit, amend, and
+/*MymoveAPI The Orders API is a RESTful API that enables to submit, amend, and
 cancel orders for MilMove.
 
 All endpoints are located under `/orders/v1`.

--- a/pkg/gen/ordersapi/ordersoperations/post_revision.go
+++ b/pkg/gen/ordersapi/ordersoperations/post_revision.go
@@ -29,8 +29,7 @@ func NewPostRevision(ctx *middleware.Context, handler PostRevisionHandler) *Post
 	return &PostRevision{Context: ctx, Handler: handler}
 }
 
-/*
-	PostRevision swagger:route POST /orders postRevision
+/* PostRevision swagger:route POST /orders postRevision
 
 Submit a new set of orders, make an amendment to an existing set of orders, or cancel a set of orders.
 
@@ -50,6 +49,8 @@ Users of this endpoint must have permission to write Orders for the specified `i
 If SSN instead of EDIPI is provided to identify the member, and DMDC's Identity Web Services does not return an EDIPI for that SSN, then this endpoint will return `404 Not Found`.
 If amending existing Orders, the supplied seqNum must be unique when compared to existing Revisions in those Orders. If it has already been used, this endpoint will return `409 Conflict`.
 If amending existing Orders, the supplied memberId, as an EDIPI, or as an EDIPI retrieved from DMDC by SSN, must match the EDIPI in the existing Orders. If the EDIPIs do not match, this endpoint will return `409 Conflict`.
+
+
 */
 type PostRevision struct {
 	Context *middleware.Context

--- a/pkg/gen/ordersapi/ordersoperations/post_revision_responses.go
+++ b/pkg/gen/ordersapi/ordersoperations/post_revision_responses.go
@@ -16,8 +16,7 @@ import (
 // PostRevisionCreatedCode is the HTTP code returned for type PostRevisionCreated
 const PostRevisionCreatedCode int = 201
 
-/*
-PostRevisionCreated Created
+/*PostRevisionCreated Created
 
 swagger:response postRevisionCreated
 */
@@ -61,8 +60,7 @@ func (o *PostRevisionCreated) WriteResponse(rw http.ResponseWriter, producer run
 // PostRevisionBadRequestCode is the HTTP code returned for type PostRevisionBadRequest
 const PostRevisionBadRequestCode int = 400
 
-/*
-PostRevisionBadRequest Invalid
+/*PostRevisionBadRequest Invalid
 
 swagger:response postRevisionBadRequest
 */
@@ -86,8 +84,7 @@ func (o *PostRevisionBadRequest) WriteResponse(rw http.ResponseWriter, producer 
 // PostRevisionUnauthorizedCode is the HTTP code returned for type PostRevisionUnauthorized
 const PostRevisionUnauthorizedCode int = 401
 
-/*
-PostRevisionUnauthorized must be authenticated to use this endpoint
+/*PostRevisionUnauthorized must be authenticated to use this endpoint
 
 swagger:response postRevisionUnauthorized
 */
@@ -111,8 +108,7 @@ func (o *PostRevisionUnauthorized) WriteResponse(rw http.ResponseWriter, produce
 // PostRevisionForbiddenCode is the HTTP code returned for type PostRevisionForbidden
 const PostRevisionForbiddenCode int = 403
 
-/*
-PostRevisionForbidden Forbidden
+/*PostRevisionForbidden Forbidden
 
 swagger:response postRevisionForbidden
 */
@@ -136,8 +132,7 @@ func (o *PostRevisionForbidden) WriteResponse(rw http.ResponseWriter, producer r
 // PostRevisionNotFoundCode is the HTTP code returned for type PostRevisionNotFound
 const PostRevisionNotFoundCode int = 404
 
-/*
-PostRevisionNotFound Not Found
+/*PostRevisionNotFound Not Found
 
 swagger:response postRevisionNotFound
 */
@@ -161,8 +156,7 @@ func (o *PostRevisionNotFound) WriteResponse(rw http.ResponseWriter, producer ru
 // PostRevisionConflictCode is the HTTP code returned for type PostRevisionConflict
 const PostRevisionConflictCode int = 409
 
-/*
-PostRevisionConflict Conflict
+/*PostRevisionConflict Conflict
 
 swagger:response postRevisionConflict
 */
@@ -186,8 +180,7 @@ func (o *PostRevisionConflict) WriteResponse(rw http.ResponseWriter, producer ru
 // PostRevisionInternalServerErrorCode is the HTTP code returned for type PostRevisionInternalServerError
 const PostRevisionInternalServerErrorCode int = 500
 
-/*
-PostRevisionInternalServerError Server error
+/*PostRevisionInternalServerError Server error
 
 swagger:response postRevisionInternalServerError
 */

--- a/pkg/gen/ordersapi/ordersoperations/post_revision_to_orders.go
+++ b/pkg/gen/ordersapi/ordersoperations/post_revision_to_orders.go
@@ -29,10 +29,9 @@ func NewPostRevisionToOrders(ctx *middleware.Context, handler PostRevisionToOrde
 	return &PostRevisionToOrders{Context: ctx, Handler: handler}
 }
 
-/*
-	PostRevisionToOrders swagger:route POST /orders/{uuid} postRevisionToOrders
+/* PostRevisionToOrders swagger:route POST /orders/{uuid} postRevisionToOrders
 
-# Make an amendment to or cancel an existing set of orders by UUID
+Make an amendment to or cancel an existing set of orders by UUID
 
 Creates a Revision of a set of orders. The Orders to be amended or canceled must already exist with the supplied UUID.
 ## Amendment requirements
@@ -41,6 +40,7 @@ The `seqNum` in the supplied Revision must be unique among all Revisions in thes
 Users of this endpoint must have permission to write Orders for the `issuer` associated with the Orders that were originally POST'd to the `orders` endpoint. If not, this endpoint will return `403 Forbidden`.
 The UUID must match an existing set of Orders. Otherwise, this endpoint will return `404 Not Found`.
 If amending existing Orders, the supplied seqNum must be unique. If it has already been used, this endpoint will return `409 Conflict`.
+
 */
 type PostRevisionToOrders struct {
 	Context *middleware.Context

--- a/pkg/gen/ordersapi/ordersoperations/post_revision_to_orders_responses.go
+++ b/pkg/gen/ordersapi/ordersoperations/post_revision_to_orders_responses.go
@@ -16,8 +16,7 @@ import (
 // PostRevisionToOrdersCreatedCode is the HTTP code returned for type PostRevisionToOrdersCreated
 const PostRevisionToOrdersCreatedCode int = 201
 
-/*
-PostRevisionToOrdersCreated Created
+/*PostRevisionToOrdersCreated Created
 
 swagger:response postRevisionToOrdersCreated
 */
@@ -61,8 +60,7 @@ func (o *PostRevisionToOrdersCreated) WriteResponse(rw http.ResponseWriter, prod
 // PostRevisionToOrdersBadRequestCode is the HTTP code returned for type PostRevisionToOrdersBadRequest
 const PostRevisionToOrdersBadRequestCode int = 400
 
-/*
-PostRevisionToOrdersBadRequest Invalid
+/*PostRevisionToOrdersBadRequest Invalid
 
 swagger:response postRevisionToOrdersBadRequest
 */
@@ -86,8 +84,7 @@ func (o *PostRevisionToOrdersBadRequest) WriteResponse(rw http.ResponseWriter, p
 // PostRevisionToOrdersUnauthorizedCode is the HTTP code returned for type PostRevisionToOrdersUnauthorized
 const PostRevisionToOrdersUnauthorizedCode int = 401
 
-/*
-PostRevisionToOrdersUnauthorized must be authenticated to use this endpoint
+/*PostRevisionToOrdersUnauthorized must be authenticated to use this endpoint
 
 swagger:response postRevisionToOrdersUnauthorized
 */
@@ -111,8 +108,7 @@ func (o *PostRevisionToOrdersUnauthorized) WriteResponse(rw http.ResponseWriter,
 // PostRevisionToOrdersForbiddenCode is the HTTP code returned for type PostRevisionToOrdersForbidden
 const PostRevisionToOrdersForbiddenCode int = 403
 
-/*
-PostRevisionToOrdersForbidden Forbidden
+/*PostRevisionToOrdersForbidden Forbidden
 
 swagger:response postRevisionToOrdersForbidden
 */
@@ -136,8 +132,7 @@ func (o *PostRevisionToOrdersForbidden) WriteResponse(rw http.ResponseWriter, pr
 // PostRevisionToOrdersNotFoundCode is the HTTP code returned for type PostRevisionToOrdersNotFound
 const PostRevisionToOrdersNotFoundCode int = 404
 
-/*
-PostRevisionToOrdersNotFound Orders not found
+/*PostRevisionToOrdersNotFound Orders not found
 
 swagger:response postRevisionToOrdersNotFound
 */
@@ -161,8 +156,7 @@ func (o *PostRevisionToOrdersNotFound) WriteResponse(rw http.ResponseWriter, pro
 // PostRevisionToOrdersConflictCode is the HTTP code returned for type PostRevisionToOrdersConflict
 const PostRevisionToOrdersConflictCode int = 409
 
-/*
-PostRevisionToOrdersConflict Conflict
+/*PostRevisionToOrdersConflict Conflict
 
 swagger:response postRevisionToOrdersConflict
 */
@@ -186,8 +180,7 @@ func (o *PostRevisionToOrdersConflict) WriteResponse(rw http.ResponseWriter, pro
 // PostRevisionToOrdersInternalServerErrorCode is the HTTP code returned for type PostRevisionToOrdersInternalServerError
 const PostRevisionToOrdersInternalServerErrorCode int = 500
 
-/*
-PostRevisionToOrdersInternalServerError Server error
+/*PostRevisionToOrdersInternalServerError Server error
 
 swagger:response postRevisionToOrdersInternalServerError
 */

--- a/pkg/gen/ordersmessages/affiliation.go
+++ b/pkg/gen/ordersmessages/affiliation.go
@@ -16,7 +16,7 @@ import (
 
 // Affiliation Branch of service
 //
-// # Military branch of service
+// Military branch of service
 //
 // swagger:model Affiliation
 type Affiliation string

--- a/pkg/gen/ordersmessages/orders_type.go
+++ b/pkg/gen/ordersmessages/orders_type.go
@@ -15,22 +15,23 @@ import (
 )
 
 // OrdersType The common types fit into the acronym ASTRO-U.
-//   - **A**ccession - Joining the military
-//   - **S**eparation / Retirement - Leaving the military
-//   - **T**raining
-//   - **R**otational
-//   - **O**perational
-//   - **U**nit Move - When an entire unit is reassigned to another installation, often as a deployment
+//   * **A**ccession - Joining the military
+//   * **S**eparation / Retirement - Leaving the military
+//   * **T**raining
+//   * **R**otational
+//   * **O**perational
+//   * **U**nit Move - When an entire unit is reassigned to another installation, often as a deployment
 //
 // As of this writing, none of the branches of service distinguish between
 // separation and retirement Orders in their systems, even though the NTS
 // entitlement lasts longer for retirement.
 //
 // Consequences of this field include
-//   - NTS entitlements are different between Orders types.
-//   - Deadlines to create a shipment associated with Orders differs by Orders type.
-//   - Accession, separation, and retirement moves currently require the
+//   * NTS entitlements are different between Orders types.
+//   * Deadlines to create a shipment associated with Orders differs by Orders type.
+//   * Accession, separation, and retirement moves currently require the
 //     member to go through in-person counseling at the TMO / PPPO.
+//
 //
 // swagger:model OrdersType
 type OrdersType string

--- a/pkg/gen/ordersmessages/tour_type.go
+++ b/pkg/gen/ordersmessages/tour_type.go
@@ -18,6 +18,7 @@ import (
 //
 // If omitted, assume accompanied.
 //
+//
 // swagger:model TourType
 type TourType string
 

--- a/pkg/gen/primeapi/doc.go
+++ b/pkg/gen/primeapi/doc.go
@@ -2,26 +2,26 @@
 
 // Package primeapi MilMove Prime API
 //
-//	The Prime API is a RESTful API that enables the Prime contractor to request
-//	information about upcoming moves, update the details and status of those moves,
-//	and make payment requests. It uses Mutual TLS for authentication procedures.
+//  The Prime API is a RESTful API that enables the Prime contractor to request
+//  information about upcoming moves, update the details and status of those moves,
+//  and make payment requests. It uses Mutual TLS for authentication procedures.
 //
-//	All endpoints are located at `/prime/v1/`.
+//  All endpoints are located at `/prime/v1/`.
 //
-//	Schemes:
-//	  http
-//	Host: localhost
-//	BasePath: /prime/v1
-//	Version: 0.0.1
-//	License: MIT https://opensource.org/licenses/MIT
-//	Contact: <dp3@truss.works>
+//  Schemes:
+//    http
+//  Host: localhost
+//  BasePath: /prime/v1
+//  Version: 0.0.1
+//  License: MIT https://opensource.org/licenses/MIT
+//  Contact: <dp3@truss.works>
 //
-//	Consumes:
-//	  - application/json
-//	  - multipart/form-data
+//  Consumes:
+//    - application/json
+//    - multipart/form-data
 //
-//	Produces:
-//	  - application/json
+//  Produces:
+//    - application/json
 //
 // swagger:meta
 package primeapi

--- a/pkg/gen/primeapi/primeoperations/move_task_order/create_excess_weight_record.go
+++ b/pkg/gen/primeapi/primeoperations/move_task_order/create_excess_weight_record.go
@@ -29,12 +29,13 @@ func NewCreateExcessWeightRecord(ctx *middleware.Context, handler CreateExcessWe
 	return &CreateExcessWeightRecord{Context: ctx, Handler: handler}
 }
 
-/*
-	CreateExcessWeightRecord swagger:route POST /move-task-orders/{moveTaskOrderID}/excess-weight-record moveTaskOrder createExcessWeightRecord
+/* CreateExcessWeightRecord swagger:route POST /move-task-orders/{moveTaskOrderID}/excess-weight-record moveTaskOrder createExcessWeightRecord
 
 createExcessWeightRecord
 
 Uploads an excess weight record, which is a document that proves that the movers or contractors have counseled the customer about their excess weight. Excess weight counseling should occur after the sum of the shipments for the customer's move crosses the excess weight alert threshold.
+
+
 */
 type CreateExcessWeightRecord struct {
 	Context *middleware.Context

--- a/pkg/gen/primeapi/primeoperations/move_task_order/create_excess_weight_record_responses.go
+++ b/pkg/gen/primeapi/primeoperations/move_task_order/create_excess_weight_record_responses.go
@@ -16,8 +16,7 @@ import (
 // CreateExcessWeightRecordCreatedCode is the HTTP code returned for type CreateExcessWeightRecordCreated
 const CreateExcessWeightRecordCreatedCode int = 201
 
-/*
-CreateExcessWeightRecordCreated Successfully uploaded the excess weight record file.
+/*CreateExcessWeightRecordCreated Successfully uploaded the excess weight record file.
 
 swagger:response createExcessWeightRecordCreated
 */
@@ -61,8 +60,7 @@ func (o *CreateExcessWeightRecordCreated) WriteResponse(rw http.ResponseWriter, 
 // CreateExcessWeightRecordUnauthorizedCode is the HTTP code returned for type CreateExcessWeightRecordUnauthorized
 const CreateExcessWeightRecordUnauthorizedCode int = 401
 
-/*
-CreateExcessWeightRecordUnauthorized The request was denied.
+/*CreateExcessWeightRecordUnauthorized The request was denied.
 
 swagger:response createExcessWeightRecordUnauthorized
 */
@@ -106,8 +104,7 @@ func (o *CreateExcessWeightRecordUnauthorized) WriteResponse(rw http.ResponseWri
 // CreateExcessWeightRecordForbiddenCode is the HTTP code returned for type CreateExcessWeightRecordForbidden
 const CreateExcessWeightRecordForbiddenCode int = 403
 
-/*
-CreateExcessWeightRecordForbidden The request was denied.
+/*CreateExcessWeightRecordForbidden The request was denied.
 
 swagger:response createExcessWeightRecordForbidden
 */
@@ -151,8 +148,7 @@ func (o *CreateExcessWeightRecordForbidden) WriteResponse(rw http.ResponseWriter
 // CreateExcessWeightRecordNotFoundCode is the HTTP code returned for type CreateExcessWeightRecordNotFound
 const CreateExcessWeightRecordNotFoundCode int = 404
 
-/*
-CreateExcessWeightRecordNotFound The requested resource wasn't found.
+/*CreateExcessWeightRecordNotFound The requested resource wasn't found.
 
 swagger:response createExcessWeightRecordNotFound
 */
@@ -196,8 +192,7 @@ func (o *CreateExcessWeightRecordNotFound) WriteResponse(rw http.ResponseWriter,
 // CreateExcessWeightRecordUnprocessableEntityCode is the HTTP code returned for type CreateExcessWeightRecordUnprocessableEntity
 const CreateExcessWeightRecordUnprocessableEntityCode int = 422
 
-/*
-CreateExcessWeightRecordUnprocessableEntity The request was unprocessable, likely due to bad input from the requester.
+/*CreateExcessWeightRecordUnprocessableEntity The request was unprocessable, likely due to bad input from the requester.
 
 swagger:response createExcessWeightRecordUnprocessableEntity
 */
@@ -241,8 +236,7 @@ func (o *CreateExcessWeightRecordUnprocessableEntity) WriteResponse(rw http.Resp
 // CreateExcessWeightRecordInternalServerErrorCode is the HTTP code returned for type CreateExcessWeightRecordInternalServerError
 const CreateExcessWeightRecordInternalServerErrorCode int = 500
 
-/*
-CreateExcessWeightRecordInternalServerError A server error occurred.
+/*CreateExcessWeightRecordInternalServerError A server error occurred.
 
 swagger:response createExcessWeightRecordInternalServerError
 */

--- a/pkg/gen/primeapi/primeoperations/move_task_order/get_move_task_order.go
+++ b/pkg/gen/primeapi/primeoperations/move_task_order/get_move_task_order.go
@@ -29,8 +29,7 @@ func NewGetMoveTaskOrder(ctx *middleware.Context, handler GetMoveTaskOrderHandle
 	return &GetMoveTaskOrder{Context: ctx, Handler: handler}
 }
 
-/*
-	GetMoveTaskOrder swagger:route GET /move-task-orders/{moveID} moveTaskOrder getMoveTaskOrder
+/* GetMoveTaskOrder swagger:route GET /move-task-orders/{moveID} moveTaskOrder getMoveTaskOrder
 
 getMoveTaskOrder
 
@@ -38,6 +37,8 @@ getMoveTaskOrder
 This endpoint gets an individual MoveTaskOrder by ID.
 
 It will provide information about the Customer and any associated MTOShipments, MTOServiceItems and PaymentRequests.
+
+
 */
 type GetMoveTaskOrder struct {
 	Context *middleware.Context

--- a/pkg/gen/primeapi/primeoperations/move_task_order/get_move_task_order_responses.go
+++ b/pkg/gen/primeapi/primeoperations/move_task_order/get_move_task_order_responses.go
@@ -16,8 +16,7 @@ import (
 // GetMoveTaskOrderOKCode is the HTTP code returned for type GetMoveTaskOrderOK
 const GetMoveTaskOrderOKCode int = 200
 
-/*
-GetMoveTaskOrderOK Successfully retrieve an individual move task order.
+/*GetMoveTaskOrderOK Successfully retrieve an individual move task order.
 
 swagger:response getMoveTaskOrderOK
 */
@@ -61,8 +60,7 @@ func (o *GetMoveTaskOrderOK) WriteResponse(rw http.ResponseWriter, producer runt
 // GetMoveTaskOrderUnauthorizedCode is the HTTP code returned for type GetMoveTaskOrderUnauthorized
 const GetMoveTaskOrderUnauthorizedCode int = 401
 
-/*
-GetMoveTaskOrderUnauthorized The request was denied.
+/*GetMoveTaskOrderUnauthorized The request was denied.
 
 swagger:response getMoveTaskOrderUnauthorized
 */
@@ -106,8 +104,7 @@ func (o *GetMoveTaskOrderUnauthorized) WriteResponse(rw http.ResponseWriter, pro
 // GetMoveTaskOrderForbiddenCode is the HTTP code returned for type GetMoveTaskOrderForbidden
 const GetMoveTaskOrderForbiddenCode int = 403
 
-/*
-GetMoveTaskOrderForbidden The request was denied.
+/*GetMoveTaskOrderForbidden The request was denied.
 
 swagger:response getMoveTaskOrderForbidden
 */
@@ -151,8 +148,7 @@ func (o *GetMoveTaskOrderForbidden) WriteResponse(rw http.ResponseWriter, produc
 // GetMoveTaskOrderNotFoundCode is the HTTP code returned for type GetMoveTaskOrderNotFound
 const GetMoveTaskOrderNotFoundCode int = 404
 
-/*
-GetMoveTaskOrderNotFound The requested resource wasn't found.
+/*GetMoveTaskOrderNotFound The requested resource wasn't found.
 
 swagger:response getMoveTaskOrderNotFound
 */
@@ -196,8 +192,7 @@ func (o *GetMoveTaskOrderNotFound) WriteResponse(rw http.ResponseWriter, produce
 // GetMoveTaskOrderInternalServerErrorCode is the HTTP code returned for type GetMoveTaskOrderInternalServerError
 const GetMoveTaskOrderInternalServerErrorCode int = 500
 
-/*
-GetMoveTaskOrderInternalServerError A server error occurred.
+/*GetMoveTaskOrderInternalServerError A server error occurred.
 
 swagger:response getMoveTaskOrderInternalServerError
 */

--- a/pkg/gen/primeapi/primeoperations/move_task_order/list_moves.go
+++ b/pkg/gen/primeapi/primeoperations/move_task_order/list_moves.go
@@ -29,8 +29,7 @@ func NewListMoves(ctx *middleware.Context, handler ListMovesHandler) *ListMoves 
 	return &ListMoves{Context: ctx, Handler: handler}
 }
 
-/*
-	ListMoves swagger:route GET /moves moveTaskOrder listMoves
+/* ListMoves swagger:route GET /moves moveTaskOrder listMoves
 
 listMoves
 
@@ -41,6 +40,8 @@ requests, is later than the provided date and time.
 
 **WIP**: Include what causes moves to leave this list. Currently, once the `availableToPrimeAt` timestamp has
 been set, that move will always appear in this list.
+
+
 */
 type ListMoves struct {
 	Context *middleware.Context

--- a/pkg/gen/primeapi/primeoperations/move_task_order/list_moves_responses.go
+++ b/pkg/gen/primeapi/primeoperations/move_task_order/list_moves_responses.go
@@ -16,8 +16,7 @@ import (
 // ListMovesOKCode is the HTTP code returned for type ListMovesOK
 const ListMovesOKCode int = 200
 
-/*
-ListMovesOK Successfully retrieved moves. A successful fetch might still return zero moves.
+/*ListMovesOK Successfully retrieved moves. A successful fetch might still return zero moves.
 
 swagger:response listMovesOK
 */
@@ -64,8 +63,7 @@ func (o *ListMovesOK) WriteResponse(rw http.ResponseWriter, producer runtime.Pro
 // ListMovesUnauthorizedCode is the HTTP code returned for type ListMovesUnauthorized
 const ListMovesUnauthorizedCode int = 401
 
-/*
-ListMovesUnauthorized The request was denied.
+/*ListMovesUnauthorized The request was denied.
 
 swagger:response listMovesUnauthorized
 */
@@ -109,8 +107,7 @@ func (o *ListMovesUnauthorized) WriteResponse(rw http.ResponseWriter, producer r
 // ListMovesForbiddenCode is the HTTP code returned for type ListMovesForbidden
 const ListMovesForbiddenCode int = 403
 
-/*
-ListMovesForbidden The request was denied.
+/*ListMovesForbidden The request was denied.
 
 swagger:response listMovesForbidden
 */
@@ -154,8 +151,7 @@ func (o *ListMovesForbidden) WriteResponse(rw http.ResponseWriter, producer runt
 // ListMovesInternalServerErrorCode is the HTTP code returned for type ListMovesInternalServerError
 const ListMovesInternalServerErrorCode int = 500
 
-/*
-ListMovesInternalServerError A server error occurred.
+/*ListMovesInternalServerError A server error occurred.
 
 swagger:response listMovesInternalServerError
 */

--- a/pkg/gen/primeapi/primeoperations/move_task_order/update_m_t_o_post_counseling_information.go
+++ b/pkg/gen/primeapi/primeoperations/move_task_order/update_m_t_o_post_counseling_information.go
@@ -29,8 +29,7 @@ func NewUpdateMTOPostCounselingInformation(ctx *middleware.Context, handler Upda
 	return &UpdateMTOPostCounselingInformation{Context: ctx, Handler: handler}
 }
 
-/*
-	UpdateMTOPostCounselingInformation swagger:route PATCH /move-task-orders/{moveTaskOrderID}/post-counseling-info moveTaskOrder updateMTOPostCounselingInformation
+/* UpdateMTOPostCounselingInformation swagger:route PATCH /move-task-orders/{moveTaskOrderID}/post-counseling-info moveTaskOrder updateMTOPostCounselingInformation
 
 updateMTOPostCounselingInformation
 
@@ -38,6 +37,8 @@ updateMTOPostCounselingInformation
 This endpoint **updates** the MoveTaskOrder after the Prime has completed Counseling.
 
 PPM related information is updated here. Most other fields will be found on the specific MTOShipment and updated using [updateMTOShipment](#operation/updateMTOShipment).
+
+
 */
 type UpdateMTOPostCounselingInformation struct {
 	Context *middleware.Context

--- a/pkg/gen/primeapi/primeoperations/move_task_order/update_m_t_o_post_counseling_information_responses.go
+++ b/pkg/gen/primeapi/primeoperations/move_task_order/update_m_t_o_post_counseling_information_responses.go
@@ -16,8 +16,7 @@ import (
 // UpdateMTOPostCounselingInformationOKCode is the HTTP code returned for type UpdateMTOPostCounselingInformationOK
 const UpdateMTOPostCounselingInformationOKCode int = 200
 
-/*
-UpdateMTOPostCounselingInformationOK Successfully updated move task order with post counseling information.
+/*UpdateMTOPostCounselingInformationOK Successfully updated move task order with post counseling information.
 
 swagger:response updateMTOPostCounselingInformationOK
 */
@@ -61,8 +60,7 @@ func (o *UpdateMTOPostCounselingInformationOK) WriteResponse(rw http.ResponseWri
 // UpdateMTOPostCounselingInformationUnauthorizedCode is the HTTP code returned for type UpdateMTOPostCounselingInformationUnauthorized
 const UpdateMTOPostCounselingInformationUnauthorizedCode int = 401
 
-/*
-UpdateMTOPostCounselingInformationUnauthorized The request was denied.
+/*UpdateMTOPostCounselingInformationUnauthorized The request was denied.
 
 swagger:response updateMTOPostCounselingInformationUnauthorized
 */
@@ -106,8 +104,7 @@ func (o *UpdateMTOPostCounselingInformationUnauthorized) WriteResponse(rw http.R
 // UpdateMTOPostCounselingInformationForbiddenCode is the HTTP code returned for type UpdateMTOPostCounselingInformationForbidden
 const UpdateMTOPostCounselingInformationForbiddenCode int = 403
 
-/*
-UpdateMTOPostCounselingInformationForbidden The request was denied.
+/*UpdateMTOPostCounselingInformationForbidden The request was denied.
 
 swagger:response updateMTOPostCounselingInformationForbidden
 */
@@ -151,8 +148,7 @@ func (o *UpdateMTOPostCounselingInformationForbidden) WriteResponse(rw http.Resp
 // UpdateMTOPostCounselingInformationNotFoundCode is the HTTP code returned for type UpdateMTOPostCounselingInformationNotFound
 const UpdateMTOPostCounselingInformationNotFoundCode int = 404
 
-/*
-UpdateMTOPostCounselingInformationNotFound The requested resource wasn't found.
+/*UpdateMTOPostCounselingInformationNotFound The requested resource wasn't found.
 
 swagger:response updateMTOPostCounselingInformationNotFound
 */
@@ -196,8 +192,7 @@ func (o *UpdateMTOPostCounselingInformationNotFound) WriteResponse(rw http.Respo
 // UpdateMTOPostCounselingInformationConflictCode is the HTTP code returned for type UpdateMTOPostCounselingInformationConflict
 const UpdateMTOPostCounselingInformationConflictCode int = 409
 
-/*
-UpdateMTOPostCounselingInformationConflict The request could not be processed because of conflict in the current state of the resource.
+/*UpdateMTOPostCounselingInformationConflict The request could not be processed because of conflict in the current state of the resource.
 
 swagger:response updateMTOPostCounselingInformationConflict
 */
@@ -241,8 +236,7 @@ func (o *UpdateMTOPostCounselingInformationConflict) WriteResponse(rw http.Respo
 // UpdateMTOPostCounselingInformationPreconditionFailedCode is the HTTP code returned for type UpdateMTOPostCounselingInformationPreconditionFailed
 const UpdateMTOPostCounselingInformationPreconditionFailedCode int = 412
 
-/*
-UpdateMTOPostCounselingInformationPreconditionFailed Precondition failed, likely due to a stale eTag (If-Match). Fetch the request again to get the updated eTag value.
+/*UpdateMTOPostCounselingInformationPreconditionFailed Precondition failed, likely due to a stale eTag (If-Match). Fetch the request again to get the updated eTag value.
 
 swagger:response updateMTOPostCounselingInformationPreconditionFailed
 */
@@ -286,8 +280,7 @@ func (o *UpdateMTOPostCounselingInformationPreconditionFailed) WriteResponse(rw 
 // UpdateMTOPostCounselingInformationUnprocessableEntityCode is the HTTP code returned for type UpdateMTOPostCounselingInformationUnprocessableEntity
 const UpdateMTOPostCounselingInformationUnprocessableEntityCode int = 422
 
-/*
-UpdateMTOPostCounselingInformationUnprocessableEntity The request was unprocessable, likely due to bad input from the requester.
+/*UpdateMTOPostCounselingInformationUnprocessableEntity The request was unprocessable, likely due to bad input from the requester.
 
 swagger:response updateMTOPostCounselingInformationUnprocessableEntity
 */
@@ -331,8 +324,7 @@ func (o *UpdateMTOPostCounselingInformationUnprocessableEntity) WriteResponse(rw
 // UpdateMTOPostCounselingInformationInternalServerErrorCode is the HTTP code returned for type UpdateMTOPostCounselingInformationInternalServerError
 const UpdateMTOPostCounselingInformationInternalServerErrorCode int = 500
 
-/*
-UpdateMTOPostCounselingInformationInternalServerError A server error occurred.
+/*UpdateMTOPostCounselingInformationInternalServerError A server error occurred.
 
 swagger:response updateMTOPostCounselingInformationInternalServerError
 */

--- a/pkg/gen/primeapi/primeoperations/mto_service_item/create_m_t_o_service_item.go
+++ b/pkg/gen/primeapi/primeoperations/mto_service_item/create_m_t_o_service_item.go
@@ -29,16 +29,14 @@ func NewCreateMTOServiceItem(ctx *middleware.Context, handler CreateMTOServiceIt
 	return &CreateMTOServiceItem{Context: ctx, Handler: handler}
 }
 
-/*
-	CreateMTOServiceItem swagger:route POST /mto-service-items mtoServiceItem createMTOServiceItem
+/* CreateMTOServiceItem swagger:route POST /mto-service-items mtoServiceItem createMTOServiceItem
 
 createMTOServiceItem
 
 Creates one or more MTOServiceItems. Not all service items may be created, please see details below.
 
 This endpoint supports different body definitions. In the modelType field below, select the modelType corresponding
-
-	to the service item you wish to create and the documentation will update with the new definition.
+ to the service item you wish to create and the documentation will update with the new definition.
 
 Upon creation these items are associated with a Move Task Order and an MTO Shipment.
 The request must include UUIDs for the MTO and MTO Shipment connected to this service item. Some service item types require
@@ -59,9 +57,9 @@ model type with the following codes:
 **DOFSIT**
 
 **1st day origin SIT service item**. When a DOFSIT is requested, the API will auto-create the following group of service items:
-  - DOFSIT - Domestic origin 1st day SIT
-  - DOASIT - Domestic origin Additional day SIT
-  - DOPSIT - Domestic origin SIT pickup
+  * DOFSIT - Domestic origin 1st day SIT
+  * DOASIT - Domestic origin Additional day SIT
+  * DOPSIT - Domestic origin SIT pickup
 
 **DOASIT**
 
@@ -80,28 +78,30 @@ model type with the following codes:
 **DDFSIT**
 
 **1st day origin SIT service item**. The additional fields are required for creating a DDFSIT:
-  - `firstAvailableDeliveryDate1`
-  - string <date>
-  - First available date that Prime can deliver SIT service item.
-  - `firstAvailableDeliveryDate2`
-  - string <date>
-  - Second available date that Prime can deliver SIT service item.
-  - `timeMilitary1`
-  - string\d{4}Z
-  - Time of delivery corresponding to `firstAvailableDeliveryDate1`, in military format.
-  - `timeMilitary2`
-  - string\d{4}Z
-  - Time of delivery corresponding to `firstAvailableDeliveryDate2`, in military format.
+  * `firstAvailableDeliveryDate1`
+    * string <date>
+    * First available date that Prime can deliver SIT service item.
+  * `firstAvailableDeliveryDate2`
+    * string <date>
+    * Second available date that Prime can deliver SIT service item.
+  * `timeMilitary1`
+    * string\d{4}Z
+    * Time of delivery corresponding to `firstAvailableDeliveryDate1`, in military format.
+  * `timeMilitary2`
+    * string\d{4}Z
+    * Time of delivery corresponding to `firstAvailableDeliveryDate2`, in military format.
 
 When a DDFSIT is requested, the API will auto-create the following group of service items:
-  - DDFSIT - Domestic destination 1st day SIT
-  - DDASIT - Domestic destination Additional day SIT
-  - DDDSIT - Domestic destination SIT delivery
+  * DDFSIT - Domestic destination 1st day SIT
+  * DDASIT - Domestic destination Additional day SIT
+  * DDDSIT - Domestic destination SIT delivery
 
 **DDASIT**
 
 **Addt'l days destination SIT service item**. This represents an additional day of storage for the same item.
 Additional DDASIT service items can be created and added to an existing shipment that **includes a DDFSIT service item**.
+
+
 */
 type CreateMTOServiceItem struct {
 	Context *middleware.Context

--- a/pkg/gen/primeapi/primeoperations/mto_service_item/create_m_t_o_service_item_responses.go
+++ b/pkg/gen/primeapi/primeoperations/mto_service_item/create_m_t_o_service_item_responses.go
@@ -16,8 +16,7 @@ import (
 // CreateMTOServiceItemOKCode is the HTTP code returned for type CreateMTOServiceItemOK
 const CreateMTOServiceItemOKCode int = 200
 
-/*
-CreateMTOServiceItemOK Successfully created an MTO service item.
+/*CreateMTOServiceItemOK Successfully created an MTO service item.
 
 swagger:response createMTOServiceItemOK
 */
@@ -64,8 +63,7 @@ func (o *CreateMTOServiceItemOK) WriteResponse(rw http.ResponseWriter, producer 
 // CreateMTOServiceItemBadRequestCode is the HTTP code returned for type CreateMTOServiceItemBadRequest
 const CreateMTOServiceItemBadRequestCode int = 400
 
-/*
-CreateMTOServiceItemBadRequest The request payload is invalid.
+/*CreateMTOServiceItemBadRequest The request payload is invalid.
 
 swagger:response createMTOServiceItemBadRequest
 */
@@ -109,8 +107,7 @@ func (o *CreateMTOServiceItemBadRequest) WriteResponse(rw http.ResponseWriter, p
 // CreateMTOServiceItemUnauthorizedCode is the HTTP code returned for type CreateMTOServiceItemUnauthorized
 const CreateMTOServiceItemUnauthorizedCode int = 401
 
-/*
-CreateMTOServiceItemUnauthorized The request was denied.
+/*CreateMTOServiceItemUnauthorized The request was denied.
 
 swagger:response createMTOServiceItemUnauthorized
 */
@@ -154,8 +151,7 @@ func (o *CreateMTOServiceItemUnauthorized) WriteResponse(rw http.ResponseWriter,
 // CreateMTOServiceItemForbiddenCode is the HTTP code returned for type CreateMTOServiceItemForbidden
 const CreateMTOServiceItemForbiddenCode int = 403
 
-/*
-CreateMTOServiceItemForbidden The request was denied.
+/*CreateMTOServiceItemForbidden The request was denied.
 
 swagger:response createMTOServiceItemForbidden
 */
@@ -199,8 +195,7 @@ func (o *CreateMTOServiceItemForbidden) WriteResponse(rw http.ResponseWriter, pr
 // CreateMTOServiceItemNotFoundCode is the HTTP code returned for type CreateMTOServiceItemNotFound
 const CreateMTOServiceItemNotFoundCode int = 404
 
-/*
-CreateMTOServiceItemNotFound The requested resource wasn't found.
+/*CreateMTOServiceItemNotFound The requested resource wasn't found.
 
 swagger:response createMTOServiceItemNotFound
 */
@@ -244,8 +239,7 @@ func (o *CreateMTOServiceItemNotFound) WriteResponse(rw http.ResponseWriter, pro
 // CreateMTOServiceItemConflictCode is the HTTP code returned for type CreateMTOServiceItemConflict
 const CreateMTOServiceItemConflictCode int = 409
 
-/*
-CreateMTOServiceItemConflict The request could not be processed because of conflict in the current state of the resource.
+/*CreateMTOServiceItemConflict The request could not be processed because of conflict in the current state of the resource.
 
 swagger:response createMTOServiceItemConflict
 */
@@ -289,8 +283,7 @@ func (o *CreateMTOServiceItemConflict) WriteResponse(rw http.ResponseWriter, pro
 // CreateMTOServiceItemUnprocessableEntityCode is the HTTP code returned for type CreateMTOServiceItemUnprocessableEntity
 const CreateMTOServiceItemUnprocessableEntityCode int = 422
 
-/*
-CreateMTOServiceItemUnprocessableEntity The request was unprocessable, likely due to bad input from the requester.
+/*CreateMTOServiceItemUnprocessableEntity The request was unprocessable, likely due to bad input from the requester.
 
 swagger:response createMTOServiceItemUnprocessableEntity
 */
@@ -334,8 +327,7 @@ func (o *CreateMTOServiceItemUnprocessableEntity) WriteResponse(rw http.Response
 // CreateMTOServiceItemInternalServerErrorCode is the HTTP code returned for type CreateMTOServiceItemInternalServerError
 const CreateMTOServiceItemInternalServerErrorCode int = 500
 
-/*
-CreateMTOServiceItemInternalServerError A server error occurred.
+/*CreateMTOServiceItemInternalServerError A server error occurred.
 
 swagger:response createMTOServiceItemInternalServerError
 */

--- a/pkg/gen/primeapi/primeoperations/mto_service_item/update_m_t_o_service_item.go
+++ b/pkg/gen/primeapi/primeoperations/mto_service_item/update_m_t_o_service_item.go
@@ -29,22 +29,22 @@ func NewUpdateMTOServiceItem(ctx *middleware.Context, handler UpdateMTOServiceIt
 	return &UpdateMTOServiceItem{Context: ctx, Handler: handler}
 }
 
-/*
-	UpdateMTOServiceItem swagger:route PATCH /mto-service-items/{mtoServiceItemID} mtoServiceItem updateMTOServiceItem
+/* UpdateMTOServiceItem swagger:route PATCH /mto-service-items/{mtoServiceItemID} mtoServiceItem updateMTOServiceItem
 
 updateMTOServiceItem
 
 Updates MTOServiceItems after creation. Not all service items or fields may be updated, please see details below.
 
 This endpoint supports different body definitions. In the modelType field below, select the modelType corresponding
-
-	to the service item you wish to update and the documentation will update with the new definition.
+ to the service item you wish to update and the documentation will update with the new definition.
 
 To create a service item, please use [createMTOServiceItem](#operation/createMTOServiceItem)) endpoint.
 
 ### Errors
 
 Currently this is not implemented and will generated the NotImplemented error.
+
+
 */
 type UpdateMTOServiceItem struct {
 	Context *middleware.Context

--- a/pkg/gen/primeapi/primeoperations/mto_service_item/update_m_t_o_service_item_responses.go
+++ b/pkg/gen/primeapi/primeoperations/mto_service_item/update_m_t_o_service_item_responses.go
@@ -16,8 +16,7 @@ import (
 // UpdateMTOServiceItemOKCode is the HTTP code returned for type UpdateMTOServiceItemOK
 const UpdateMTOServiceItemOKCode int = 200
 
-/*
-UpdateMTOServiceItemOK Successfully updated the MTO service item.
+/*UpdateMTOServiceItemOK Successfully updated the MTO service item.
 
 swagger:response updateMTOServiceItemOK
 */
@@ -61,8 +60,7 @@ func (o *UpdateMTOServiceItemOK) WriteResponse(rw http.ResponseWriter, producer 
 // UpdateMTOServiceItemBadRequestCode is the HTTP code returned for type UpdateMTOServiceItemBadRequest
 const UpdateMTOServiceItemBadRequestCode int = 400
 
-/*
-UpdateMTOServiceItemBadRequest The request payload is invalid.
+/*UpdateMTOServiceItemBadRequest The request payload is invalid.
 
 swagger:response updateMTOServiceItemBadRequest
 */
@@ -106,8 +104,7 @@ func (o *UpdateMTOServiceItemBadRequest) WriteResponse(rw http.ResponseWriter, p
 // UpdateMTOServiceItemUnauthorizedCode is the HTTP code returned for type UpdateMTOServiceItemUnauthorized
 const UpdateMTOServiceItemUnauthorizedCode int = 401
 
-/*
-UpdateMTOServiceItemUnauthorized The request was denied.
+/*UpdateMTOServiceItemUnauthorized The request was denied.
 
 swagger:response updateMTOServiceItemUnauthorized
 */
@@ -151,8 +148,7 @@ func (o *UpdateMTOServiceItemUnauthorized) WriteResponse(rw http.ResponseWriter,
 // UpdateMTOServiceItemForbiddenCode is the HTTP code returned for type UpdateMTOServiceItemForbidden
 const UpdateMTOServiceItemForbiddenCode int = 403
 
-/*
-UpdateMTOServiceItemForbidden The request was denied.
+/*UpdateMTOServiceItemForbidden The request was denied.
 
 swagger:response updateMTOServiceItemForbidden
 */
@@ -196,8 +192,7 @@ func (o *UpdateMTOServiceItemForbidden) WriteResponse(rw http.ResponseWriter, pr
 // UpdateMTOServiceItemNotFoundCode is the HTTP code returned for type UpdateMTOServiceItemNotFound
 const UpdateMTOServiceItemNotFoundCode int = 404
 
-/*
-UpdateMTOServiceItemNotFound The requested resource wasn't found.
+/*UpdateMTOServiceItemNotFound The requested resource wasn't found.
 
 swagger:response updateMTOServiceItemNotFound
 */
@@ -241,8 +236,7 @@ func (o *UpdateMTOServiceItemNotFound) WriteResponse(rw http.ResponseWriter, pro
 // UpdateMTOServiceItemConflictCode is the HTTP code returned for type UpdateMTOServiceItemConflict
 const UpdateMTOServiceItemConflictCode int = 409
 
-/*
-UpdateMTOServiceItemConflict The request could not be processed because of conflict in the current state of the resource.
+/*UpdateMTOServiceItemConflict The request could not be processed because of conflict in the current state of the resource.
 
 swagger:response updateMTOServiceItemConflict
 */
@@ -286,8 +280,7 @@ func (o *UpdateMTOServiceItemConflict) WriteResponse(rw http.ResponseWriter, pro
 // UpdateMTOServiceItemPreconditionFailedCode is the HTTP code returned for type UpdateMTOServiceItemPreconditionFailed
 const UpdateMTOServiceItemPreconditionFailedCode int = 412
 
-/*
-UpdateMTOServiceItemPreconditionFailed Precondition failed, likely due to a stale eTag (If-Match). Fetch the request again to get the updated eTag value.
+/*UpdateMTOServiceItemPreconditionFailed Precondition failed, likely due to a stale eTag (If-Match). Fetch the request again to get the updated eTag value.
 
 swagger:response updateMTOServiceItemPreconditionFailed
 */
@@ -331,8 +324,7 @@ func (o *UpdateMTOServiceItemPreconditionFailed) WriteResponse(rw http.ResponseW
 // UpdateMTOServiceItemUnprocessableEntityCode is the HTTP code returned for type UpdateMTOServiceItemUnprocessableEntity
 const UpdateMTOServiceItemUnprocessableEntityCode int = 422
 
-/*
-UpdateMTOServiceItemUnprocessableEntity The request was unprocessable, likely due to bad input from the requester.
+/*UpdateMTOServiceItemUnprocessableEntity The request was unprocessable, likely due to bad input from the requester.
 
 swagger:response updateMTOServiceItemUnprocessableEntity
 */
@@ -376,8 +368,7 @@ func (o *UpdateMTOServiceItemUnprocessableEntity) WriteResponse(rw http.Response
 // UpdateMTOServiceItemInternalServerErrorCode is the HTTP code returned for type UpdateMTOServiceItemInternalServerError
 const UpdateMTOServiceItemInternalServerErrorCode int = 500
 
-/*
-UpdateMTOServiceItemInternalServerError A server error occurred.
+/*UpdateMTOServiceItemInternalServerError A server error occurred.
 
 swagger:response updateMTOServiceItemInternalServerError
 */

--- a/pkg/gen/primeapi/primeoperations/mto_shipment/create_m_t_o_agent.go
+++ b/pkg/gen/primeapi/primeoperations/mto_shipment/create_m_t_o_agent.go
@@ -29,8 +29,7 @@ func NewCreateMTOAgent(ctx *middleware.Context, handler CreateMTOAgentHandler) *
 	return &CreateMTOAgent{Context: ctx, Handler: handler}
 }
 
-/*
-	CreateMTOAgent swagger:route POST /mto-shipments/{mtoShipmentID}/agents mtoShipment createMTOAgent
+/* CreateMTOAgent swagger:route POST /mto-shipments/{mtoShipmentID}/agents mtoShipment createMTOAgent
 
 createMTOAgent
 
@@ -44,6 +43,8 @@ The agent must be associated with the MTO shipment passed in the url.
 
 The shipment should be associated with an MTO that is available to the Pime.
 If the caller requests a new agent, and the shipment is not on an available MTO, the caller will receive a **NotFound** response.
+
+
 */
 type CreateMTOAgent struct {
 	Context *middleware.Context

--- a/pkg/gen/primeapi/primeoperations/mto_shipment/create_m_t_o_agent_responses.go
+++ b/pkg/gen/primeapi/primeoperations/mto_shipment/create_m_t_o_agent_responses.go
@@ -16,8 +16,7 @@ import (
 // CreateMTOAgentOKCode is the HTTP code returned for type CreateMTOAgentOK
 const CreateMTOAgentOKCode int = 200
 
-/*
-CreateMTOAgentOK Successfully added the agent.
+/*CreateMTOAgentOK Successfully added the agent.
 
 swagger:response createMTOAgentOK
 */
@@ -61,8 +60,7 @@ func (o *CreateMTOAgentOK) WriteResponse(rw http.ResponseWriter, producer runtim
 // CreateMTOAgentBadRequestCode is the HTTP code returned for type CreateMTOAgentBadRequest
 const CreateMTOAgentBadRequestCode int = 400
 
-/*
-CreateMTOAgentBadRequest The request payload is invalid.
+/*CreateMTOAgentBadRequest The request payload is invalid.
 
 swagger:response createMTOAgentBadRequest
 */
@@ -106,8 +104,7 @@ func (o *CreateMTOAgentBadRequest) WriteResponse(rw http.ResponseWriter, produce
 // CreateMTOAgentUnauthorizedCode is the HTTP code returned for type CreateMTOAgentUnauthorized
 const CreateMTOAgentUnauthorizedCode int = 401
 
-/*
-CreateMTOAgentUnauthorized The request was denied.
+/*CreateMTOAgentUnauthorized The request was denied.
 
 swagger:response createMTOAgentUnauthorized
 */
@@ -151,8 +148,7 @@ func (o *CreateMTOAgentUnauthorized) WriteResponse(rw http.ResponseWriter, produ
 // CreateMTOAgentForbiddenCode is the HTTP code returned for type CreateMTOAgentForbidden
 const CreateMTOAgentForbiddenCode int = 403
 
-/*
-CreateMTOAgentForbidden The request was denied.
+/*CreateMTOAgentForbidden The request was denied.
 
 swagger:response createMTOAgentForbidden
 */
@@ -196,8 +192,7 @@ func (o *CreateMTOAgentForbidden) WriteResponse(rw http.ResponseWriter, producer
 // CreateMTOAgentNotFoundCode is the HTTP code returned for type CreateMTOAgentNotFound
 const CreateMTOAgentNotFoundCode int = 404
 
-/*
-CreateMTOAgentNotFound The requested resource wasn't found.
+/*CreateMTOAgentNotFound The requested resource wasn't found.
 
 swagger:response createMTOAgentNotFound
 */
@@ -241,8 +236,7 @@ func (o *CreateMTOAgentNotFound) WriteResponse(rw http.ResponseWriter, producer 
 // CreateMTOAgentConflictCode is the HTTP code returned for type CreateMTOAgentConflict
 const CreateMTOAgentConflictCode int = 409
 
-/*
-CreateMTOAgentConflict The request could not be processed because of conflict in the current state of the resource.
+/*CreateMTOAgentConflict The request could not be processed because of conflict in the current state of the resource.
 
 swagger:response createMTOAgentConflict
 */
@@ -286,8 +280,7 @@ func (o *CreateMTOAgentConflict) WriteResponse(rw http.ResponseWriter, producer 
 // CreateMTOAgentUnprocessableEntityCode is the HTTP code returned for type CreateMTOAgentUnprocessableEntity
 const CreateMTOAgentUnprocessableEntityCode int = 422
 
-/*
-CreateMTOAgentUnprocessableEntity The request was unprocessable, likely due to bad input from the requester.
+/*CreateMTOAgentUnprocessableEntity The request was unprocessable, likely due to bad input from the requester.
 
 swagger:response createMTOAgentUnprocessableEntity
 */
@@ -331,8 +324,7 @@ func (o *CreateMTOAgentUnprocessableEntity) WriteResponse(rw http.ResponseWriter
 // CreateMTOAgentInternalServerErrorCode is the HTTP code returned for type CreateMTOAgentInternalServerError
 const CreateMTOAgentInternalServerErrorCode int = 500
 
-/*
-CreateMTOAgentInternalServerError A server error occurred.
+/*CreateMTOAgentInternalServerError A server error occurred.
 
 swagger:response createMTOAgentInternalServerError
 */

--- a/pkg/gen/primeapi/primeoperations/mto_shipment/create_m_t_o_shipment.go
+++ b/pkg/gen/primeapi/primeoperations/mto_shipment/create_m_t_o_shipment.go
@@ -29,8 +29,7 @@ func NewCreateMTOShipment(ctx *middleware.Context, handler CreateMTOShipmentHand
 	return &CreateMTOShipment{Context: ctx, Handler: handler}
 }
 
-/*
-	CreateMTOShipment swagger:route POST /mto-shipments mtoShipment createMTOShipment
+/* CreateMTOShipment swagger:route POST /mto-shipments mtoShipment createMTOShipment
 
 createMTOShipment
 
@@ -41,6 +40,8 @@ approve it before the contractor can proceed with billing.
 **WIP**: The Prime should be notified by a push notification whenever the TOO approves a shipment connected to
 one of their moves. Otherwise, the Prime can fetch the related move using the
 [getMoveTaskOrder](#operation/getMoveTaskOrder) endpoint and see if this shipment has the status `"APPROVED"`.
+
+
 */
 type CreateMTOShipment struct {
 	Context *middleware.Context

--- a/pkg/gen/primeapi/primeoperations/mto_shipment/create_m_t_o_shipment_responses.go
+++ b/pkg/gen/primeapi/primeoperations/mto_shipment/create_m_t_o_shipment_responses.go
@@ -16,8 +16,7 @@ import (
 // CreateMTOShipmentOKCode is the HTTP code returned for type CreateMTOShipmentOK
 const CreateMTOShipmentOKCode int = 200
 
-/*
-CreateMTOShipmentOK Successfully created a MTO shipment.
+/*CreateMTOShipmentOK Successfully created a MTO shipment.
 
 swagger:response createMTOShipmentOK
 */
@@ -61,8 +60,7 @@ func (o *CreateMTOShipmentOK) WriteResponse(rw http.ResponseWriter, producer run
 // CreateMTOShipmentBadRequestCode is the HTTP code returned for type CreateMTOShipmentBadRequest
 const CreateMTOShipmentBadRequestCode int = 400
 
-/*
-CreateMTOShipmentBadRequest The request payload is invalid.
+/*CreateMTOShipmentBadRequest The request payload is invalid.
 
 swagger:response createMTOShipmentBadRequest
 */
@@ -106,8 +104,7 @@ func (o *CreateMTOShipmentBadRequest) WriteResponse(rw http.ResponseWriter, prod
 // CreateMTOShipmentNotFoundCode is the HTTP code returned for type CreateMTOShipmentNotFound
 const CreateMTOShipmentNotFoundCode int = 404
 
-/*
-CreateMTOShipmentNotFound The requested resource wasn't found.
+/*CreateMTOShipmentNotFound The requested resource wasn't found.
 
 swagger:response createMTOShipmentNotFound
 */
@@ -151,8 +148,7 @@ func (o *CreateMTOShipmentNotFound) WriteResponse(rw http.ResponseWriter, produc
 // CreateMTOShipmentUnprocessableEntityCode is the HTTP code returned for type CreateMTOShipmentUnprocessableEntity
 const CreateMTOShipmentUnprocessableEntityCode int = 422
 
-/*
-CreateMTOShipmentUnprocessableEntity The request was unprocessable, likely due to bad input from the requester.
+/*CreateMTOShipmentUnprocessableEntity The request was unprocessable, likely due to bad input from the requester.
 
 swagger:response createMTOShipmentUnprocessableEntity
 */
@@ -196,8 +192,7 @@ func (o *CreateMTOShipmentUnprocessableEntity) WriteResponse(rw http.ResponseWri
 // CreateMTOShipmentInternalServerErrorCode is the HTTP code returned for type CreateMTOShipmentInternalServerError
 const CreateMTOShipmentInternalServerErrorCode int = 500
 
-/*
-CreateMTOShipmentInternalServerError A server error occurred.
+/*CreateMTOShipmentInternalServerError A server error occurred.
 
 swagger:response createMTOShipmentInternalServerError
 */

--- a/pkg/gen/primeapi/primeoperations/mto_shipment/create_s_i_t_extension.go
+++ b/pkg/gen/primeapi/primeoperations/mto_shipment/create_s_i_t_extension.go
@@ -29,8 +29,7 @@ func NewCreateSITExtension(ctx *middleware.Context, handler CreateSITExtensionHa
 	return &CreateSITExtension{Context: ctx, Handler: handler}
 }
 
-/*
-	CreateSITExtension swagger:route POST /mto-shipments/{mtoShipmentID}/sit-extensions mtoShipment createSITExtension
+/* CreateSITExtension swagger:route POST /mto-shipments/{mtoShipmentID}/sit-extensions mtoShipment createSITExtension
 
 createSITExtension
 
@@ -38,6 +37,8 @@ createSITExtension
 This endpoint creates a storage in transit (SIT) extension request for a shipment. A SIT extension request is a request an
 increase in the shipment day allowance for the number of days a shipment is allowed to be in SIT. The total SIT day allowance
 includes time spent in both origin and destination SIT.
+
+
 */
 type CreateSITExtension struct {
 	Context *middleware.Context

--- a/pkg/gen/primeapi/primeoperations/mto_shipment/create_s_i_t_extension_responses.go
+++ b/pkg/gen/primeapi/primeoperations/mto_shipment/create_s_i_t_extension_responses.go
@@ -16,8 +16,7 @@ import (
 // CreateSITExtensionCreatedCode is the HTTP code returned for type CreateSITExtensionCreated
 const CreateSITExtensionCreatedCode int = 201
 
-/*
-CreateSITExtensionCreated Successfully created the sit extension request.
+/*CreateSITExtensionCreated Successfully created the sit extension request.
 
 swagger:response createSITExtensionCreated
 */
@@ -61,8 +60,7 @@ func (o *CreateSITExtensionCreated) WriteResponse(rw http.ResponseWriter, produc
 // CreateSITExtensionBadRequestCode is the HTTP code returned for type CreateSITExtensionBadRequest
 const CreateSITExtensionBadRequestCode int = 400
 
-/*
-CreateSITExtensionBadRequest The request payload is invalid.
+/*CreateSITExtensionBadRequest The request payload is invalid.
 
 swagger:response createSITExtensionBadRequest
 */
@@ -106,8 +104,7 @@ func (o *CreateSITExtensionBadRequest) WriteResponse(rw http.ResponseWriter, pro
 // CreateSITExtensionUnauthorizedCode is the HTTP code returned for type CreateSITExtensionUnauthorized
 const CreateSITExtensionUnauthorizedCode int = 401
 
-/*
-CreateSITExtensionUnauthorized The request was denied.
+/*CreateSITExtensionUnauthorized The request was denied.
 
 swagger:response createSITExtensionUnauthorized
 */
@@ -151,8 +148,7 @@ func (o *CreateSITExtensionUnauthorized) WriteResponse(rw http.ResponseWriter, p
 // CreateSITExtensionForbiddenCode is the HTTP code returned for type CreateSITExtensionForbidden
 const CreateSITExtensionForbiddenCode int = 403
 
-/*
-CreateSITExtensionForbidden The request was denied.
+/*CreateSITExtensionForbidden The request was denied.
 
 swagger:response createSITExtensionForbidden
 */
@@ -196,8 +192,7 @@ func (o *CreateSITExtensionForbidden) WriteResponse(rw http.ResponseWriter, prod
 // CreateSITExtensionNotFoundCode is the HTTP code returned for type CreateSITExtensionNotFound
 const CreateSITExtensionNotFoundCode int = 404
 
-/*
-CreateSITExtensionNotFound The requested resource wasn't found.
+/*CreateSITExtensionNotFound The requested resource wasn't found.
 
 swagger:response createSITExtensionNotFound
 */
@@ -241,8 +236,7 @@ func (o *CreateSITExtensionNotFound) WriteResponse(rw http.ResponseWriter, produ
 // CreateSITExtensionConflictCode is the HTTP code returned for type CreateSITExtensionConflict
 const CreateSITExtensionConflictCode int = 409
 
-/*
-CreateSITExtensionConflict The request could not be processed because of conflict in the current state of the resource.
+/*CreateSITExtensionConflict The request could not be processed because of conflict in the current state of the resource.
 
 swagger:response createSITExtensionConflict
 */
@@ -286,8 +280,7 @@ func (o *CreateSITExtensionConflict) WriteResponse(rw http.ResponseWriter, produ
 // CreateSITExtensionUnprocessableEntityCode is the HTTP code returned for type CreateSITExtensionUnprocessableEntity
 const CreateSITExtensionUnprocessableEntityCode int = 422
 
-/*
-CreateSITExtensionUnprocessableEntity The request was unprocessable, likely due to bad input from the requester.
+/*CreateSITExtensionUnprocessableEntity The request was unprocessable, likely due to bad input from the requester.
 
 swagger:response createSITExtensionUnprocessableEntity
 */
@@ -331,8 +324,7 @@ func (o *CreateSITExtensionUnprocessableEntity) WriteResponse(rw http.ResponseWr
 // CreateSITExtensionInternalServerErrorCode is the HTTP code returned for type CreateSITExtensionInternalServerError
 const CreateSITExtensionInternalServerErrorCode int = 500
 
-/*
-CreateSITExtensionInternalServerError A server error occurred.
+/*CreateSITExtensionInternalServerError A server error occurred.
 
 swagger:response createSITExtensionInternalServerError
 */

--- a/pkg/gen/primeapi/primeoperations/mto_shipment/delete_m_t_o_shipment.go
+++ b/pkg/gen/primeapi/primeoperations/mto_shipment/delete_m_t_o_shipment.go
@@ -29,8 +29,7 @@ func NewDeleteMTOShipment(ctx *middleware.Context, handler DeleteMTOShipmentHand
 	return &DeleteMTOShipment{Context: ctx, Handler: handler}
 }
 
-/*
-	DeleteMTOShipment swagger:route DELETE /mto-shipments/{mtoShipmentID} mtoShipment deleteMTOShipment
+/* DeleteMTOShipment swagger:route DELETE /mto-shipments/{mtoShipmentID} mtoShipment deleteMTOShipment
 
 deleteMTOShipment
 
@@ -41,6 +40,8 @@ This endpoint deletes an individual shipment by ID.
 * The mtoShipment should be associated with an MTO that is available to prime.
 * The mtoShipment must be a PPM shipment.
 * Counseling should not have already been completed for the associated MTO.
+
+
 */
 type DeleteMTOShipment struct {
 	Context *middleware.Context

--- a/pkg/gen/primeapi/primeoperations/mto_shipment/delete_m_t_o_shipment_responses.go
+++ b/pkg/gen/primeapi/primeoperations/mto_shipment/delete_m_t_o_shipment_responses.go
@@ -16,8 +16,7 @@ import (
 // DeleteMTOShipmentNoContentCode is the HTTP code returned for type DeleteMTOShipmentNoContent
 const DeleteMTOShipmentNoContentCode int = 204
 
-/*
-DeleteMTOShipmentNoContent Successfully deleted the MTO shipment.
+/*DeleteMTOShipmentNoContent Successfully deleted the MTO shipment.
 
 swagger:response deleteMTOShipmentNoContent
 */
@@ -41,8 +40,7 @@ func (o *DeleteMTOShipmentNoContent) WriteResponse(rw http.ResponseWriter, produ
 // DeleteMTOShipmentBadRequestCode is the HTTP code returned for type DeleteMTOShipmentBadRequest
 const DeleteMTOShipmentBadRequestCode int = 400
 
-/*
-DeleteMTOShipmentBadRequest The request payload is invalid.
+/*DeleteMTOShipmentBadRequest The request payload is invalid.
 
 swagger:response deleteMTOShipmentBadRequest
 */
@@ -86,8 +84,7 @@ func (o *DeleteMTOShipmentBadRequest) WriteResponse(rw http.ResponseWriter, prod
 // DeleteMTOShipmentForbiddenCode is the HTTP code returned for type DeleteMTOShipmentForbidden
 const DeleteMTOShipmentForbiddenCode int = 403
 
-/*
-DeleteMTOShipmentForbidden The request was denied.
+/*DeleteMTOShipmentForbidden The request was denied.
 
 swagger:response deleteMTOShipmentForbidden
 */
@@ -131,8 +128,7 @@ func (o *DeleteMTOShipmentForbidden) WriteResponse(rw http.ResponseWriter, produ
 // DeleteMTOShipmentNotFoundCode is the HTTP code returned for type DeleteMTOShipmentNotFound
 const DeleteMTOShipmentNotFoundCode int = 404
 
-/*
-DeleteMTOShipmentNotFound The requested resource wasn't found.
+/*DeleteMTOShipmentNotFound The requested resource wasn't found.
 
 swagger:response deleteMTOShipmentNotFound
 */
@@ -176,8 +172,7 @@ func (o *DeleteMTOShipmentNotFound) WriteResponse(rw http.ResponseWriter, produc
 // DeleteMTOShipmentConflictCode is the HTTP code returned for type DeleteMTOShipmentConflict
 const DeleteMTOShipmentConflictCode int = 409
 
-/*
-DeleteMTOShipmentConflict The request could not be processed because of conflict in the current state of the resource.
+/*DeleteMTOShipmentConflict The request could not be processed because of conflict in the current state of the resource.
 
 swagger:response deleteMTOShipmentConflict
 */
@@ -221,8 +216,7 @@ func (o *DeleteMTOShipmentConflict) WriteResponse(rw http.ResponseWriter, produc
 // DeleteMTOShipmentUnprocessableEntityCode is the HTTP code returned for type DeleteMTOShipmentUnprocessableEntity
 const DeleteMTOShipmentUnprocessableEntityCode int = 422
 
-/*
-DeleteMTOShipmentUnprocessableEntity The request was unprocessable, likely due to bad input from the requester.
+/*DeleteMTOShipmentUnprocessableEntity The request was unprocessable, likely due to bad input from the requester.
 
 swagger:response deleteMTOShipmentUnprocessableEntity
 */
@@ -266,8 +260,7 @@ func (o *DeleteMTOShipmentUnprocessableEntity) WriteResponse(rw http.ResponseWri
 // DeleteMTOShipmentInternalServerErrorCode is the HTTP code returned for type DeleteMTOShipmentInternalServerError
 const DeleteMTOShipmentInternalServerErrorCode int = 500
 
-/*
-DeleteMTOShipmentInternalServerError A server error occurred.
+/*DeleteMTOShipmentInternalServerError A server error occurred.
 
 swagger:response deleteMTOShipmentInternalServerError
 */

--- a/pkg/gen/primeapi/primeoperations/mto_shipment/update_m_t_o_agent.go
+++ b/pkg/gen/primeapi/primeoperations/mto_shipment/update_m_t_o_agent.go
@@ -29,8 +29,7 @@ func NewUpdateMTOAgent(ctx *middleware.Context, handler UpdateMTOAgentHandler) *
 	return &UpdateMTOAgent{Context: ctx, Handler: handler}
 }
 
-/*
-	UpdateMTOAgent swagger:route PUT /mto-shipments/{mtoShipmentID}/agents/{agentID} mtoShipment updateMTOAgent
+/* UpdateMTOAgent swagger:route PUT /mto-shipments/{mtoShipmentID}/agents/{agentID} mtoShipment updateMTOAgent
 
 updateMTOAgent
 
@@ -44,6 +43,8 @@ The agent must be associated with the MTO shipment passed in the url.
 
 The shipment should be associated with an MTO that is available to the Prime.
 If the caller requests an update to an agent, and the shipment is not on an available MTO, the caller will receive a **NotFound** response.
+
+
 */
 type UpdateMTOAgent struct {
 	Context *middleware.Context

--- a/pkg/gen/primeapi/primeoperations/mto_shipment/update_m_t_o_agent_responses.go
+++ b/pkg/gen/primeapi/primeoperations/mto_shipment/update_m_t_o_agent_responses.go
@@ -16,8 +16,7 @@ import (
 // UpdateMTOAgentOKCode is the HTTP code returned for type UpdateMTOAgentOK
 const UpdateMTOAgentOKCode int = 200
 
-/*
-UpdateMTOAgentOK Successfully updated the agent.
+/*UpdateMTOAgentOK Successfully updated the agent.
 
 swagger:response updateMTOAgentOK
 */
@@ -61,8 +60,7 @@ func (o *UpdateMTOAgentOK) WriteResponse(rw http.ResponseWriter, producer runtim
 // UpdateMTOAgentBadRequestCode is the HTTP code returned for type UpdateMTOAgentBadRequest
 const UpdateMTOAgentBadRequestCode int = 400
 
-/*
-UpdateMTOAgentBadRequest The request payload is invalid.
+/*UpdateMTOAgentBadRequest The request payload is invalid.
 
 swagger:response updateMTOAgentBadRequest
 */
@@ -106,8 +104,7 @@ func (o *UpdateMTOAgentBadRequest) WriteResponse(rw http.ResponseWriter, produce
 // UpdateMTOAgentUnauthorizedCode is the HTTP code returned for type UpdateMTOAgentUnauthorized
 const UpdateMTOAgentUnauthorizedCode int = 401
 
-/*
-UpdateMTOAgentUnauthorized The request was denied.
+/*UpdateMTOAgentUnauthorized The request was denied.
 
 swagger:response updateMTOAgentUnauthorized
 */
@@ -151,8 +148,7 @@ func (o *UpdateMTOAgentUnauthorized) WriteResponse(rw http.ResponseWriter, produ
 // UpdateMTOAgentForbiddenCode is the HTTP code returned for type UpdateMTOAgentForbidden
 const UpdateMTOAgentForbiddenCode int = 403
 
-/*
-UpdateMTOAgentForbidden The request was denied.
+/*UpdateMTOAgentForbidden The request was denied.
 
 swagger:response updateMTOAgentForbidden
 */
@@ -196,8 +192,7 @@ func (o *UpdateMTOAgentForbidden) WriteResponse(rw http.ResponseWriter, producer
 // UpdateMTOAgentNotFoundCode is the HTTP code returned for type UpdateMTOAgentNotFound
 const UpdateMTOAgentNotFoundCode int = 404
 
-/*
-UpdateMTOAgentNotFound The requested resource wasn't found.
+/*UpdateMTOAgentNotFound The requested resource wasn't found.
 
 swagger:response updateMTOAgentNotFound
 */
@@ -241,8 +236,7 @@ func (o *UpdateMTOAgentNotFound) WriteResponse(rw http.ResponseWriter, producer 
 // UpdateMTOAgentPreconditionFailedCode is the HTTP code returned for type UpdateMTOAgentPreconditionFailed
 const UpdateMTOAgentPreconditionFailedCode int = 412
 
-/*
-UpdateMTOAgentPreconditionFailed Precondition failed, likely due to a stale eTag (If-Match). Fetch the request again to get the updated eTag value.
+/*UpdateMTOAgentPreconditionFailed Precondition failed, likely due to a stale eTag (If-Match). Fetch the request again to get the updated eTag value.
 
 swagger:response updateMTOAgentPreconditionFailed
 */
@@ -286,8 +280,7 @@ func (o *UpdateMTOAgentPreconditionFailed) WriteResponse(rw http.ResponseWriter,
 // UpdateMTOAgentUnprocessableEntityCode is the HTTP code returned for type UpdateMTOAgentUnprocessableEntity
 const UpdateMTOAgentUnprocessableEntityCode int = 422
 
-/*
-UpdateMTOAgentUnprocessableEntity The request was unprocessable, likely due to bad input from the requester.
+/*UpdateMTOAgentUnprocessableEntity The request was unprocessable, likely due to bad input from the requester.
 
 swagger:response updateMTOAgentUnprocessableEntity
 */
@@ -331,8 +324,7 @@ func (o *UpdateMTOAgentUnprocessableEntity) WriteResponse(rw http.ResponseWriter
 // UpdateMTOAgentInternalServerErrorCode is the HTTP code returned for type UpdateMTOAgentInternalServerError
 const UpdateMTOAgentInternalServerErrorCode int = 500
 
-/*
-UpdateMTOAgentInternalServerError A server error occurred.
+/*UpdateMTOAgentInternalServerError A server error occurred.
 
 swagger:response updateMTOAgentInternalServerError
 */

--- a/pkg/gen/primeapi/primeoperations/mto_shipment/update_m_t_o_shipment.go
+++ b/pkg/gen/primeapi/primeoperations/mto_shipment/update_m_t_o_shipment.go
@@ -29,8 +29,7 @@ func NewUpdateMTOShipment(ctx *middleware.Context, handler UpdateMTOShipmentHand
 	return &UpdateMTOShipment{Context: ctx, Handler: handler}
 }
 
-/*
-	UpdateMTOShipment swagger:route PATCH /mto-shipments/{mtoShipmentID} mtoShipment updateMTOShipment
+/* UpdateMTOShipment swagger:route PATCH /mto-shipments/{mtoShipmentID} mtoShipment updateMTOShipment
 
 updateMTOShipment
 
@@ -45,6 +44,8 @@ Note that there are some restrictions on nested objects:
 These restrictions are due to our [optimistic locking/concurrency control](https://transcom.github.io/mymove-docs/docs/dev/contributing/backend/use-optimistic-locking) mechanism.
 
 Note that some fields cannot be manually changed but will still be updated automatically, such as `primeEstimatedWeightRecordedDate` and `requiredDeliveryDate`.
+
+
 */
 type UpdateMTOShipment struct {
 	Context *middleware.Context

--- a/pkg/gen/primeapi/primeoperations/mto_shipment/update_m_t_o_shipment_address.go
+++ b/pkg/gen/primeapi/primeoperations/mto_shipment/update_m_t_o_shipment_address.go
@@ -29,8 +29,7 @@ func NewUpdateMTOShipmentAddress(ctx *middleware.Context, handler UpdateMTOShipm
 	return &UpdateMTOShipmentAddress{Context: ctx, Handler: handler}
 }
 
-/*
-	UpdateMTOShipmentAddress swagger:route PUT /mto-shipments/{mtoShipmentID}/addresses/{addressID} mtoShipment updateMTOShipmentAddress
+/* UpdateMTOShipmentAddress swagger:route PUT /mto-shipments/{mtoShipmentID}/addresses/{addressID} mtoShipment updateMTOShipmentAddress
 
 updateMTOShipmentAddress
 
@@ -48,6 +47,8 @@ If it is not, caller will receive a **Conflict** Error.
 
 The mtoShipment should be associated with an MTO that is available to prime.
 If the caller requests an update to an address, and the shipment is not on an available MTO, the caller will receive a **NotFound** Error.
+
+
 */
 type UpdateMTOShipmentAddress struct {
 	Context *middleware.Context

--- a/pkg/gen/primeapi/primeoperations/mto_shipment/update_m_t_o_shipment_address_responses.go
+++ b/pkg/gen/primeapi/primeoperations/mto_shipment/update_m_t_o_shipment_address_responses.go
@@ -16,8 +16,7 @@ import (
 // UpdateMTOShipmentAddressOKCode is the HTTP code returned for type UpdateMTOShipmentAddressOK
 const UpdateMTOShipmentAddressOKCode int = 200
 
-/*
-UpdateMTOShipmentAddressOK Successfully updated the address.
+/*UpdateMTOShipmentAddressOK Successfully updated the address.
 
 swagger:response updateMTOShipmentAddressOK
 */
@@ -61,8 +60,7 @@ func (o *UpdateMTOShipmentAddressOK) WriteResponse(rw http.ResponseWriter, produ
 // UpdateMTOShipmentAddressBadRequestCode is the HTTP code returned for type UpdateMTOShipmentAddressBadRequest
 const UpdateMTOShipmentAddressBadRequestCode int = 400
 
-/*
-UpdateMTOShipmentAddressBadRequest The request payload is invalid.
+/*UpdateMTOShipmentAddressBadRequest The request payload is invalid.
 
 swagger:response updateMTOShipmentAddressBadRequest
 */
@@ -106,8 +104,7 @@ func (o *UpdateMTOShipmentAddressBadRequest) WriteResponse(rw http.ResponseWrite
 // UpdateMTOShipmentAddressUnauthorizedCode is the HTTP code returned for type UpdateMTOShipmentAddressUnauthorized
 const UpdateMTOShipmentAddressUnauthorizedCode int = 401
 
-/*
-UpdateMTOShipmentAddressUnauthorized The request was denied.
+/*UpdateMTOShipmentAddressUnauthorized The request was denied.
 
 swagger:response updateMTOShipmentAddressUnauthorized
 */
@@ -151,8 +148,7 @@ func (o *UpdateMTOShipmentAddressUnauthorized) WriteResponse(rw http.ResponseWri
 // UpdateMTOShipmentAddressForbiddenCode is the HTTP code returned for type UpdateMTOShipmentAddressForbidden
 const UpdateMTOShipmentAddressForbiddenCode int = 403
 
-/*
-UpdateMTOShipmentAddressForbidden The request was denied.
+/*UpdateMTOShipmentAddressForbidden The request was denied.
 
 swagger:response updateMTOShipmentAddressForbidden
 */
@@ -196,8 +192,7 @@ func (o *UpdateMTOShipmentAddressForbidden) WriteResponse(rw http.ResponseWriter
 // UpdateMTOShipmentAddressNotFoundCode is the HTTP code returned for type UpdateMTOShipmentAddressNotFound
 const UpdateMTOShipmentAddressNotFoundCode int = 404
 
-/*
-UpdateMTOShipmentAddressNotFound The requested resource wasn't found.
+/*UpdateMTOShipmentAddressNotFound The requested resource wasn't found.
 
 swagger:response updateMTOShipmentAddressNotFound
 */
@@ -241,8 +236,7 @@ func (o *UpdateMTOShipmentAddressNotFound) WriteResponse(rw http.ResponseWriter,
 // UpdateMTOShipmentAddressConflictCode is the HTTP code returned for type UpdateMTOShipmentAddressConflict
 const UpdateMTOShipmentAddressConflictCode int = 409
 
-/*
-UpdateMTOShipmentAddressConflict The request could not be processed because of conflict in the current state of the resource.
+/*UpdateMTOShipmentAddressConflict The request could not be processed because of conflict in the current state of the resource.
 
 swagger:response updateMTOShipmentAddressConflict
 */
@@ -286,8 +280,7 @@ func (o *UpdateMTOShipmentAddressConflict) WriteResponse(rw http.ResponseWriter,
 // UpdateMTOShipmentAddressPreconditionFailedCode is the HTTP code returned for type UpdateMTOShipmentAddressPreconditionFailed
 const UpdateMTOShipmentAddressPreconditionFailedCode int = 412
 
-/*
-UpdateMTOShipmentAddressPreconditionFailed Precondition failed, likely due to a stale eTag (If-Match). Fetch the request again to get the updated eTag value.
+/*UpdateMTOShipmentAddressPreconditionFailed Precondition failed, likely due to a stale eTag (If-Match). Fetch the request again to get the updated eTag value.
 
 swagger:response updateMTOShipmentAddressPreconditionFailed
 */
@@ -331,8 +324,7 @@ func (o *UpdateMTOShipmentAddressPreconditionFailed) WriteResponse(rw http.Respo
 // UpdateMTOShipmentAddressUnprocessableEntityCode is the HTTP code returned for type UpdateMTOShipmentAddressUnprocessableEntity
 const UpdateMTOShipmentAddressUnprocessableEntityCode int = 422
 
-/*
-UpdateMTOShipmentAddressUnprocessableEntity The request was unprocessable, likely due to bad input from the requester.
+/*UpdateMTOShipmentAddressUnprocessableEntity The request was unprocessable, likely due to bad input from the requester.
 
 swagger:response updateMTOShipmentAddressUnprocessableEntity
 */
@@ -376,8 +368,7 @@ func (o *UpdateMTOShipmentAddressUnprocessableEntity) WriteResponse(rw http.Resp
 // UpdateMTOShipmentAddressInternalServerErrorCode is the HTTP code returned for type UpdateMTOShipmentAddressInternalServerError
 const UpdateMTOShipmentAddressInternalServerErrorCode int = 500
 
-/*
-UpdateMTOShipmentAddressInternalServerError A server error occurred.
+/*UpdateMTOShipmentAddressInternalServerError A server error occurred.
 
 swagger:response updateMTOShipmentAddressInternalServerError
 */

--- a/pkg/gen/primeapi/primeoperations/mto_shipment/update_m_t_o_shipment_responses.go
+++ b/pkg/gen/primeapi/primeoperations/mto_shipment/update_m_t_o_shipment_responses.go
@@ -16,8 +16,7 @@ import (
 // UpdateMTOShipmentOKCode is the HTTP code returned for type UpdateMTOShipmentOK
 const UpdateMTOShipmentOKCode int = 200
 
-/*
-UpdateMTOShipmentOK Successfully updated the MTO shipment.
+/*UpdateMTOShipmentOK Successfully updated the MTO shipment.
 
 swagger:response updateMTOShipmentOK
 */
@@ -61,8 +60,7 @@ func (o *UpdateMTOShipmentOK) WriteResponse(rw http.ResponseWriter, producer run
 // UpdateMTOShipmentBadRequestCode is the HTTP code returned for type UpdateMTOShipmentBadRequest
 const UpdateMTOShipmentBadRequestCode int = 400
 
-/*
-UpdateMTOShipmentBadRequest The request payload is invalid.
+/*UpdateMTOShipmentBadRequest The request payload is invalid.
 
 swagger:response updateMTOShipmentBadRequest
 */
@@ -106,8 +104,7 @@ func (o *UpdateMTOShipmentBadRequest) WriteResponse(rw http.ResponseWriter, prod
 // UpdateMTOShipmentUnauthorizedCode is the HTTP code returned for type UpdateMTOShipmentUnauthorized
 const UpdateMTOShipmentUnauthorizedCode int = 401
 
-/*
-UpdateMTOShipmentUnauthorized The request was denied.
+/*UpdateMTOShipmentUnauthorized The request was denied.
 
 swagger:response updateMTOShipmentUnauthorized
 */
@@ -151,8 +148,7 @@ func (o *UpdateMTOShipmentUnauthorized) WriteResponse(rw http.ResponseWriter, pr
 // UpdateMTOShipmentForbiddenCode is the HTTP code returned for type UpdateMTOShipmentForbidden
 const UpdateMTOShipmentForbiddenCode int = 403
 
-/*
-UpdateMTOShipmentForbidden The request was denied.
+/*UpdateMTOShipmentForbidden The request was denied.
 
 swagger:response updateMTOShipmentForbidden
 */
@@ -196,8 +192,7 @@ func (o *UpdateMTOShipmentForbidden) WriteResponse(rw http.ResponseWriter, produ
 // UpdateMTOShipmentNotFoundCode is the HTTP code returned for type UpdateMTOShipmentNotFound
 const UpdateMTOShipmentNotFoundCode int = 404
 
-/*
-UpdateMTOShipmentNotFound The requested resource wasn't found.
+/*UpdateMTOShipmentNotFound The requested resource wasn't found.
 
 swagger:response updateMTOShipmentNotFound
 */
@@ -241,8 +236,7 @@ func (o *UpdateMTOShipmentNotFound) WriteResponse(rw http.ResponseWriter, produc
 // UpdateMTOShipmentPreconditionFailedCode is the HTTP code returned for type UpdateMTOShipmentPreconditionFailed
 const UpdateMTOShipmentPreconditionFailedCode int = 412
 
-/*
-UpdateMTOShipmentPreconditionFailed Precondition failed, likely due to a stale eTag (If-Match). Fetch the request again to get the updated eTag value.
+/*UpdateMTOShipmentPreconditionFailed Precondition failed, likely due to a stale eTag (If-Match). Fetch the request again to get the updated eTag value.
 
 swagger:response updateMTOShipmentPreconditionFailed
 */
@@ -286,8 +280,7 @@ func (o *UpdateMTOShipmentPreconditionFailed) WriteResponse(rw http.ResponseWrit
 // UpdateMTOShipmentUnprocessableEntityCode is the HTTP code returned for type UpdateMTOShipmentUnprocessableEntity
 const UpdateMTOShipmentUnprocessableEntityCode int = 422
 
-/*
-UpdateMTOShipmentUnprocessableEntity The request was unprocessable, likely due to bad input from the requester.
+/*UpdateMTOShipmentUnprocessableEntity The request was unprocessable, likely due to bad input from the requester.
 
 swagger:response updateMTOShipmentUnprocessableEntity
 */
@@ -331,8 +324,7 @@ func (o *UpdateMTOShipmentUnprocessableEntity) WriteResponse(rw http.ResponseWri
 // UpdateMTOShipmentInternalServerErrorCode is the HTTP code returned for type UpdateMTOShipmentInternalServerError
 const UpdateMTOShipmentInternalServerErrorCode int = 500
 
-/*
-UpdateMTOShipmentInternalServerError A server error occurred.
+/*UpdateMTOShipmentInternalServerError A server error occurred.
 
 swagger:response updateMTOShipmentInternalServerError
 */

--- a/pkg/gen/primeapi/primeoperations/mto_shipment/update_m_t_o_shipment_status.go
+++ b/pkg/gen/primeapi/primeoperations/mto_shipment/update_m_t_o_shipment_status.go
@@ -29,14 +29,15 @@ func NewUpdateMTOShipmentStatus(ctx *middleware.Context, handler UpdateMTOShipme
 	return &UpdateMTOShipmentStatus{Context: ctx, Handler: handler}
 }
 
-/*
-	UpdateMTOShipmentStatus swagger:route PATCH /mto-shipments/{mtoShipmentID}/status mtoShipment updateMTOShipmentStatus
+/* UpdateMTOShipmentStatus swagger:route PATCH /mto-shipments/{mtoShipmentID}/status mtoShipment updateMTOShipmentStatus
 
 updateMTOShipmentStatus
 
 ### Functionality
 This endpoint should be used by the Prime to confirm the cancellation of a shipment. It allows the shipment
 status to be changed to "CANCELED." Currently, the Prime cannot update the shipment to any other status.
+
+
 */
 type UpdateMTOShipmentStatus struct {
 	Context *middleware.Context

--- a/pkg/gen/primeapi/primeoperations/mto_shipment/update_m_t_o_shipment_status_responses.go
+++ b/pkg/gen/primeapi/primeoperations/mto_shipment/update_m_t_o_shipment_status_responses.go
@@ -16,8 +16,7 @@ import (
 // UpdateMTOShipmentStatusOKCode is the HTTP code returned for type UpdateMTOShipmentStatusOK
 const UpdateMTOShipmentStatusOKCode int = 200
 
-/*
-UpdateMTOShipmentStatusOK Successfully updated the shipment's status.
+/*UpdateMTOShipmentStatusOK Successfully updated the shipment's status.
 
 swagger:response updateMTOShipmentStatusOK
 */
@@ -61,8 +60,7 @@ func (o *UpdateMTOShipmentStatusOK) WriteResponse(rw http.ResponseWriter, produc
 // UpdateMTOShipmentStatusBadRequestCode is the HTTP code returned for type UpdateMTOShipmentStatusBadRequest
 const UpdateMTOShipmentStatusBadRequestCode int = 400
 
-/*
-UpdateMTOShipmentStatusBadRequest The request payload is invalid.
+/*UpdateMTOShipmentStatusBadRequest The request payload is invalid.
 
 swagger:response updateMTOShipmentStatusBadRequest
 */
@@ -106,8 +104,7 @@ func (o *UpdateMTOShipmentStatusBadRequest) WriteResponse(rw http.ResponseWriter
 // UpdateMTOShipmentStatusUnauthorizedCode is the HTTP code returned for type UpdateMTOShipmentStatusUnauthorized
 const UpdateMTOShipmentStatusUnauthorizedCode int = 401
 
-/*
-UpdateMTOShipmentStatusUnauthorized The request was denied.
+/*UpdateMTOShipmentStatusUnauthorized The request was denied.
 
 swagger:response updateMTOShipmentStatusUnauthorized
 */
@@ -151,8 +148,7 @@ func (o *UpdateMTOShipmentStatusUnauthorized) WriteResponse(rw http.ResponseWrit
 // UpdateMTOShipmentStatusForbiddenCode is the HTTP code returned for type UpdateMTOShipmentStatusForbidden
 const UpdateMTOShipmentStatusForbiddenCode int = 403
 
-/*
-UpdateMTOShipmentStatusForbidden The request was denied.
+/*UpdateMTOShipmentStatusForbidden The request was denied.
 
 swagger:response updateMTOShipmentStatusForbidden
 */
@@ -196,8 +192,7 @@ func (o *UpdateMTOShipmentStatusForbidden) WriteResponse(rw http.ResponseWriter,
 // UpdateMTOShipmentStatusNotFoundCode is the HTTP code returned for type UpdateMTOShipmentStatusNotFound
 const UpdateMTOShipmentStatusNotFoundCode int = 404
 
-/*
-UpdateMTOShipmentStatusNotFound The requested resource wasn't found.
+/*UpdateMTOShipmentStatusNotFound The requested resource wasn't found.
 
 swagger:response updateMTOShipmentStatusNotFound
 */
@@ -241,8 +236,7 @@ func (o *UpdateMTOShipmentStatusNotFound) WriteResponse(rw http.ResponseWriter, 
 // UpdateMTOShipmentStatusConflictCode is the HTTP code returned for type UpdateMTOShipmentStatusConflict
 const UpdateMTOShipmentStatusConflictCode int = 409
 
-/*
-UpdateMTOShipmentStatusConflict The request could not be processed because of conflict in the current state of the resource.
+/*UpdateMTOShipmentStatusConflict The request could not be processed because of conflict in the current state of the resource.
 
 swagger:response updateMTOShipmentStatusConflict
 */
@@ -286,8 +280,7 @@ func (o *UpdateMTOShipmentStatusConflict) WriteResponse(rw http.ResponseWriter, 
 // UpdateMTOShipmentStatusPreconditionFailedCode is the HTTP code returned for type UpdateMTOShipmentStatusPreconditionFailed
 const UpdateMTOShipmentStatusPreconditionFailedCode int = 412
 
-/*
-UpdateMTOShipmentStatusPreconditionFailed Precondition failed, likely due to a stale eTag (If-Match). Fetch the request again to get the updated eTag value.
+/*UpdateMTOShipmentStatusPreconditionFailed Precondition failed, likely due to a stale eTag (If-Match). Fetch the request again to get the updated eTag value.
 
 swagger:response updateMTOShipmentStatusPreconditionFailed
 */
@@ -331,8 +324,7 @@ func (o *UpdateMTOShipmentStatusPreconditionFailed) WriteResponse(rw http.Respon
 // UpdateMTOShipmentStatusUnprocessableEntityCode is the HTTP code returned for type UpdateMTOShipmentStatusUnprocessableEntity
 const UpdateMTOShipmentStatusUnprocessableEntityCode int = 422
 
-/*
-UpdateMTOShipmentStatusUnprocessableEntity The request was unprocessable, likely due to bad input from the requester.
+/*UpdateMTOShipmentStatusUnprocessableEntity The request was unprocessable, likely due to bad input from the requester.
 
 swagger:response updateMTOShipmentStatusUnprocessableEntity
 */
@@ -376,8 +368,7 @@ func (o *UpdateMTOShipmentStatusUnprocessableEntity) WriteResponse(rw http.Respo
 // UpdateMTOShipmentStatusInternalServerErrorCode is the HTTP code returned for type UpdateMTOShipmentStatusInternalServerError
 const UpdateMTOShipmentStatusInternalServerErrorCode int = 500
 
-/*
-UpdateMTOShipmentStatusInternalServerError A server error occurred.
+/*UpdateMTOShipmentStatusInternalServerError A server error occurred.
 
 swagger:response updateMTOShipmentStatusInternalServerError
 */

--- a/pkg/gen/primeapi/primeoperations/mto_shipment/update_reweigh.go
+++ b/pkg/gen/primeapi/primeoperations/mto_shipment/update_reweigh.go
@@ -29,8 +29,7 @@ func NewUpdateReweigh(ctx *middleware.Context, handler UpdateReweighHandler) *Up
 	return &UpdateReweigh{Context: ctx, Handler: handler}
 }
 
-/*
-	UpdateReweigh swagger:route PATCH /mto-shipments/{mtoShipmentID}/reweighs/{reweighID} mtoShipment updateReweigh
+/* UpdateReweigh swagger:route PATCH /mto-shipments/{mtoShipmentID}/reweighs/{reweighID} mtoShipment updateReweigh
 
 updateReweigh
 
@@ -41,6 +40,8 @@ Only one of weight or verificationReason should be sent in the request body.
 A reweigh is the second recorded weight for a shipment, as validated by certified weight tickets. Applies to one shipment.
 A reweigh can be triggered automatically, or requested by the customer or transportation office. Not all shipments are reweighed,
 so not all shipments will have a reweigh weight.
+
+
 */
 type UpdateReweigh struct {
 	Context *middleware.Context

--- a/pkg/gen/primeapi/primeoperations/mto_shipment/update_reweigh_responses.go
+++ b/pkg/gen/primeapi/primeoperations/mto_shipment/update_reweigh_responses.go
@@ -16,8 +16,7 @@ import (
 // UpdateReweighOKCode is the HTTP code returned for type UpdateReweighOK
 const UpdateReweighOKCode int = 200
 
-/*
-UpdateReweighOK Successfully updated the reweigh.
+/*UpdateReweighOK Successfully updated the reweigh.
 
 swagger:response updateReweighOK
 */
@@ -61,8 +60,7 @@ func (o *UpdateReweighOK) WriteResponse(rw http.ResponseWriter, producer runtime
 // UpdateReweighBadRequestCode is the HTTP code returned for type UpdateReweighBadRequest
 const UpdateReweighBadRequestCode int = 400
 
-/*
-UpdateReweighBadRequest The request payload is invalid.
+/*UpdateReweighBadRequest The request payload is invalid.
 
 swagger:response updateReweighBadRequest
 */
@@ -106,8 +104,7 @@ func (o *UpdateReweighBadRequest) WriteResponse(rw http.ResponseWriter, producer
 // UpdateReweighUnauthorizedCode is the HTTP code returned for type UpdateReweighUnauthorized
 const UpdateReweighUnauthorizedCode int = 401
 
-/*
-UpdateReweighUnauthorized The request was denied.
+/*UpdateReweighUnauthorized The request was denied.
 
 swagger:response updateReweighUnauthorized
 */
@@ -151,8 +148,7 @@ func (o *UpdateReweighUnauthorized) WriteResponse(rw http.ResponseWriter, produc
 // UpdateReweighForbiddenCode is the HTTP code returned for type UpdateReweighForbidden
 const UpdateReweighForbiddenCode int = 403
 
-/*
-UpdateReweighForbidden The request was denied.
+/*UpdateReweighForbidden The request was denied.
 
 swagger:response updateReweighForbidden
 */
@@ -196,8 +192,7 @@ func (o *UpdateReweighForbidden) WriteResponse(rw http.ResponseWriter, producer 
 // UpdateReweighNotFoundCode is the HTTP code returned for type UpdateReweighNotFound
 const UpdateReweighNotFoundCode int = 404
 
-/*
-UpdateReweighNotFound The requested resource wasn't found.
+/*UpdateReweighNotFound The requested resource wasn't found.
 
 swagger:response updateReweighNotFound
 */
@@ -241,8 +236,7 @@ func (o *UpdateReweighNotFound) WriteResponse(rw http.ResponseWriter, producer r
 // UpdateReweighConflictCode is the HTTP code returned for type UpdateReweighConflict
 const UpdateReweighConflictCode int = 409
 
-/*
-UpdateReweighConflict The request could not be processed because of conflict in the current state of the resource.
+/*UpdateReweighConflict The request could not be processed because of conflict in the current state of the resource.
 
 swagger:response updateReweighConflict
 */
@@ -286,8 +280,7 @@ func (o *UpdateReweighConflict) WriteResponse(rw http.ResponseWriter, producer r
 // UpdateReweighPreconditionFailedCode is the HTTP code returned for type UpdateReweighPreconditionFailed
 const UpdateReweighPreconditionFailedCode int = 412
 
-/*
-UpdateReweighPreconditionFailed Precondition failed, likely due to a stale eTag (If-Match). Fetch the request again to get the updated eTag value.
+/*UpdateReweighPreconditionFailed Precondition failed, likely due to a stale eTag (If-Match). Fetch the request again to get the updated eTag value.
 
 swagger:response updateReweighPreconditionFailed
 */
@@ -331,8 +324,7 @@ func (o *UpdateReweighPreconditionFailed) WriteResponse(rw http.ResponseWriter, 
 // UpdateReweighUnprocessableEntityCode is the HTTP code returned for type UpdateReweighUnprocessableEntity
 const UpdateReweighUnprocessableEntityCode int = 422
 
-/*
-UpdateReweighUnprocessableEntity The request was unprocessable, likely due to bad input from the requester.
+/*UpdateReweighUnprocessableEntity The request was unprocessable, likely due to bad input from the requester.
 
 swagger:response updateReweighUnprocessableEntity
 */
@@ -376,8 +368,7 @@ func (o *UpdateReweighUnprocessableEntity) WriteResponse(rw http.ResponseWriter,
 // UpdateReweighInternalServerErrorCode is the HTTP code returned for type UpdateReweighInternalServerError
 const UpdateReweighInternalServerErrorCode int = 500
 
-/*
-UpdateReweighInternalServerError A server error occurred.
+/*UpdateReweighInternalServerError A server error occurred.
 
 swagger:response updateReweighInternalServerError
 */

--- a/pkg/gen/primeapi/primeoperations/mymove_api.go
+++ b/pkg/gen/primeapi/primeoperations/mymove_api.go
@@ -102,8 +102,7 @@ func NewMymoveAPI(spec *loads.Document) *MymoveAPI {
 	}
 }
 
-/*
-MymoveAPI The Prime API is a RESTful API that enables the Prime contractor to request
+/*MymoveAPI The Prime API is a RESTful API that enables the Prime contractor to request
 information about upcoming moves, update the details and status of those moves,
 and make payment requests. It uses Mutual TLS for authentication procedures.
 

--- a/pkg/gen/primeapi/primeoperations/payment_request/create_payment_request.go
+++ b/pkg/gen/primeapi/primeoperations/payment_request/create_payment_request.go
@@ -29,8 +29,7 @@ func NewCreatePaymentRequest(ctx *middleware.Context, handler CreatePaymentReque
 	return &CreatePaymentRequest{Context: ctx, Handler: handler}
 }
 
-/*
-	CreatePaymentRequest swagger:route POST /payment-requests paymentRequest createPaymentRequest
+/* CreatePaymentRequest swagger:route POST /payment-requests paymentRequest createPaymentRequest
 
 createPaymentRequest
 
@@ -38,6 +37,8 @@ Creates a new instance of a paymentRequest.
 A newly created payment request is assigned the status `PENDING`.
 A move task order can have multiple payment requests, and
 a final payment request can be marked using boolean `isFinal`.
+
+
 */
 type CreatePaymentRequest struct {
 	Context *middleware.Context

--- a/pkg/gen/primeapi/primeoperations/payment_request/create_payment_request_responses.go
+++ b/pkg/gen/primeapi/primeoperations/payment_request/create_payment_request_responses.go
@@ -16,8 +16,7 @@ import (
 // CreatePaymentRequestCreatedCode is the HTTP code returned for type CreatePaymentRequestCreated
 const CreatePaymentRequestCreatedCode int = 201
 
-/*
-CreatePaymentRequestCreated Successfully created a paymentRequest object.
+/*CreatePaymentRequestCreated Successfully created a paymentRequest object.
 
 swagger:response createPaymentRequestCreated
 */
@@ -61,8 +60,7 @@ func (o *CreatePaymentRequestCreated) WriteResponse(rw http.ResponseWriter, prod
 // CreatePaymentRequestBadRequestCode is the HTTP code returned for type CreatePaymentRequestBadRequest
 const CreatePaymentRequestBadRequestCode int = 400
 
-/*
-CreatePaymentRequestBadRequest Request payload is invalid.
+/*CreatePaymentRequestBadRequest Request payload is invalid.
 
 swagger:response createPaymentRequestBadRequest
 */
@@ -106,8 +104,7 @@ func (o *CreatePaymentRequestBadRequest) WriteResponse(rw http.ResponseWriter, p
 // CreatePaymentRequestUnauthorizedCode is the HTTP code returned for type CreatePaymentRequestUnauthorized
 const CreatePaymentRequestUnauthorizedCode int = 401
 
-/*
-CreatePaymentRequestUnauthorized The request was denied.
+/*CreatePaymentRequestUnauthorized The request was denied.
 
 swagger:response createPaymentRequestUnauthorized
 */
@@ -151,8 +148,7 @@ func (o *CreatePaymentRequestUnauthorized) WriteResponse(rw http.ResponseWriter,
 // CreatePaymentRequestForbiddenCode is the HTTP code returned for type CreatePaymentRequestForbidden
 const CreatePaymentRequestForbiddenCode int = 403
 
-/*
-CreatePaymentRequestForbidden The request was denied.
+/*CreatePaymentRequestForbidden The request was denied.
 
 swagger:response createPaymentRequestForbidden
 */
@@ -196,8 +192,7 @@ func (o *CreatePaymentRequestForbidden) WriteResponse(rw http.ResponseWriter, pr
 // CreatePaymentRequestNotFoundCode is the HTTP code returned for type CreatePaymentRequestNotFound
 const CreatePaymentRequestNotFoundCode int = 404
 
-/*
-CreatePaymentRequestNotFound The requested resource wasn't found.
+/*CreatePaymentRequestNotFound The requested resource wasn't found.
 
 swagger:response createPaymentRequestNotFound
 */
@@ -241,8 +236,7 @@ func (o *CreatePaymentRequestNotFound) WriteResponse(rw http.ResponseWriter, pro
 // CreatePaymentRequestConflictCode is the HTTP code returned for type CreatePaymentRequestConflict
 const CreatePaymentRequestConflictCode int = 409
 
-/*
-CreatePaymentRequestConflict The request could not be processed because of conflict in the current state of the resource.
+/*CreatePaymentRequestConflict The request could not be processed because of conflict in the current state of the resource.
 
 swagger:response createPaymentRequestConflict
 */
@@ -286,8 +280,7 @@ func (o *CreatePaymentRequestConflict) WriteResponse(rw http.ResponseWriter, pro
 // CreatePaymentRequestUnprocessableEntityCode is the HTTP code returned for type CreatePaymentRequestUnprocessableEntity
 const CreatePaymentRequestUnprocessableEntityCode int = 422
 
-/*
-CreatePaymentRequestUnprocessableEntity The request was unprocessable, likely due to bad input from the requester.
+/*CreatePaymentRequestUnprocessableEntity The request was unprocessable, likely due to bad input from the requester.
 
 swagger:response createPaymentRequestUnprocessableEntity
 */
@@ -331,8 +324,7 @@ func (o *CreatePaymentRequestUnprocessableEntity) WriteResponse(rw http.Response
 // CreatePaymentRequestInternalServerErrorCode is the HTTP code returned for type CreatePaymentRequestInternalServerError
 const CreatePaymentRequestInternalServerErrorCode int = 500
 
-/*
-CreatePaymentRequestInternalServerError A server error occurred.
+/*CreatePaymentRequestInternalServerError A server error occurred.
 
 swagger:response createPaymentRequestInternalServerError
 */

--- a/pkg/gen/primeapi/primeoperations/payment_request/create_upload.go
+++ b/pkg/gen/primeapi/primeoperations/payment_request/create_upload.go
@@ -29,8 +29,7 @@ func NewCreateUpload(ctx *middleware.Context, handler CreateUploadHandler) *Crea
 	return &CreateUpload{Context: ctx, Handler: handler}
 }
 
-/*
-	CreateUpload swagger:route POST /payment-requests/{paymentRequestID}/uploads paymentRequest createUpload
+/* CreateUpload swagger:route POST /payment-requests/{paymentRequestID}/uploads paymentRequest createUpload
 
 createUpload
 
@@ -40,6 +39,8 @@ This endpoint **uploads** a Proof of Service document for a PaymentRequest.
 The PaymentRequest should already exist.
 
 PaymentRequests are created with the [createPaymentRequest](#operation/createPaymentRequest) endpoint.
+
+
 */
 type CreateUpload struct {
 	Context *middleware.Context

--- a/pkg/gen/primeapi/primeoperations/payment_request/create_upload_responses.go
+++ b/pkg/gen/primeapi/primeoperations/payment_request/create_upload_responses.go
@@ -16,8 +16,7 @@ import (
 // CreateUploadCreatedCode is the HTTP code returned for type CreateUploadCreated
 const CreateUploadCreatedCode int = 201
 
-/*
-CreateUploadCreated Successfully created upload of digital file.
+/*CreateUploadCreated Successfully created upload of digital file.
 
 swagger:response createUploadCreated
 */
@@ -61,8 +60,7 @@ func (o *CreateUploadCreated) WriteResponse(rw http.ResponseWriter, producer run
 // CreateUploadBadRequestCode is the HTTP code returned for type CreateUploadBadRequest
 const CreateUploadBadRequestCode int = 400
 
-/*
-CreateUploadBadRequest The request payload is invalid.
+/*CreateUploadBadRequest The request payload is invalid.
 
 swagger:response createUploadBadRequest
 */
@@ -106,8 +104,7 @@ func (o *CreateUploadBadRequest) WriteResponse(rw http.ResponseWriter, producer 
 // CreateUploadUnauthorizedCode is the HTTP code returned for type CreateUploadUnauthorized
 const CreateUploadUnauthorizedCode int = 401
 
-/*
-CreateUploadUnauthorized The request was denied.
+/*CreateUploadUnauthorized The request was denied.
 
 swagger:response createUploadUnauthorized
 */
@@ -151,8 +148,7 @@ func (o *CreateUploadUnauthorized) WriteResponse(rw http.ResponseWriter, produce
 // CreateUploadForbiddenCode is the HTTP code returned for type CreateUploadForbidden
 const CreateUploadForbiddenCode int = 403
 
-/*
-CreateUploadForbidden The request was denied.
+/*CreateUploadForbidden The request was denied.
 
 swagger:response createUploadForbidden
 */
@@ -196,8 +192,7 @@ func (o *CreateUploadForbidden) WriteResponse(rw http.ResponseWriter, producer r
 // CreateUploadNotFoundCode is the HTTP code returned for type CreateUploadNotFound
 const CreateUploadNotFoundCode int = 404
 
-/*
-CreateUploadNotFound The requested resource wasn't found.
+/*CreateUploadNotFound The requested resource wasn't found.
 
 swagger:response createUploadNotFound
 */
@@ -241,8 +236,7 @@ func (o *CreateUploadNotFound) WriteResponse(rw http.ResponseWriter, producer ru
 // CreateUploadUnprocessableEntityCode is the HTTP code returned for type CreateUploadUnprocessableEntity
 const CreateUploadUnprocessableEntityCode int = 422
 
-/*
-CreateUploadUnprocessableEntity The request was unprocessable, likely due to bad input from the requester.
+/*CreateUploadUnprocessableEntity The request was unprocessable, likely due to bad input from the requester.
 
 swagger:response createUploadUnprocessableEntity
 */
@@ -286,8 +280,7 @@ func (o *CreateUploadUnprocessableEntity) WriteResponse(rw http.ResponseWriter, 
 // CreateUploadInternalServerErrorCode is the HTTP code returned for type CreateUploadInternalServerError
 const CreateUploadInternalServerErrorCode int = 500
 
-/*
-CreateUploadInternalServerError A server error occurred.
+/*CreateUploadInternalServerError A server error occurred.
 
 swagger:response createUploadInternalServerError
 */

--- a/pkg/gen/primeclient/move_task_order/create_excess_weight_record_parameters.go
+++ b/pkg/gen/primeclient/move_task_order/create_excess_weight_record_parameters.go
@@ -52,12 +52,10 @@ func NewCreateExcessWeightRecordParamsWithHTTPClient(client *http.Client) *Creat
 	}
 }
 
-/*
-CreateExcessWeightRecordParams contains all the parameters to send to the API endpoint
+/* CreateExcessWeightRecordParams contains all the parameters to send to the API endpoint
+   for the create excess weight record operation.
 
-	for the create excess weight record operation.
-
-	Typically these are written to a http.Request.
+   Typically these are written to a http.Request.
 */
 type CreateExcessWeightRecordParams struct {
 

--- a/pkg/gen/primeclient/move_task_order/create_excess_weight_record_responses.go
+++ b/pkg/gen/primeclient/move_task_order/create_excess_weight_record_responses.go
@@ -69,8 +69,7 @@ func NewCreateExcessWeightRecordCreated() *CreateExcessWeightRecordCreated {
 	return &CreateExcessWeightRecordCreated{}
 }
 
-/*
-CreateExcessWeightRecordCreated describes a response with status code 201, with default header values.
+/* CreateExcessWeightRecordCreated describes a response with status code 201, with default header values.
 
 Successfully uploaded the excess weight record file.
 */
@@ -132,8 +131,7 @@ func NewCreateExcessWeightRecordUnauthorized() *CreateExcessWeightRecordUnauthor
 	return &CreateExcessWeightRecordUnauthorized{}
 }
 
-/*
-CreateExcessWeightRecordUnauthorized describes a response with status code 401, with default header values.
+/* CreateExcessWeightRecordUnauthorized describes a response with status code 401, with default header values.
 
 The request was denied.
 */
@@ -195,8 +193,7 @@ func NewCreateExcessWeightRecordForbidden() *CreateExcessWeightRecordForbidden {
 	return &CreateExcessWeightRecordForbidden{}
 }
 
-/*
-CreateExcessWeightRecordForbidden describes a response with status code 403, with default header values.
+/* CreateExcessWeightRecordForbidden describes a response with status code 403, with default header values.
 
 The request was denied.
 */
@@ -258,8 +255,7 @@ func NewCreateExcessWeightRecordNotFound() *CreateExcessWeightRecordNotFound {
 	return &CreateExcessWeightRecordNotFound{}
 }
 
-/*
-CreateExcessWeightRecordNotFound describes a response with status code 404, with default header values.
+/* CreateExcessWeightRecordNotFound describes a response with status code 404, with default header values.
 
 The requested resource wasn't found.
 */
@@ -321,8 +317,7 @@ func NewCreateExcessWeightRecordUnprocessableEntity() *CreateExcessWeightRecordU
 	return &CreateExcessWeightRecordUnprocessableEntity{}
 }
 
-/*
-CreateExcessWeightRecordUnprocessableEntity describes a response with status code 422, with default header values.
+/* CreateExcessWeightRecordUnprocessableEntity describes a response with status code 422, with default header values.
 
 The request was unprocessable, likely due to bad input from the requester.
 */
@@ -384,8 +379,7 @@ func NewCreateExcessWeightRecordInternalServerError() *CreateExcessWeightRecordI
 	return &CreateExcessWeightRecordInternalServerError{}
 }
 
-/*
-CreateExcessWeightRecordInternalServerError describes a response with status code 500, with default header values.
+/* CreateExcessWeightRecordInternalServerError describes a response with status code 500, with default header values.
 
 A server error occurred.
 */

--- a/pkg/gen/primeclient/move_task_order/get_move_task_order_parameters.go
+++ b/pkg/gen/primeclient/move_task_order/get_move_task_order_parameters.go
@@ -52,12 +52,10 @@ func NewGetMoveTaskOrderParamsWithHTTPClient(client *http.Client) *GetMoveTaskOr
 	}
 }
 
-/*
-GetMoveTaskOrderParams contains all the parameters to send to the API endpoint
+/* GetMoveTaskOrderParams contains all the parameters to send to the API endpoint
+   for the get move task order operation.
 
-	for the get move task order operation.
-
-	Typically these are written to a http.Request.
+   Typically these are written to a http.Request.
 */
 type GetMoveTaskOrderParams struct {
 

--- a/pkg/gen/primeclient/move_task_order/get_move_task_order_responses.go
+++ b/pkg/gen/primeclient/move_task_order/get_move_task_order_responses.go
@@ -63,8 +63,7 @@ func NewGetMoveTaskOrderOK() *GetMoveTaskOrderOK {
 	return &GetMoveTaskOrderOK{}
 }
 
-/*
-GetMoveTaskOrderOK describes a response with status code 200, with default header values.
+/* GetMoveTaskOrderOK describes a response with status code 200, with default header values.
 
 Successfully retrieve an individual move task order.
 */
@@ -126,8 +125,7 @@ func NewGetMoveTaskOrderUnauthorized() *GetMoveTaskOrderUnauthorized {
 	return &GetMoveTaskOrderUnauthorized{}
 }
 
-/*
-GetMoveTaskOrderUnauthorized describes a response with status code 401, with default header values.
+/* GetMoveTaskOrderUnauthorized describes a response with status code 401, with default header values.
 
 The request was denied.
 */
@@ -189,8 +187,7 @@ func NewGetMoveTaskOrderForbidden() *GetMoveTaskOrderForbidden {
 	return &GetMoveTaskOrderForbidden{}
 }
 
-/*
-GetMoveTaskOrderForbidden describes a response with status code 403, with default header values.
+/* GetMoveTaskOrderForbidden describes a response with status code 403, with default header values.
 
 The request was denied.
 */
@@ -252,8 +249,7 @@ func NewGetMoveTaskOrderNotFound() *GetMoveTaskOrderNotFound {
 	return &GetMoveTaskOrderNotFound{}
 }
 
-/*
-GetMoveTaskOrderNotFound describes a response with status code 404, with default header values.
+/* GetMoveTaskOrderNotFound describes a response with status code 404, with default header values.
 
 The requested resource wasn't found.
 */
@@ -315,8 +311,7 @@ func NewGetMoveTaskOrderInternalServerError() *GetMoveTaskOrderInternalServerErr
 	return &GetMoveTaskOrderInternalServerError{}
 }
 
-/*
-GetMoveTaskOrderInternalServerError describes a response with status code 500, with default header values.
+/* GetMoveTaskOrderInternalServerError describes a response with status code 500, with default header values.
 
 A server error occurred.
 */

--- a/pkg/gen/primeclient/move_task_order/list_moves_parameters.go
+++ b/pkg/gen/primeclient/move_task_order/list_moves_parameters.go
@@ -52,12 +52,10 @@ func NewListMovesParamsWithHTTPClient(client *http.Client) *ListMovesParams {
 	}
 }
 
-/*
-ListMovesParams contains all the parameters to send to the API endpoint
+/* ListMovesParams contains all the parameters to send to the API endpoint
+   for the list moves operation.
 
-	for the list moves operation.
-
-	Typically these are written to a http.Request.
+   Typically these are written to a http.Request.
 */
 type ListMovesParams struct {
 

--- a/pkg/gen/primeclient/move_task_order/list_moves_responses.go
+++ b/pkg/gen/primeclient/move_task_order/list_moves_responses.go
@@ -57,8 +57,7 @@ func NewListMovesOK() *ListMovesOK {
 	return &ListMovesOK{}
 }
 
-/*
-ListMovesOK describes a response with status code 200, with default header values.
+/* ListMovesOK describes a response with status code 200, with default header values.
 
 Successfully retrieved moves. A successful fetch might still return zero moves.
 */
@@ -118,8 +117,7 @@ func NewListMovesUnauthorized() *ListMovesUnauthorized {
 	return &ListMovesUnauthorized{}
 }
 
-/*
-ListMovesUnauthorized describes a response with status code 401, with default header values.
+/* ListMovesUnauthorized describes a response with status code 401, with default header values.
 
 The request was denied.
 */
@@ -181,8 +179,7 @@ func NewListMovesForbidden() *ListMovesForbidden {
 	return &ListMovesForbidden{}
 }
 
-/*
-ListMovesForbidden describes a response with status code 403, with default header values.
+/* ListMovesForbidden describes a response with status code 403, with default header values.
 
 The request was denied.
 */
@@ -244,8 +241,7 @@ func NewListMovesInternalServerError() *ListMovesInternalServerError {
 	return &ListMovesInternalServerError{}
 }
 
-/*
-ListMovesInternalServerError describes a response with status code 500, with default header values.
+/* ListMovesInternalServerError describes a response with status code 500, with default header values.
 
 A server error occurred.
 */

--- a/pkg/gen/primeclient/move_task_order/move_task_order_client.go
+++ b/pkg/gen/primeclient/move_task_order/move_task_order_client.go
@@ -42,9 +42,10 @@ type ClientService interface {
 }
 
 /*
-CreateExcessWeightRecord creates excess weight record
+  CreateExcessWeightRecord creates excess weight record
 
-Uploads an excess weight record, which is a document that proves that the movers or contractors have counseled the customer about their excess weight. Excess weight counseling should occur after the sum of the shipments for the customer's move crosses the excess weight alert threshold.
+  Uploads an excess weight record, which is a document that proves that the movers or contractors have counseled the customer about their excess weight. Excess weight counseling should occur after the sum of the shipments for the customer's move crosses the excess weight alert threshold.
+
 */
 func (a *Client) CreateExcessWeightRecord(params *CreateExcessWeightRecordParams, opts ...ClientOption) (*CreateExcessWeightRecordCreated, error) {
 	// TODO: Validate the params before sending
@@ -82,13 +83,13 @@ func (a *Client) CreateExcessWeightRecord(params *CreateExcessWeightRecordParams
 }
 
 /*
-	GetMoveTaskOrder gets move task order
+  GetMoveTaskOrder gets move task order
 
-	### Functionality
-
+  ### Functionality
 This endpoint gets an individual MoveTaskOrder by ID.
 
 It will provide information about the Customer and any associated MTOShipments, MTOServiceItems and PaymentRequests.
+
 */
 func (a *Client) GetMoveTaskOrder(params *GetMoveTaskOrderParams, opts ...ClientOption) (*GetMoveTaskOrderOK, error) {
 	// TODO: Validate the params before sending
@@ -126,16 +127,16 @@ func (a *Client) GetMoveTaskOrder(params *GetMoveTaskOrderParams, opts ...Client
 }
 
 /*
-	ListMoves lists moves
+  ListMoves lists moves
 
-	Gets all moves that have been reviewed and approved by the TOO. The `since` parameter can be used to filter this
-
+  Gets all moves that have been reviewed and approved by the TOO. The `since` parameter can be used to filter this
 list down to only the moves that have been updated since the provided timestamp. A move will be considered
 updated if the `updatedAt` timestamp on the move or on its orders, shipments, service items, or payment
 requests, is later than the provided date and time.
 
 **WIP**: Include what causes moves to leave this list. Currently, once the `availableToPrimeAt` timestamp has
 been set, that move will always appear in this list.
+
 */
 func (a *Client) ListMoves(params *ListMovesParams, opts ...ClientOption) (*ListMovesOK, error) {
 	// TODO: Validate the params before sending
@@ -173,13 +174,13 @@ func (a *Client) ListMoves(params *ListMovesParams, opts ...ClientOption) (*List
 }
 
 /*
-	UpdateMTOPostCounselingInformation updates m t o post counseling information
+  UpdateMTOPostCounselingInformation updates m t o post counseling information
 
-	### Functionality
-
+  ### Functionality
 This endpoint **updates** the MoveTaskOrder after the Prime has completed Counseling.
 
 PPM related information is updated here. Most other fields will be found on the specific MTOShipment and updated using [updateMTOShipment](#operation/updateMTOShipment).
+
 */
 func (a *Client) UpdateMTOPostCounselingInformation(params *UpdateMTOPostCounselingInformationParams, opts ...ClientOption) (*UpdateMTOPostCounselingInformationOK, error) {
 	// TODO: Validate the params before sending

--- a/pkg/gen/primeclient/move_task_order/update_m_t_o_post_counseling_information_parameters.go
+++ b/pkg/gen/primeclient/move_task_order/update_m_t_o_post_counseling_information_parameters.go
@@ -52,12 +52,10 @@ func NewUpdateMTOPostCounselingInformationParamsWithHTTPClient(client *http.Clie
 	}
 }
 
-/*
-UpdateMTOPostCounselingInformationParams contains all the parameters to send to the API endpoint
+/* UpdateMTOPostCounselingInformationParams contains all the parameters to send to the API endpoint
+   for the update m t o post counseling information operation.
 
-	for the update m t o post counseling information operation.
-
-	Typically these are written to a http.Request.
+   Typically these are written to a http.Request.
 */
 type UpdateMTOPostCounselingInformationParams struct {
 

--- a/pkg/gen/primeclient/move_task_order/update_m_t_o_post_counseling_information_responses.go
+++ b/pkg/gen/primeclient/move_task_order/update_m_t_o_post_counseling_information_responses.go
@@ -81,8 +81,7 @@ func NewUpdateMTOPostCounselingInformationOK() *UpdateMTOPostCounselingInformati
 	return &UpdateMTOPostCounselingInformationOK{}
 }
 
-/*
-UpdateMTOPostCounselingInformationOK describes a response with status code 200, with default header values.
+/* UpdateMTOPostCounselingInformationOK describes a response with status code 200, with default header values.
 
 Successfully updated move task order with post counseling information.
 */
@@ -144,8 +143,7 @@ func NewUpdateMTOPostCounselingInformationUnauthorized() *UpdateMTOPostCounselin
 	return &UpdateMTOPostCounselingInformationUnauthorized{}
 }
 
-/*
-UpdateMTOPostCounselingInformationUnauthorized describes a response with status code 401, with default header values.
+/* UpdateMTOPostCounselingInformationUnauthorized describes a response with status code 401, with default header values.
 
 The request was denied.
 */
@@ -207,8 +205,7 @@ func NewUpdateMTOPostCounselingInformationForbidden() *UpdateMTOPostCounselingIn
 	return &UpdateMTOPostCounselingInformationForbidden{}
 }
 
-/*
-UpdateMTOPostCounselingInformationForbidden describes a response with status code 403, with default header values.
+/* UpdateMTOPostCounselingInformationForbidden describes a response with status code 403, with default header values.
 
 The request was denied.
 */
@@ -270,8 +267,7 @@ func NewUpdateMTOPostCounselingInformationNotFound() *UpdateMTOPostCounselingInf
 	return &UpdateMTOPostCounselingInformationNotFound{}
 }
 
-/*
-UpdateMTOPostCounselingInformationNotFound describes a response with status code 404, with default header values.
+/* UpdateMTOPostCounselingInformationNotFound describes a response with status code 404, with default header values.
 
 The requested resource wasn't found.
 */
@@ -333,8 +329,7 @@ func NewUpdateMTOPostCounselingInformationConflict() *UpdateMTOPostCounselingInf
 	return &UpdateMTOPostCounselingInformationConflict{}
 }
 
-/*
-UpdateMTOPostCounselingInformationConflict describes a response with status code 409, with default header values.
+/* UpdateMTOPostCounselingInformationConflict describes a response with status code 409, with default header values.
 
 The request could not be processed because of conflict in the current state of the resource.
 */
@@ -396,8 +391,7 @@ func NewUpdateMTOPostCounselingInformationPreconditionFailed() *UpdateMTOPostCou
 	return &UpdateMTOPostCounselingInformationPreconditionFailed{}
 }
 
-/*
-UpdateMTOPostCounselingInformationPreconditionFailed describes a response with status code 412, with default header values.
+/* UpdateMTOPostCounselingInformationPreconditionFailed describes a response with status code 412, with default header values.
 
 Precondition failed, likely due to a stale eTag (If-Match). Fetch the request again to get the updated eTag value.
 */
@@ -459,8 +453,7 @@ func NewUpdateMTOPostCounselingInformationUnprocessableEntity() *UpdateMTOPostCo
 	return &UpdateMTOPostCounselingInformationUnprocessableEntity{}
 }
 
-/*
-UpdateMTOPostCounselingInformationUnprocessableEntity describes a response with status code 422, with default header values.
+/* UpdateMTOPostCounselingInformationUnprocessableEntity describes a response with status code 422, with default header values.
 
 The request was unprocessable, likely due to bad input from the requester.
 */
@@ -522,8 +515,7 @@ func NewUpdateMTOPostCounselingInformationInternalServerError() *UpdateMTOPostCo
 	return &UpdateMTOPostCounselingInformationInternalServerError{}
 }
 
-/*
-UpdateMTOPostCounselingInformationInternalServerError describes a response with status code 500, with default header values.
+/* UpdateMTOPostCounselingInformationInternalServerError describes a response with status code 500, with default header values.
 
 A server error occurred.
 */

--- a/pkg/gen/primeclient/mto_service_item/create_m_t_o_service_item_parameters.go
+++ b/pkg/gen/primeclient/mto_service_item/create_m_t_o_service_item_parameters.go
@@ -54,12 +54,10 @@ func NewCreateMTOServiceItemParamsWithHTTPClient(client *http.Client) *CreateMTO
 	}
 }
 
-/*
-CreateMTOServiceItemParams contains all the parameters to send to the API endpoint
+/* CreateMTOServiceItemParams contains all the parameters to send to the API endpoint
+   for the create m t o service item operation.
 
-	for the create m t o service item operation.
-
-	Typically these are written to a http.Request.
+   Typically these are written to a http.Request.
 */
 type CreateMTOServiceItemParams struct {
 

--- a/pkg/gen/primeclient/mto_service_item/create_m_t_o_service_item_responses.go
+++ b/pkg/gen/primeclient/mto_service_item/create_m_t_o_service_item_responses.go
@@ -81,8 +81,7 @@ func NewCreateMTOServiceItemOK() *CreateMTOServiceItemOK {
 	return &CreateMTOServiceItemOK{}
 }
 
-/*
-CreateMTOServiceItemOK describes a response with status code 200, with default header values.
+/* CreateMTOServiceItemOK describes a response with status code 200, with default header values.
 
 Successfully created an MTO service item.
 */
@@ -144,8 +143,7 @@ func NewCreateMTOServiceItemBadRequest() *CreateMTOServiceItemBadRequest {
 	return &CreateMTOServiceItemBadRequest{}
 }
 
-/*
-CreateMTOServiceItemBadRequest describes a response with status code 400, with default header values.
+/* CreateMTOServiceItemBadRequest describes a response with status code 400, with default header values.
 
 The request payload is invalid.
 */
@@ -207,8 +205,7 @@ func NewCreateMTOServiceItemUnauthorized() *CreateMTOServiceItemUnauthorized {
 	return &CreateMTOServiceItemUnauthorized{}
 }
 
-/*
-CreateMTOServiceItemUnauthorized describes a response with status code 401, with default header values.
+/* CreateMTOServiceItemUnauthorized describes a response with status code 401, with default header values.
 
 The request was denied.
 */
@@ -270,8 +267,7 @@ func NewCreateMTOServiceItemForbidden() *CreateMTOServiceItemForbidden {
 	return &CreateMTOServiceItemForbidden{}
 }
 
-/*
-CreateMTOServiceItemForbidden describes a response with status code 403, with default header values.
+/* CreateMTOServiceItemForbidden describes a response with status code 403, with default header values.
 
 The request was denied.
 */
@@ -333,8 +329,7 @@ func NewCreateMTOServiceItemNotFound() *CreateMTOServiceItemNotFound {
 	return &CreateMTOServiceItemNotFound{}
 }
 
-/*
-CreateMTOServiceItemNotFound describes a response with status code 404, with default header values.
+/* CreateMTOServiceItemNotFound describes a response with status code 404, with default header values.
 
 The requested resource wasn't found.
 */
@@ -396,8 +391,7 @@ func NewCreateMTOServiceItemConflict() *CreateMTOServiceItemConflict {
 	return &CreateMTOServiceItemConflict{}
 }
 
-/*
-CreateMTOServiceItemConflict describes a response with status code 409, with default header values.
+/* CreateMTOServiceItemConflict describes a response with status code 409, with default header values.
 
 The request could not be processed because of conflict in the current state of the resource.
 */
@@ -459,8 +453,7 @@ func NewCreateMTOServiceItemUnprocessableEntity() *CreateMTOServiceItemUnprocess
 	return &CreateMTOServiceItemUnprocessableEntity{}
 }
 
-/*
-CreateMTOServiceItemUnprocessableEntity describes a response with status code 422, with default header values.
+/* CreateMTOServiceItemUnprocessableEntity describes a response with status code 422, with default header values.
 
 The request was unprocessable, likely due to bad input from the requester.
 */
@@ -522,8 +515,7 @@ func NewCreateMTOServiceItemInternalServerError() *CreateMTOServiceItemInternalS
 	return &CreateMTOServiceItemInternalServerError{}
 }
 
-/*
-CreateMTOServiceItemInternalServerError describes a response with status code 500, with default header values.
+/* CreateMTOServiceItemInternalServerError describes a response with status code 500, with default header values.
 
 A server error occurred.
 */

--- a/pkg/gen/primeclient/mto_service_item/mto_service_item_client.go
+++ b/pkg/gen/primeclient/mto_service_item/mto_service_item_client.go
@@ -38,13 +38,12 @@ type ClientService interface {
 }
 
 /*
-	CreateMTOServiceItem creates m t o service item
+  CreateMTOServiceItem creates m t o service item
 
-	Creates one or more MTOServiceItems. Not all service items may be created, please see details below.
+  Creates one or more MTOServiceItems. Not all service items may be created, please see details below.
 
 This endpoint supports different body definitions. In the modelType field below, select the modelType corresponding
-
-	to the service item you wish to create and the documentation will update with the new definition.
+ to the service item you wish to create and the documentation will update with the new definition.
 
 Upon creation these items are associated with a Move Task Order and an MTO Shipment.
 The request must include UUIDs for the MTO and MTO Shipment connected to this service item. Some service item types require
@@ -65,9 +64,9 @@ model type with the following codes:
 **DOFSIT**
 
 **1st day origin SIT service item**. When a DOFSIT is requested, the API will auto-create the following group of service items:
-  - DOFSIT - Domestic origin 1st day SIT
-  - DOASIT - Domestic origin Additional day SIT
-  - DOPSIT - Domestic origin SIT pickup
+  * DOFSIT - Domestic origin 1st day SIT
+  * DOASIT - Domestic origin Additional day SIT
+  * DOPSIT - Domestic origin SIT pickup
 
 **DOASIT**
 
@@ -86,28 +85,29 @@ model type with the following codes:
 **DDFSIT**
 
 **1st day origin SIT service item**. The additional fields are required for creating a DDFSIT:
-  - `firstAvailableDeliveryDate1`
-  - string <date>
-  - First available date that Prime can deliver SIT service item.
-  - `firstAvailableDeliveryDate2`
-  - string <date>
-  - Second available date that Prime can deliver SIT service item.
-  - `timeMilitary1`
-  - string\d{4}Z
-  - Time of delivery corresponding to `firstAvailableDeliveryDate1`, in military format.
-  - `timeMilitary2`
-  - string\d{4}Z
-  - Time of delivery corresponding to `firstAvailableDeliveryDate2`, in military format.
+  * `firstAvailableDeliveryDate1`
+    * string <date>
+    * First available date that Prime can deliver SIT service item.
+  * `firstAvailableDeliveryDate2`
+    * string <date>
+    * Second available date that Prime can deliver SIT service item.
+  * `timeMilitary1`
+    * string\d{4}Z
+    * Time of delivery corresponding to `firstAvailableDeliveryDate1`, in military format.
+  * `timeMilitary2`
+    * string\d{4}Z
+    * Time of delivery corresponding to `firstAvailableDeliveryDate2`, in military format.
 
 When a DDFSIT is requested, the API will auto-create the following group of service items:
-  - DDFSIT - Domestic destination 1st day SIT
-  - DDASIT - Domestic destination Additional day SIT
-  - DDDSIT - Domestic destination SIT delivery
+  * DDFSIT - Domestic destination 1st day SIT
+  * DDASIT - Domestic destination Additional day SIT
+  * DDDSIT - Domestic destination SIT delivery
 
 **DDASIT**
 
 **Addt'l days destination SIT service item**. This represents an additional day of storage for the same item.
 Additional DDASIT service items can be created and added to an existing shipment that **includes a DDFSIT service item**.
+
 */
 func (a *Client) CreateMTOServiceItem(params *CreateMTOServiceItemParams, opts ...ClientOption) (*CreateMTOServiceItemOK, error) {
 	// TODO: Validate the params before sending
@@ -145,19 +145,19 @@ func (a *Client) CreateMTOServiceItem(params *CreateMTOServiceItemParams, opts .
 }
 
 /*
-	UpdateMTOServiceItem updates m t o service item
+  UpdateMTOServiceItem updates m t o service item
 
-	Updates MTOServiceItems after creation. Not all service items or fields may be updated, please see details below.
+  Updates MTOServiceItems after creation. Not all service items or fields may be updated, please see details below.
 
 This endpoint supports different body definitions. In the modelType field below, select the modelType corresponding
-
-	to the service item you wish to update and the documentation will update with the new definition.
+ to the service item you wish to update and the documentation will update with the new definition.
 
 To create a service item, please use [createMTOServiceItem](#operation/createMTOServiceItem)) endpoint.
 
 ### Errors
 
 Currently this is not implemented and will generated the NotImplemented error.
+
 */
 func (a *Client) UpdateMTOServiceItem(params *UpdateMTOServiceItemParams, opts ...ClientOption) (*UpdateMTOServiceItemOK, error) {
 	// TODO: Validate the params before sending

--- a/pkg/gen/primeclient/mto_service_item/update_m_t_o_service_item_parameters.go
+++ b/pkg/gen/primeclient/mto_service_item/update_m_t_o_service_item_parameters.go
@@ -54,12 +54,10 @@ func NewUpdateMTOServiceItemParamsWithHTTPClient(client *http.Client) *UpdateMTO
 	}
 }
 
-/*
-UpdateMTOServiceItemParams contains all the parameters to send to the API endpoint
+/* UpdateMTOServiceItemParams contains all the parameters to send to the API endpoint
+   for the update m t o service item operation.
 
-	for the update m t o service item operation.
-
-	Typically these are written to a http.Request.
+   Typically these are written to a http.Request.
 */
 type UpdateMTOServiceItemParams struct {
 

--- a/pkg/gen/primeclient/mto_service_item/update_m_t_o_service_item_responses.go
+++ b/pkg/gen/primeclient/mto_service_item/update_m_t_o_service_item_responses.go
@@ -87,8 +87,7 @@ func NewUpdateMTOServiceItemOK() *UpdateMTOServiceItemOK {
 	return &UpdateMTOServiceItemOK{}
 }
 
-/*
-UpdateMTOServiceItemOK describes a response with status code 200, with default header values.
+/* UpdateMTOServiceItemOK describes a response with status code 200, with default header values.
 
 Successfully updated the MTO service item.
 */
@@ -150,8 +149,7 @@ func NewUpdateMTOServiceItemBadRequest() *UpdateMTOServiceItemBadRequest {
 	return &UpdateMTOServiceItemBadRequest{}
 }
 
-/*
-UpdateMTOServiceItemBadRequest describes a response with status code 400, with default header values.
+/* UpdateMTOServiceItemBadRequest describes a response with status code 400, with default header values.
 
 The request payload is invalid.
 */
@@ -213,8 +211,7 @@ func NewUpdateMTOServiceItemUnauthorized() *UpdateMTOServiceItemUnauthorized {
 	return &UpdateMTOServiceItemUnauthorized{}
 }
 
-/*
-UpdateMTOServiceItemUnauthorized describes a response with status code 401, with default header values.
+/* UpdateMTOServiceItemUnauthorized describes a response with status code 401, with default header values.
 
 The request was denied.
 */
@@ -276,8 +273,7 @@ func NewUpdateMTOServiceItemForbidden() *UpdateMTOServiceItemForbidden {
 	return &UpdateMTOServiceItemForbidden{}
 }
 
-/*
-UpdateMTOServiceItemForbidden describes a response with status code 403, with default header values.
+/* UpdateMTOServiceItemForbidden describes a response with status code 403, with default header values.
 
 The request was denied.
 */
@@ -339,8 +335,7 @@ func NewUpdateMTOServiceItemNotFound() *UpdateMTOServiceItemNotFound {
 	return &UpdateMTOServiceItemNotFound{}
 }
 
-/*
-UpdateMTOServiceItemNotFound describes a response with status code 404, with default header values.
+/* UpdateMTOServiceItemNotFound describes a response with status code 404, with default header values.
 
 The requested resource wasn't found.
 */
@@ -402,8 +397,7 @@ func NewUpdateMTOServiceItemConflict() *UpdateMTOServiceItemConflict {
 	return &UpdateMTOServiceItemConflict{}
 }
 
-/*
-UpdateMTOServiceItemConflict describes a response with status code 409, with default header values.
+/* UpdateMTOServiceItemConflict describes a response with status code 409, with default header values.
 
 The request could not be processed because of conflict in the current state of the resource.
 */
@@ -465,8 +459,7 @@ func NewUpdateMTOServiceItemPreconditionFailed() *UpdateMTOServiceItemPreconditi
 	return &UpdateMTOServiceItemPreconditionFailed{}
 }
 
-/*
-UpdateMTOServiceItemPreconditionFailed describes a response with status code 412, with default header values.
+/* UpdateMTOServiceItemPreconditionFailed describes a response with status code 412, with default header values.
 
 Precondition failed, likely due to a stale eTag (If-Match). Fetch the request again to get the updated eTag value.
 */
@@ -528,8 +521,7 @@ func NewUpdateMTOServiceItemUnprocessableEntity() *UpdateMTOServiceItemUnprocess
 	return &UpdateMTOServiceItemUnprocessableEntity{}
 }
 
-/*
-UpdateMTOServiceItemUnprocessableEntity describes a response with status code 422, with default header values.
+/* UpdateMTOServiceItemUnprocessableEntity describes a response with status code 422, with default header values.
 
 The request was unprocessable, likely due to bad input from the requester.
 */
@@ -591,8 +583,7 @@ func NewUpdateMTOServiceItemInternalServerError() *UpdateMTOServiceItemInternalS
 	return &UpdateMTOServiceItemInternalServerError{}
 }
 
-/*
-UpdateMTOServiceItemInternalServerError describes a response with status code 500, with default header values.
+/* UpdateMTOServiceItemInternalServerError describes a response with status code 500, with default header values.
 
 A server error occurred.
 */

--- a/pkg/gen/primeclient/mto_shipment/create_m_t_o_agent_parameters.go
+++ b/pkg/gen/primeclient/mto_shipment/create_m_t_o_agent_parameters.go
@@ -54,12 +54,10 @@ func NewCreateMTOAgentParamsWithHTTPClient(client *http.Client) *CreateMTOAgentP
 	}
 }
 
-/*
-CreateMTOAgentParams contains all the parameters to send to the API endpoint
+/* CreateMTOAgentParams contains all the parameters to send to the API endpoint
+   for the create m t o agent operation.
 
-	for the create m t o agent operation.
-
-	Typically these are written to a http.Request.
+   Typically these are written to a http.Request.
 */
 type CreateMTOAgentParams struct {
 

--- a/pkg/gen/primeclient/mto_shipment/create_m_t_o_agent_responses.go
+++ b/pkg/gen/primeclient/mto_shipment/create_m_t_o_agent_responses.go
@@ -81,8 +81,7 @@ func NewCreateMTOAgentOK() *CreateMTOAgentOK {
 	return &CreateMTOAgentOK{}
 }
 
-/*
-CreateMTOAgentOK describes a response with status code 200, with default header values.
+/* CreateMTOAgentOK describes a response with status code 200, with default header values.
 
 Successfully added the agent.
 */
@@ -144,8 +143,7 @@ func NewCreateMTOAgentBadRequest() *CreateMTOAgentBadRequest {
 	return &CreateMTOAgentBadRequest{}
 }
 
-/*
-CreateMTOAgentBadRequest describes a response with status code 400, with default header values.
+/* CreateMTOAgentBadRequest describes a response with status code 400, with default header values.
 
 The request payload is invalid.
 */
@@ -207,8 +205,7 @@ func NewCreateMTOAgentUnauthorized() *CreateMTOAgentUnauthorized {
 	return &CreateMTOAgentUnauthorized{}
 }
 
-/*
-CreateMTOAgentUnauthorized describes a response with status code 401, with default header values.
+/* CreateMTOAgentUnauthorized describes a response with status code 401, with default header values.
 
 The request was denied.
 */
@@ -270,8 +267,7 @@ func NewCreateMTOAgentForbidden() *CreateMTOAgentForbidden {
 	return &CreateMTOAgentForbidden{}
 }
 
-/*
-CreateMTOAgentForbidden describes a response with status code 403, with default header values.
+/* CreateMTOAgentForbidden describes a response with status code 403, with default header values.
 
 The request was denied.
 */
@@ -333,8 +329,7 @@ func NewCreateMTOAgentNotFound() *CreateMTOAgentNotFound {
 	return &CreateMTOAgentNotFound{}
 }
 
-/*
-CreateMTOAgentNotFound describes a response with status code 404, with default header values.
+/* CreateMTOAgentNotFound describes a response with status code 404, with default header values.
 
 The requested resource wasn't found.
 */
@@ -396,8 +391,7 @@ func NewCreateMTOAgentConflict() *CreateMTOAgentConflict {
 	return &CreateMTOAgentConflict{}
 }
 
-/*
-CreateMTOAgentConflict describes a response with status code 409, with default header values.
+/* CreateMTOAgentConflict describes a response with status code 409, with default header values.
 
 The request could not be processed because of conflict in the current state of the resource.
 */
@@ -459,8 +453,7 @@ func NewCreateMTOAgentUnprocessableEntity() *CreateMTOAgentUnprocessableEntity {
 	return &CreateMTOAgentUnprocessableEntity{}
 }
 
-/*
-CreateMTOAgentUnprocessableEntity describes a response with status code 422, with default header values.
+/* CreateMTOAgentUnprocessableEntity describes a response with status code 422, with default header values.
 
 The request was unprocessable, likely due to bad input from the requester.
 */
@@ -522,8 +515,7 @@ func NewCreateMTOAgentInternalServerError() *CreateMTOAgentInternalServerError {
 	return &CreateMTOAgentInternalServerError{}
 }
 
-/*
-CreateMTOAgentInternalServerError describes a response with status code 500, with default header values.
+/* CreateMTOAgentInternalServerError describes a response with status code 500, with default header values.
 
 A server error occurred.
 */

--- a/pkg/gen/primeclient/mto_shipment/create_m_t_o_shipment_parameters.go
+++ b/pkg/gen/primeclient/mto_shipment/create_m_t_o_shipment_parameters.go
@@ -54,12 +54,10 @@ func NewCreateMTOShipmentParamsWithHTTPClient(client *http.Client) *CreateMTOShi
 	}
 }
 
-/*
-CreateMTOShipmentParams contains all the parameters to send to the API endpoint
+/* CreateMTOShipmentParams contains all the parameters to send to the API endpoint
+   for the create m t o shipment operation.
 
-	for the create m t o shipment operation.
-
-	Typically these are written to a http.Request.
+   Typically these are written to a http.Request.
 */
 type CreateMTOShipmentParams struct {
 

--- a/pkg/gen/primeclient/mto_shipment/create_m_t_o_shipment_responses.go
+++ b/pkg/gen/primeclient/mto_shipment/create_m_t_o_shipment_responses.go
@@ -63,8 +63,7 @@ func NewCreateMTOShipmentOK() *CreateMTOShipmentOK {
 	return &CreateMTOShipmentOK{}
 }
 
-/*
-CreateMTOShipmentOK describes a response with status code 200, with default header values.
+/* CreateMTOShipmentOK describes a response with status code 200, with default header values.
 
 Successfully created a MTO shipment.
 */
@@ -126,8 +125,7 @@ func NewCreateMTOShipmentBadRequest() *CreateMTOShipmentBadRequest {
 	return &CreateMTOShipmentBadRequest{}
 }
 
-/*
-CreateMTOShipmentBadRequest describes a response with status code 400, with default header values.
+/* CreateMTOShipmentBadRequest describes a response with status code 400, with default header values.
 
 The request payload is invalid.
 */
@@ -189,8 +187,7 @@ func NewCreateMTOShipmentNotFound() *CreateMTOShipmentNotFound {
 	return &CreateMTOShipmentNotFound{}
 }
 
-/*
-CreateMTOShipmentNotFound describes a response with status code 404, with default header values.
+/* CreateMTOShipmentNotFound describes a response with status code 404, with default header values.
 
 The requested resource wasn't found.
 */
@@ -252,8 +249,7 @@ func NewCreateMTOShipmentUnprocessableEntity() *CreateMTOShipmentUnprocessableEn
 	return &CreateMTOShipmentUnprocessableEntity{}
 }
 
-/*
-CreateMTOShipmentUnprocessableEntity describes a response with status code 422, with default header values.
+/* CreateMTOShipmentUnprocessableEntity describes a response with status code 422, with default header values.
 
 The request was unprocessable, likely due to bad input from the requester.
 */
@@ -315,8 +311,7 @@ func NewCreateMTOShipmentInternalServerError() *CreateMTOShipmentInternalServerE
 	return &CreateMTOShipmentInternalServerError{}
 }
 
-/*
-CreateMTOShipmentInternalServerError describes a response with status code 500, with default header values.
+/* CreateMTOShipmentInternalServerError describes a response with status code 500, with default header values.
 
 A server error occurred.
 */

--- a/pkg/gen/primeclient/mto_shipment/create_s_i_t_extension_parameters.go
+++ b/pkg/gen/primeclient/mto_shipment/create_s_i_t_extension_parameters.go
@@ -54,12 +54,10 @@ func NewCreateSITExtensionParamsWithHTTPClient(client *http.Client) *CreateSITEx
 	}
 }
 
-/*
-CreateSITExtensionParams contains all the parameters to send to the API endpoint
+/* CreateSITExtensionParams contains all the parameters to send to the API endpoint
+   for the create s i t extension operation.
 
-	for the create s i t extension operation.
-
-	Typically these are written to a http.Request.
+   Typically these are written to a http.Request.
 */
 type CreateSITExtensionParams struct {
 

--- a/pkg/gen/primeclient/mto_shipment/create_s_i_t_extension_responses.go
+++ b/pkg/gen/primeclient/mto_shipment/create_s_i_t_extension_responses.go
@@ -81,8 +81,7 @@ func NewCreateSITExtensionCreated() *CreateSITExtensionCreated {
 	return &CreateSITExtensionCreated{}
 }
 
-/*
-CreateSITExtensionCreated describes a response with status code 201, with default header values.
+/* CreateSITExtensionCreated describes a response with status code 201, with default header values.
 
 Successfully created the sit extension request.
 */
@@ -144,8 +143,7 @@ func NewCreateSITExtensionBadRequest() *CreateSITExtensionBadRequest {
 	return &CreateSITExtensionBadRequest{}
 }
 
-/*
-CreateSITExtensionBadRequest describes a response with status code 400, with default header values.
+/* CreateSITExtensionBadRequest describes a response with status code 400, with default header values.
 
 The request payload is invalid.
 */
@@ -207,8 +205,7 @@ func NewCreateSITExtensionUnauthorized() *CreateSITExtensionUnauthorized {
 	return &CreateSITExtensionUnauthorized{}
 }
 
-/*
-CreateSITExtensionUnauthorized describes a response with status code 401, with default header values.
+/* CreateSITExtensionUnauthorized describes a response with status code 401, with default header values.
 
 The request was denied.
 */
@@ -270,8 +267,7 @@ func NewCreateSITExtensionForbidden() *CreateSITExtensionForbidden {
 	return &CreateSITExtensionForbidden{}
 }
 
-/*
-CreateSITExtensionForbidden describes a response with status code 403, with default header values.
+/* CreateSITExtensionForbidden describes a response with status code 403, with default header values.
 
 The request was denied.
 */
@@ -333,8 +329,7 @@ func NewCreateSITExtensionNotFound() *CreateSITExtensionNotFound {
 	return &CreateSITExtensionNotFound{}
 }
 
-/*
-CreateSITExtensionNotFound describes a response with status code 404, with default header values.
+/* CreateSITExtensionNotFound describes a response with status code 404, with default header values.
 
 The requested resource wasn't found.
 */
@@ -396,8 +391,7 @@ func NewCreateSITExtensionConflict() *CreateSITExtensionConflict {
 	return &CreateSITExtensionConflict{}
 }
 
-/*
-CreateSITExtensionConflict describes a response with status code 409, with default header values.
+/* CreateSITExtensionConflict describes a response with status code 409, with default header values.
 
 The request could not be processed because of conflict in the current state of the resource.
 */
@@ -459,8 +453,7 @@ func NewCreateSITExtensionUnprocessableEntity() *CreateSITExtensionUnprocessable
 	return &CreateSITExtensionUnprocessableEntity{}
 }
 
-/*
-CreateSITExtensionUnprocessableEntity describes a response with status code 422, with default header values.
+/* CreateSITExtensionUnprocessableEntity describes a response with status code 422, with default header values.
 
 The request was unprocessable, likely due to bad input from the requester.
 */
@@ -522,8 +515,7 @@ func NewCreateSITExtensionInternalServerError() *CreateSITExtensionInternalServe
 	return &CreateSITExtensionInternalServerError{}
 }
 
-/*
-CreateSITExtensionInternalServerError describes a response with status code 500, with default header values.
+/* CreateSITExtensionInternalServerError describes a response with status code 500, with default header values.
 
 A server error occurred.
 */

--- a/pkg/gen/primeclient/mto_shipment/delete_m_t_o_shipment_parameters.go
+++ b/pkg/gen/primeclient/mto_shipment/delete_m_t_o_shipment_parameters.go
@@ -52,12 +52,10 @@ func NewDeleteMTOShipmentParamsWithHTTPClient(client *http.Client) *DeleteMTOShi
 	}
 }
 
-/*
-DeleteMTOShipmentParams contains all the parameters to send to the API endpoint
+/* DeleteMTOShipmentParams contains all the parameters to send to the API endpoint
+   for the delete m t o shipment operation.
 
-	for the delete m t o shipment operation.
-
-	Typically these are written to a http.Request.
+   Typically these are written to a http.Request.
 */
 type DeleteMTOShipmentParams struct {
 

--- a/pkg/gen/primeclient/mto_shipment/delete_m_t_o_shipment_responses.go
+++ b/pkg/gen/primeclient/mto_shipment/delete_m_t_o_shipment_responses.go
@@ -75,8 +75,7 @@ func NewDeleteMTOShipmentNoContent() *DeleteMTOShipmentNoContent {
 	return &DeleteMTOShipmentNoContent{}
 }
 
-/*
-DeleteMTOShipmentNoContent describes a response with status code 204, with default header values.
+/* DeleteMTOShipmentNoContent describes a response with status code 204, with default header values.
 
 Successfully deleted the MTO shipment.
 */
@@ -126,8 +125,7 @@ func NewDeleteMTOShipmentBadRequest() *DeleteMTOShipmentBadRequest {
 	return &DeleteMTOShipmentBadRequest{}
 }
 
-/*
-DeleteMTOShipmentBadRequest describes a response with status code 400, with default header values.
+/* DeleteMTOShipmentBadRequest describes a response with status code 400, with default header values.
 
 The request payload is invalid.
 */
@@ -189,8 +187,7 @@ func NewDeleteMTOShipmentForbidden() *DeleteMTOShipmentForbidden {
 	return &DeleteMTOShipmentForbidden{}
 }
 
-/*
-DeleteMTOShipmentForbidden describes a response with status code 403, with default header values.
+/* DeleteMTOShipmentForbidden describes a response with status code 403, with default header values.
 
 The request was denied.
 */
@@ -252,8 +249,7 @@ func NewDeleteMTOShipmentNotFound() *DeleteMTOShipmentNotFound {
 	return &DeleteMTOShipmentNotFound{}
 }
 
-/*
-DeleteMTOShipmentNotFound describes a response with status code 404, with default header values.
+/* DeleteMTOShipmentNotFound describes a response with status code 404, with default header values.
 
 The requested resource wasn't found.
 */
@@ -315,8 +311,7 @@ func NewDeleteMTOShipmentConflict() *DeleteMTOShipmentConflict {
 	return &DeleteMTOShipmentConflict{}
 }
 
-/*
-DeleteMTOShipmentConflict describes a response with status code 409, with default header values.
+/* DeleteMTOShipmentConflict describes a response with status code 409, with default header values.
 
 The request could not be processed because of conflict in the current state of the resource.
 */
@@ -378,8 +373,7 @@ func NewDeleteMTOShipmentUnprocessableEntity() *DeleteMTOShipmentUnprocessableEn
 	return &DeleteMTOShipmentUnprocessableEntity{}
 }
 
-/*
-DeleteMTOShipmentUnprocessableEntity describes a response with status code 422, with default header values.
+/* DeleteMTOShipmentUnprocessableEntity describes a response with status code 422, with default header values.
 
 The request was unprocessable, likely due to bad input from the requester.
 */
@@ -441,8 +435,7 @@ func NewDeleteMTOShipmentInternalServerError() *DeleteMTOShipmentInternalServerE
 	return &DeleteMTOShipmentInternalServerError{}
 }
 
-/*
-DeleteMTOShipmentInternalServerError describes a response with status code 500, with default header values.
+/* DeleteMTOShipmentInternalServerError describes a response with status code 500, with default header values.
 
 A server error occurred.
 */

--- a/pkg/gen/primeclient/mto_shipment/mto_shipment_client.go
+++ b/pkg/gen/primeclient/mto_shipment/mto_shipment_client.go
@@ -52,10 +52,9 @@ type ClientService interface {
 }
 
 /*
-	CreateMTOAgent creates m t o agent
+  CreateMTOAgent creates m t o agent
 
-	### Functionality
-
+  ### Functionality
 This endpoint is used to **create** and add agents for an existing MTO Shipment. Only the fields being modified need to be sent in the request body.
 
 ### Errors
@@ -65,6 +64,7 @@ The agent must be associated with the MTO shipment passed in the url.
 
 The shipment should be associated with an MTO that is available to the Pime.
 If the caller requests a new agent, and the shipment is not on an available MTO, the caller will receive a **NotFound** response.
+
 */
 func (a *Client) CreateMTOAgent(params *CreateMTOAgentParams, opts ...ClientOption) (*CreateMTOAgentOK, error) {
 	// TODO: Validate the params before sending
@@ -102,16 +102,16 @@ func (a *Client) CreateMTOAgent(params *CreateMTOAgentParams, opts ...ClientOpti
 }
 
 /*
-	CreateMTOShipment creates m t o shipment
+  CreateMTOShipment creates m t o shipment
 
-	Creates a new shipment within the specified move. This endpoint should be used whenever the movers identify a
-
+  Creates a new shipment within the specified move. This endpoint should be used whenever the movers identify a
 need for an additional shipment. The new shipment will be submitted to the TOO for review, and the TOO must
 approve it before the contractor can proceed with billing.
 
 **WIP**: The Prime should be notified by a push notification whenever the TOO approves a shipment connected to
 one of their moves. Otherwise, the Prime can fetch the related move using the
 [getMoveTaskOrder](#operation/getMoveTaskOrder) endpoint and see if this shipment has the status `"APPROVED"`.
+
 */
 func (a *Client) CreateMTOShipment(params *CreateMTOShipmentParams, opts ...ClientOption) (*CreateMTOShipmentOK, error) {
 	// TODO: Validate the params before sending
@@ -149,13 +149,13 @@ func (a *Client) CreateMTOShipment(params *CreateMTOShipmentParams, opts ...Clie
 }
 
 /*
-	CreateSITExtension creates s i t extension
+  CreateSITExtension creates s i t extension
 
-	### Functionality
-
+  ### Functionality
 This endpoint creates a storage in transit (SIT) extension request for a shipment. A SIT extension request is a request an
 increase in the shipment day allowance for the number of days a shipment is allowed to be in SIT. The total SIT day allowance
 includes time spent in both origin and destination SIT.
+
 */
 func (a *Client) CreateSITExtension(params *CreateSITExtensionParams, opts ...ClientOption) (*CreateSITExtensionCreated, error) {
 	// TODO: Validate the params before sending
@@ -193,16 +193,16 @@ func (a *Client) CreateSITExtension(params *CreateSITExtensionParams, opts ...Cl
 }
 
 /*
-	DeleteMTOShipment deletes m t o shipment
+  DeleteMTOShipment deletes m t o shipment
 
-	### Functionality
-
+  ### Functionality
 This endpoint deletes an individual shipment by ID.
 
 ### Errors
 * The mtoShipment should be associated with an MTO that is available to prime.
 * The mtoShipment must be a PPM shipment.
 * Counseling should not have already been completed for the associated MTO.
+
 */
 func (a *Client) DeleteMTOShipment(params *DeleteMTOShipmentParams, opts ...ClientOption) (*DeleteMTOShipmentNoContent, error) {
 	// TODO: Validate the params before sending
@@ -240,10 +240,9 @@ func (a *Client) DeleteMTOShipment(params *DeleteMTOShipmentParams, opts ...Clie
 }
 
 /*
-	UpdateMTOAgent updates m t o agent
+  UpdateMTOAgent updates m t o agent
 
-	### Functionality
-
+  ### Functionality
 This endpoint is used to **update** the agents for an MTO Shipment. Only the fields being modified need to be sent in the request body.
 
 ### Errors:
@@ -253,6 +252,7 @@ The agent must be associated with the MTO shipment passed in the url.
 
 The shipment should be associated with an MTO that is available to the Prime.
 If the caller requests an update to an agent, and the shipment is not on an available MTO, the caller will receive a **NotFound** response.
+
 */
 func (a *Client) UpdateMTOAgent(params *UpdateMTOAgentParams, opts ...ClientOption) (*UpdateMTOAgentOK, error) {
 	// TODO: Validate the params before sending
@@ -290,9 +290,9 @@ func (a *Client) UpdateMTOAgent(params *UpdateMTOAgentParams, opts ...ClientOpti
 }
 
 /*
-	UpdateMTOShipment updates m t o shipment
+  UpdateMTOShipment updates m t o shipment
 
-	Updates an existing shipment for a move.
+  Updates an existing shipment for a move.
 
 Note that there are some restrictions on nested objects:
 
@@ -303,6 +303,7 @@ Note that there are some restrictions on nested objects:
 These restrictions are due to our [optimistic locking/concurrency control](https://transcom.github.io/mymove-docs/docs/dev/contributing/backend/use-optimistic-locking) mechanism.
 
 Note that some fields cannot be manually changed but will still be updated automatically, such as `primeEstimatedWeightRecordedDate` and `requiredDeliveryDate`.
+
 */
 func (a *Client) UpdateMTOShipment(params *UpdateMTOShipmentParams, opts ...ClientOption) (*UpdateMTOShipmentOK, error) {
 	// TODO: Validate the params before sending
@@ -340,10 +341,9 @@ func (a *Client) UpdateMTOShipment(params *UpdateMTOShipmentParams, opts ...Clie
 }
 
 /*
-	UpdateMTOShipmentAddress updates m t o shipment address
+  UpdateMTOShipmentAddress updates m t o shipment address
 
-	### Functionality
-
+  ### Functionality
 This endpoint is used to **update** the addresses on an MTO Shipment. The address details completely replace the original, except for the UUID.
 Therefore a complete address should be sent in the request.
 
@@ -357,6 +357,7 @@ If it is not, caller will receive a **Conflict** Error.
 
 The mtoShipment should be associated with an MTO that is available to prime.
 If the caller requests an update to an address, and the shipment is not on an available MTO, the caller will receive a **NotFound** Error.
+
 */
 func (a *Client) UpdateMTOShipmentAddress(params *UpdateMTOShipmentAddressParams, opts ...ClientOption) (*UpdateMTOShipmentAddressOK, error) {
 	// TODO: Validate the params before sending
@@ -394,12 +395,12 @@ func (a *Client) UpdateMTOShipmentAddress(params *UpdateMTOShipmentAddressParams
 }
 
 /*
-	UpdateMTOShipmentStatus updates m t o shipment status
+  UpdateMTOShipmentStatus updates m t o shipment status
 
-	### Functionality
-
+  ### Functionality
 This endpoint should be used by the Prime to confirm the cancellation of a shipment. It allows the shipment
 status to be changed to "CANCELED." Currently, the Prime cannot update the shipment to any other status.
+
 */
 func (a *Client) UpdateMTOShipmentStatus(params *UpdateMTOShipmentStatusParams, opts ...ClientOption) (*UpdateMTOShipmentStatusOK, error) {
 	// TODO: Validate the params before sending
@@ -437,16 +438,16 @@ func (a *Client) UpdateMTOShipmentStatus(params *UpdateMTOShipmentStatusParams, 
 }
 
 /*
-	UpdateReweigh updates reweigh
+  UpdateReweigh updates reweigh
 
-	### Functionality
-
+  ### Functionality
 This endpoint can be used to update a reweigh with a new weight or to provide the reason why a reweigh did not occur.
 Only one of weight or verificationReason should be sent in the request body.
 
 A reweigh is the second recorded weight for a shipment, as validated by certified weight tickets. Applies to one shipment.
 A reweigh can be triggered automatically, or requested by the customer or transportation office. Not all shipments are reweighed,
 so not all shipments will have a reweigh weight.
+
 */
 func (a *Client) UpdateReweigh(params *UpdateReweighParams, opts ...ClientOption) (*UpdateReweighOK, error) {
 	// TODO: Validate the params before sending

--- a/pkg/gen/primeclient/mto_shipment/update_m_t_o_agent_parameters.go
+++ b/pkg/gen/primeclient/mto_shipment/update_m_t_o_agent_parameters.go
@@ -54,12 +54,10 @@ func NewUpdateMTOAgentParamsWithHTTPClient(client *http.Client) *UpdateMTOAgentP
 	}
 }
 
-/*
-UpdateMTOAgentParams contains all the parameters to send to the API endpoint
+/* UpdateMTOAgentParams contains all the parameters to send to the API endpoint
+   for the update m t o agent operation.
 
-	for the update m t o agent operation.
-
-	Typically these are written to a http.Request.
+   Typically these are written to a http.Request.
 */
 type UpdateMTOAgentParams struct {
 

--- a/pkg/gen/primeclient/mto_shipment/update_m_t_o_agent_responses.go
+++ b/pkg/gen/primeclient/mto_shipment/update_m_t_o_agent_responses.go
@@ -81,8 +81,7 @@ func NewUpdateMTOAgentOK() *UpdateMTOAgentOK {
 	return &UpdateMTOAgentOK{}
 }
 
-/*
-UpdateMTOAgentOK describes a response with status code 200, with default header values.
+/* UpdateMTOAgentOK describes a response with status code 200, with default header values.
 
 Successfully updated the agent.
 */
@@ -144,8 +143,7 @@ func NewUpdateMTOAgentBadRequest() *UpdateMTOAgentBadRequest {
 	return &UpdateMTOAgentBadRequest{}
 }
 
-/*
-UpdateMTOAgentBadRequest describes a response with status code 400, with default header values.
+/* UpdateMTOAgentBadRequest describes a response with status code 400, with default header values.
 
 The request payload is invalid.
 */
@@ -207,8 +205,7 @@ func NewUpdateMTOAgentUnauthorized() *UpdateMTOAgentUnauthorized {
 	return &UpdateMTOAgentUnauthorized{}
 }
 
-/*
-UpdateMTOAgentUnauthorized describes a response with status code 401, with default header values.
+/* UpdateMTOAgentUnauthorized describes a response with status code 401, with default header values.
 
 The request was denied.
 */
@@ -270,8 +267,7 @@ func NewUpdateMTOAgentForbidden() *UpdateMTOAgentForbidden {
 	return &UpdateMTOAgentForbidden{}
 }
 
-/*
-UpdateMTOAgentForbidden describes a response with status code 403, with default header values.
+/* UpdateMTOAgentForbidden describes a response with status code 403, with default header values.
 
 The request was denied.
 */
@@ -333,8 +329,7 @@ func NewUpdateMTOAgentNotFound() *UpdateMTOAgentNotFound {
 	return &UpdateMTOAgentNotFound{}
 }
 
-/*
-UpdateMTOAgentNotFound describes a response with status code 404, with default header values.
+/* UpdateMTOAgentNotFound describes a response with status code 404, with default header values.
 
 The requested resource wasn't found.
 */
@@ -396,8 +391,7 @@ func NewUpdateMTOAgentPreconditionFailed() *UpdateMTOAgentPreconditionFailed {
 	return &UpdateMTOAgentPreconditionFailed{}
 }
 
-/*
-UpdateMTOAgentPreconditionFailed describes a response with status code 412, with default header values.
+/* UpdateMTOAgentPreconditionFailed describes a response with status code 412, with default header values.
 
 Precondition failed, likely due to a stale eTag (If-Match). Fetch the request again to get the updated eTag value.
 */
@@ -459,8 +453,7 @@ func NewUpdateMTOAgentUnprocessableEntity() *UpdateMTOAgentUnprocessableEntity {
 	return &UpdateMTOAgentUnprocessableEntity{}
 }
 
-/*
-UpdateMTOAgentUnprocessableEntity describes a response with status code 422, with default header values.
+/* UpdateMTOAgentUnprocessableEntity describes a response with status code 422, with default header values.
 
 The request was unprocessable, likely due to bad input from the requester.
 */
@@ -522,8 +515,7 @@ func NewUpdateMTOAgentInternalServerError() *UpdateMTOAgentInternalServerError {
 	return &UpdateMTOAgentInternalServerError{}
 }
 
-/*
-UpdateMTOAgentInternalServerError describes a response with status code 500, with default header values.
+/* UpdateMTOAgentInternalServerError describes a response with status code 500, with default header values.
 
 A server error occurred.
 */

--- a/pkg/gen/primeclient/mto_shipment/update_m_t_o_shipment_address_parameters.go
+++ b/pkg/gen/primeclient/mto_shipment/update_m_t_o_shipment_address_parameters.go
@@ -54,12 +54,10 @@ func NewUpdateMTOShipmentAddressParamsWithHTTPClient(client *http.Client) *Updat
 	}
 }
 
-/*
-UpdateMTOShipmentAddressParams contains all the parameters to send to the API endpoint
+/* UpdateMTOShipmentAddressParams contains all the parameters to send to the API endpoint
+   for the update m t o shipment address operation.
 
-	for the update m t o shipment address operation.
-
-	Typically these are written to a http.Request.
+   Typically these are written to a http.Request.
 */
 type UpdateMTOShipmentAddressParams struct {
 

--- a/pkg/gen/primeclient/mto_shipment/update_m_t_o_shipment_address_responses.go
+++ b/pkg/gen/primeclient/mto_shipment/update_m_t_o_shipment_address_responses.go
@@ -87,8 +87,7 @@ func NewUpdateMTOShipmentAddressOK() *UpdateMTOShipmentAddressOK {
 	return &UpdateMTOShipmentAddressOK{}
 }
 
-/*
-UpdateMTOShipmentAddressOK describes a response with status code 200, with default header values.
+/* UpdateMTOShipmentAddressOK describes a response with status code 200, with default header values.
 
 Successfully updated the address.
 */
@@ -150,8 +149,7 @@ func NewUpdateMTOShipmentAddressBadRequest() *UpdateMTOShipmentAddressBadRequest
 	return &UpdateMTOShipmentAddressBadRequest{}
 }
 
-/*
-UpdateMTOShipmentAddressBadRequest describes a response with status code 400, with default header values.
+/* UpdateMTOShipmentAddressBadRequest describes a response with status code 400, with default header values.
 
 The request payload is invalid.
 */
@@ -213,8 +211,7 @@ func NewUpdateMTOShipmentAddressUnauthorized() *UpdateMTOShipmentAddressUnauthor
 	return &UpdateMTOShipmentAddressUnauthorized{}
 }
 
-/*
-UpdateMTOShipmentAddressUnauthorized describes a response with status code 401, with default header values.
+/* UpdateMTOShipmentAddressUnauthorized describes a response with status code 401, with default header values.
 
 The request was denied.
 */
@@ -276,8 +273,7 @@ func NewUpdateMTOShipmentAddressForbidden() *UpdateMTOShipmentAddressForbidden {
 	return &UpdateMTOShipmentAddressForbidden{}
 }
 
-/*
-UpdateMTOShipmentAddressForbidden describes a response with status code 403, with default header values.
+/* UpdateMTOShipmentAddressForbidden describes a response with status code 403, with default header values.
 
 The request was denied.
 */
@@ -339,8 +335,7 @@ func NewUpdateMTOShipmentAddressNotFound() *UpdateMTOShipmentAddressNotFound {
 	return &UpdateMTOShipmentAddressNotFound{}
 }
 
-/*
-UpdateMTOShipmentAddressNotFound describes a response with status code 404, with default header values.
+/* UpdateMTOShipmentAddressNotFound describes a response with status code 404, with default header values.
 
 The requested resource wasn't found.
 */
@@ -402,8 +397,7 @@ func NewUpdateMTOShipmentAddressConflict() *UpdateMTOShipmentAddressConflict {
 	return &UpdateMTOShipmentAddressConflict{}
 }
 
-/*
-UpdateMTOShipmentAddressConflict describes a response with status code 409, with default header values.
+/* UpdateMTOShipmentAddressConflict describes a response with status code 409, with default header values.
 
 The request could not be processed because of conflict in the current state of the resource.
 */
@@ -465,8 +459,7 @@ func NewUpdateMTOShipmentAddressPreconditionFailed() *UpdateMTOShipmentAddressPr
 	return &UpdateMTOShipmentAddressPreconditionFailed{}
 }
 
-/*
-UpdateMTOShipmentAddressPreconditionFailed describes a response with status code 412, with default header values.
+/* UpdateMTOShipmentAddressPreconditionFailed describes a response with status code 412, with default header values.
 
 Precondition failed, likely due to a stale eTag (If-Match). Fetch the request again to get the updated eTag value.
 */
@@ -528,8 +521,7 @@ func NewUpdateMTOShipmentAddressUnprocessableEntity() *UpdateMTOShipmentAddressU
 	return &UpdateMTOShipmentAddressUnprocessableEntity{}
 }
 
-/*
-UpdateMTOShipmentAddressUnprocessableEntity describes a response with status code 422, with default header values.
+/* UpdateMTOShipmentAddressUnprocessableEntity describes a response with status code 422, with default header values.
 
 The request was unprocessable, likely due to bad input from the requester.
 */
@@ -591,8 +583,7 @@ func NewUpdateMTOShipmentAddressInternalServerError() *UpdateMTOShipmentAddressI
 	return &UpdateMTOShipmentAddressInternalServerError{}
 }
 
-/*
-UpdateMTOShipmentAddressInternalServerError describes a response with status code 500, with default header values.
+/* UpdateMTOShipmentAddressInternalServerError describes a response with status code 500, with default header values.
 
 A server error occurred.
 */

--- a/pkg/gen/primeclient/mto_shipment/update_m_t_o_shipment_parameters.go
+++ b/pkg/gen/primeclient/mto_shipment/update_m_t_o_shipment_parameters.go
@@ -54,12 +54,10 @@ func NewUpdateMTOShipmentParamsWithHTTPClient(client *http.Client) *UpdateMTOShi
 	}
 }
 
-/*
-UpdateMTOShipmentParams contains all the parameters to send to the API endpoint
+/* UpdateMTOShipmentParams contains all the parameters to send to the API endpoint
+   for the update m t o shipment operation.
 
-	for the update m t o shipment operation.
-
-	Typically these are written to a http.Request.
+   Typically these are written to a http.Request.
 */
 type UpdateMTOShipmentParams struct {
 

--- a/pkg/gen/primeclient/mto_shipment/update_m_t_o_shipment_responses.go
+++ b/pkg/gen/primeclient/mto_shipment/update_m_t_o_shipment_responses.go
@@ -81,8 +81,7 @@ func NewUpdateMTOShipmentOK() *UpdateMTOShipmentOK {
 	return &UpdateMTOShipmentOK{}
 }
 
-/*
-UpdateMTOShipmentOK describes a response with status code 200, with default header values.
+/* UpdateMTOShipmentOK describes a response with status code 200, with default header values.
 
 Successfully updated the MTO shipment.
 */
@@ -144,8 +143,7 @@ func NewUpdateMTOShipmentBadRequest() *UpdateMTOShipmentBadRequest {
 	return &UpdateMTOShipmentBadRequest{}
 }
 
-/*
-UpdateMTOShipmentBadRequest describes a response with status code 400, with default header values.
+/* UpdateMTOShipmentBadRequest describes a response with status code 400, with default header values.
 
 The request payload is invalid.
 */
@@ -207,8 +205,7 @@ func NewUpdateMTOShipmentUnauthorized() *UpdateMTOShipmentUnauthorized {
 	return &UpdateMTOShipmentUnauthorized{}
 }
 
-/*
-UpdateMTOShipmentUnauthorized describes a response with status code 401, with default header values.
+/* UpdateMTOShipmentUnauthorized describes a response with status code 401, with default header values.
 
 The request was denied.
 */
@@ -270,8 +267,7 @@ func NewUpdateMTOShipmentForbidden() *UpdateMTOShipmentForbidden {
 	return &UpdateMTOShipmentForbidden{}
 }
 
-/*
-UpdateMTOShipmentForbidden describes a response with status code 403, with default header values.
+/* UpdateMTOShipmentForbidden describes a response with status code 403, with default header values.
 
 The request was denied.
 */
@@ -333,8 +329,7 @@ func NewUpdateMTOShipmentNotFound() *UpdateMTOShipmentNotFound {
 	return &UpdateMTOShipmentNotFound{}
 }
 
-/*
-UpdateMTOShipmentNotFound describes a response with status code 404, with default header values.
+/* UpdateMTOShipmentNotFound describes a response with status code 404, with default header values.
 
 The requested resource wasn't found.
 */
@@ -396,8 +391,7 @@ func NewUpdateMTOShipmentPreconditionFailed() *UpdateMTOShipmentPreconditionFail
 	return &UpdateMTOShipmentPreconditionFailed{}
 }
 
-/*
-UpdateMTOShipmentPreconditionFailed describes a response with status code 412, with default header values.
+/* UpdateMTOShipmentPreconditionFailed describes a response with status code 412, with default header values.
 
 Precondition failed, likely due to a stale eTag (If-Match). Fetch the request again to get the updated eTag value.
 */
@@ -459,8 +453,7 @@ func NewUpdateMTOShipmentUnprocessableEntity() *UpdateMTOShipmentUnprocessableEn
 	return &UpdateMTOShipmentUnprocessableEntity{}
 }
 
-/*
-UpdateMTOShipmentUnprocessableEntity describes a response with status code 422, with default header values.
+/* UpdateMTOShipmentUnprocessableEntity describes a response with status code 422, with default header values.
 
 The request was unprocessable, likely due to bad input from the requester.
 */
@@ -522,8 +515,7 @@ func NewUpdateMTOShipmentInternalServerError() *UpdateMTOShipmentInternalServerE
 	return &UpdateMTOShipmentInternalServerError{}
 }
 
-/*
-UpdateMTOShipmentInternalServerError describes a response with status code 500, with default header values.
+/* UpdateMTOShipmentInternalServerError describes a response with status code 500, with default header values.
 
 A server error occurred.
 */

--- a/pkg/gen/primeclient/mto_shipment/update_m_t_o_shipment_status_parameters.go
+++ b/pkg/gen/primeclient/mto_shipment/update_m_t_o_shipment_status_parameters.go
@@ -54,12 +54,10 @@ func NewUpdateMTOShipmentStatusParamsWithHTTPClient(client *http.Client) *Update
 	}
 }
 
-/*
-UpdateMTOShipmentStatusParams contains all the parameters to send to the API endpoint
+/* UpdateMTOShipmentStatusParams contains all the parameters to send to the API endpoint
+   for the update m t o shipment status operation.
 
-	for the update m t o shipment status operation.
-
-	Typically these are written to a http.Request.
+   Typically these are written to a http.Request.
 */
 type UpdateMTOShipmentStatusParams struct {
 

--- a/pkg/gen/primeclient/mto_shipment/update_m_t_o_shipment_status_responses.go
+++ b/pkg/gen/primeclient/mto_shipment/update_m_t_o_shipment_status_responses.go
@@ -87,8 +87,7 @@ func NewUpdateMTOShipmentStatusOK() *UpdateMTOShipmentStatusOK {
 	return &UpdateMTOShipmentStatusOK{}
 }
 
-/*
-UpdateMTOShipmentStatusOK describes a response with status code 200, with default header values.
+/* UpdateMTOShipmentStatusOK describes a response with status code 200, with default header values.
 
 Successfully updated the shipment's status.
 */
@@ -150,8 +149,7 @@ func NewUpdateMTOShipmentStatusBadRequest() *UpdateMTOShipmentStatusBadRequest {
 	return &UpdateMTOShipmentStatusBadRequest{}
 }
 
-/*
-UpdateMTOShipmentStatusBadRequest describes a response with status code 400, with default header values.
+/* UpdateMTOShipmentStatusBadRequest describes a response with status code 400, with default header values.
 
 The request payload is invalid.
 */
@@ -213,8 +211,7 @@ func NewUpdateMTOShipmentStatusUnauthorized() *UpdateMTOShipmentStatusUnauthoriz
 	return &UpdateMTOShipmentStatusUnauthorized{}
 }
 
-/*
-UpdateMTOShipmentStatusUnauthorized describes a response with status code 401, with default header values.
+/* UpdateMTOShipmentStatusUnauthorized describes a response with status code 401, with default header values.
 
 The request was denied.
 */
@@ -276,8 +273,7 @@ func NewUpdateMTOShipmentStatusForbidden() *UpdateMTOShipmentStatusForbidden {
 	return &UpdateMTOShipmentStatusForbidden{}
 }
 
-/*
-UpdateMTOShipmentStatusForbidden describes a response with status code 403, with default header values.
+/* UpdateMTOShipmentStatusForbidden describes a response with status code 403, with default header values.
 
 The request was denied.
 */
@@ -339,8 +335,7 @@ func NewUpdateMTOShipmentStatusNotFound() *UpdateMTOShipmentStatusNotFound {
 	return &UpdateMTOShipmentStatusNotFound{}
 }
 
-/*
-UpdateMTOShipmentStatusNotFound describes a response with status code 404, with default header values.
+/* UpdateMTOShipmentStatusNotFound describes a response with status code 404, with default header values.
 
 The requested resource wasn't found.
 */
@@ -402,8 +397,7 @@ func NewUpdateMTOShipmentStatusConflict() *UpdateMTOShipmentStatusConflict {
 	return &UpdateMTOShipmentStatusConflict{}
 }
 
-/*
-UpdateMTOShipmentStatusConflict describes a response with status code 409, with default header values.
+/* UpdateMTOShipmentStatusConflict describes a response with status code 409, with default header values.
 
 The request could not be processed because of conflict in the current state of the resource.
 */
@@ -465,8 +459,7 @@ func NewUpdateMTOShipmentStatusPreconditionFailed() *UpdateMTOShipmentStatusPrec
 	return &UpdateMTOShipmentStatusPreconditionFailed{}
 }
 
-/*
-UpdateMTOShipmentStatusPreconditionFailed describes a response with status code 412, with default header values.
+/* UpdateMTOShipmentStatusPreconditionFailed describes a response with status code 412, with default header values.
 
 Precondition failed, likely due to a stale eTag (If-Match). Fetch the request again to get the updated eTag value.
 */
@@ -528,8 +521,7 @@ func NewUpdateMTOShipmentStatusUnprocessableEntity() *UpdateMTOShipmentStatusUnp
 	return &UpdateMTOShipmentStatusUnprocessableEntity{}
 }
 
-/*
-UpdateMTOShipmentStatusUnprocessableEntity describes a response with status code 422, with default header values.
+/* UpdateMTOShipmentStatusUnprocessableEntity describes a response with status code 422, with default header values.
 
 The request was unprocessable, likely due to bad input from the requester.
 */
@@ -591,8 +583,7 @@ func NewUpdateMTOShipmentStatusInternalServerError() *UpdateMTOShipmentStatusInt
 	return &UpdateMTOShipmentStatusInternalServerError{}
 }
 
-/*
-UpdateMTOShipmentStatusInternalServerError describes a response with status code 500, with default header values.
+/* UpdateMTOShipmentStatusInternalServerError describes a response with status code 500, with default header values.
 
 A server error occurred.
 */

--- a/pkg/gen/primeclient/mto_shipment/update_reweigh_parameters.go
+++ b/pkg/gen/primeclient/mto_shipment/update_reweigh_parameters.go
@@ -54,12 +54,10 @@ func NewUpdateReweighParamsWithHTTPClient(client *http.Client) *UpdateReweighPar
 	}
 }
 
-/*
-UpdateReweighParams contains all the parameters to send to the API endpoint
+/* UpdateReweighParams contains all the parameters to send to the API endpoint
+   for the update reweigh operation.
 
-	for the update reweigh operation.
-
-	Typically these are written to a http.Request.
+   Typically these are written to a http.Request.
 */
 type UpdateReweighParams struct {
 

--- a/pkg/gen/primeclient/mto_shipment/update_reweigh_responses.go
+++ b/pkg/gen/primeclient/mto_shipment/update_reweigh_responses.go
@@ -87,8 +87,7 @@ func NewUpdateReweighOK() *UpdateReweighOK {
 	return &UpdateReweighOK{}
 }
 
-/*
-UpdateReweighOK describes a response with status code 200, with default header values.
+/* UpdateReweighOK describes a response with status code 200, with default header values.
 
 Successfully updated the reweigh.
 */
@@ -150,8 +149,7 @@ func NewUpdateReweighBadRequest() *UpdateReweighBadRequest {
 	return &UpdateReweighBadRequest{}
 }
 
-/*
-UpdateReweighBadRequest describes a response with status code 400, with default header values.
+/* UpdateReweighBadRequest describes a response with status code 400, with default header values.
 
 The request payload is invalid.
 */
@@ -213,8 +211,7 @@ func NewUpdateReweighUnauthorized() *UpdateReweighUnauthorized {
 	return &UpdateReweighUnauthorized{}
 }
 
-/*
-UpdateReweighUnauthorized describes a response with status code 401, with default header values.
+/* UpdateReweighUnauthorized describes a response with status code 401, with default header values.
 
 The request was denied.
 */
@@ -276,8 +273,7 @@ func NewUpdateReweighForbidden() *UpdateReweighForbidden {
 	return &UpdateReweighForbidden{}
 }
 
-/*
-UpdateReweighForbidden describes a response with status code 403, with default header values.
+/* UpdateReweighForbidden describes a response with status code 403, with default header values.
 
 The request was denied.
 */
@@ -339,8 +335,7 @@ func NewUpdateReweighNotFound() *UpdateReweighNotFound {
 	return &UpdateReweighNotFound{}
 }
 
-/*
-UpdateReweighNotFound describes a response with status code 404, with default header values.
+/* UpdateReweighNotFound describes a response with status code 404, with default header values.
 
 The requested resource wasn't found.
 */
@@ -402,8 +397,7 @@ func NewUpdateReweighConflict() *UpdateReweighConflict {
 	return &UpdateReweighConflict{}
 }
 
-/*
-UpdateReweighConflict describes a response with status code 409, with default header values.
+/* UpdateReweighConflict describes a response with status code 409, with default header values.
 
 The request could not be processed because of conflict in the current state of the resource.
 */
@@ -465,8 +459,7 @@ func NewUpdateReweighPreconditionFailed() *UpdateReweighPreconditionFailed {
 	return &UpdateReweighPreconditionFailed{}
 }
 
-/*
-UpdateReweighPreconditionFailed describes a response with status code 412, with default header values.
+/* UpdateReweighPreconditionFailed describes a response with status code 412, with default header values.
 
 Precondition failed, likely due to a stale eTag (If-Match). Fetch the request again to get the updated eTag value.
 */
@@ -528,8 +521,7 @@ func NewUpdateReweighUnprocessableEntity() *UpdateReweighUnprocessableEntity {
 	return &UpdateReweighUnprocessableEntity{}
 }
 
-/*
-UpdateReweighUnprocessableEntity describes a response with status code 422, with default header values.
+/* UpdateReweighUnprocessableEntity describes a response with status code 422, with default header values.
 
 The request was unprocessable, likely due to bad input from the requester.
 */
@@ -591,8 +583,7 @@ func NewUpdateReweighInternalServerError() *UpdateReweighInternalServerError {
 	return &UpdateReweighInternalServerError{}
 }
 
-/*
-UpdateReweighInternalServerError describes a response with status code 500, with default header values.
+/* UpdateReweighInternalServerError describes a response with status code 500, with default header values.
 
 A server error occurred.
 */

--- a/pkg/gen/primeclient/payment_request/create_payment_request_parameters.go
+++ b/pkg/gen/primeclient/payment_request/create_payment_request_parameters.go
@@ -54,12 +54,10 @@ func NewCreatePaymentRequestParamsWithHTTPClient(client *http.Client) *CreatePay
 	}
 }
 
-/*
-CreatePaymentRequestParams contains all the parameters to send to the API endpoint
+/* CreatePaymentRequestParams contains all the parameters to send to the API endpoint
+   for the create payment request operation.
 
-	for the create payment request operation.
-
-	Typically these are written to a http.Request.
+   Typically these are written to a http.Request.
 */
 type CreatePaymentRequestParams struct {
 

--- a/pkg/gen/primeclient/payment_request/create_payment_request_responses.go
+++ b/pkg/gen/primeclient/payment_request/create_payment_request_responses.go
@@ -81,8 +81,7 @@ func NewCreatePaymentRequestCreated() *CreatePaymentRequestCreated {
 	return &CreatePaymentRequestCreated{}
 }
 
-/*
-CreatePaymentRequestCreated describes a response with status code 201, with default header values.
+/* CreatePaymentRequestCreated describes a response with status code 201, with default header values.
 
 Successfully created a paymentRequest object.
 */
@@ -144,8 +143,7 @@ func NewCreatePaymentRequestBadRequest() *CreatePaymentRequestBadRequest {
 	return &CreatePaymentRequestBadRequest{}
 }
 
-/*
-CreatePaymentRequestBadRequest describes a response with status code 400, with default header values.
+/* CreatePaymentRequestBadRequest describes a response with status code 400, with default header values.
 
 Request payload is invalid.
 */
@@ -207,8 +205,7 @@ func NewCreatePaymentRequestUnauthorized() *CreatePaymentRequestUnauthorized {
 	return &CreatePaymentRequestUnauthorized{}
 }
 
-/*
-CreatePaymentRequestUnauthorized describes a response with status code 401, with default header values.
+/* CreatePaymentRequestUnauthorized describes a response with status code 401, with default header values.
 
 The request was denied.
 */
@@ -270,8 +267,7 @@ func NewCreatePaymentRequestForbidden() *CreatePaymentRequestForbidden {
 	return &CreatePaymentRequestForbidden{}
 }
 
-/*
-CreatePaymentRequestForbidden describes a response with status code 403, with default header values.
+/* CreatePaymentRequestForbidden describes a response with status code 403, with default header values.
 
 The request was denied.
 */
@@ -333,8 +329,7 @@ func NewCreatePaymentRequestNotFound() *CreatePaymentRequestNotFound {
 	return &CreatePaymentRequestNotFound{}
 }
 
-/*
-CreatePaymentRequestNotFound describes a response with status code 404, with default header values.
+/* CreatePaymentRequestNotFound describes a response with status code 404, with default header values.
 
 The requested resource wasn't found.
 */
@@ -396,8 +391,7 @@ func NewCreatePaymentRequestConflict() *CreatePaymentRequestConflict {
 	return &CreatePaymentRequestConflict{}
 }
 
-/*
-CreatePaymentRequestConflict describes a response with status code 409, with default header values.
+/* CreatePaymentRequestConflict describes a response with status code 409, with default header values.
 
 The request could not be processed because of conflict in the current state of the resource.
 */
@@ -459,8 +453,7 @@ func NewCreatePaymentRequestUnprocessableEntity() *CreatePaymentRequestUnprocess
 	return &CreatePaymentRequestUnprocessableEntity{}
 }
 
-/*
-CreatePaymentRequestUnprocessableEntity describes a response with status code 422, with default header values.
+/* CreatePaymentRequestUnprocessableEntity describes a response with status code 422, with default header values.
 
 The request was unprocessable, likely due to bad input from the requester.
 */
@@ -522,8 +515,7 @@ func NewCreatePaymentRequestInternalServerError() *CreatePaymentRequestInternalS
 	return &CreatePaymentRequestInternalServerError{}
 }
 
-/*
-CreatePaymentRequestInternalServerError describes a response with status code 500, with default header values.
+/* CreatePaymentRequestInternalServerError describes a response with status code 500, with default header values.
 
 A server error occurred.
 */

--- a/pkg/gen/primeclient/payment_request/create_upload_parameters.go
+++ b/pkg/gen/primeclient/payment_request/create_upload_parameters.go
@@ -52,12 +52,10 @@ func NewCreateUploadParamsWithHTTPClient(client *http.Client) *CreateUploadParam
 	}
 }
 
-/*
-CreateUploadParams contains all the parameters to send to the API endpoint
+/* CreateUploadParams contains all the parameters to send to the API endpoint
+   for the create upload operation.
 
-	for the create upload operation.
-
-	Typically these are written to a http.Request.
+   Typically these are written to a http.Request.
 */
 type CreateUploadParams struct {
 

--- a/pkg/gen/primeclient/payment_request/create_upload_responses.go
+++ b/pkg/gen/primeclient/payment_request/create_upload_responses.go
@@ -75,8 +75,7 @@ func NewCreateUploadCreated() *CreateUploadCreated {
 	return &CreateUploadCreated{}
 }
 
-/*
-CreateUploadCreated describes a response with status code 201, with default header values.
+/* CreateUploadCreated describes a response with status code 201, with default header values.
 
 Successfully created upload of digital file.
 */
@@ -138,8 +137,7 @@ func NewCreateUploadBadRequest() *CreateUploadBadRequest {
 	return &CreateUploadBadRequest{}
 }
 
-/*
-CreateUploadBadRequest describes a response with status code 400, with default header values.
+/* CreateUploadBadRequest describes a response with status code 400, with default header values.
 
 The request payload is invalid.
 */
@@ -201,8 +199,7 @@ func NewCreateUploadUnauthorized() *CreateUploadUnauthorized {
 	return &CreateUploadUnauthorized{}
 }
 
-/*
-CreateUploadUnauthorized describes a response with status code 401, with default header values.
+/* CreateUploadUnauthorized describes a response with status code 401, with default header values.
 
 The request was denied.
 */
@@ -264,8 +261,7 @@ func NewCreateUploadForbidden() *CreateUploadForbidden {
 	return &CreateUploadForbidden{}
 }
 
-/*
-CreateUploadForbidden describes a response with status code 403, with default header values.
+/* CreateUploadForbidden describes a response with status code 403, with default header values.
 
 The request was denied.
 */
@@ -327,8 +323,7 @@ func NewCreateUploadNotFound() *CreateUploadNotFound {
 	return &CreateUploadNotFound{}
 }
 
-/*
-CreateUploadNotFound describes a response with status code 404, with default header values.
+/* CreateUploadNotFound describes a response with status code 404, with default header values.
 
 The requested resource wasn't found.
 */
@@ -390,8 +385,7 @@ func NewCreateUploadUnprocessableEntity() *CreateUploadUnprocessableEntity {
 	return &CreateUploadUnprocessableEntity{}
 }
 
-/*
-CreateUploadUnprocessableEntity describes a response with status code 422, with default header values.
+/* CreateUploadUnprocessableEntity describes a response with status code 422, with default header values.
 
 The request was unprocessable, likely due to bad input from the requester.
 */
@@ -453,8 +447,7 @@ func NewCreateUploadInternalServerError() *CreateUploadInternalServerError {
 	return &CreateUploadInternalServerError{}
 }
 
-/*
-CreateUploadInternalServerError describes a response with status code 500, with default header values.
+/* CreateUploadInternalServerError describes a response with status code 500, with default header values.
 
 A server error occurred.
 */

--- a/pkg/gen/primeclient/payment_request/payment_request_client.go
+++ b/pkg/gen/primeclient/payment_request/payment_request_client.go
@@ -38,13 +38,13 @@ type ClientService interface {
 }
 
 /*
-	CreatePaymentRequest creates payment request
+  CreatePaymentRequest creates payment request
 
-	Creates a new instance of a paymentRequest.
-
+  Creates a new instance of a paymentRequest.
 A newly created payment request is assigned the status `PENDING`.
 A move task order can have multiple payment requests, and
 a final payment request can be marked using boolean `isFinal`.
+
 */
 func (a *Client) CreatePaymentRequest(params *CreatePaymentRequestParams, opts ...ClientOption) (*CreatePaymentRequestCreated, error) {
 	// TODO: Validate the params before sending
@@ -82,15 +82,15 @@ func (a *Client) CreatePaymentRequest(params *CreatePaymentRequestParams, opts .
 }
 
 /*
-	CreateUpload creates upload
+  CreateUpload creates upload
 
-	### Functionality
-
+  ### Functionality
 This endpoint **uploads** a Proof of Service document for a PaymentRequest.
 
 The PaymentRequest should already exist.
 
 PaymentRequests are created with the [createPaymentRequest](#operation/createPaymentRequest) endpoint.
+
 */
 func (a *Client) CreateUpload(params *CreateUploadParams, opts ...ClientOption) (*CreateUploadCreated, error) {
 	// TODO: Validate the params before sending

--- a/pkg/gen/primemessages/list_move.go
+++ b/pkg/gen/primemessages/list_move.go
@@ -17,6 +17,7 @@ import (
 
 // ListMove An abbreviated definition for a move, without all the nested information (shipments, service items, etc). Used to fetch a list of moves more efficiently.
 //
+//
 // swagger:model ListMove
 type ListMove struct {
 

--- a/pkg/gen/primemessages/m_t_o_agents.go
+++ b/pkg/gen/primemessages/m_t_o_agents.go
@@ -17,6 +17,7 @@ import (
 
 // MTOAgents A list of the agents for a shipment. Agents are the people who the Prime contractor recognize as permitted to release (in the case of pickup) or receive (on delivery) a shipment.
 //
+//
 // swagger:model MTOAgents
 type MTOAgents []*MTOAgent
 

--- a/pkg/gen/primemessages/m_t_o_service_item_model_type.go
+++ b/pkg/gen/primemessages/m_t_o_service_item_model_type.go
@@ -17,12 +17,13 @@ import (
 // MTOServiceItemModelType Describes all model sub-types for a MTOServiceItem model.
 //
 // Using this list, choose the correct modelType in the dropdown, corresponding to the service item type.
-//   - DOFSIT, DOASIT - MTOServiceItemOriginSIT
-//   - DDFSIT, DDASIT - MTOServiceItemDestSIT
-//   - DOSHUT, DDSHUT - MTOServiceItemShuttle
-//   - DCRT, DUCRT - MTOServiceItemDomesticCrating
+//   * DOFSIT, DOASIT - MTOServiceItemOriginSIT
+//   * DDFSIT, DDASIT - MTOServiceItemDestSIT
+//   * DOSHUT, DDSHUT - MTOServiceItemShuttle
+//   * DCRT, DUCRT - MTOServiceItemDomesticCrating
 //
 // The documentation will then update with the supported fields.
+//
 //
 // swagger:model MTOServiceItemModelType
 type MTOServiceItemModelType string

--- a/pkg/gen/primemessages/m_t_o_shipment_type.go
+++ b/pkg/gen/primemessages/m_t_o_shipment_type.go
@@ -17,10 +17,10 @@ import (
 // MTOShipmentType Shipment Type
 //
 // The type of shipment.
-//   - `HHG` = Household goods move
-//   - `HHG_INTO_NTS_DOMESTIC` = HHG into Non-temporary storage (NTS)
-//   - `HHG_OUTOF_NTS_DOMESTIC` = HHG out of Non-temporary storage (NTS Release)
-//   - `PPM` = Personally Procured Move also known as Do It Yourself (DITY)
+//   * `HHG` = Household goods move
+//   * `HHG_INTO_NTS_DOMESTIC` = HHG into Non-temporary storage (NTS)
+//   * `HHG_OUTOF_NTS_DOMESTIC` = HHG out of Non-temporary storage (NTS Release)
+//   * `PPM` = Personally Procured Move also known as Do It Yourself (DITY)
 //
 // Example: HHG
 //

--- a/pkg/gen/primemessages/p_p_m_shipment_status.go
+++ b/pkg/gen/primemessages/p_p_m_shipment_status.go
@@ -15,12 +15,13 @@ import (
 )
 
 // PPMShipmentStatus Status of the PPM Shipment:
-//   - **DRAFT**: The customer has created the PPM shipment but has not yet submitted their move for counseling.
-//   - **SUBMITTED**: The shipment belongs to a move that has been submitted by the customer or has been created by a Service Counselor or Prime Contractor for a submitted move.
-//   - **WAITING_ON_CUSTOMER**: The PPM shipment has been approved and the customer may now provide their actual move closeout information and documentation required to get paid.
-//   - **NEEDS_ADVANCE_APPROVAL**: The shipment was counseled by the Prime Contractor and approved but an advance was requested so will need further financial approval from the government.
-//   - **NEEDS_PAYMENT_APPROVAL**: The customer has provided their closeout weight tickets, receipts, and expenses and certified it for the Service Counselor to approve, exclude or reject.
-//   - **PAYMENT_APPROVED**: The Service Counselor has reviewed all of the customer's PPM closeout documentation and authorizes the customer can download and submit their finalized SSW packet.
+//   * **DRAFT**: The customer has created the PPM shipment but has not yet submitted their move for counseling.
+//   * **SUBMITTED**: The shipment belongs to a move that has been submitted by the customer or has been created by a Service Counselor or Prime Contractor for a submitted move.
+//   * **WAITING_ON_CUSTOMER**: The PPM shipment has been approved and the customer may now provide their actual move closeout information and documentation required to get paid.
+//   * **NEEDS_ADVANCE_APPROVAL**: The shipment was counseled by the Prime Contractor and approved but an advance was requested so will need further financial approval from the government.
+//   * **NEEDS_PAYMENT_APPROVAL**: The customer has provided their closeout weight tickets, receipts, and expenses and certified it for the Service Counselor to approve, exclude or reject.
+//   * **PAYMENT_APPROVED**: The Service Counselor has reviewed all of the customer's PPM closeout documentation and authorizes the customer can download and submit their finalized SSW packet.
+//
 //
 // swagger:model PPMShipmentStatus
 type PPMShipmentStatus string

--- a/pkg/gen/primemessages/re_service_code.go
+++ b/pkg/gen/primemessages/re_service_code.go
@@ -19,6 +19,7 @@ import (
 //
 // Documentation of all the service items will be provided.
 //
+//
 // swagger:model ReServiceCode
 type ReServiceCode string
 

--- a/pkg/gen/primemessages/update_m_t_o_service_item_model_type.go
+++ b/pkg/gen/primemessages/update_m_t_o_service_item_model_type.go
@@ -15,12 +15,13 @@ import (
 )
 
 // UpdateMTOServiceItemModelType Using this list, choose the correct modelType in the dropdown, corresponding to the service item type.
-//   - DDDSIT - UpdateMTOServiceItemSIT
-//   - DOPSIT - UpdateMTOServiceItemSIT
-//   - DDSHUT - UpdateMTOServiceItemShuttle
-//   - DOSHUT - UpdateMTOServiceItemShuttle
+//   * DDDSIT - UpdateMTOServiceItemSIT
+//   * DOPSIT - UpdateMTOServiceItemSIT
+//   * DDSHUT - UpdateMTOServiceItemShuttle
+//   * DOSHUT - UpdateMTOServiceItemShuttle
 //
 // The documentation will then update with the supported fields.
+//
 //
 // swagger:model UpdateMTOServiceItemModelType
 type UpdateMTOServiceItemModelType string

--- a/pkg/gen/primemessages/update_m_t_o_service_item_s_i_t.go
+++ b/pkg/gen/primemessages/update_m_t_o_service_item_s_i_t.go
@@ -18,6 +18,7 @@ import (
 
 // UpdateMTOServiceItemSIT Subtype used to provide the departure date for origin or destination SIT. This is not creating a new service item but rather updating and existing service item.
 //
+//
 // swagger:model UpdateMTOServiceItemSIT
 type UpdateMTOServiceItemSIT struct {
 	idField strfmt.UUID

--- a/pkg/gen/primemessages/update_m_t_o_service_item_shuttle.go
+++ b/pkg/gen/primemessages/update_m_t_o_service_item_shuttle.go
@@ -18,6 +18,7 @@ import (
 
 // UpdateMTOServiceItemShuttle Subtype used to provide the estimated weight and actual weight for shuttle. This is not creating a new service item but rather updating an existing service item.
 //
+//
 // swagger:model UpdateMTOServiceItemShuttle
 type UpdateMTOServiceItemShuttle struct {
 	idField strfmt.UUID

--- a/pkg/gen/restapi/apioperations/tsps/index_t_s_ps.go
+++ b/pkg/gen/restapi/apioperations/tsps/index_t_s_ps.go
@@ -29,12 +29,12 @@ func NewIndexTSPs(ctx *middleware.Context, handler IndexTSPsHandler) *IndexTSPs 
 	return &IndexTSPs{Context: ctx, Handler: handler}
 }
 
-/*
-	IndexTSPs swagger:route GET /tsps tsps indexTSPs
+/* IndexTSPs swagger:route GET /tsps tsps indexTSPs
 
-# List all TSPs
+List all TSPs
 
 Gets a list of all the TSPs which the logged in user has access to.
+
 */
 type IndexTSPs struct {
 	Context *middleware.Context

--- a/pkg/gen/restapi/apioperations/tsps/index_t_s_ps_responses.go
+++ b/pkg/gen/restapi/apioperations/tsps/index_t_s_ps_responses.go
@@ -16,8 +16,7 @@ import (
 // IndexTSPsOKCode is the HTTP code returned for type IndexTSPsOK
 const IndexTSPsOKCode int = 200
 
-/*
-IndexTSPsOK list of TSPs
+/*IndexTSPsOK list of TSPs
 
 swagger:response indexTSPsOK
 */
@@ -64,8 +63,7 @@ func (o *IndexTSPsOK) WriteResponse(rw http.ResponseWriter, producer runtime.Pro
 // IndexTSPsBadRequestCode is the HTTP code returned for type IndexTSPsBadRequest
 const IndexTSPsBadRequestCode int = 400
 
-/*
-IndexTSPsBadRequest invalid request
+/*IndexTSPsBadRequest invalid request
 
 swagger:response indexTSPsBadRequest
 */
@@ -89,8 +87,7 @@ func (o *IndexTSPsBadRequest) WriteResponse(rw http.ResponseWriter, producer run
 // IndexTSPsUnauthorizedCode is the HTTP code returned for type IndexTSPsUnauthorized
 const IndexTSPsUnauthorizedCode int = 401
 
-/*
-IndexTSPsUnauthorized must be authenticated to access this endpoint
+/*IndexTSPsUnauthorized must be authenticated to access this endpoint
 
 swagger:response indexTSPsUnauthorized
 */
@@ -114,8 +111,7 @@ func (o *IndexTSPsUnauthorized) WriteResponse(rw http.ResponseWriter, producer r
 // IndexTSPsInternalServerErrorCode is the HTTP code returned for type IndexTSPsInternalServerError
 const IndexTSPsInternalServerErrorCode int = 500
 
-/*
-IndexTSPsInternalServerError server error
+/*IndexTSPsInternalServerError server error
 
 swagger:response indexTSPsInternalServerError
 */

--- a/pkg/gen/restapi/doc.go
+++ b/pkg/gen/restapi/doc.go
@@ -2,19 +2,19 @@
 
 // Package restapi my.move.mil
 //
-//	The public API for my.move.mil. This is a work in-progress, and is not a final product. We will be continuously updating this site based on feedback.
-//	Schemes:
-//	  http
-//	Host: localhost
-//	BasePath: /api/v1
-//	Version: 0.0.1
-//	License: MIT https://github.com/transcom/mymove/blob/master/LICENSE.md
+//  The public API for my.move.mil. This is a work in-progress, and is not a final product. We will be continuously updating this site based on feedback.
+//  Schemes:
+//    http
+//  Host: localhost
+//  BasePath: /api/v1
+//  Version: 0.0.1
+//  License: MIT https://github.com/transcom/mymove/blob/master/LICENSE.md
 //
-//	Consumes:
-//	  - application/json
+//  Consumes:
+//    - application/json
 //
-//	Produces:
-//	  - application/json
+//  Produces:
+//    - application/json
 //
 // swagger:meta
 package restapi

--- a/pkg/gen/supportapi/doc.go
+++ b/pkg/gen/supportapi/doc.go
@@ -2,25 +2,25 @@
 
 // Package supportapi MilMove Support API
 //
-//	The Support API gives you programmatic access to support functionality useful
-//	for testing and debugging. **This API is not available in the Production
-//	environment**.
+//  The Support API gives you programmatic access to support functionality useful
+//  for testing and debugging. **This API is not available in the Production
+//  environment**.
 //
-//	All endpoints are located at `/support/v1/`.
+//  All endpoints are located at `/support/v1/`.
 //
-//	Schemes:
-//	  http
-//	Host: localhost
-//	BasePath: /support/v1
-//	Version: 0.0.1
-//	License: MIT https://opensource.org/licenses/MIT
-//	Contact: <dp3@truss.works>
+//  Schemes:
+//    http
+//  Host: localhost
+//  BasePath: /support/v1
+//  Version: 0.0.1
+//  License: MIT https://opensource.org/licenses/MIT
+//  Contact: <dp3@truss.works>
 //
-//	Consumes:
-//	  - application/json
+//  Consumes:
+//    - application/json
 //
-//	Produces:
-//	  - application/json
+//  Produces:
+//    - application/json
 //
 // swagger:meta
 package supportapi

--- a/pkg/gen/supportapi/supportoperations/move_task_order/create_move_task_order.go
+++ b/pkg/gen/supportapi/supportoperations/move_task_order/create_move_task_order.go
@@ -29,8 +29,7 @@ func NewCreateMoveTaskOrder(ctx *middleware.Context, handler CreateMoveTaskOrder
 	return &CreateMoveTaskOrder{Context: ctx, Handler: handler}
 }
 
-/*
-	CreateMoveTaskOrder swagger:route POST /move-task-orders moveTaskOrder createMoveTaskOrder
+/* CreateMoveTaskOrder swagger:route POST /move-task-orders moveTaskOrder createMoveTaskOrder
 
 createMoveTaskOrder
 
@@ -47,6 +46,8 @@ It will not create addresses, duty stations, shipments, payment requests or serv
 origin duty station ID, and an uploaded orders ID to be passed into the request.
 
 This is a support endpoint and will not be available in production.
+
+
 */
 type CreateMoveTaskOrder struct {
 	Context *middleware.Context

--- a/pkg/gen/supportapi/supportoperations/move_task_order/create_move_task_order_responses.go
+++ b/pkg/gen/supportapi/supportoperations/move_task_order/create_move_task_order_responses.go
@@ -16,8 +16,7 @@ import (
 // CreateMoveTaskOrderCreatedCode is the HTTP code returned for type CreateMoveTaskOrderCreated
 const CreateMoveTaskOrderCreatedCode int = 201
 
-/*
-CreateMoveTaskOrderCreated Successfully created MoveTaskOrder object.
+/*CreateMoveTaskOrderCreated Successfully created MoveTaskOrder object.
 
 swagger:response createMoveTaskOrderCreated
 */
@@ -61,8 +60,7 @@ func (o *CreateMoveTaskOrderCreated) WriteResponse(rw http.ResponseWriter, produ
 // CreateMoveTaskOrderBadRequestCode is the HTTP code returned for type CreateMoveTaskOrderBadRequest
 const CreateMoveTaskOrderBadRequestCode int = 400
 
-/*
-CreateMoveTaskOrderBadRequest The request payload is invalid.
+/*CreateMoveTaskOrderBadRequest The request payload is invalid.
 
 swagger:response createMoveTaskOrderBadRequest
 */
@@ -106,8 +104,7 @@ func (o *CreateMoveTaskOrderBadRequest) WriteResponse(rw http.ResponseWriter, pr
 // CreateMoveTaskOrderUnauthorizedCode is the HTTP code returned for type CreateMoveTaskOrderUnauthorized
 const CreateMoveTaskOrderUnauthorizedCode int = 401
 
-/*
-CreateMoveTaskOrderUnauthorized The request was denied.
+/*CreateMoveTaskOrderUnauthorized The request was denied.
 
 swagger:response createMoveTaskOrderUnauthorized
 */
@@ -151,8 +148,7 @@ func (o *CreateMoveTaskOrderUnauthorized) WriteResponse(rw http.ResponseWriter, 
 // CreateMoveTaskOrderForbiddenCode is the HTTP code returned for type CreateMoveTaskOrderForbidden
 const CreateMoveTaskOrderForbiddenCode int = 403
 
-/*
-CreateMoveTaskOrderForbidden The request was denied.
+/*CreateMoveTaskOrderForbidden The request was denied.
 
 swagger:response createMoveTaskOrderForbidden
 */
@@ -196,8 +192,7 @@ func (o *CreateMoveTaskOrderForbidden) WriteResponse(rw http.ResponseWriter, pro
 // CreateMoveTaskOrderNotFoundCode is the HTTP code returned for type CreateMoveTaskOrderNotFound
 const CreateMoveTaskOrderNotFoundCode int = 404
 
-/*
-CreateMoveTaskOrderNotFound The requested resource wasn't found.
+/*CreateMoveTaskOrderNotFound The requested resource wasn't found.
 
 swagger:response createMoveTaskOrderNotFound
 */
@@ -241,8 +236,7 @@ func (o *CreateMoveTaskOrderNotFound) WriteResponse(rw http.ResponseWriter, prod
 // CreateMoveTaskOrderUnprocessableEntityCode is the HTTP code returned for type CreateMoveTaskOrderUnprocessableEntity
 const CreateMoveTaskOrderUnprocessableEntityCode int = 422
 
-/*
-CreateMoveTaskOrderUnprocessableEntity The payload was unprocessable.
+/*CreateMoveTaskOrderUnprocessableEntity The payload was unprocessable.
 
 swagger:response createMoveTaskOrderUnprocessableEntity
 */
@@ -286,8 +280,7 @@ func (o *CreateMoveTaskOrderUnprocessableEntity) WriteResponse(rw http.ResponseW
 // CreateMoveTaskOrderInternalServerErrorCode is the HTTP code returned for type CreateMoveTaskOrderInternalServerError
 const CreateMoveTaskOrderInternalServerErrorCode int = 500
 
-/*
-CreateMoveTaskOrderInternalServerError A server error occurred.
+/*CreateMoveTaskOrderInternalServerError A server error occurred.
 
 swagger:response createMoveTaskOrderInternalServerError
 */

--- a/pkg/gen/supportapi/supportoperations/move_task_order/get_move_task_order.go
+++ b/pkg/gen/supportapi/supportoperations/move_task_order/get_move_task_order.go
@@ -29,8 +29,7 @@ func NewGetMoveTaskOrder(ctx *middleware.Context, handler GetMoveTaskOrderHandle
 	return &GetMoveTaskOrder{Context: ctx, Handler: handler}
 }
 
-/*
-	GetMoveTaskOrder swagger:route GET /move-task-orders/{moveTaskOrderID} moveTaskOrder getMoveTaskOrder
+/* GetMoveTaskOrder swagger:route GET /move-task-orders/{moveTaskOrderID} moveTaskOrder getMoveTaskOrder
 
 getMoveTaskOrder
 
@@ -40,6 +39,8 @@ This endpoint gets an individual MoveTaskOrder by ID.
 It will provide nested information about the Customer and any associated MTOShipments, MTOServiceItems and PaymentRequests.
 
 This is a support endpoint and is not available in production.
+
+
 */
 type GetMoveTaskOrder struct {
 	Context *middleware.Context

--- a/pkg/gen/supportapi/supportoperations/move_task_order/get_move_task_order_responses.go
+++ b/pkg/gen/supportapi/supportoperations/move_task_order/get_move_task_order_responses.go
@@ -16,8 +16,7 @@ import (
 // GetMoveTaskOrderOKCode is the HTTP code returned for type GetMoveTaskOrderOK
 const GetMoveTaskOrderOKCode int = 200
 
-/*
-GetMoveTaskOrderOK Successfully retrieve an individual move task order.
+/*GetMoveTaskOrderOK Successfully retrieve an individual move task order.
 
 swagger:response getMoveTaskOrderOK
 */
@@ -61,8 +60,7 @@ func (o *GetMoveTaskOrderOK) WriteResponse(rw http.ResponseWriter, producer runt
 // GetMoveTaskOrderUnauthorizedCode is the HTTP code returned for type GetMoveTaskOrderUnauthorized
 const GetMoveTaskOrderUnauthorizedCode int = 401
 
-/*
-GetMoveTaskOrderUnauthorized The request was denied.
+/*GetMoveTaskOrderUnauthorized The request was denied.
 
 swagger:response getMoveTaskOrderUnauthorized
 */
@@ -106,8 +104,7 @@ func (o *GetMoveTaskOrderUnauthorized) WriteResponse(rw http.ResponseWriter, pro
 // GetMoveTaskOrderForbiddenCode is the HTTP code returned for type GetMoveTaskOrderForbidden
 const GetMoveTaskOrderForbiddenCode int = 403
 
-/*
-GetMoveTaskOrderForbidden The request was denied.
+/*GetMoveTaskOrderForbidden The request was denied.
 
 swagger:response getMoveTaskOrderForbidden
 */
@@ -151,8 +148,7 @@ func (o *GetMoveTaskOrderForbidden) WriteResponse(rw http.ResponseWriter, produc
 // GetMoveTaskOrderNotFoundCode is the HTTP code returned for type GetMoveTaskOrderNotFound
 const GetMoveTaskOrderNotFoundCode int = 404
 
-/*
-GetMoveTaskOrderNotFound The requested resource wasn't found.
+/*GetMoveTaskOrderNotFound The requested resource wasn't found.
 
 swagger:response getMoveTaskOrderNotFound
 */
@@ -196,8 +192,7 @@ func (o *GetMoveTaskOrderNotFound) WriteResponse(rw http.ResponseWriter, produce
 // GetMoveTaskOrderInternalServerErrorCode is the HTTP code returned for type GetMoveTaskOrderInternalServerError
 const GetMoveTaskOrderInternalServerErrorCode int = 500
 
-/*
-GetMoveTaskOrderInternalServerError A server error occurred.
+/*GetMoveTaskOrderInternalServerError A server error occurred.
 
 swagger:response getMoveTaskOrderInternalServerError
 */

--- a/pkg/gen/supportapi/supportoperations/move_task_order/hide_non_fake_move_task_orders.go
+++ b/pkg/gen/supportapi/supportoperations/move_task_order/hide_non_fake_move_task_orders.go
@@ -29,14 +29,15 @@ func NewHideNonFakeMoveTaskOrders(ctx *middleware.Context, handler HideNonFakeMo
 	return &HideNonFakeMoveTaskOrders{Context: ctx, Handler: handler}
 }
 
-/*
-	HideNonFakeMoveTaskOrders swagger:route PATCH /move-task-orders/hide moveTaskOrder hideNonFakeMoveTaskOrders
+/* HideNonFakeMoveTaskOrders swagger:route PATCH /move-task-orders/hide moveTaskOrder hideNonFakeMoveTaskOrders
 
 hideNonFakeMoveTaskOrders
 
 Updates move task order without fake user data `show` to false. No request body required. <br />
 <br />
 This is a support endpoint and will not be available in production.
+
+
 */
 type HideNonFakeMoveTaskOrders struct {
 	Context *middleware.Context

--- a/pkg/gen/supportapi/supportoperations/move_task_order/hide_non_fake_move_task_orders_responses.go
+++ b/pkg/gen/supportapi/supportoperations/move_task_order/hide_non_fake_move_task_orders_responses.go
@@ -16,8 +16,7 @@ import (
 // HideNonFakeMoveTaskOrdersOKCode is the HTTP code returned for type HideNonFakeMoveTaskOrdersOK
 const HideNonFakeMoveTaskOrdersOKCode int = 200
 
-/*
-HideNonFakeMoveTaskOrdersOK Successfully hid MTOs.
+/*HideNonFakeMoveTaskOrdersOK Successfully hid MTOs.
 
 swagger:response hideNonFakeMoveTaskOrdersOK
 */
@@ -61,8 +60,7 @@ func (o *HideNonFakeMoveTaskOrdersOK) WriteResponse(rw http.ResponseWriter, prod
 // HideNonFakeMoveTaskOrdersBadRequestCode is the HTTP code returned for type HideNonFakeMoveTaskOrdersBadRequest
 const HideNonFakeMoveTaskOrdersBadRequestCode int = 400
 
-/*
-HideNonFakeMoveTaskOrdersBadRequest The request payload is invalid.
+/*HideNonFakeMoveTaskOrdersBadRequest The request payload is invalid.
 
 swagger:response hideNonFakeMoveTaskOrdersBadRequest
 */
@@ -106,8 +104,7 @@ func (o *HideNonFakeMoveTaskOrdersBadRequest) WriteResponse(rw http.ResponseWrit
 // HideNonFakeMoveTaskOrdersUnauthorizedCode is the HTTP code returned for type HideNonFakeMoveTaskOrdersUnauthorized
 const HideNonFakeMoveTaskOrdersUnauthorizedCode int = 401
 
-/*
-HideNonFakeMoveTaskOrdersUnauthorized The request was denied.
+/*HideNonFakeMoveTaskOrdersUnauthorized The request was denied.
 
 swagger:response hideNonFakeMoveTaskOrdersUnauthorized
 */
@@ -151,8 +148,7 @@ func (o *HideNonFakeMoveTaskOrdersUnauthorized) WriteResponse(rw http.ResponseWr
 // HideNonFakeMoveTaskOrdersForbiddenCode is the HTTP code returned for type HideNonFakeMoveTaskOrdersForbidden
 const HideNonFakeMoveTaskOrdersForbiddenCode int = 403
 
-/*
-HideNonFakeMoveTaskOrdersForbidden The request was denied.
+/*HideNonFakeMoveTaskOrdersForbidden The request was denied.
 
 swagger:response hideNonFakeMoveTaskOrdersForbidden
 */
@@ -196,8 +192,7 @@ func (o *HideNonFakeMoveTaskOrdersForbidden) WriteResponse(rw http.ResponseWrite
 // HideNonFakeMoveTaskOrdersNotFoundCode is the HTTP code returned for type HideNonFakeMoveTaskOrdersNotFound
 const HideNonFakeMoveTaskOrdersNotFoundCode int = 404
 
-/*
-HideNonFakeMoveTaskOrdersNotFound The requested resource wasn't found.
+/*HideNonFakeMoveTaskOrdersNotFound The requested resource wasn't found.
 
 swagger:response hideNonFakeMoveTaskOrdersNotFound
 */
@@ -241,8 +236,7 @@ func (o *HideNonFakeMoveTaskOrdersNotFound) WriteResponse(rw http.ResponseWriter
 // HideNonFakeMoveTaskOrdersConflictCode is the HTTP code returned for type HideNonFakeMoveTaskOrdersConflict
 const HideNonFakeMoveTaskOrdersConflictCode int = 409
 
-/*
-HideNonFakeMoveTaskOrdersConflict There was a conflict with the request.
+/*HideNonFakeMoveTaskOrdersConflict There was a conflict with the request.
 
 swagger:response hideNonFakeMoveTaskOrdersConflict
 */
@@ -286,8 +280,7 @@ func (o *HideNonFakeMoveTaskOrdersConflict) WriteResponse(rw http.ResponseWriter
 // HideNonFakeMoveTaskOrdersPreconditionFailedCode is the HTTP code returned for type HideNonFakeMoveTaskOrdersPreconditionFailed
 const HideNonFakeMoveTaskOrdersPreconditionFailedCode int = 412
 
-/*
-HideNonFakeMoveTaskOrdersPreconditionFailed Precondition failed, likely due to a stale eTag (If-Match). Fetch the request again to get the updated eTag value.
+/*HideNonFakeMoveTaskOrdersPreconditionFailed Precondition failed, likely due to a stale eTag (If-Match). Fetch the request again to get the updated eTag value.
 
 swagger:response hideNonFakeMoveTaskOrdersPreconditionFailed
 */
@@ -331,8 +324,7 @@ func (o *HideNonFakeMoveTaskOrdersPreconditionFailed) WriteResponse(rw http.Resp
 // HideNonFakeMoveTaskOrdersUnprocessableEntityCode is the HTTP code returned for type HideNonFakeMoveTaskOrdersUnprocessableEntity
 const HideNonFakeMoveTaskOrdersUnprocessableEntityCode int = 422
 
-/*
-HideNonFakeMoveTaskOrdersUnprocessableEntity The payload was unprocessable.
+/*HideNonFakeMoveTaskOrdersUnprocessableEntity The payload was unprocessable.
 
 swagger:response hideNonFakeMoveTaskOrdersUnprocessableEntity
 */
@@ -376,8 +368,7 @@ func (o *HideNonFakeMoveTaskOrdersUnprocessableEntity) WriteResponse(rw http.Res
 // HideNonFakeMoveTaskOrdersInternalServerErrorCode is the HTTP code returned for type HideNonFakeMoveTaskOrdersInternalServerError
 const HideNonFakeMoveTaskOrdersInternalServerErrorCode int = 500
 
-/*
-HideNonFakeMoveTaskOrdersInternalServerError A server error occurred.
+/*HideNonFakeMoveTaskOrdersInternalServerError A server error occurred.
 
 swagger:response hideNonFakeMoveTaskOrdersInternalServerError
 */

--- a/pkg/gen/supportapi/supportoperations/move_task_order/list_m_t_os.go
+++ b/pkg/gen/supportapi/supportoperations/move_task_order/list_m_t_os.go
@@ -29,8 +29,7 @@ func NewListMTOs(ctx *middleware.Context, handler ListMTOsHandler) *ListMTOs {
 	return &ListMTOs{Context: ctx, Handler: handler}
 }
 
-/*
-	ListMTOs swagger:route GET /move-task-orders moveTaskOrder listMTOs
+/* ListMTOs swagger:route GET /move-task-orders moveTaskOrder listMTOs
 
 listMTOs
 
@@ -38,6 +37,8 @@ listMTOs
 This endpoint lists all MoveTaskOrders regardless of whether or not they have been made available to Prime.
 
 It will provide nested information about the Customer and any associated MTOShipments, MTOServiceItems and PaymentRequests.
+
+
 */
 type ListMTOs struct {
 	Context *middleware.Context

--- a/pkg/gen/supportapi/supportoperations/move_task_order/list_m_t_os_responses.go
+++ b/pkg/gen/supportapi/supportoperations/move_task_order/list_m_t_os_responses.go
@@ -16,8 +16,7 @@ import (
 // ListMTOsOKCode is the HTTP code returned for type ListMTOsOK
 const ListMTOsOKCode int = 200
 
-/*
-ListMTOsOK Successfully retrieved all move task orders.
+/*ListMTOsOK Successfully retrieved all move task orders.
 
 swagger:response listMTOsOK
 */
@@ -64,8 +63,7 @@ func (o *ListMTOsOK) WriteResponse(rw http.ResponseWriter, producer runtime.Prod
 // ListMTOsBadRequestCode is the HTTP code returned for type ListMTOsBadRequest
 const ListMTOsBadRequestCode int = 400
 
-/*
-ListMTOsBadRequest The request payload is invalid.
+/*ListMTOsBadRequest The request payload is invalid.
 
 swagger:response listMTOsBadRequest
 */
@@ -109,8 +107,7 @@ func (o *ListMTOsBadRequest) WriteResponse(rw http.ResponseWriter, producer runt
 // ListMTOsUnauthorizedCode is the HTTP code returned for type ListMTOsUnauthorized
 const ListMTOsUnauthorizedCode int = 401
 
-/*
-ListMTOsUnauthorized The request was denied.
+/*ListMTOsUnauthorized The request was denied.
 
 swagger:response listMTOsUnauthorized
 */
@@ -154,8 +151,7 @@ func (o *ListMTOsUnauthorized) WriteResponse(rw http.ResponseWriter, producer ru
 // ListMTOsForbiddenCode is the HTTP code returned for type ListMTOsForbidden
 const ListMTOsForbiddenCode int = 403
 
-/*
-ListMTOsForbidden The request was denied.
+/*ListMTOsForbidden The request was denied.
 
 swagger:response listMTOsForbidden
 */
@@ -199,8 +195,7 @@ func (o *ListMTOsForbidden) WriteResponse(rw http.ResponseWriter, producer runti
 // ListMTOsNotFoundCode is the HTTP code returned for type ListMTOsNotFound
 const ListMTOsNotFoundCode int = 404
 
-/*
-ListMTOsNotFound The requested resource wasn't found.
+/*ListMTOsNotFound The requested resource wasn't found.
 
 swagger:response listMTOsNotFound
 */
@@ -244,8 +239,7 @@ func (o *ListMTOsNotFound) WriteResponse(rw http.ResponseWriter, producer runtim
 // ListMTOsInternalServerErrorCode is the HTTP code returned for type ListMTOsInternalServerError
 const ListMTOsInternalServerErrorCode int = 500
 
-/*
-ListMTOsInternalServerError A server error occurred.
+/*ListMTOsInternalServerError A server error occurred.
 
 swagger:response listMTOsInternalServerError
 */

--- a/pkg/gen/supportapi/supportoperations/move_task_order/make_move_task_order_available.go
+++ b/pkg/gen/supportapi/supportoperations/move_task_order/make_move_task_order_available.go
@@ -29,14 +29,15 @@ func NewMakeMoveTaskOrderAvailable(ctx *middleware.Context, handler MakeMoveTask
 	return &MakeMoveTaskOrderAvailable{Context: ctx, Handler: handler}
 }
 
-/*
-	MakeMoveTaskOrderAvailable swagger:route PATCH /move-task-orders/{moveTaskOrderID}/available-to-prime moveTaskOrder makeMoveTaskOrderAvailable
+/* MakeMoveTaskOrderAvailable swagger:route PATCH /move-task-orders/{moveTaskOrderID}/available-to-prime moveTaskOrder makeMoveTaskOrderAvailable
 
 makeMoveTaskOrderAvailable
 
 Updates move task order `availableToPrimeAt` to make it available to prime. No request body required. <br />
 <br />
 This is a support endpoint and will not be available in production.
+
+
 */
 type MakeMoveTaskOrderAvailable struct {
 	Context *middleware.Context

--- a/pkg/gen/supportapi/supportoperations/move_task_order/make_move_task_order_available_responses.go
+++ b/pkg/gen/supportapi/supportoperations/move_task_order/make_move_task_order_available_responses.go
@@ -16,8 +16,7 @@ import (
 // MakeMoveTaskOrderAvailableOKCode is the HTTP code returned for type MakeMoveTaskOrderAvailableOK
 const MakeMoveTaskOrderAvailableOKCode int = 200
 
-/*
-MakeMoveTaskOrderAvailableOK Successfully made MTO available to Prime.
+/*MakeMoveTaskOrderAvailableOK Successfully made MTO available to Prime.
 
 swagger:response makeMoveTaskOrderAvailableOK
 */
@@ -61,8 +60,7 @@ func (o *MakeMoveTaskOrderAvailableOK) WriteResponse(rw http.ResponseWriter, pro
 // MakeMoveTaskOrderAvailableBadRequestCode is the HTTP code returned for type MakeMoveTaskOrderAvailableBadRequest
 const MakeMoveTaskOrderAvailableBadRequestCode int = 400
 
-/*
-MakeMoveTaskOrderAvailableBadRequest The request payload is invalid.
+/*MakeMoveTaskOrderAvailableBadRequest The request payload is invalid.
 
 swagger:response makeMoveTaskOrderAvailableBadRequest
 */
@@ -106,8 +104,7 @@ func (o *MakeMoveTaskOrderAvailableBadRequest) WriteResponse(rw http.ResponseWri
 // MakeMoveTaskOrderAvailableUnauthorizedCode is the HTTP code returned for type MakeMoveTaskOrderAvailableUnauthorized
 const MakeMoveTaskOrderAvailableUnauthorizedCode int = 401
 
-/*
-MakeMoveTaskOrderAvailableUnauthorized The request was denied.
+/*MakeMoveTaskOrderAvailableUnauthorized The request was denied.
 
 swagger:response makeMoveTaskOrderAvailableUnauthorized
 */
@@ -151,8 +148,7 @@ func (o *MakeMoveTaskOrderAvailableUnauthorized) WriteResponse(rw http.ResponseW
 // MakeMoveTaskOrderAvailableForbiddenCode is the HTTP code returned for type MakeMoveTaskOrderAvailableForbidden
 const MakeMoveTaskOrderAvailableForbiddenCode int = 403
 
-/*
-MakeMoveTaskOrderAvailableForbidden The request was denied.
+/*MakeMoveTaskOrderAvailableForbidden The request was denied.
 
 swagger:response makeMoveTaskOrderAvailableForbidden
 */
@@ -196,8 +192,7 @@ func (o *MakeMoveTaskOrderAvailableForbidden) WriteResponse(rw http.ResponseWrit
 // MakeMoveTaskOrderAvailableNotFoundCode is the HTTP code returned for type MakeMoveTaskOrderAvailableNotFound
 const MakeMoveTaskOrderAvailableNotFoundCode int = 404
 
-/*
-MakeMoveTaskOrderAvailableNotFound The requested resource wasn't found.
+/*MakeMoveTaskOrderAvailableNotFound The requested resource wasn't found.
 
 swagger:response makeMoveTaskOrderAvailableNotFound
 */
@@ -241,8 +236,7 @@ func (o *MakeMoveTaskOrderAvailableNotFound) WriteResponse(rw http.ResponseWrite
 // MakeMoveTaskOrderAvailablePreconditionFailedCode is the HTTP code returned for type MakeMoveTaskOrderAvailablePreconditionFailed
 const MakeMoveTaskOrderAvailablePreconditionFailedCode int = 412
 
-/*
-MakeMoveTaskOrderAvailablePreconditionFailed Precondition failed, likely due to a stale eTag (If-Match). Fetch the request again to get the updated eTag value.
+/*MakeMoveTaskOrderAvailablePreconditionFailed Precondition failed, likely due to a stale eTag (If-Match). Fetch the request again to get the updated eTag value.
 
 swagger:response makeMoveTaskOrderAvailablePreconditionFailed
 */
@@ -286,8 +280,7 @@ func (o *MakeMoveTaskOrderAvailablePreconditionFailed) WriteResponse(rw http.Res
 // MakeMoveTaskOrderAvailableUnprocessableEntityCode is the HTTP code returned for type MakeMoveTaskOrderAvailableUnprocessableEntity
 const MakeMoveTaskOrderAvailableUnprocessableEntityCode int = 422
 
-/*
-MakeMoveTaskOrderAvailableUnprocessableEntity The payload was unprocessable.
+/*MakeMoveTaskOrderAvailableUnprocessableEntity The payload was unprocessable.
 
 swagger:response makeMoveTaskOrderAvailableUnprocessableEntity
 */
@@ -331,8 +324,7 @@ func (o *MakeMoveTaskOrderAvailableUnprocessableEntity) WriteResponse(rw http.Re
 // MakeMoveTaskOrderAvailableInternalServerErrorCode is the HTTP code returned for type MakeMoveTaskOrderAvailableInternalServerError
 const MakeMoveTaskOrderAvailableInternalServerErrorCode int = 500
 
-/*
-MakeMoveTaskOrderAvailableInternalServerError A server error occurred.
+/*MakeMoveTaskOrderAvailableInternalServerError A server error occurred.
 
 swagger:response makeMoveTaskOrderAvailableInternalServerError
 */

--- a/pkg/gen/supportapi/supportoperations/mto_service_item/update_m_t_o_service_item_status.go
+++ b/pkg/gen/supportapi/supportoperations/mto_service_item/update_m_t_o_service_item_status.go
@@ -29,14 +29,15 @@ func NewUpdateMTOServiceItemStatus(ctx *middleware.Context, handler UpdateMTOSer
 	return &UpdateMTOServiceItemStatus{Context: ctx, Handler: handler}
 }
 
-/*
-	UpdateMTOServiceItemStatus swagger:route PATCH /mto-service-items/{mtoServiceItemID}/status mtoServiceItem updateMTOServiceItemStatus
+/* UpdateMTOServiceItemStatus swagger:route PATCH /mto-service-items/{mtoServiceItemID}/status mtoServiceItem updateMTOServiceItemStatus
 
 updateMTOServiceItemStatus
 
 Updates the status of a service item for a move to APPROVED or REJECTED. <br />
 <br />
 This is a support endpoint and will not be available in production.
+
+
 */
 type UpdateMTOServiceItemStatus struct {
 	Context *middleware.Context

--- a/pkg/gen/supportapi/supportoperations/mto_service_item/update_m_t_o_service_item_status_responses.go
+++ b/pkg/gen/supportapi/supportoperations/mto_service_item/update_m_t_o_service_item_status_responses.go
@@ -16,8 +16,7 @@ import (
 // UpdateMTOServiceItemStatusOKCode is the HTTP code returned for type UpdateMTOServiceItemStatusOK
 const UpdateMTOServiceItemStatusOKCode int = 200
 
-/*
-UpdateMTOServiceItemStatusOK Successfully updated service item status for a move task order.
+/*UpdateMTOServiceItemStatusOK Successfully updated service item status for a move task order.
 
 swagger:response updateMTOServiceItemStatusOK
 */
@@ -61,8 +60,7 @@ func (o *UpdateMTOServiceItemStatusOK) WriteResponse(rw http.ResponseWriter, pro
 // UpdateMTOServiceItemStatusBadRequestCode is the HTTP code returned for type UpdateMTOServiceItemStatusBadRequest
 const UpdateMTOServiceItemStatusBadRequestCode int = 400
 
-/*
-UpdateMTOServiceItemStatusBadRequest The request payload is invalid.
+/*UpdateMTOServiceItemStatusBadRequest The request payload is invalid.
 
 swagger:response updateMTOServiceItemStatusBadRequest
 */
@@ -106,8 +104,7 @@ func (o *UpdateMTOServiceItemStatusBadRequest) WriteResponse(rw http.ResponseWri
 // UpdateMTOServiceItemStatusUnauthorizedCode is the HTTP code returned for type UpdateMTOServiceItemStatusUnauthorized
 const UpdateMTOServiceItemStatusUnauthorizedCode int = 401
 
-/*
-UpdateMTOServiceItemStatusUnauthorized The request was denied.
+/*UpdateMTOServiceItemStatusUnauthorized The request was denied.
 
 swagger:response updateMTOServiceItemStatusUnauthorized
 */
@@ -151,8 +148,7 @@ func (o *UpdateMTOServiceItemStatusUnauthorized) WriteResponse(rw http.ResponseW
 // UpdateMTOServiceItemStatusForbiddenCode is the HTTP code returned for type UpdateMTOServiceItemStatusForbidden
 const UpdateMTOServiceItemStatusForbiddenCode int = 403
 
-/*
-UpdateMTOServiceItemStatusForbidden The request was denied.
+/*UpdateMTOServiceItemStatusForbidden The request was denied.
 
 swagger:response updateMTOServiceItemStatusForbidden
 */
@@ -196,8 +192,7 @@ func (o *UpdateMTOServiceItemStatusForbidden) WriteResponse(rw http.ResponseWrit
 // UpdateMTOServiceItemStatusNotFoundCode is the HTTP code returned for type UpdateMTOServiceItemStatusNotFound
 const UpdateMTOServiceItemStatusNotFoundCode int = 404
 
-/*
-UpdateMTOServiceItemStatusNotFound The requested resource wasn't found.
+/*UpdateMTOServiceItemStatusNotFound The requested resource wasn't found.
 
 swagger:response updateMTOServiceItemStatusNotFound
 */
@@ -241,8 +236,7 @@ func (o *UpdateMTOServiceItemStatusNotFound) WriteResponse(rw http.ResponseWrite
 // UpdateMTOServiceItemStatusConflictCode is the HTTP code returned for type UpdateMTOServiceItemStatusConflict
 const UpdateMTOServiceItemStatusConflictCode int = 409
 
-/*
-UpdateMTOServiceItemStatusConflict There was a conflict with the request.
+/*UpdateMTOServiceItemStatusConflict There was a conflict with the request.
 
 swagger:response updateMTOServiceItemStatusConflict
 */
@@ -286,8 +280,7 @@ func (o *UpdateMTOServiceItemStatusConflict) WriteResponse(rw http.ResponseWrite
 // UpdateMTOServiceItemStatusPreconditionFailedCode is the HTTP code returned for type UpdateMTOServiceItemStatusPreconditionFailed
 const UpdateMTOServiceItemStatusPreconditionFailedCode int = 412
 
-/*
-UpdateMTOServiceItemStatusPreconditionFailed Precondition failed, likely due to a stale eTag (If-Match). Fetch the request again to get the updated eTag value.
+/*UpdateMTOServiceItemStatusPreconditionFailed Precondition failed, likely due to a stale eTag (If-Match). Fetch the request again to get the updated eTag value.
 
 swagger:response updateMTOServiceItemStatusPreconditionFailed
 */
@@ -331,8 +324,7 @@ func (o *UpdateMTOServiceItemStatusPreconditionFailed) WriteResponse(rw http.Res
 // UpdateMTOServiceItemStatusUnprocessableEntityCode is the HTTP code returned for type UpdateMTOServiceItemStatusUnprocessableEntity
 const UpdateMTOServiceItemStatusUnprocessableEntityCode int = 422
 
-/*
-UpdateMTOServiceItemStatusUnprocessableEntity The payload was unprocessable.
+/*UpdateMTOServiceItemStatusUnprocessableEntity The payload was unprocessable.
 
 swagger:response updateMTOServiceItemStatusUnprocessableEntity
 */
@@ -376,8 +368,7 @@ func (o *UpdateMTOServiceItemStatusUnprocessableEntity) WriteResponse(rw http.Re
 // UpdateMTOServiceItemStatusInternalServerErrorCode is the HTTP code returned for type UpdateMTOServiceItemStatusInternalServerError
 const UpdateMTOServiceItemStatusInternalServerErrorCode int = 500
 
-/*
-UpdateMTOServiceItemStatusInternalServerError A server error occurred.
+/*UpdateMTOServiceItemStatusInternalServerError A server error occurred.
 
 swagger:response updateMTOServiceItemStatusInternalServerError
 */

--- a/pkg/gen/supportapi/supportoperations/mto_shipment/update_m_t_o_shipment_status.go
+++ b/pkg/gen/supportapi/supportoperations/mto_shipment/update_m_t_o_shipment_status.go
@@ -29,12 +29,13 @@ func NewUpdateMTOShipmentStatus(ctx *middleware.Context, handler UpdateMTOShipme
 	return &UpdateMTOShipmentStatus{Context: ctx, Handler: handler}
 }
 
-/*
-	UpdateMTOShipmentStatus swagger:route PATCH /mto-shipments/{mtoShipmentID}/status mtoShipment updateMTOShipmentStatus
+/* UpdateMTOShipmentStatus swagger:route PATCH /mto-shipments/{mtoShipmentID}/status mtoShipment updateMTOShipmentStatus
 
 updateMTOShipmentStatus
 
 Updates a shipment's status to APPROVED or REJECTED for the purpose of testing the Prime API. If APPROVED, `rejectionReason` should be blank and any value passed through the body will be ignored. If REJECTED, a value in `rejectionReason` is required. <br /> <br /> This is a support endpoint and will not be available in production.
+
+
 */
 type UpdateMTOShipmentStatus struct {
 	Context *middleware.Context

--- a/pkg/gen/supportapi/supportoperations/mto_shipment/update_m_t_o_shipment_status_responses.go
+++ b/pkg/gen/supportapi/supportoperations/mto_shipment/update_m_t_o_shipment_status_responses.go
@@ -16,8 +16,7 @@ import (
 // UpdateMTOShipmentStatusOKCode is the HTTP code returned for type UpdateMTOShipmentStatusOK
 const UpdateMTOShipmentStatusOKCode int = 200
 
-/*
-UpdateMTOShipmentStatusOK Successfully updated the shipment's status.
+/*UpdateMTOShipmentStatusOK Successfully updated the shipment's status.
 
 swagger:response updateMTOShipmentStatusOK
 */
@@ -61,8 +60,7 @@ func (o *UpdateMTOShipmentStatusOK) WriteResponse(rw http.ResponseWriter, produc
 // UpdateMTOShipmentStatusBadRequestCode is the HTTP code returned for type UpdateMTOShipmentStatusBadRequest
 const UpdateMTOShipmentStatusBadRequestCode int = 400
 
-/*
-UpdateMTOShipmentStatusBadRequest The request payload is invalid.
+/*UpdateMTOShipmentStatusBadRequest The request payload is invalid.
 
 swagger:response updateMTOShipmentStatusBadRequest
 */
@@ -106,8 +104,7 @@ func (o *UpdateMTOShipmentStatusBadRequest) WriteResponse(rw http.ResponseWriter
 // UpdateMTOShipmentStatusUnauthorizedCode is the HTTP code returned for type UpdateMTOShipmentStatusUnauthorized
 const UpdateMTOShipmentStatusUnauthorizedCode int = 401
 
-/*
-UpdateMTOShipmentStatusUnauthorized The request was denied.
+/*UpdateMTOShipmentStatusUnauthorized The request was denied.
 
 swagger:response updateMTOShipmentStatusUnauthorized
 */
@@ -151,8 +148,7 @@ func (o *UpdateMTOShipmentStatusUnauthorized) WriteResponse(rw http.ResponseWrit
 // UpdateMTOShipmentStatusForbiddenCode is the HTTP code returned for type UpdateMTOShipmentStatusForbidden
 const UpdateMTOShipmentStatusForbiddenCode int = 403
 
-/*
-UpdateMTOShipmentStatusForbidden The request was denied.
+/*UpdateMTOShipmentStatusForbidden The request was denied.
 
 swagger:response updateMTOShipmentStatusForbidden
 */
@@ -196,8 +192,7 @@ func (o *UpdateMTOShipmentStatusForbidden) WriteResponse(rw http.ResponseWriter,
 // UpdateMTOShipmentStatusNotFoundCode is the HTTP code returned for type UpdateMTOShipmentStatusNotFound
 const UpdateMTOShipmentStatusNotFoundCode int = 404
 
-/*
-UpdateMTOShipmentStatusNotFound The requested resource wasn't found.
+/*UpdateMTOShipmentStatusNotFound The requested resource wasn't found.
 
 swagger:response updateMTOShipmentStatusNotFound
 */
@@ -241,8 +236,7 @@ func (o *UpdateMTOShipmentStatusNotFound) WriteResponse(rw http.ResponseWriter, 
 // UpdateMTOShipmentStatusConflictCode is the HTTP code returned for type UpdateMTOShipmentStatusConflict
 const UpdateMTOShipmentStatusConflictCode int = 409
 
-/*
-UpdateMTOShipmentStatusConflict There was a conflict with the request.
+/*UpdateMTOShipmentStatusConflict There was a conflict with the request.
 
 swagger:response updateMTOShipmentStatusConflict
 */
@@ -286,8 +280,7 @@ func (o *UpdateMTOShipmentStatusConflict) WriteResponse(rw http.ResponseWriter, 
 // UpdateMTOShipmentStatusPreconditionFailedCode is the HTTP code returned for type UpdateMTOShipmentStatusPreconditionFailed
 const UpdateMTOShipmentStatusPreconditionFailedCode int = 412
 
-/*
-UpdateMTOShipmentStatusPreconditionFailed Precondition failed, likely due to a stale eTag (If-Match). Fetch the request again to get the updated eTag value.
+/*UpdateMTOShipmentStatusPreconditionFailed Precondition failed, likely due to a stale eTag (If-Match). Fetch the request again to get the updated eTag value.
 
 swagger:response updateMTOShipmentStatusPreconditionFailed
 */
@@ -331,8 +324,7 @@ func (o *UpdateMTOShipmentStatusPreconditionFailed) WriteResponse(rw http.Respon
 // UpdateMTOShipmentStatusUnprocessableEntityCode is the HTTP code returned for type UpdateMTOShipmentStatusUnprocessableEntity
 const UpdateMTOShipmentStatusUnprocessableEntityCode int = 422
 
-/*
-UpdateMTOShipmentStatusUnprocessableEntity The payload was unprocessable.
+/*UpdateMTOShipmentStatusUnprocessableEntity The payload was unprocessable.
 
 swagger:response updateMTOShipmentStatusUnprocessableEntity
 */
@@ -376,8 +368,7 @@ func (o *UpdateMTOShipmentStatusUnprocessableEntity) WriteResponse(rw http.Respo
 // UpdateMTOShipmentStatusInternalServerErrorCode is the HTTP code returned for type UpdateMTOShipmentStatusInternalServerError
 const UpdateMTOShipmentStatusInternalServerErrorCode int = 500
 
-/*
-UpdateMTOShipmentStatusInternalServerError A server error occurred.
+/*UpdateMTOShipmentStatusInternalServerError A server error occurred.
 
 swagger:response updateMTOShipmentStatusInternalServerError
 */

--- a/pkg/gen/supportapi/supportoperations/mymove_api.go
+++ b/pkg/gen/supportapi/supportoperations/mymove_api.go
@@ -93,8 +93,7 @@ func NewMymoveAPI(spec *loads.Document) *MymoveAPI {
 	}
 }
 
-/*
-MymoveAPI The Support API gives you programmatic access to support functionality useful
+/*MymoveAPI The Support API gives you programmatic access to support functionality useful
 for testing and debugging. **This API is not available in the Production
 environment**.
 

--- a/pkg/gen/supportapi/supportoperations/payment_request/get_payment_request_e_d_i.go
+++ b/pkg/gen/supportapi/supportoperations/payment_request/get_payment_request_e_d_i.go
@@ -29,8 +29,7 @@ func NewGetPaymentRequestEDI(ctx *middleware.Context, handler GetPaymentRequestE
 	return &GetPaymentRequestEDI{Context: ctx, Handler: handler}
 }
 
-/*
-	GetPaymentRequestEDI swagger:route GET /payment-requests/{paymentRequestID}/edi paymentRequest getPaymentRequestEDI
+/* GetPaymentRequestEDI swagger:route GET /payment-requests/{paymentRequestID}/edi paymentRequest getPaymentRequestEDI
 
 getPaymentRequestEDI
 
@@ -39,6 +38,8 @@ by the given payment request ID. Note that the EDI returned in the JSON payload 
 would normally be line breaks (due to JSON not allowing line breaks in a string).
 
 This is a support endpoint and will not be available in production.
+
+
 */
 type GetPaymentRequestEDI struct {
 	Context *middleware.Context

--- a/pkg/gen/supportapi/supportoperations/payment_request/get_payment_request_e_d_i_responses.go
+++ b/pkg/gen/supportapi/supportoperations/payment_request/get_payment_request_e_d_i_responses.go
@@ -16,8 +16,7 @@ import (
 // GetPaymentRequestEDIOKCode is the HTTP code returned for type GetPaymentRequestEDIOK
 const GetPaymentRequestEDIOKCode int = 200
 
-/*
-GetPaymentRequestEDIOK Successfully retrieved payment requests associated with a given move task order
+/*GetPaymentRequestEDIOK Successfully retrieved payment requests associated with a given move task order
 
 swagger:response getPaymentRequestEDIOK
 */
@@ -61,8 +60,7 @@ func (o *GetPaymentRequestEDIOK) WriteResponse(rw http.ResponseWriter, producer 
 // GetPaymentRequestEDIBadRequestCode is the HTTP code returned for type GetPaymentRequestEDIBadRequest
 const GetPaymentRequestEDIBadRequestCode int = 400
 
-/*
-GetPaymentRequestEDIBadRequest The request payload is invalid.
+/*GetPaymentRequestEDIBadRequest The request payload is invalid.
 
 swagger:response getPaymentRequestEDIBadRequest
 */
@@ -106,8 +104,7 @@ func (o *GetPaymentRequestEDIBadRequest) WriteResponse(rw http.ResponseWriter, p
 // GetPaymentRequestEDIUnauthorizedCode is the HTTP code returned for type GetPaymentRequestEDIUnauthorized
 const GetPaymentRequestEDIUnauthorizedCode int = 401
 
-/*
-GetPaymentRequestEDIUnauthorized The request was denied.
+/*GetPaymentRequestEDIUnauthorized The request was denied.
 
 swagger:response getPaymentRequestEDIUnauthorized
 */
@@ -151,8 +148,7 @@ func (o *GetPaymentRequestEDIUnauthorized) WriteResponse(rw http.ResponseWriter,
 // GetPaymentRequestEDIForbiddenCode is the HTTP code returned for type GetPaymentRequestEDIForbidden
 const GetPaymentRequestEDIForbiddenCode int = 403
 
-/*
-GetPaymentRequestEDIForbidden The request was denied.
+/*GetPaymentRequestEDIForbidden The request was denied.
 
 swagger:response getPaymentRequestEDIForbidden
 */
@@ -196,8 +192,7 @@ func (o *GetPaymentRequestEDIForbidden) WriteResponse(rw http.ResponseWriter, pr
 // GetPaymentRequestEDINotFoundCode is the HTTP code returned for type GetPaymentRequestEDINotFound
 const GetPaymentRequestEDINotFoundCode int = 404
 
-/*
-GetPaymentRequestEDINotFound The requested resource wasn't found.
+/*GetPaymentRequestEDINotFound The requested resource wasn't found.
 
 swagger:response getPaymentRequestEDINotFound
 */
@@ -241,8 +236,7 @@ func (o *GetPaymentRequestEDINotFound) WriteResponse(rw http.ResponseWriter, pro
 // GetPaymentRequestEDIConflictCode is the HTTP code returned for type GetPaymentRequestEDIConflict
 const GetPaymentRequestEDIConflictCode int = 409
 
-/*
-GetPaymentRequestEDIConflict There was a conflict with the request.
+/*GetPaymentRequestEDIConflict There was a conflict with the request.
 
 swagger:response getPaymentRequestEDIConflict
 */
@@ -286,8 +280,7 @@ func (o *GetPaymentRequestEDIConflict) WriteResponse(rw http.ResponseWriter, pro
 // GetPaymentRequestEDIUnprocessableEntityCode is the HTTP code returned for type GetPaymentRequestEDIUnprocessableEntity
 const GetPaymentRequestEDIUnprocessableEntityCode int = 422
 
-/*
-GetPaymentRequestEDIUnprocessableEntity The payload was unprocessable.
+/*GetPaymentRequestEDIUnprocessableEntity The payload was unprocessable.
 
 swagger:response getPaymentRequestEDIUnprocessableEntity
 */
@@ -331,8 +324,7 @@ func (o *GetPaymentRequestEDIUnprocessableEntity) WriteResponse(rw http.Response
 // GetPaymentRequestEDIInternalServerErrorCode is the HTTP code returned for type GetPaymentRequestEDIInternalServerError
 const GetPaymentRequestEDIInternalServerErrorCode int = 500
 
-/*
-GetPaymentRequestEDIInternalServerError A server error occurred.
+/*GetPaymentRequestEDIInternalServerError A server error occurred.
 
 swagger:response getPaymentRequestEDIInternalServerError
 */

--- a/pkg/gen/supportapi/supportoperations/payment_request/list_m_t_o_payment_requests.go
+++ b/pkg/gen/supportapi/supportoperations/payment_request/list_m_t_o_payment_requests.go
@@ -29,8 +29,7 @@ func NewListMTOPaymentRequests(ctx *middleware.Context, handler ListMTOPaymentRe
 	return &ListMTOPaymentRequests{Context: ctx, Handler: handler}
 }
 
-/*
-	ListMTOPaymentRequests swagger:route GET /move-task-orders/{moveTaskOrderID}/payment-requests paymentRequest listMTOPaymentRequests
+/* ListMTOPaymentRequests swagger:route GET /move-task-orders/{moveTaskOrderID}/payment-requests paymentRequest listMTOPaymentRequests
 
 listMTOPaymentRequests
 
@@ -39,6 +38,8 @@ listMTOPaymentRequests
 This endpoint lists all PaymentRequests associated with a given MoveTaskOrder.
 
 This is a support endpoint and is not available in production.
+
+
 */
 type ListMTOPaymentRequests struct {
 	Context *middleware.Context

--- a/pkg/gen/supportapi/supportoperations/payment_request/list_m_t_o_payment_requests_responses.go
+++ b/pkg/gen/supportapi/supportoperations/payment_request/list_m_t_o_payment_requests_responses.go
@@ -16,8 +16,7 @@ import (
 // ListMTOPaymentRequestsOKCode is the HTTP code returned for type ListMTOPaymentRequestsOK
 const ListMTOPaymentRequestsOKCode int = 200
 
-/*
-ListMTOPaymentRequestsOK Successfully retrieved payment requests associated with a given move task order
+/*ListMTOPaymentRequestsOK Successfully retrieved payment requests associated with a given move task order
 
 swagger:response listMTOPaymentRequestsOK
 */
@@ -64,8 +63,7 @@ func (o *ListMTOPaymentRequestsOK) WriteResponse(rw http.ResponseWriter, produce
 // ListMTOPaymentRequestsBadRequestCode is the HTTP code returned for type ListMTOPaymentRequestsBadRequest
 const ListMTOPaymentRequestsBadRequestCode int = 400
 
-/*
-ListMTOPaymentRequestsBadRequest The request payload is invalid.
+/*ListMTOPaymentRequestsBadRequest The request payload is invalid.
 
 swagger:response listMTOPaymentRequestsBadRequest
 */
@@ -109,8 +107,7 @@ func (o *ListMTOPaymentRequestsBadRequest) WriteResponse(rw http.ResponseWriter,
 // ListMTOPaymentRequestsUnauthorizedCode is the HTTP code returned for type ListMTOPaymentRequestsUnauthorized
 const ListMTOPaymentRequestsUnauthorizedCode int = 401
 
-/*
-ListMTOPaymentRequestsUnauthorized The request was denied.
+/*ListMTOPaymentRequestsUnauthorized The request was denied.
 
 swagger:response listMTOPaymentRequestsUnauthorized
 */
@@ -154,8 +151,7 @@ func (o *ListMTOPaymentRequestsUnauthorized) WriteResponse(rw http.ResponseWrite
 // ListMTOPaymentRequestsForbiddenCode is the HTTP code returned for type ListMTOPaymentRequestsForbidden
 const ListMTOPaymentRequestsForbiddenCode int = 403
 
-/*
-ListMTOPaymentRequestsForbidden The request was denied.
+/*ListMTOPaymentRequestsForbidden The request was denied.
 
 swagger:response listMTOPaymentRequestsForbidden
 */
@@ -199,8 +195,7 @@ func (o *ListMTOPaymentRequestsForbidden) WriteResponse(rw http.ResponseWriter, 
 // ListMTOPaymentRequestsNotFoundCode is the HTTP code returned for type ListMTOPaymentRequestsNotFound
 const ListMTOPaymentRequestsNotFoundCode int = 404
 
-/*
-ListMTOPaymentRequestsNotFound The requested resource wasn't found.
+/*ListMTOPaymentRequestsNotFound The requested resource wasn't found.
 
 swagger:response listMTOPaymentRequestsNotFound
 */
@@ -244,8 +239,7 @@ func (o *ListMTOPaymentRequestsNotFound) WriteResponse(rw http.ResponseWriter, p
 // ListMTOPaymentRequestsInternalServerErrorCode is the HTTP code returned for type ListMTOPaymentRequestsInternalServerError
 const ListMTOPaymentRequestsInternalServerErrorCode int = 500
 
-/*
-ListMTOPaymentRequestsInternalServerError A server error occurred.
+/*ListMTOPaymentRequestsInternalServerError A server error occurred.
 
 swagger:response listMTOPaymentRequestsInternalServerError
 */

--- a/pkg/gen/supportapi/supportoperations/payment_request/process_reviewed_payment_requests.go
+++ b/pkg/gen/supportapi/supportoperations/payment_request/process_reviewed_payment_requests.go
@@ -29,8 +29,7 @@ func NewProcessReviewedPaymentRequests(ctx *middleware.Context, handler ProcessR
 	return &ProcessReviewedPaymentRequests{Context: ctx, Handler: handler}
 }
 
-/*
-	ProcessReviewedPaymentRequests swagger:route PATCH /payment-requests/process-reviewed paymentRequest processReviewedPaymentRequests
+/* ProcessReviewedPaymentRequests swagger:route PATCH /payment-requests/process-reviewed paymentRequest processReviewedPaymentRequests
 
 processReviewedPaymentRequests
 
@@ -38,6 +37,8 @@ Updates the status of reviewed payment requests and sends PRs to Syncada if
 the SendToSyncada flag is set
 
 This is a support endpoint and will not be available in production.
+
+
 */
 type ProcessReviewedPaymentRequests struct {
 	Context *middleware.Context

--- a/pkg/gen/supportapi/supportoperations/payment_request/process_reviewed_payment_requests_responses.go
+++ b/pkg/gen/supportapi/supportoperations/payment_request/process_reviewed_payment_requests_responses.go
@@ -16,8 +16,7 @@ import (
 // ProcessReviewedPaymentRequestsOKCode is the HTTP code returned for type ProcessReviewedPaymentRequestsOK
 const ProcessReviewedPaymentRequestsOKCode int = 200
 
-/*
-ProcessReviewedPaymentRequestsOK Successfully updated status of reviewed payment request and sent to Syncada if that flag is set
+/*ProcessReviewedPaymentRequestsOK Successfully updated status of reviewed payment request and sent to Syncada if that flag is set
 
 swagger:response processReviewedPaymentRequestsOK
 */
@@ -64,8 +63,7 @@ func (o *ProcessReviewedPaymentRequestsOK) WriteResponse(rw http.ResponseWriter,
 // ProcessReviewedPaymentRequestsBadRequestCode is the HTTP code returned for type ProcessReviewedPaymentRequestsBadRequest
 const ProcessReviewedPaymentRequestsBadRequestCode int = 400
 
-/*
-ProcessReviewedPaymentRequestsBadRequest The request payload is invalid.
+/*ProcessReviewedPaymentRequestsBadRequest The request payload is invalid.
 
 swagger:response processReviewedPaymentRequestsBadRequest
 */
@@ -109,8 +107,7 @@ func (o *ProcessReviewedPaymentRequestsBadRequest) WriteResponse(rw http.Respons
 // ProcessReviewedPaymentRequestsUnauthorizedCode is the HTTP code returned for type ProcessReviewedPaymentRequestsUnauthorized
 const ProcessReviewedPaymentRequestsUnauthorizedCode int = 401
 
-/*
-ProcessReviewedPaymentRequestsUnauthorized The request was denied.
+/*ProcessReviewedPaymentRequestsUnauthorized The request was denied.
 
 swagger:response processReviewedPaymentRequestsUnauthorized
 */
@@ -154,8 +151,7 @@ func (o *ProcessReviewedPaymentRequestsUnauthorized) WriteResponse(rw http.Respo
 // ProcessReviewedPaymentRequestsForbiddenCode is the HTTP code returned for type ProcessReviewedPaymentRequestsForbidden
 const ProcessReviewedPaymentRequestsForbiddenCode int = 403
 
-/*
-ProcessReviewedPaymentRequestsForbidden The request was denied.
+/*ProcessReviewedPaymentRequestsForbidden The request was denied.
 
 swagger:response processReviewedPaymentRequestsForbidden
 */
@@ -199,8 +195,7 @@ func (o *ProcessReviewedPaymentRequestsForbidden) WriteResponse(rw http.Response
 // ProcessReviewedPaymentRequestsNotFoundCode is the HTTP code returned for type ProcessReviewedPaymentRequestsNotFound
 const ProcessReviewedPaymentRequestsNotFoundCode int = 404
 
-/*
-ProcessReviewedPaymentRequestsNotFound The requested resource wasn't found.
+/*ProcessReviewedPaymentRequestsNotFound The requested resource wasn't found.
 
 swagger:response processReviewedPaymentRequestsNotFound
 */
@@ -244,8 +239,7 @@ func (o *ProcessReviewedPaymentRequestsNotFound) WriteResponse(rw http.ResponseW
 // ProcessReviewedPaymentRequestsUnprocessableEntityCode is the HTTP code returned for type ProcessReviewedPaymentRequestsUnprocessableEntity
 const ProcessReviewedPaymentRequestsUnprocessableEntityCode int = 422
 
-/*
-ProcessReviewedPaymentRequestsUnprocessableEntity The payload was unprocessable.
+/*ProcessReviewedPaymentRequestsUnprocessableEntity The payload was unprocessable.
 
 swagger:response processReviewedPaymentRequestsUnprocessableEntity
 */
@@ -289,8 +283,7 @@ func (o *ProcessReviewedPaymentRequestsUnprocessableEntity) WriteResponse(rw htt
 // ProcessReviewedPaymentRequestsInternalServerErrorCode is the HTTP code returned for type ProcessReviewedPaymentRequestsInternalServerError
 const ProcessReviewedPaymentRequestsInternalServerErrorCode int = 500
 
-/*
-ProcessReviewedPaymentRequestsInternalServerError A server error occurred.
+/*ProcessReviewedPaymentRequestsInternalServerError A server error occurred.
 
 swagger:response processReviewedPaymentRequestsInternalServerError
 */

--- a/pkg/gen/supportapi/supportoperations/payment_request/recalculate_payment_request.go
+++ b/pkg/gen/supportapi/supportoperations/payment_request/recalculate_payment_request.go
@@ -29,8 +29,7 @@ func NewRecalculatePaymentRequest(ctx *middleware.Context, handler RecalculatePa
 	return &RecalculatePaymentRequest{Context: ctx, Handler: handler}
 }
 
-/*
-	RecalculatePaymentRequest swagger:route POST /payment-requests/{paymentRequestID}/recalculate paymentRequest recalculatePaymentRequest
+/* RecalculatePaymentRequest swagger:route POST /payment-requests/{paymentRequestID}/recalculate paymentRequest recalculatePaymentRequest
 
 recalculatePaymentRequest
 
@@ -39,6 +38,8 @@ items but is priced based on the current inputs (weights, dates, etc.). The prev
 request is then deprecated. A link is made between the new and existing payment requests.
 
 This is a support endpoint and will not be available in production.
+
+
 */
 type RecalculatePaymentRequest struct {
 	Context *middleware.Context

--- a/pkg/gen/supportapi/supportoperations/payment_request/recalculate_payment_request_responses.go
+++ b/pkg/gen/supportapi/supportoperations/payment_request/recalculate_payment_request_responses.go
@@ -16,8 +16,7 @@ import (
 // RecalculatePaymentRequestCreatedCode is the HTTP code returned for type RecalculatePaymentRequestCreated
 const RecalculatePaymentRequestCreatedCode int = 201
 
-/*
-RecalculatePaymentRequestCreated The new payment request with recalculated pricing.
+/*RecalculatePaymentRequestCreated The new payment request with recalculated pricing.
 
 swagger:response recalculatePaymentRequestCreated
 */
@@ -61,8 +60,7 @@ func (o *RecalculatePaymentRequestCreated) WriteResponse(rw http.ResponseWriter,
 // RecalculatePaymentRequestBadRequestCode is the HTTP code returned for type RecalculatePaymentRequestBadRequest
 const RecalculatePaymentRequestBadRequestCode int = 400
 
-/*
-RecalculatePaymentRequestBadRequest The request payload is invalid.
+/*RecalculatePaymentRequestBadRequest The request payload is invalid.
 
 swagger:response recalculatePaymentRequestBadRequest
 */
@@ -106,8 +104,7 @@ func (o *RecalculatePaymentRequestBadRequest) WriteResponse(rw http.ResponseWrit
 // RecalculatePaymentRequestUnauthorizedCode is the HTTP code returned for type RecalculatePaymentRequestUnauthorized
 const RecalculatePaymentRequestUnauthorizedCode int = 401
 
-/*
-RecalculatePaymentRequestUnauthorized The request was denied.
+/*RecalculatePaymentRequestUnauthorized The request was denied.
 
 swagger:response recalculatePaymentRequestUnauthorized
 */
@@ -151,8 +148,7 @@ func (o *RecalculatePaymentRequestUnauthorized) WriteResponse(rw http.ResponseWr
 // RecalculatePaymentRequestForbiddenCode is the HTTP code returned for type RecalculatePaymentRequestForbidden
 const RecalculatePaymentRequestForbiddenCode int = 403
 
-/*
-RecalculatePaymentRequestForbidden The request was denied.
+/*RecalculatePaymentRequestForbidden The request was denied.
 
 swagger:response recalculatePaymentRequestForbidden
 */
@@ -196,8 +192,7 @@ func (o *RecalculatePaymentRequestForbidden) WriteResponse(rw http.ResponseWrite
 // RecalculatePaymentRequestNotFoundCode is the HTTP code returned for type RecalculatePaymentRequestNotFound
 const RecalculatePaymentRequestNotFoundCode int = 404
 
-/*
-RecalculatePaymentRequestNotFound The requested resource wasn't found.
+/*RecalculatePaymentRequestNotFound The requested resource wasn't found.
 
 swagger:response recalculatePaymentRequestNotFound
 */
@@ -241,8 +236,7 @@ func (o *RecalculatePaymentRequestNotFound) WriteResponse(rw http.ResponseWriter
 // RecalculatePaymentRequestConflictCode is the HTTP code returned for type RecalculatePaymentRequestConflict
 const RecalculatePaymentRequestConflictCode int = 409
 
-/*
-RecalculatePaymentRequestConflict There was a conflict with the request.
+/*RecalculatePaymentRequestConflict There was a conflict with the request.
 
 swagger:response recalculatePaymentRequestConflict
 */
@@ -286,8 +280,7 @@ func (o *RecalculatePaymentRequestConflict) WriteResponse(rw http.ResponseWriter
 // RecalculatePaymentRequestPreconditionFailedCode is the HTTP code returned for type RecalculatePaymentRequestPreconditionFailed
 const RecalculatePaymentRequestPreconditionFailedCode int = 412
 
-/*
-RecalculatePaymentRequestPreconditionFailed Precondition failed, likely due to a stale eTag (If-Match). Fetch the request again to get the updated eTag value.
+/*RecalculatePaymentRequestPreconditionFailed Precondition failed, likely due to a stale eTag (If-Match). Fetch the request again to get the updated eTag value.
 
 swagger:response recalculatePaymentRequestPreconditionFailed
 */
@@ -331,8 +324,7 @@ func (o *RecalculatePaymentRequestPreconditionFailed) WriteResponse(rw http.Resp
 // RecalculatePaymentRequestUnprocessableEntityCode is the HTTP code returned for type RecalculatePaymentRequestUnprocessableEntity
 const RecalculatePaymentRequestUnprocessableEntityCode int = 422
 
-/*
-RecalculatePaymentRequestUnprocessableEntity The payload was unprocessable.
+/*RecalculatePaymentRequestUnprocessableEntity The payload was unprocessable.
 
 swagger:response recalculatePaymentRequestUnprocessableEntity
 */
@@ -376,8 +368,7 @@ func (o *RecalculatePaymentRequestUnprocessableEntity) WriteResponse(rw http.Res
 // RecalculatePaymentRequestInternalServerErrorCode is the HTTP code returned for type RecalculatePaymentRequestInternalServerError
 const RecalculatePaymentRequestInternalServerErrorCode int = 500
 
-/*
-RecalculatePaymentRequestInternalServerError A server error occurred.
+/*RecalculatePaymentRequestInternalServerError A server error occurred.
 
 swagger:response recalculatePaymentRequestInternalServerError
 */

--- a/pkg/gen/supportapi/supportoperations/payment_request/update_payment_request_status.go
+++ b/pkg/gen/supportapi/supportoperations/payment_request/update_payment_request_status.go
@@ -29,8 +29,7 @@ func NewUpdatePaymentRequestStatus(ctx *middleware.Context, handler UpdatePaymen
 	return &UpdatePaymentRequestStatus{Context: ctx, Handler: handler}
 }
 
-/*
-	UpdatePaymentRequestStatus swagger:route PATCH /payment-requests/{paymentRequestID}/status paymentRequest updatePaymentRequestStatus
+/* UpdatePaymentRequestStatus swagger:route PATCH /payment-requests/{paymentRequestID}/status paymentRequest updatePaymentRequestStatus
 
 updatePaymentRequestStatus
 
@@ -39,6 +38,8 @@ Updates status of a payment request to REVIEWED, SENT_TO_GEX, RECEIVED_BY_GEX, R
 A status of REVIEWED can optionally have a `rejectionReason`.
 
 This is a support endpoint and is not available in production.
+
+
 */
 type UpdatePaymentRequestStatus struct {
 	Context *middleware.Context

--- a/pkg/gen/supportapi/supportoperations/payment_request/update_payment_request_status_responses.go
+++ b/pkg/gen/supportapi/supportoperations/payment_request/update_payment_request_status_responses.go
@@ -16,8 +16,7 @@ import (
 // UpdatePaymentRequestStatusOKCode is the HTTP code returned for type UpdatePaymentRequestStatusOK
 const UpdatePaymentRequestStatusOKCode int = 200
 
-/*
-UpdatePaymentRequestStatusOK Successfully updated payment request status.
+/*UpdatePaymentRequestStatusOK Successfully updated payment request status.
 
 swagger:response updatePaymentRequestStatusOK
 */
@@ -61,8 +60,7 @@ func (o *UpdatePaymentRequestStatusOK) WriteResponse(rw http.ResponseWriter, pro
 // UpdatePaymentRequestStatusBadRequestCode is the HTTP code returned for type UpdatePaymentRequestStatusBadRequest
 const UpdatePaymentRequestStatusBadRequestCode int = 400
 
-/*
-UpdatePaymentRequestStatusBadRequest The request payload is invalid.
+/*UpdatePaymentRequestStatusBadRequest The request payload is invalid.
 
 swagger:response updatePaymentRequestStatusBadRequest
 */
@@ -106,8 +104,7 @@ func (o *UpdatePaymentRequestStatusBadRequest) WriteResponse(rw http.ResponseWri
 // UpdatePaymentRequestStatusUnauthorizedCode is the HTTP code returned for type UpdatePaymentRequestStatusUnauthorized
 const UpdatePaymentRequestStatusUnauthorizedCode int = 401
 
-/*
-UpdatePaymentRequestStatusUnauthorized The request was denied.
+/*UpdatePaymentRequestStatusUnauthorized The request was denied.
 
 swagger:response updatePaymentRequestStatusUnauthorized
 */
@@ -151,8 +148,7 @@ func (o *UpdatePaymentRequestStatusUnauthorized) WriteResponse(rw http.ResponseW
 // UpdatePaymentRequestStatusForbiddenCode is the HTTP code returned for type UpdatePaymentRequestStatusForbidden
 const UpdatePaymentRequestStatusForbiddenCode int = 403
 
-/*
-UpdatePaymentRequestStatusForbidden The request was denied.
+/*UpdatePaymentRequestStatusForbidden The request was denied.
 
 swagger:response updatePaymentRequestStatusForbidden
 */
@@ -196,8 +192,7 @@ func (o *UpdatePaymentRequestStatusForbidden) WriteResponse(rw http.ResponseWrit
 // UpdatePaymentRequestStatusNotFoundCode is the HTTP code returned for type UpdatePaymentRequestStatusNotFound
 const UpdatePaymentRequestStatusNotFoundCode int = 404
 
-/*
-UpdatePaymentRequestStatusNotFound The requested resource wasn't found.
+/*UpdatePaymentRequestStatusNotFound The requested resource wasn't found.
 
 swagger:response updatePaymentRequestStatusNotFound
 */
@@ -241,8 +236,7 @@ func (o *UpdatePaymentRequestStatusNotFound) WriteResponse(rw http.ResponseWrite
 // UpdatePaymentRequestStatusConflictCode is the HTTP code returned for type UpdatePaymentRequestStatusConflict
 const UpdatePaymentRequestStatusConflictCode int = 409
 
-/*
-UpdatePaymentRequestStatusConflict There was a conflict with the request.
+/*UpdatePaymentRequestStatusConflict There was a conflict with the request.
 
 swagger:response updatePaymentRequestStatusConflict
 */
@@ -286,8 +280,7 @@ func (o *UpdatePaymentRequestStatusConflict) WriteResponse(rw http.ResponseWrite
 // UpdatePaymentRequestStatusPreconditionFailedCode is the HTTP code returned for type UpdatePaymentRequestStatusPreconditionFailed
 const UpdatePaymentRequestStatusPreconditionFailedCode int = 412
 
-/*
-UpdatePaymentRequestStatusPreconditionFailed Precondition failed, likely due to a stale eTag (If-Match). Fetch the request again to get the updated eTag value.
+/*UpdatePaymentRequestStatusPreconditionFailed Precondition failed, likely due to a stale eTag (If-Match). Fetch the request again to get the updated eTag value.
 
 swagger:response updatePaymentRequestStatusPreconditionFailed
 */
@@ -331,8 +324,7 @@ func (o *UpdatePaymentRequestStatusPreconditionFailed) WriteResponse(rw http.Res
 // UpdatePaymentRequestStatusUnprocessableEntityCode is the HTTP code returned for type UpdatePaymentRequestStatusUnprocessableEntity
 const UpdatePaymentRequestStatusUnprocessableEntityCode int = 422
 
-/*
-UpdatePaymentRequestStatusUnprocessableEntity The payload was unprocessable.
+/*UpdatePaymentRequestStatusUnprocessableEntity The payload was unprocessable.
 
 swagger:response updatePaymentRequestStatusUnprocessableEntity
 */
@@ -376,8 +368,7 @@ func (o *UpdatePaymentRequestStatusUnprocessableEntity) WriteResponse(rw http.Re
 // UpdatePaymentRequestStatusInternalServerErrorCode is the HTTP code returned for type UpdatePaymentRequestStatusInternalServerError
 const UpdatePaymentRequestStatusInternalServerErrorCode int = 500
 
-/*
-UpdatePaymentRequestStatusInternalServerError A server error occurred.
+/*UpdatePaymentRequestStatusInternalServerError A server error occurred.
 
 swagger:response updatePaymentRequestStatusInternalServerError
 */

--- a/pkg/gen/supportapi/supportoperations/webhook/create_webhook_notification.go
+++ b/pkg/gen/supportapi/supportoperations/webhook/create_webhook_notification.go
@@ -29,12 +29,13 @@ func NewCreateWebhookNotification(ctx *middleware.Context, handler CreateWebhook
 	return &CreateWebhookNotification{Context: ctx, Handler: handler}
 }
 
-/*
-	CreateWebhookNotification swagger:route POST /webhook-notifications webhook createWebhookNotification
+/* CreateWebhookNotification swagger:route POST /webhook-notifications webhook createWebhookNotification
 
-# Test endpoint for creating webhook notifications
+Test endpoint for creating webhook notifications
 
 This endpoint creates a webhook notification in the database. If the webhook client is running, it may send the notification soon after creation.
+
+
 */
 type CreateWebhookNotification struct {
 	Context *middleware.Context

--- a/pkg/gen/supportapi/supportoperations/webhook/create_webhook_notification_responses.go
+++ b/pkg/gen/supportapi/supportoperations/webhook/create_webhook_notification_responses.go
@@ -16,8 +16,7 @@ import (
 // CreateWebhookNotificationCreatedCode is the HTTP code returned for type CreateWebhookNotificationCreated
 const CreateWebhookNotificationCreatedCode int = 201
 
-/*
-CreateWebhookNotificationCreated Successful creation
+/*CreateWebhookNotificationCreated Successful creation
 
 swagger:response createWebhookNotificationCreated
 */
@@ -61,8 +60,7 @@ func (o *CreateWebhookNotificationCreated) WriteResponse(rw http.ResponseWriter,
 // CreateWebhookNotificationUnprocessableEntityCode is the HTTP code returned for type CreateWebhookNotificationUnprocessableEntity
 const CreateWebhookNotificationUnprocessableEntityCode int = 422
 
-/*
-CreateWebhookNotificationUnprocessableEntity The payload was unprocessable.
+/*CreateWebhookNotificationUnprocessableEntity The payload was unprocessable.
 
 swagger:response createWebhookNotificationUnprocessableEntity
 */
@@ -106,8 +104,7 @@ func (o *CreateWebhookNotificationUnprocessableEntity) WriteResponse(rw http.Res
 // CreateWebhookNotificationInternalServerErrorCode is the HTTP code returned for type CreateWebhookNotificationInternalServerError
 const CreateWebhookNotificationInternalServerErrorCode int = 500
 
-/*
-CreateWebhookNotificationInternalServerError A server error occurred.
+/*CreateWebhookNotificationInternalServerError A server error occurred.
 
 swagger:response createWebhookNotificationInternalServerError
 */

--- a/pkg/gen/supportapi/supportoperations/webhook/receive_webhook_notification.go
+++ b/pkg/gen/supportapi/supportoperations/webhook/receive_webhook_notification.go
@@ -29,12 +29,13 @@ func NewReceiveWebhookNotification(ctx *middleware.Context, handler ReceiveWebho
 	return &ReceiveWebhookNotification{Context: ctx, Handler: handler}
 }
 
-/*
-	ReceiveWebhookNotification swagger:route POST /webhook-notify webhook receiveWebhookNotification
+/* ReceiveWebhookNotification swagger:route POST /webhook-notify webhook receiveWebhookNotification
 
-# Test endpoint for receiving messages from our own webhook-client
+Test endpoint for receiving messages from our own webhook-client
 
 This endpoint receives a notification that matches the webhook notification model. This is a test endpoint that represents a receiving server. In production, the Prime will set up a receiving endpoint. In testing, this server accepts notifications at this endpoint and simply responds with success and logs them. The `webhook-client` is responsible for retrieving messages from the webhook_notifications table and sending them to the Prime (this endpoint in our testing case) via an mTLS connection.
+
+
 */
 type ReceiveWebhookNotification struct {
 	Context *middleware.Context

--- a/pkg/gen/supportapi/supportoperations/webhook/receive_webhook_notification_responses.go
+++ b/pkg/gen/supportapi/supportoperations/webhook/receive_webhook_notification_responses.go
@@ -16,8 +16,7 @@ import (
 // ReceiveWebhookNotificationOKCode is the HTTP code returned for type ReceiveWebhookNotificationOK
 const ReceiveWebhookNotificationOKCode int = 200
 
-/*
-ReceiveWebhookNotificationOK Received notification
+/*ReceiveWebhookNotificationOK Received notification
 
 swagger:response receiveWebhookNotificationOK
 */
@@ -61,8 +60,7 @@ func (o *ReceiveWebhookNotificationOK) WriteResponse(rw http.ResponseWriter, pro
 // ReceiveWebhookNotificationBadRequestCode is the HTTP code returned for type ReceiveWebhookNotificationBadRequest
 const ReceiveWebhookNotificationBadRequestCode int = 400
 
-/*
-ReceiveWebhookNotificationBadRequest The request payload is invalid.
+/*ReceiveWebhookNotificationBadRequest The request payload is invalid.
 
 swagger:response receiveWebhookNotificationBadRequest
 */
@@ -106,8 +104,7 @@ func (o *ReceiveWebhookNotificationBadRequest) WriteResponse(rw http.ResponseWri
 // ReceiveWebhookNotificationUnauthorizedCode is the HTTP code returned for type ReceiveWebhookNotificationUnauthorized
 const ReceiveWebhookNotificationUnauthorizedCode int = 401
 
-/*
-ReceiveWebhookNotificationUnauthorized The request was denied.
+/*ReceiveWebhookNotificationUnauthorized The request was denied.
 
 swagger:response receiveWebhookNotificationUnauthorized
 */
@@ -151,8 +148,7 @@ func (o *ReceiveWebhookNotificationUnauthorized) WriteResponse(rw http.ResponseW
 // ReceiveWebhookNotificationForbiddenCode is the HTTP code returned for type ReceiveWebhookNotificationForbidden
 const ReceiveWebhookNotificationForbiddenCode int = 403
 
-/*
-ReceiveWebhookNotificationForbidden The request was denied.
+/*ReceiveWebhookNotificationForbidden The request was denied.
 
 swagger:response receiveWebhookNotificationForbidden
 */
@@ -196,8 +192,7 @@ func (o *ReceiveWebhookNotificationForbidden) WriteResponse(rw http.ResponseWrit
 // ReceiveWebhookNotificationInternalServerErrorCode is the HTTP code returned for type ReceiveWebhookNotificationInternalServerError
 const ReceiveWebhookNotificationInternalServerErrorCode int = 500
 
-/*
-ReceiveWebhookNotificationInternalServerError A server error occurred.
+/*ReceiveWebhookNotificationInternalServerError A server error occurred.
 
 swagger:response receiveWebhookNotificationInternalServerError
 */

--- a/pkg/gen/supportclient/move_task_order/create_move_task_order_parameters.go
+++ b/pkg/gen/supportclient/move_task_order/create_move_task_order_parameters.go
@@ -54,12 +54,10 @@ func NewCreateMoveTaskOrderParamsWithHTTPClient(client *http.Client) *CreateMove
 	}
 }
 
-/*
-CreateMoveTaskOrderParams contains all the parameters to send to the API endpoint
+/* CreateMoveTaskOrderParams contains all the parameters to send to the API endpoint
+   for the create move task order operation.
 
-	for the create move task order operation.
-
-	Typically these are written to a http.Request.
+   Typically these are written to a http.Request.
 */
 type CreateMoveTaskOrderParams struct {
 

--- a/pkg/gen/supportclient/move_task_order/create_move_task_order_responses.go
+++ b/pkg/gen/supportclient/move_task_order/create_move_task_order_responses.go
@@ -75,8 +75,7 @@ func NewCreateMoveTaskOrderCreated() *CreateMoveTaskOrderCreated {
 	return &CreateMoveTaskOrderCreated{}
 }
 
-/*
-CreateMoveTaskOrderCreated describes a response with status code 201, with default header values.
+/* CreateMoveTaskOrderCreated describes a response with status code 201, with default header values.
 
 Successfully created MoveTaskOrder object.
 */
@@ -138,8 +137,7 @@ func NewCreateMoveTaskOrderBadRequest() *CreateMoveTaskOrderBadRequest {
 	return &CreateMoveTaskOrderBadRequest{}
 }
 
-/*
-CreateMoveTaskOrderBadRequest describes a response with status code 400, with default header values.
+/* CreateMoveTaskOrderBadRequest describes a response with status code 400, with default header values.
 
 The request payload is invalid.
 */
@@ -201,8 +199,7 @@ func NewCreateMoveTaskOrderUnauthorized() *CreateMoveTaskOrderUnauthorized {
 	return &CreateMoveTaskOrderUnauthorized{}
 }
 
-/*
-CreateMoveTaskOrderUnauthorized describes a response with status code 401, with default header values.
+/* CreateMoveTaskOrderUnauthorized describes a response with status code 401, with default header values.
 
 The request was denied.
 */
@@ -264,8 +261,7 @@ func NewCreateMoveTaskOrderForbidden() *CreateMoveTaskOrderForbidden {
 	return &CreateMoveTaskOrderForbidden{}
 }
 
-/*
-CreateMoveTaskOrderForbidden describes a response with status code 403, with default header values.
+/* CreateMoveTaskOrderForbidden describes a response with status code 403, with default header values.
 
 The request was denied.
 */
@@ -327,8 +323,7 @@ func NewCreateMoveTaskOrderNotFound() *CreateMoveTaskOrderNotFound {
 	return &CreateMoveTaskOrderNotFound{}
 }
 
-/*
-CreateMoveTaskOrderNotFound describes a response with status code 404, with default header values.
+/* CreateMoveTaskOrderNotFound describes a response with status code 404, with default header values.
 
 The requested resource wasn't found.
 */
@@ -390,8 +385,7 @@ func NewCreateMoveTaskOrderUnprocessableEntity() *CreateMoveTaskOrderUnprocessab
 	return &CreateMoveTaskOrderUnprocessableEntity{}
 }
 
-/*
-CreateMoveTaskOrderUnprocessableEntity describes a response with status code 422, with default header values.
+/* CreateMoveTaskOrderUnprocessableEntity describes a response with status code 422, with default header values.
 
 The payload was unprocessable.
 */
@@ -453,8 +447,7 @@ func NewCreateMoveTaskOrderInternalServerError() *CreateMoveTaskOrderInternalSer
 	return &CreateMoveTaskOrderInternalServerError{}
 }
 
-/*
-CreateMoveTaskOrderInternalServerError describes a response with status code 500, with default header values.
+/* CreateMoveTaskOrderInternalServerError describes a response with status code 500, with default header values.
 
 A server error occurred.
 */

--- a/pkg/gen/supportclient/move_task_order/get_move_task_order_parameters.go
+++ b/pkg/gen/supportclient/move_task_order/get_move_task_order_parameters.go
@@ -52,12 +52,10 @@ func NewGetMoveTaskOrderParamsWithHTTPClient(client *http.Client) *GetMoveTaskOr
 	}
 }
 
-/*
-GetMoveTaskOrderParams contains all the parameters to send to the API endpoint
+/* GetMoveTaskOrderParams contains all the parameters to send to the API endpoint
+   for the get move task order operation.
 
-	for the get move task order operation.
-
-	Typically these are written to a http.Request.
+   Typically these are written to a http.Request.
 */
 type GetMoveTaskOrderParams struct {
 

--- a/pkg/gen/supportclient/move_task_order/get_move_task_order_responses.go
+++ b/pkg/gen/supportclient/move_task_order/get_move_task_order_responses.go
@@ -63,8 +63,7 @@ func NewGetMoveTaskOrderOK() *GetMoveTaskOrderOK {
 	return &GetMoveTaskOrderOK{}
 }
 
-/*
-GetMoveTaskOrderOK describes a response with status code 200, with default header values.
+/* GetMoveTaskOrderOK describes a response with status code 200, with default header values.
 
 Successfully retrieve an individual move task order.
 */
@@ -126,8 +125,7 @@ func NewGetMoveTaskOrderUnauthorized() *GetMoveTaskOrderUnauthorized {
 	return &GetMoveTaskOrderUnauthorized{}
 }
 
-/*
-GetMoveTaskOrderUnauthorized describes a response with status code 401, with default header values.
+/* GetMoveTaskOrderUnauthorized describes a response with status code 401, with default header values.
 
 The request was denied.
 */
@@ -189,8 +187,7 @@ func NewGetMoveTaskOrderForbidden() *GetMoveTaskOrderForbidden {
 	return &GetMoveTaskOrderForbidden{}
 }
 
-/*
-GetMoveTaskOrderForbidden describes a response with status code 403, with default header values.
+/* GetMoveTaskOrderForbidden describes a response with status code 403, with default header values.
 
 The request was denied.
 */
@@ -252,8 +249,7 @@ func NewGetMoveTaskOrderNotFound() *GetMoveTaskOrderNotFound {
 	return &GetMoveTaskOrderNotFound{}
 }
 
-/*
-GetMoveTaskOrderNotFound describes a response with status code 404, with default header values.
+/* GetMoveTaskOrderNotFound describes a response with status code 404, with default header values.
 
 The requested resource wasn't found.
 */
@@ -315,8 +311,7 @@ func NewGetMoveTaskOrderInternalServerError() *GetMoveTaskOrderInternalServerErr
 	return &GetMoveTaskOrderInternalServerError{}
 }
 
-/*
-GetMoveTaskOrderInternalServerError describes a response with status code 500, with default header values.
+/* GetMoveTaskOrderInternalServerError describes a response with status code 500, with default header values.
 
 A server error occurred.
 */

--- a/pkg/gen/supportclient/move_task_order/hide_non_fake_move_task_orders_parameters.go
+++ b/pkg/gen/supportclient/move_task_order/hide_non_fake_move_task_orders_parameters.go
@@ -52,12 +52,10 @@ func NewHideNonFakeMoveTaskOrdersParamsWithHTTPClient(client *http.Client) *Hide
 	}
 }
 
-/*
-HideNonFakeMoveTaskOrdersParams contains all the parameters to send to the API endpoint
+/* HideNonFakeMoveTaskOrdersParams contains all the parameters to send to the API endpoint
+   for the hide non fake move task orders operation.
 
-	for the hide non fake move task orders operation.
-
-	Typically these are written to a http.Request.
+   Typically these are written to a http.Request.
 */
 type HideNonFakeMoveTaskOrdersParams struct {
 	timeout    time.Duration

--- a/pkg/gen/supportclient/move_task_order/hide_non_fake_move_task_orders_responses.go
+++ b/pkg/gen/supportclient/move_task_order/hide_non_fake_move_task_orders_responses.go
@@ -87,8 +87,7 @@ func NewHideNonFakeMoveTaskOrdersOK() *HideNonFakeMoveTaskOrdersOK {
 	return &HideNonFakeMoveTaskOrdersOK{}
 }
 
-/*
-HideNonFakeMoveTaskOrdersOK describes a response with status code 200, with default header values.
+/* HideNonFakeMoveTaskOrdersOK describes a response with status code 200, with default header values.
 
 Successfully hid MTOs.
 */
@@ -150,8 +149,7 @@ func NewHideNonFakeMoveTaskOrdersBadRequest() *HideNonFakeMoveTaskOrdersBadReque
 	return &HideNonFakeMoveTaskOrdersBadRequest{}
 }
 
-/*
-HideNonFakeMoveTaskOrdersBadRequest describes a response with status code 400, with default header values.
+/* HideNonFakeMoveTaskOrdersBadRequest describes a response with status code 400, with default header values.
 
 The request payload is invalid.
 */
@@ -213,8 +211,7 @@ func NewHideNonFakeMoveTaskOrdersUnauthorized() *HideNonFakeMoveTaskOrdersUnauth
 	return &HideNonFakeMoveTaskOrdersUnauthorized{}
 }
 
-/*
-HideNonFakeMoveTaskOrdersUnauthorized describes a response with status code 401, with default header values.
+/* HideNonFakeMoveTaskOrdersUnauthorized describes a response with status code 401, with default header values.
 
 The request was denied.
 */
@@ -276,8 +273,7 @@ func NewHideNonFakeMoveTaskOrdersForbidden() *HideNonFakeMoveTaskOrdersForbidden
 	return &HideNonFakeMoveTaskOrdersForbidden{}
 }
 
-/*
-HideNonFakeMoveTaskOrdersForbidden describes a response with status code 403, with default header values.
+/* HideNonFakeMoveTaskOrdersForbidden describes a response with status code 403, with default header values.
 
 The request was denied.
 */
@@ -339,8 +335,7 @@ func NewHideNonFakeMoveTaskOrdersNotFound() *HideNonFakeMoveTaskOrdersNotFound {
 	return &HideNonFakeMoveTaskOrdersNotFound{}
 }
 
-/*
-HideNonFakeMoveTaskOrdersNotFound describes a response with status code 404, with default header values.
+/* HideNonFakeMoveTaskOrdersNotFound describes a response with status code 404, with default header values.
 
 The requested resource wasn't found.
 */
@@ -402,8 +397,7 @@ func NewHideNonFakeMoveTaskOrdersConflict() *HideNonFakeMoveTaskOrdersConflict {
 	return &HideNonFakeMoveTaskOrdersConflict{}
 }
 
-/*
-HideNonFakeMoveTaskOrdersConflict describes a response with status code 409, with default header values.
+/* HideNonFakeMoveTaskOrdersConflict describes a response with status code 409, with default header values.
 
 There was a conflict with the request.
 */
@@ -465,8 +459,7 @@ func NewHideNonFakeMoveTaskOrdersPreconditionFailed() *HideNonFakeMoveTaskOrders
 	return &HideNonFakeMoveTaskOrdersPreconditionFailed{}
 }
 
-/*
-HideNonFakeMoveTaskOrdersPreconditionFailed describes a response with status code 412, with default header values.
+/* HideNonFakeMoveTaskOrdersPreconditionFailed describes a response with status code 412, with default header values.
 
 Precondition failed, likely due to a stale eTag (If-Match). Fetch the request again to get the updated eTag value.
 */
@@ -528,8 +521,7 @@ func NewHideNonFakeMoveTaskOrdersUnprocessableEntity() *HideNonFakeMoveTaskOrder
 	return &HideNonFakeMoveTaskOrdersUnprocessableEntity{}
 }
 
-/*
-HideNonFakeMoveTaskOrdersUnprocessableEntity describes a response with status code 422, with default header values.
+/* HideNonFakeMoveTaskOrdersUnprocessableEntity describes a response with status code 422, with default header values.
 
 The payload was unprocessable.
 */
@@ -591,8 +583,7 @@ func NewHideNonFakeMoveTaskOrdersInternalServerError() *HideNonFakeMoveTaskOrder
 	return &HideNonFakeMoveTaskOrdersInternalServerError{}
 }
 
-/*
-HideNonFakeMoveTaskOrdersInternalServerError describes a response with status code 500, with default header values.
+/* HideNonFakeMoveTaskOrdersInternalServerError describes a response with status code 500, with default header values.
 
 A server error occurred.
 */

--- a/pkg/gen/supportclient/move_task_order/list_m_t_os_parameters.go
+++ b/pkg/gen/supportclient/move_task_order/list_m_t_os_parameters.go
@@ -53,12 +53,10 @@ func NewListMTOsParamsWithHTTPClient(client *http.Client) *ListMTOsParams {
 	}
 }
 
-/*
-ListMTOsParams contains all the parameters to send to the API endpoint
+/* ListMTOsParams contains all the parameters to send to the API endpoint
+   for the list m t os operation.
 
-	for the list m t os operation.
-
-	Typically these are written to a http.Request.
+   Typically these are written to a http.Request.
 */
 type ListMTOsParams struct {
 

--- a/pkg/gen/supportclient/move_task_order/list_m_t_os_responses.go
+++ b/pkg/gen/supportclient/move_task_order/list_m_t_os_responses.go
@@ -69,8 +69,7 @@ func NewListMTOsOK() *ListMTOsOK {
 	return &ListMTOsOK{}
 }
 
-/*
-ListMTOsOK describes a response with status code 200, with default header values.
+/* ListMTOsOK describes a response with status code 200, with default header values.
 
 Successfully retrieved all move task orders.
 */
@@ -130,8 +129,7 @@ func NewListMTOsBadRequest() *ListMTOsBadRequest {
 	return &ListMTOsBadRequest{}
 }
 
-/*
-ListMTOsBadRequest describes a response with status code 400, with default header values.
+/* ListMTOsBadRequest describes a response with status code 400, with default header values.
 
 The request payload is invalid.
 */
@@ -193,8 +191,7 @@ func NewListMTOsUnauthorized() *ListMTOsUnauthorized {
 	return &ListMTOsUnauthorized{}
 }
 
-/*
-ListMTOsUnauthorized describes a response with status code 401, with default header values.
+/* ListMTOsUnauthorized describes a response with status code 401, with default header values.
 
 The request was denied.
 */
@@ -256,8 +253,7 @@ func NewListMTOsForbidden() *ListMTOsForbidden {
 	return &ListMTOsForbidden{}
 }
 
-/*
-ListMTOsForbidden describes a response with status code 403, with default header values.
+/* ListMTOsForbidden describes a response with status code 403, with default header values.
 
 The request was denied.
 */
@@ -319,8 +315,7 @@ func NewListMTOsNotFound() *ListMTOsNotFound {
 	return &ListMTOsNotFound{}
 }
 
-/*
-ListMTOsNotFound describes a response with status code 404, with default header values.
+/* ListMTOsNotFound describes a response with status code 404, with default header values.
 
 The requested resource wasn't found.
 */
@@ -382,8 +377,7 @@ func NewListMTOsInternalServerError() *ListMTOsInternalServerError {
 	return &ListMTOsInternalServerError{}
 }
 
-/*
-ListMTOsInternalServerError describes a response with status code 500, with default header values.
+/* ListMTOsInternalServerError describes a response with status code 500, with default header values.
 
 A server error occurred.
 */

--- a/pkg/gen/supportclient/move_task_order/make_move_task_order_available_parameters.go
+++ b/pkg/gen/supportclient/move_task_order/make_move_task_order_available_parameters.go
@@ -52,12 +52,10 @@ func NewMakeMoveTaskOrderAvailableParamsWithHTTPClient(client *http.Client) *Mak
 	}
 }
 
-/*
-MakeMoveTaskOrderAvailableParams contains all the parameters to send to the API endpoint
+/* MakeMoveTaskOrderAvailableParams contains all the parameters to send to the API endpoint
+   for the make move task order available operation.
 
-	for the make move task order available operation.
-
-	Typically these are written to a http.Request.
+   Typically these are written to a http.Request.
 */
 type MakeMoveTaskOrderAvailableParams struct {
 

--- a/pkg/gen/supportclient/move_task_order/make_move_task_order_available_responses.go
+++ b/pkg/gen/supportclient/move_task_order/make_move_task_order_available_responses.go
@@ -81,8 +81,7 @@ func NewMakeMoveTaskOrderAvailableOK() *MakeMoveTaskOrderAvailableOK {
 	return &MakeMoveTaskOrderAvailableOK{}
 }
 
-/*
-MakeMoveTaskOrderAvailableOK describes a response with status code 200, with default header values.
+/* MakeMoveTaskOrderAvailableOK describes a response with status code 200, with default header values.
 
 Successfully made MTO available to Prime.
 */
@@ -144,8 +143,7 @@ func NewMakeMoveTaskOrderAvailableBadRequest() *MakeMoveTaskOrderAvailableBadReq
 	return &MakeMoveTaskOrderAvailableBadRequest{}
 }
 
-/*
-MakeMoveTaskOrderAvailableBadRequest describes a response with status code 400, with default header values.
+/* MakeMoveTaskOrderAvailableBadRequest describes a response with status code 400, with default header values.
 
 The request payload is invalid.
 */
@@ -207,8 +205,7 @@ func NewMakeMoveTaskOrderAvailableUnauthorized() *MakeMoveTaskOrderAvailableUnau
 	return &MakeMoveTaskOrderAvailableUnauthorized{}
 }
 
-/*
-MakeMoveTaskOrderAvailableUnauthorized describes a response with status code 401, with default header values.
+/* MakeMoveTaskOrderAvailableUnauthorized describes a response with status code 401, with default header values.
 
 The request was denied.
 */
@@ -270,8 +267,7 @@ func NewMakeMoveTaskOrderAvailableForbidden() *MakeMoveTaskOrderAvailableForbidd
 	return &MakeMoveTaskOrderAvailableForbidden{}
 }
 
-/*
-MakeMoveTaskOrderAvailableForbidden describes a response with status code 403, with default header values.
+/* MakeMoveTaskOrderAvailableForbidden describes a response with status code 403, with default header values.
 
 The request was denied.
 */
@@ -333,8 +329,7 @@ func NewMakeMoveTaskOrderAvailableNotFound() *MakeMoveTaskOrderAvailableNotFound
 	return &MakeMoveTaskOrderAvailableNotFound{}
 }
 
-/*
-MakeMoveTaskOrderAvailableNotFound describes a response with status code 404, with default header values.
+/* MakeMoveTaskOrderAvailableNotFound describes a response with status code 404, with default header values.
 
 The requested resource wasn't found.
 */
@@ -396,8 +391,7 @@ func NewMakeMoveTaskOrderAvailablePreconditionFailed() *MakeMoveTaskOrderAvailab
 	return &MakeMoveTaskOrderAvailablePreconditionFailed{}
 }
 
-/*
-MakeMoveTaskOrderAvailablePreconditionFailed describes a response with status code 412, with default header values.
+/* MakeMoveTaskOrderAvailablePreconditionFailed describes a response with status code 412, with default header values.
 
 Precondition failed, likely due to a stale eTag (If-Match). Fetch the request again to get the updated eTag value.
 */
@@ -459,8 +453,7 @@ func NewMakeMoveTaskOrderAvailableUnprocessableEntity() *MakeMoveTaskOrderAvaila
 	return &MakeMoveTaskOrderAvailableUnprocessableEntity{}
 }
 
-/*
-MakeMoveTaskOrderAvailableUnprocessableEntity describes a response with status code 422, with default header values.
+/* MakeMoveTaskOrderAvailableUnprocessableEntity describes a response with status code 422, with default header values.
 
 The payload was unprocessable.
 */
@@ -522,8 +515,7 @@ func NewMakeMoveTaskOrderAvailableInternalServerError() *MakeMoveTaskOrderAvaila
 	return &MakeMoveTaskOrderAvailableInternalServerError{}
 }
 
-/*
-MakeMoveTaskOrderAvailableInternalServerError describes a response with status code 500, with default header values.
+/* MakeMoveTaskOrderAvailableInternalServerError describes a response with status code 500, with default header values.
 
 A server error occurred.
 */

--- a/pkg/gen/supportclient/move_task_order/move_task_order_client.go
+++ b/pkg/gen/supportclient/move_task_order/move_task_order_client.go
@@ -44,10 +44,9 @@ type ClientService interface {
 }
 
 /*
-	CreateMoveTaskOrder creates move task order
+  CreateMoveTaskOrder creates move task order
 
-	Creates an instance of moveTaskOrder.
-
+  Creates an instance of moveTaskOrder.
 Currently this will also create a number of nested objects but not all.
 It will currently create
 * MoveTaskOrder
@@ -60,6 +59,7 @@ It will not create addresses, duty stations, shipments, payment requests or serv
 origin duty station ID, and an uploaded orders ID to be passed into the request.
 
 This is a support endpoint and will not be available in production.
+
 */
 func (a *Client) CreateMoveTaskOrder(params *CreateMoveTaskOrderParams, opts ...ClientOption) (*CreateMoveTaskOrderCreated, error) {
 	// TODO: Validate the params before sending
@@ -97,15 +97,15 @@ func (a *Client) CreateMoveTaskOrder(params *CreateMoveTaskOrderParams, opts ...
 }
 
 /*
-	GetMoveTaskOrder gets move task order
+  GetMoveTaskOrder gets move task order
 
-	### Functionality
-
+  ### Functionality
 This endpoint gets an individual MoveTaskOrder by ID.
 
 It will provide nested information about the Customer and any associated MTOShipments, MTOServiceItems and PaymentRequests.
 
 This is a support endpoint and is not available in production.
+
 */
 func (a *Client) GetMoveTaskOrder(params *GetMoveTaskOrderParams, opts ...ClientOption) (*GetMoveTaskOrderOK, error) {
 	// TODO: Validate the params before sending
@@ -143,12 +143,12 @@ func (a *Client) GetMoveTaskOrder(params *GetMoveTaskOrderParams, opts ...Client
 }
 
 /*
-	HideNonFakeMoveTaskOrders hides non fake move task orders
+  HideNonFakeMoveTaskOrders hides non fake move task orders
 
-	Updates move task order without fake user data `show` to false. No request body required. <br />
-
+  Updates move task order without fake user data `show` to false. No request body required. <br />
 <br />
 This is a support endpoint and will not be available in production.
+
 */
 func (a *Client) HideNonFakeMoveTaskOrders(params *HideNonFakeMoveTaskOrdersParams, opts ...ClientOption) (*HideNonFakeMoveTaskOrdersOK, error) {
 	// TODO: Validate the params before sending
@@ -186,13 +186,13 @@ func (a *Client) HideNonFakeMoveTaskOrders(params *HideNonFakeMoveTaskOrdersPara
 }
 
 /*
-	ListMTOs lists m t os
+  ListMTOs lists m t os
 
-	### Functionality
-
+  ### Functionality
 This endpoint lists all MoveTaskOrders regardless of whether or not they have been made available to Prime.
 
 It will provide nested information about the Customer and any associated MTOShipments, MTOServiceItems and PaymentRequests.
+
 */
 func (a *Client) ListMTOs(params *ListMTOsParams, opts ...ClientOption) (*ListMTOsOK, error) {
 	// TODO: Validate the params before sending
@@ -230,12 +230,12 @@ func (a *Client) ListMTOs(params *ListMTOsParams, opts ...ClientOption) (*ListMT
 }
 
 /*
-	MakeMoveTaskOrderAvailable makes move task order available
+  MakeMoveTaskOrderAvailable makes move task order available
 
-	Updates move task order `availableToPrimeAt` to make it available to prime. No request body required. <br />
-
+  Updates move task order `availableToPrimeAt` to make it available to prime. No request body required. <br />
 <br />
 This is a support endpoint and will not be available in production.
+
 */
 func (a *Client) MakeMoveTaskOrderAvailable(params *MakeMoveTaskOrderAvailableParams, opts ...ClientOption) (*MakeMoveTaskOrderAvailableOK, error) {
 	// TODO: Validate the params before sending

--- a/pkg/gen/supportclient/mto_service_item/mto_service_item_client.go
+++ b/pkg/gen/supportclient/mto_service_item/mto_service_item_client.go
@@ -36,12 +36,12 @@ type ClientService interface {
 }
 
 /*
-	UpdateMTOServiceItemStatus updates m t o service item status
+  UpdateMTOServiceItemStatus updates m t o service item status
 
-	Updates the status of a service item for a move to APPROVED or REJECTED. <br />
-
+  Updates the status of a service item for a move to APPROVED or REJECTED. <br />
 <br />
 This is a support endpoint and will not be available in production.
+
 */
 func (a *Client) UpdateMTOServiceItemStatus(params *UpdateMTOServiceItemStatusParams, opts ...ClientOption) (*UpdateMTOServiceItemStatusOK, error) {
 	// TODO: Validate the params before sending

--- a/pkg/gen/supportclient/mto_service_item/update_m_t_o_service_item_status_parameters.go
+++ b/pkg/gen/supportclient/mto_service_item/update_m_t_o_service_item_status_parameters.go
@@ -54,12 +54,10 @@ func NewUpdateMTOServiceItemStatusParamsWithHTTPClient(client *http.Client) *Upd
 	}
 }
 
-/*
-UpdateMTOServiceItemStatusParams contains all the parameters to send to the API endpoint
+/* UpdateMTOServiceItemStatusParams contains all the parameters to send to the API endpoint
+   for the update m t o service item status operation.
 
-	for the update m t o service item status operation.
-
-	Typically these are written to a http.Request.
+   Typically these are written to a http.Request.
 */
 type UpdateMTOServiceItemStatusParams struct {
 

--- a/pkg/gen/supportclient/mto_service_item/update_m_t_o_service_item_status_responses.go
+++ b/pkg/gen/supportclient/mto_service_item/update_m_t_o_service_item_status_responses.go
@@ -87,8 +87,7 @@ func NewUpdateMTOServiceItemStatusOK() *UpdateMTOServiceItemStatusOK {
 	return &UpdateMTOServiceItemStatusOK{}
 }
 
-/*
-UpdateMTOServiceItemStatusOK describes a response with status code 200, with default header values.
+/* UpdateMTOServiceItemStatusOK describes a response with status code 200, with default header values.
 
 Successfully updated service item status for a move task order.
 */
@@ -150,8 +149,7 @@ func NewUpdateMTOServiceItemStatusBadRequest() *UpdateMTOServiceItemStatusBadReq
 	return &UpdateMTOServiceItemStatusBadRequest{}
 }
 
-/*
-UpdateMTOServiceItemStatusBadRequest describes a response with status code 400, with default header values.
+/* UpdateMTOServiceItemStatusBadRequest describes a response with status code 400, with default header values.
 
 The request payload is invalid.
 */
@@ -213,8 +211,7 @@ func NewUpdateMTOServiceItemStatusUnauthorized() *UpdateMTOServiceItemStatusUnau
 	return &UpdateMTOServiceItemStatusUnauthorized{}
 }
 
-/*
-UpdateMTOServiceItemStatusUnauthorized describes a response with status code 401, with default header values.
+/* UpdateMTOServiceItemStatusUnauthorized describes a response with status code 401, with default header values.
 
 The request was denied.
 */
@@ -276,8 +273,7 @@ func NewUpdateMTOServiceItemStatusForbidden() *UpdateMTOServiceItemStatusForbidd
 	return &UpdateMTOServiceItemStatusForbidden{}
 }
 
-/*
-UpdateMTOServiceItemStatusForbidden describes a response with status code 403, with default header values.
+/* UpdateMTOServiceItemStatusForbidden describes a response with status code 403, with default header values.
 
 The request was denied.
 */
@@ -339,8 +335,7 @@ func NewUpdateMTOServiceItemStatusNotFound() *UpdateMTOServiceItemStatusNotFound
 	return &UpdateMTOServiceItemStatusNotFound{}
 }
 
-/*
-UpdateMTOServiceItemStatusNotFound describes a response with status code 404, with default header values.
+/* UpdateMTOServiceItemStatusNotFound describes a response with status code 404, with default header values.
 
 The requested resource wasn't found.
 */
@@ -402,8 +397,7 @@ func NewUpdateMTOServiceItemStatusConflict() *UpdateMTOServiceItemStatusConflict
 	return &UpdateMTOServiceItemStatusConflict{}
 }
 
-/*
-UpdateMTOServiceItemStatusConflict describes a response with status code 409, with default header values.
+/* UpdateMTOServiceItemStatusConflict describes a response with status code 409, with default header values.
 
 There was a conflict with the request.
 */
@@ -465,8 +459,7 @@ func NewUpdateMTOServiceItemStatusPreconditionFailed() *UpdateMTOServiceItemStat
 	return &UpdateMTOServiceItemStatusPreconditionFailed{}
 }
 
-/*
-UpdateMTOServiceItemStatusPreconditionFailed describes a response with status code 412, with default header values.
+/* UpdateMTOServiceItemStatusPreconditionFailed describes a response with status code 412, with default header values.
 
 Precondition failed, likely due to a stale eTag (If-Match). Fetch the request again to get the updated eTag value.
 */
@@ -528,8 +521,7 @@ func NewUpdateMTOServiceItemStatusUnprocessableEntity() *UpdateMTOServiceItemSta
 	return &UpdateMTOServiceItemStatusUnprocessableEntity{}
 }
 
-/*
-UpdateMTOServiceItemStatusUnprocessableEntity describes a response with status code 422, with default header values.
+/* UpdateMTOServiceItemStatusUnprocessableEntity describes a response with status code 422, with default header values.
 
 The payload was unprocessable.
 */
@@ -591,8 +583,7 @@ func NewUpdateMTOServiceItemStatusInternalServerError() *UpdateMTOServiceItemSta
 	return &UpdateMTOServiceItemStatusInternalServerError{}
 }
 
-/*
-UpdateMTOServiceItemStatusInternalServerError describes a response with status code 500, with default header values.
+/* UpdateMTOServiceItemStatusInternalServerError describes a response with status code 500, with default header values.
 
 A server error occurred.
 */

--- a/pkg/gen/supportclient/mto_shipment/mto_shipment_client.go
+++ b/pkg/gen/supportclient/mto_shipment/mto_shipment_client.go
@@ -36,9 +36,10 @@ type ClientService interface {
 }
 
 /*
-UpdateMTOShipmentStatus updates m t o shipment status
+  UpdateMTOShipmentStatus updates m t o shipment status
 
-Updates a shipment's status to APPROVED or REJECTED for the purpose of testing the Prime API. If APPROVED, `rejectionReason` should be blank and any value passed through the body will be ignored. If REJECTED, a value in `rejectionReason` is required. <br /> <br /> This is a support endpoint and will not be available in production.
+  Updates a shipment's status to APPROVED or REJECTED for the purpose of testing the Prime API. If APPROVED, `rejectionReason` should be blank and any value passed through the body will be ignored. If REJECTED, a value in `rejectionReason` is required. <br /> <br /> This is a support endpoint and will not be available in production.
+
 */
 func (a *Client) UpdateMTOShipmentStatus(params *UpdateMTOShipmentStatusParams, opts ...ClientOption) (*UpdateMTOShipmentStatusOK, error) {
 	// TODO: Validate the params before sending

--- a/pkg/gen/supportclient/mto_shipment/update_m_t_o_shipment_status_parameters.go
+++ b/pkg/gen/supportclient/mto_shipment/update_m_t_o_shipment_status_parameters.go
@@ -54,12 +54,10 @@ func NewUpdateMTOShipmentStatusParamsWithHTTPClient(client *http.Client) *Update
 	}
 }
 
-/*
-UpdateMTOShipmentStatusParams contains all the parameters to send to the API endpoint
+/* UpdateMTOShipmentStatusParams contains all the parameters to send to the API endpoint
+   for the update m t o shipment status operation.
 
-	for the update m t o shipment status operation.
-
-	Typically these are written to a http.Request.
+   Typically these are written to a http.Request.
 */
 type UpdateMTOShipmentStatusParams struct {
 

--- a/pkg/gen/supportclient/mto_shipment/update_m_t_o_shipment_status_responses.go
+++ b/pkg/gen/supportclient/mto_shipment/update_m_t_o_shipment_status_responses.go
@@ -87,8 +87,7 @@ func NewUpdateMTOShipmentStatusOK() *UpdateMTOShipmentStatusOK {
 	return &UpdateMTOShipmentStatusOK{}
 }
 
-/*
-UpdateMTOShipmentStatusOK describes a response with status code 200, with default header values.
+/* UpdateMTOShipmentStatusOK describes a response with status code 200, with default header values.
 
 Successfully updated the shipment's status.
 */
@@ -150,8 +149,7 @@ func NewUpdateMTOShipmentStatusBadRequest() *UpdateMTOShipmentStatusBadRequest {
 	return &UpdateMTOShipmentStatusBadRequest{}
 }
 
-/*
-UpdateMTOShipmentStatusBadRequest describes a response with status code 400, with default header values.
+/* UpdateMTOShipmentStatusBadRequest describes a response with status code 400, with default header values.
 
 The request payload is invalid.
 */
@@ -213,8 +211,7 @@ func NewUpdateMTOShipmentStatusUnauthorized() *UpdateMTOShipmentStatusUnauthoriz
 	return &UpdateMTOShipmentStatusUnauthorized{}
 }
 
-/*
-UpdateMTOShipmentStatusUnauthorized describes a response with status code 401, with default header values.
+/* UpdateMTOShipmentStatusUnauthorized describes a response with status code 401, with default header values.
 
 The request was denied.
 */
@@ -276,8 +273,7 @@ func NewUpdateMTOShipmentStatusForbidden() *UpdateMTOShipmentStatusForbidden {
 	return &UpdateMTOShipmentStatusForbidden{}
 }
 
-/*
-UpdateMTOShipmentStatusForbidden describes a response with status code 403, with default header values.
+/* UpdateMTOShipmentStatusForbidden describes a response with status code 403, with default header values.
 
 The request was denied.
 */
@@ -339,8 +335,7 @@ func NewUpdateMTOShipmentStatusNotFound() *UpdateMTOShipmentStatusNotFound {
 	return &UpdateMTOShipmentStatusNotFound{}
 }
 
-/*
-UpdateMTOShipmentStatusNotFound describes a response with status code 404, with default header values.
+/* UpdateMTOShipmentStatusNotFound describes a response with status code 404, with default header values.
 
 The requested resource wasn't found.
 */
@@ -402,8 +397,7 @@ func NewUpdateMTOShipmentStatusConflict() *UpdateMTOShipmentStatusConflict {
 	return &UpdateMTOShipmentStatusConflict{}
 }
 
-/*
-UpdateMTOShipmentStatusConflict describes a response with status code 409, with default header values.
+/* UpdateMTOShipmentStatusConflict describes a response with status code 409, with default header values.
 
 There was a conflict with the request.
 */
@@ -465,8 +459,7 @@ func NewUpdateMTOShipmentStatusPreconditionFailed() *UpdateMTOShipmentStatusPrec
 	return &UpdateMTOShipmentStatusPreconditionFailed{}
 }
 
-/*
-UpdateMTOShipmentStatusPreconditionFailed describes a response with status code 412, with default header values.
+/* UpdateMTOShipmentStatusPreconditionFailed describes a response with status code 412, with default header values.
 
 Precondition failed, likely due to a stale eTag (If-Match). Fetch the request again to get the updated eTag value.
 */
@@ -528,8 +521,7 @@ func NewUpdateMTOShipmentStatusUnprocessableEntity() *UpdateMTOShipmentStatusUnp
 	return &UpdateMTOShipmentStatusUnprocessableEntity{}
 }
 
-/*
-UpdateMTOShipmentStatusUnprocessableEntity describes a response with status code 422, with default header values.
+/* UpdateMTOShipmentStatusUnprocessableEntity describes a response with status code 422, with default header values.
 
 The payload was unprocessable.
 */
@@ -591,8 +583,7 @@ func NewUpdateMTOShipmentStatusInternalServerError() *UpdateMTOShipmentStatusInt
 	return &UpdateMTOShipmentStatusInternalServerError{}
 }
 
-/*
-UpdateMTOShipmentStatusInternalServerError describes a response with status code 500, with default header values.
+/* UpdateMTOShipmentStatusInternalServerError describes a response with status code 500, with default header values.
 
 A server error occurred.
 */

--- a/pkg/gen/supportclient/payment_request/get_payment_request_e_d_i_parameters.go
+++ b/pkg/gen/supportclient/payment_request/get_payment_request_e_d_i_parameters.go
@@ -52,12 +52,10 @@ func NewGetPaymentRequestEDIParamsWithHTTPClient(client *http.Client) *GetPaymen
 	}
 }
 
-/*
-GetPaymentRequestEDIParams contains all the parameters to send to the API endpoint
+/* GetPaymentRequestEDIParams contains all the parameters to send to the API endpoint
+   for the get payment request e d i operation.
 
-	for the get payment request e d i operation.
-
-	Typically these are written to a http.Request.
+   Typically these are written to a http.Request.
 */
 type GetPaymentRequestEDIParams struct {
 

--- a/pkg/gen/supportclient/payment_request/get_payment_request_e_d_i_responses.go
+++ b/pkg/gen/supportclient/payment_request/get_payment_request_e_d_i_responses.go
@@ -81,8 +81,7 @@ func NewGetPaymentRequestEDIOK() *GetPaymentRequestEDIOK {
 	return &GetPaymentRequestEDIOK{}
 }
 
-/*
-GetPaymentRequestEDIOK describes a response with status code 200, with default header values.
+/* GetPaymentRequestEDIOK describes a response with status code 200, with default header values.
 
 Successfully retrieved payment requests associated with a given move task order
 */
@@ -144,8 +143,7 @@ func NewGetPaymentRequestEDIBadRequest() *GetPaymentRequestEDIBadRequest {
 	return &GetPaymentRequestEDIBadRequest{}
 }
 
-/*
-GetPaymentRequestEDIBadRequest describes a response with status code 400, with default header values.
+/* GetPaymentRequestEDIBadRequest describes a response with status code 400, with default header values.
 
 The request payload is invalid.
 */
@@ -207,8 +205,7 @@ func NewGetPaymentRequestEDIUnauthorized() *GetPaymentRequestEDIUnauthorized {
 	return &GetPaymentRequestEDIUnauthorized{}
 }
 
-/*
-GetPaymentRequestEDIUnauthorized describes a response with status code 401, with default header values.
+/* GetPaymentRequestEDIUnauthorized describes a response with status code 401, with default header values.
 
 The request was denied.
 */
@@ -270,8 +267,7 @@ func NewGetPaymentRequestEDIForbidden() *GetPaymentRequestEDIForbidden {
 	return &GetPaymentRequestEDIForbidden{}
 }
 
-/*
-GetPaymentRequestEDIForbidden describes a response with status code 403, with default header values.
+/* GetPaymentRequestEDIForbidden describes a response with status code 403, with default header values.
 
 The request was denied.
 */
@@ -333,8 +329,7 @@ func NewGetPaymentRequestEDINotFound() *GetPaymentRequestEDINotFound {
 	return &GetPaymentRequestEDINotFound{}
 }
 
-/*
-GetPaymentRequestEDINotFound describes a response with status code 404, with default header values.
+/* GetPaymentRequestEDINotFound describes a response with status code 404, with default header values.
 
 The requested resource wasn't found.
 */
@@ -396,8 +391,7 @@ func NewGetPaymentRequestEDIConflict() *GetPaymentRequestEDIConflict {
 	return &GetPaymentRequestEDIConflict{}
 }
 
-/*
-GetPaymentRequestEDIConflict describes a response with status code 409, with default header values.
+/* GetPaymentRequestEDIConflict describes a response with status code 409, with default header values.
 
 There was a conflict with the request.
 */
@@ -459,8 +453,7 @@ func NewGetPaymentRequestEDIUnprocessableEntity() *GetPaymentRequestEDIUnprocess
 	return &GetPaymentRequestEDIUnprocessableEntity{}
 }
 
-/*
-GetPaymentRequestEDIUnprocessableEntity describes a response with status code 422, with default header values.
+/* GetPaymentRequestEDIUnprocessableEntity describes a response with status code 422, with default header values.
 
 The payload was unprocessable.
 */
@@ -522,8 +515,7 @@ func NewGetPaymentRequestEDIInternalServerError() *GetPaymentRequestEDIInternalS
 	return &GetPaymentRequestEDIInternalServerError{}
 }
 
-/*
-GetPaymentRequestEDIInternalServerError describes a response with status code 500, with default header values.
+/* GetPaymentRequestEDIInternalServerError describes a response with status code 500, with default header values.
 
 A server error occurred.
 */

--- a/pkg/gen/supportclient/payment_request/list_m_t_o_payment_requests_parameters.go
+++ b/pkg/gen/supportclient/payment_request/list_m_t_o_payment_requests_parameters.go
@@ -52,12 +52,10 @@ func NewListMTOPaymentRequestsParamsWithHTTPClient(client *http.Client) *ListMTO
 	}
 }
 
-/*
-ListMTOPaymentRequestsParams contains all the parameters to send to the API endpoint
+/* ListMTOPaymentRequestsParams contains all the parameters to send to the API endpoint
+   for the list m t o payment requests operation.
 
-	for the list m t o payment requests operation.
-
-	Typically these are written to a http.Request.
+   Typically these are written to a http.Request.
 */
 type ListMTOPaymentRequestsParams struct {
 

--- a/pkg/gen/supportclient/payment_request/list_m_t_o_payment_requests_responses.go
+++ b/pkg/gen/supportclient/payment_request/list_m_t_o_payment_requests_responses.go
@@ -69,8 +69,7 @@ func NewListMTOPaymentRequestsOK() *ListMTOPaymentRequestsOK {
 	return &ListMTOPaymentRequestsOK{}
 }
 
-/*
-ListMTOPaymentRequestsOK describes a response with status code 200, with default header values.
+/* ListMTOPaymentRequestsOK describes a response with status code 200, with default header values.
 
 Successfully retrieved payment requests associated with a given move task order
 */
@@ -130,8 +129,7 @@ func NewListMTOPaymentRequestsBadRequest() *ListMTOPaymentRequestsBadRequest {
 	return &ListMTOPaymentRequestsBadRequest{}
 }
 
-/*
-ListMTOPaymentRequestsBadRequest describes a response with status code 400, with default header values.
+/* ListMTOPaymentRequestsBadRequest describes a response with status code 400, with default header values.
 
 The request payload is invalid.
 */
@@ -193,8 +191,7 @@ func NewListMTOPaymentRequestsUnauthorized() *ListMTOPaymentRequestsUnauthorized
 	return &ListMTOPaymentRequestsUnauthorized{}
 }
 
-/*
-ListMTOPaymentRequestsUnauthorized describes a response with status code 401, with default header values.
+/* ListMTOPaymentRequestsUnauthorized describes a response with status code 401, with default header values.
 
 The request was denied.
 */
@@ -256,8 +253,7 @@ func NewListMTOPaymentRequestsForbidden() *ListMTOPaymentRequestsForbidden {
 	return &ListMTOPaymentRequestsForbidden{}
 }
 
-/*
-ListMTOPaymentRequestsForbidden describes a response with status code 403, with default header values.
+/* ListMTOPaymentRequestsForbidden describes a response with status code 403, with default header values.
 
 The request was denied.
 */
@@ -319,8 +315,7 @@ func NewListMTOPaymentRequestsNotFound() *ListMTOPaymentRequestsNotFound {
 	return &ListMTOPaymentRequestsNotFound{}
 }
 
-/*
-ListMTOPaymentRequestsNotFound describes a response with status code 404, with default header values.
+/* ListMTOPaymentRequestsNotFound describes a response with status code 404, with default header values.
 
 The requested resource wasn't found.
 */
@@ -382,8 +377,7 @@ func NewListMTOPaymentRequestsInternalServerError() *ListMTOPaymentRequestsInter
 	return &ListMTOPaymentRequestsInternalServerError{}
 }
 
-/*
-ListMTOPaymentRequestsInternalServerError describes a response with status code 500, with default header values.
+/* ListMTOPaymentRequestsInternalServerError describes a response with status code 500, with default header values.
 
 A server error occurred.
 */

--- a/pkg/gen/supportclient/payment_request/payment_request_client.go
+++ b/pkg/gen/supportclient/payment_request/payment_request_client.go
@@ -44,14 +44,14 @@ type ClientService interface {
 }
 
 /*
-	GetPaymentRequestEDI gets payment request e d i
+  GetPaymentRequestEDI gets payment request e d i
 
-	Returns the EDI (Electronic Data Interchange) message for the payment request identified
-
+  Returns the EDI (Electronic Data Interchange) message for the payment request identified
 by the given payment request ID. Note that the EDI returned in the JSON payload will have where there
 would normally be line breaks (due to JSON not allowing line breaks in a string).
 
 This is a support endpoint and will not be available in production.
+
 */
 func (a *Client) GetPaymentRequestEDI(params *GetPaymentRequestEDIParams, opts ...ClientOption) (*GetPaymentRequestEDIOK, error) {
 	// TODO: Validate the params before sending
@@ -89,13 +89,14 @@ func (a *Client) GetPaymentRequestEDI(params *GetPaymentRequestEDIParams, opts .
 }
 
 /*
-	ListMTOPaymentRequests lists m t o payment requests
+  ListMTOPaymentRequests lists m t o payment requests
 
-	### Functionality
+  ### Functionality
 
 This endpoint lists all PaymentRequests associated with a given MoveTaskOrder.
 
 This is a support endpoint and is not available in production.
+
 */
 func (a *Client) ListMTOPaymentRequests(params *ListMTOPaymentRequestsParams, opts ...ClientOption) (*ListMTOPaymentRequestsOK, error) {
 	// TODO: Validate the params before sending
@@ -133,13 +134,13 @@ func (a *Client) ListMTOPaymentRequests(params *ListMTOPaymentRequestsParams, op
 }
 
 /*
-	ProcessReviewedPaymentRequests processes reviewed payment requests
+  ProcessReviewedPaymentRequests processes reviewed payment requests
 
-	Updates the status of reviewed payment requests and sends PRs to Syncada if
-
+  Updates the status of reviewed payment requests and sends PRs to Syncada if
 the SendToSyncada flag is set
 
 This is a support endpoint and will not be available in production.
+
 */
 func (a *Client) ProcessReviewedPaymentRequests(params *ProcessReviewedPaymentRequestsParams, opts ...ClientOption) (*ProcessReviewedPaymentRequestsOK, error) {
 	// TODO: Validate the params before sending
@@ -177,14 +178,14 @@ func (a *Client) ProcessReviewedPaymentRequests(params *ProcessReviewedPaymentRe
 }
 
 /*
-	RecalculatePaymentRequest recalculates payment request
+  RecalculatePaymentRequest recalculates payment request
 
-	Recalculates an existing pending payment request by creating a new payment request for the same service
-
+  Recalculates an existing pending payment request by creating a new payment request for the same service
 items but is priced based on the current inputs (weights, dates, etc.). The previously existing payment
 request is then deprecated. A link is made between the new and existing payment requests.
 
 This is a support endpoint and will not be available in production.
+
 */
 func (a *Client) RecalculatePaymentRequest(params *RecalculatePaymentRequestParams, opts ...ClientOption) (*RecalculatePaymentRequestCreated, error) {
 	// TODO: Validate the params before sending
@@ -222,13 +223,14 @@ func (a *Client) RecalculatePaymentRequest(params *RecalculatePaymentRequestPara
 }
 
 /*
-	UpdatePaymentRequestStatus updates payment request status
+  UpdatePaymentRequestStatus updates payment request status
 
-	Updates status of a payment request to REVIEWED, SENT_TO_GEX, RECEIVED_BY_GEX, REVIEWED_AND_ALL_SERVICE_ITEMS_REJECTED, PAID, EDI_ERROR, or DEPRECATED.
+  Updates status of a payment request to REVIEWED, SENT_TO_GEX, RECEIVED_BY_GEX, REVIEWED_AND_ALL_SERVICE_ITEMS_REJECTED, PAID, EDI_ERROR, or DEPRECATED.
 
 A status of REVIEWED can optionally have a `rejectionReason`.
 
 This is a support endpoint and is not available in production.
+
 */
 func (a *Client) UpdatePaymentRequestStatus(params *UpdatePaymentRequestStatusParams, opts ...ClientOption) (*UpdatePaymentRequestStatusOK, error) {
 	// TODO: Validate the params before sending

--- a/pkg/gen/supportclient/payment_request/process_reviewed_payment_requests_parameters.go
+++ b/pkg/gen/supportclient/payment_request/process_reviewed_payment_requests_parameters.go
@@ -54,12 +54,10 @@ func NewProcessReviewedPaymentRequestsParamsWithHTTPClient(client *http.Client) 
 	}
 }
 
-/*
-ProcessReviewedPaymentRequestsParams contains all the parameters to send to the API endpoint
+/* ProcessReviewedPaymentRequestsParams contains all the parameters to send to the API endpoint
+   for the process reviewed payment requests operation.
 
-	for the process reviewed payment requests operation.
-
-	Typically these are written to a http.Request.
+   Typically these are written to a http.Request.
 */
 type ProcessReviewedPaymentRequestsParams struct {
 

--- a/pkg/gen/supportclient/payment_request/process_reviewed_payment_requests_responses.go
+++ b/pkg/gen/supportclient/payment_request/process_reviewed_payment_requests_responses.go
@@ -75,8 +75,7 @@ func NewProcessReviewedPaymentRequestsOK() *ProcessReviewedPaymentRequestsOK {
 	return &ProcessReviewedPaymentRequestsOK{}
 }
 
-/*
-ProcessReviewedPaymentRequestsOK describes a response with status code 200, with default header values.
+/* ProcessReviewedPaymentRequestsOK describes a response with status code 200, with default header values.
 
 Successfully updated status of reviewed payment request and sent to Syncada if that flag is set
 */
@@ -136,8 +135,7 @@ func NewProcessReviewedPaymentRequestsBadRequest() *ProcessReviewedPaymentReques
 	return &ProcessReviewedPaymentRequestsBadRequest{}
 }
 
-/*
-ProcessReviewedPaymentRequestsBadRequest describes a response with status code 400, with default header values.
+/* ProcessReviewedPaymentRequestsBadRequest describes a response with status code 400, with default header values.
 
 The request payload is invalid.
 */
@@ -199,8 +197,7 @@ func NewProcessReviewedPaymentRequestsUnauthorized() *ProcessReviewedPaymentRequ
 	return &ProcessReviewedPaymentRequestsUnauthorized{}
 }
 
-/*
-ProcessReviewedPaymentRequestsUnauthorized describes a response with status code 401, with default header values.
+/* ProcessReviewedPaymentRequestsUnauthorized describes a response with status code 401, with default header values.
 
 The request was denied.
 */
@@ -262,8 +259,7 @@ func NewProcessReviewedPaymentRequestsForbidden() *ProcessReviewedPaymentRequest
 	return &ProcessReviewedPaymentRequestsForbidden{}
 }
 
-/*
-ProcessReviewedPaymentRequestsForbidden describes a response with status code 403, with default header values.
+/* ProcessReviewedPaymentRequestsForbidden describes a response with status code 403, with default header values.
 
 The request was denied.
 */
@@ -325,8 +321,7 @@ func NewProcessReviewedPaymentRequestsNotFound() *ProcessReviewedPaymentRequests
 	return &ProcessReviewedPaymentRequestsNotFound{}
 }
 
-/*
-ProcessReviewedPaymentRequestsNotFound describes a response with status code 404, with default header values.
+/* ProcessReviewedPaymentRequestsNotFound describes a response with status code 404, with default header values.
 
 The requested resource wasn't found.
 */
@@ -388,8 +383,7 @@ func NewProcessReviewedPaymentRequestsUnprocessableEntity() *ProcessReviewedPaym
 	return &ProcessReviewedPaymentRequestsUnprocessableEntity{}
 }
 
-/*
-ProcessReviewedPaymentRequestsUnprocessableEntity describes a response with status code 422, with default header values.
+/* ProcessReviewedPaymentRequestsUnprocessableEntity describes a response with status code 422, with default header values.
 
 The payload was unprocessable.
 */
@@ -451,8 +445,7 @@ func NewProcessReviewedPaymentRequestsInternalServerError() *ProcessReviewedPaym
 	return &ProcessReviewedPaymentRequestsInternalServerError{}
 }
 
-/*
-ProcessReviewedPaymentRequestsInternalServerError describes a response with status code 500, with default header values.
+/* ProcessReviewedPaymentRequestsInternalServerError describes a response with status code 500, with default header values.
 
 A server error occurred.
 */

--- a/pkg/gen/supportclient/payment_request/recalculate_payment_request_parameters.go
+++ b/pkg/gen/supportclient/payment_request/recalculate_payment_request_parameters.go
@@ -52,12 +52,10 @@ func NewRecalculatePaymentRequestParamsWithHTTPClient(client *http.Client) *Reca
 	}
 }
 
-/*
-RecalculatePaymentRequestParams contains all the parameters to send to the API endpoint
+/* RecalculatePaymentRequestParams contains all the parameters to send to the API endpoint
+   for the recalculate payment request operation.
 
-	for the recalculate payment request operation.
-
-	Typically these are written to a http.Request.
+   Typically these are written to a http.Request.
 */
 type RecalculatePaymentRequestParams struct {
 

--- a/pkg/gen/supportclient/payment_request/recalculate_payment_request_responses.go
+++ b/pkg/gen/supportclient/payment_request/recalculate_payment_request_responses.go
@@ -87,8 +87,7 @@ func NewRecalculatePaymentRequestCreated() *RecalculatePaymentRequestCreated {
 	return &RecalculatePaymentRequestCreated{}
 }
 
-/*
-RecalculatePaymentRequestCreated describes a response with status code 201, with default header values.
+/* RecalculatePaymentRequestCreated describes a response with status code 201, with default header values.
 
 The new payment request with recalculated pricing.
 */
@@ -150,8 +149,7 @@ func NewRecalculatePaymentRequestBadRequest() *RecalculatePaymentRequestBadReque
 	return &RecalculatePaymentRequestBadRequest{}
 }
 
-/*
-RecalculatePaymentRequestBadRequest describes a response with status code 400, with default header values.
+/* RecalculatePaymentRequestBadRequest describes a response with status code 400, with default header values.
 
 The request payload is invalid.
 */
@@ -213,8 +211,7 @@ func NewRecalculatePaymentRequestUnauthorized() *RecalculatePaymentRequestUnauth
 	return &RecalculatePaymentRequestUnauthorized{}
 }
 
-/*
-RecalculatePaymentRequestUnauthorized describes a response with status code 401, with default header values.
+/* RecalculatePaymentRequestUnauthorized describes a response with status code 401, with default header values.
 
 The request was denied.
 */
@@ -276,8 +273,7 @@ func NewRecalculatePaymentRequestForbidden() *RecalculatePaymentRequestForbidden
 	return &RecalculatePaymentRequestForbidden{}
 }
 
-/*
-RecalculatePaymentRequestForbidden describes a response with status code 403, with default header values.
+/* RecalculatePaymentRequestForbidden describes a response with status code 403, with default header values.
 
 The request was denied.
 */
@@ -339,8 +335,7 @@ func NewRecalculatePaymentRequestNotFound() *RecalculatePaymentRequestNotFound {
 	return &RecalculatePaymentRequestNotFound{}
 }
 
-/*
-RecalculatePaymentRequestNotFound describes a response with status code 404, with default header values.
+/* RecalculatePaymentRequestNotFound describes a response with status code 404, with default header values.
 
 The requested resource wasn't found.
 */
@@ -402,8 +397,7 @@ func NewRecalculatePaymentRequestConflict() *RecalculatePaymentRequestConflict {
 	return &RecalculatePaymentRequestConflict{}
 }
 
-/*
-RecalculatePaymentRequestConflict describes a response with status code 409, with default header values.
+/* RecalculatePaymentRequestConflict describes a response with status code 409, with default header values.
 
 There was a conflict with the request.
 */
@@ -465,8 +459,7 @@ func NewRecalculatePaymentRequestPreconditionFailed() *RecalculatePaymentRequest
 	return &RecalculatePaymentRequestPreconditionFailed{}
 }
 
-/*
-RecalculatePaymentRequestPreconditionFailed describes a response with status code 412, with default header values.
+/* RecalculatePaymentRequestPreconditionFailed describes a response with status code 412, with default header values.
 
 Precondition failed, likely due to a stale eTag (If-Match). Fetch the request again to get the updated eTag value.
 */
@@ -528,8 +521,7 @@ func NewRecalculatePaymentRequestUnprocessableEntity() *RecalculatePaymentReques
 	return &RecalculatePaymentRequestUnprocessableEntity{}
 }
 
-/*
-RecalculatePaymentRequestUnprocessableEntity describes a response with status code 422, with default header values.
+/* RecalculatePaymentRequestUnprocessableEntity describes a response with status code 422, with default header values.
 
 The payload was unprocessable.
 */
@@ -591,8 +583,7 @@ func NewRecalculatePaymentRequestInternalServerError() *RecalculatePaymentReques
 	return &RecalculatePaymentRequestInternalServerError{}
 }
 
-/*
-RecalculatePaymentRequestInternalServerError describes a response with status code 500, with default header values.
+/* RecalculatePaymentRequestInternalServerError describes a response with status code 500, with default header values.
 
 A server error occurred.
 */

--- a/pkg/gen/supportclient/payment_request/update_payment_request_status_parameters.go
+++ b/pkg/gen/supportclient/payment_request/update_payment_request_status_parameters.go
@@ -54,12 +54,10 @@ func NewUpdatePaymentRequestStatusParamsWithHTTPClient(client *http.Client) *Upd
 	}
 }
 
-/*
-UpdatePaymentRequestStatusParams contains all the parameters to send to the API endpoint
+/* UpdatePaymentRequestStatusParams contains all the parameters to send to the API endpoint
+   for the update payment request status operation.
 
-	for the update payment request status operation.
-
-	Typically these are written to a http.Request.
+   Typically these are written to a http.Request.
 */
 type UpdatePaymentRequestStatusParams struct {
 

--- a/pkg/gen/supportclient/payment_request/update_payment_request_status_responses.go
+++ b/pkg/gen/supportclient/payment_request/update_payment_request_status_responses.go
@@ -87,8 +87,7 @@ func NewUpdatePaymentRequestStatusOK() *UpdatePaymentRequestStatusOK {
 	return &UpdatePaymentRequestStatusOK{}
 }
 
-/*
-UpdatePaymentRequestStatusOK describes a response with status code 200, with default header values.
+/* UpdatePaymentRequestStatusOK describes a response with status code 200, with default header values.
 
 Successfully updated payment request status.
 */
@@ -150,8 +149,7 @@ func NewUpdatePaymentRequestStatusBadRequest() *UpdatePaymentRequestStatusBadReq
 	return &UpdatePaymentRequestStatusBadRequest{}
 }
 
-/*
-UpdatePaymentRequestStatusBadRequest describes a response with status code 400, with default header values.
+/* UpdatePaymentRequestStatusBadRequest describes a response with status code 400, with default header values.
 
 The request payload is invalid.
 */
@@ -213,8 +211,7 @@ func NewUpdatePaymentRequestStatusUnauthorized() *UpdatePaymentRequestStatusUnau
 	return &UpdatePaymentRequestStatusUnauthorized{}
 }
 
-/*
-UpdatePaymentRequestStatusUnauthorized describes a response with status code 401, with default header values.
+/* UpdatePaymentRequestStatusUnauthorized describes a response with status code 401, with default header values.
 
 The request was denied.
 */
@@ -276,8 +273,7 @@ func NewUpdatePaymentRequestStatusForbidden() *UpdatePaymentRequestStatusForbidd
 	return &UpdatePaymentRequestStatusForbidden{}
 }
 
-/*
-UpdatePaymentRequestStatusForbidden describes a response with status code 403, with default header values.
+/* UpdatePaymentRequestStatusForbidden describes a response with status code 403, with default header values.
 
 The request was denied.
 */
@@ -339,8 +335,7 @@ func NewUpdatePaymentRequestStatusNotFound() *UpdatePaymentRequestStatusNotFound
 	return &UpdatePaymentRequestStatusNotFound{}
 }
 
-/*
-UpdatePaymentRequestStatusNotFound describes a response with status code 404, with default header values.
+/* UpdatePaymentRequestStatusNotFound describes a response with status code 404, with default header values.
 
 The requested resource wasn't found.
 */
@@ -402,8 +397,7 @@ func NewUpdatePaymentRequestStatusConflict() *UpdatePaymentRequestStatusConflict
 	return &UpdatePaymentRequestStatusConflict{}
 }
 
-/*
-UpdatePaymentRequestStatusConflict describes a response with status code 409, with default header values.
+/* UpdatePaymentRequestStatusConflict describes a response with status code 409, with default header values.
 
 There was a conflict with the request.
 */
@@ -465,8 +459,7 @@ func NewUpdatePaymentRequestStatusPreconditionFailed() *UpdatePaymentRequestStat
 	return &UpdatePaymentRequestStatusPreconditionFailed{}
 }
 
-/*
-UpdatePaymentRequestStatusPreconditionFailed describes a response with status code 412, with default header values.
+/* UpdatePaymentRequestStatusPreconditionFailed describes a response with status code 412, with default header values.
 
 Precondition failed, likely due to a stale eTag (If-Match). Fetch the request again to get the updated eTag value.
 */
@@ -528,8 +521,7 @@ func NewUpdatePaymentRequestStatusUnprocessableEntity() *UpdatePaymentRequestSta
 	return &UpdatePaymentRequestStatusUnprocessableEntity{}
 }
 
-/*
-UpdatePaymentRequestStatusUnprocessableEntity describes a response with status code 422, with default header values.
+/* UpdatePaymentRequestStatusUnprocessableEntity describes a response with status code 422, with default header values.
 
 The payload was unprocessable.
 */
@@ -591,8 +583,7 @@ func NewUpdatePaymentRequestStatusInternalServerError() *UpdatePaymentRequestSta
 	return &UpdatePaymentRequestStatusInternalServerError{}
 }
 
-/*
-UpdatePaymentRequestStatusInternalServerError describes a response with status code 500, with default header values.
+/* UpdatePaymentRequestStatusInternalServerError describes a response with status code 500, with default header values.
 
 A server error occurred.
 */

--- a/pkg/gen/supportclient/webhook/create_webhook_notification_parameters.go
+++ b/pkg/gen/supportclient/webhook/create_webhook_notification_parameters.go
@@ -54,12 +54,10 @@ func NewCreateWebhookNotificationParamsWithHTTPClient(client *http.Client) *Crea
 	}
 }
 
-/*
-CreateWebhookNotificationParams contains all the parameters to send to the API endpoint
+/* CreateWebhookNotificationParams contains all the parameters to send to the API endpoint
+   for the create webhook notification operation.
 
-	for the create webhook notification operation.
-
-	Typically these are written to a http.Request.
+   Typically these are written to a http.Request.
 */
 type CreateWebhookNotificationParams struct {
 

--- a/pkg/gen/supportclient/webhook/create_webhook_notification_responses.go
+++ b/pkg/gen/supportclient/webhook/create_webhook_notification_responses.go
@@ -51,8 +51,7 @@ func NewCreateWebhookNotificationCreated() *CreateWebhookNotificationCreated {
 	return &CreateWebhookNotificationCreated{}
 }
 
-/*
-CreateWebhookNotificationCreated describes a response with status code 201, with default header values.
+/* CreateWebhookNotificationCreated describes a response with status code 201, with default header values.
 
 Successful creation
 */
@@ -114,8 +113,7 @@ func NewCreateWebhookNotificationUnprocessableEntity() *CreateWebhookNotificatio
 	return &CreateWebhookNotificationUnprocessableEntity{}
 }
 
-/*
-CreateWebhookNotificationUnprocessableEntity describes a response with status code 422, with default header values.
+/* CreateWebhookNotificationUnprocessableEntity describes a response with status code 422, with default header values.
 
 The payload was unprocessable.
 */
@@ -177,8 +175,7 @@ func NewCreateWebhookNotificationInternalServerError() *CreateWebhookNotificatio
 	return &CreateWebhookNotificationInternalServerError{}
 }
 
-/*
-CreateWebhookNotificationInternalServerError describes a response with status code 500, with default header values.
+/* CreateWebhookNotificationInternalServerError describes a response with status code 500, with default header values.
 
 A server error occurred.
 */

--- a/pkg/gen/supportclient/webhook/receive_webhook_notification_parameters.go
+++ b/pkg/gen/supportclient/webhook/receive_webhook_notification_parameters.go
@@ -54,12 +54,10 @@ func NewReceiveWebhookNotificationParamsWithHTTPClient(client *http.Client) *Rec
 	}
 }
 
-/*
-ReceiveWebhookNotificationParams contains all the parameters to send to the API endpoint
+/* ReceiveWebhookNotificationParams contains all the parameters to send to the API endpoint
+   for the receive webhook notification operation.
 
-	for the receive webhook notification operation.
-
-	Typically these are written to a http.Request.
+   Typically these are written to a http.Request.
 */
 type ReceiveWebhookNotificationParams struct {
 

--- a/pkg/gen/supportclient/webhook/receive_webhook_notification_responses.go
+++ b/pkg/gen/supportclient/webhook/receive_webhook_notification_responses.go
@@ -63,8 +63,7 @@ func NewReceiveWebhookNotificationOK() *ReceiveWebhookNotificationOK {
 	return &ReceiveWebhookNotificationOK{}
 }
 
-/*
-ReceiveWebhookNotificationOK describes a response with status code 200, with default header values.
+/* ReceiveWebhookNotificationOK describes a response with status code 200, with default header values.
 
 Received notification
 */
@@ -126,8 +125,7 @@ func NewReceiveWebhookNotificationBadRequest() *ReceiveWebhookNotificationBadReq
 	return &ReceiveWebhookNotificationBadRequest{}
 }
 
-/*
-ReceiveWebhookNotificationBadRequest describes a response with status code 400, with default header values.
+/* ReceiveWebhookNotificationBadRequest describes a response with status code 400, with default header values.
 
 The request payload is invalid.
 */
@@ -189,8 +187,7 @@ func NewReceiveWebhookNotificationUnauthorized() *ReceiveWebhookNotificationUnau
 	return &ReceiveWebhookNotificationUnauthorized{}
 }
 
-/*
-ReceiveWebhookNotificationUnauthorized describes a response with status code 401, with default header values.
+/* ReceiveWebhookNotificationUnauthorized describes a response with status code 401, with default header values.
 
 The request was denied.
 */
@@ -252,8 +249,7 @@ func NewReceiveWebhookNotificationForbidden() *ReceiveWebhookNotificationForbidd
 	return &ReceiveWebhookNotificationForbidden{}
 }
 
-/*
-ReceiveWebhookNotificationForbidden describes a response with status code 403, with default header values.
+/* ReceiveWebhookNotificationForbidden describes a response with status code 403, with default header values.
 
 The request was denied.
 */
@@ -315,8 +311,7 @@ func NewReceiveWebhookNotificationInternalServerError() *ReceiveWebhookNotificat
 	return &ReceiveWebhookNotificationInternalServerError{}
 }
 
-/*
-ReceiveWebhookNotificationInternalServerError describes a response with status code 500, with default header values.
+/* ReceiveWebhookNotificationInternalServerError describes a response with status code 500, with default header values.
 
 A server error occurred.
 */

--- a/pkg/gen/supportclient/webhook/webhook_client.go
+++ b/pkg/gen/supportclient/webhook/webhook_client.go
@@ -38,9 +38,10 @@ type ClientService interface {
 }
 
 /*
-CreateWebhookNotification tests endpoint for creating webhook notifications
+  CreateWebhookNotification tests endpoint for creating webhook notifications
 
-This endpoint creates a webhook notification in the database. If the webhook client is running, it may send the notification soon after creation.
+  This endpoint creates a webhook notification in the database. If the webhook client is running, it may send the notification soon after creation.
+
 */
 func (a *Client) CreateWebhookNotification(params *CreateWebhookNotificationParams, opts ...ClientOption) (*CreateWebhookNotificationCreated, error) {
 	// TODO: Validate the params before sending
@@ -78,9 +79,10 @@ func (a *Client) CreateWebhookNotification(params *CreateWebhookNotificationPara
 }
 
 /*
-ReceiveWebhookNotification tests endpoint for receiving messages from our own webhook client
+  ReceiveWebhookNotification tests endpoint for receiving messages from our own webhook client
 
-This endpoint receives a notification that matches the webhook notification model. This is a test endpoint that represents a receiving server. In production, the Prime will set up a receiving endpoint. In testing, this server accepts notifications at this endpoint and simply responds with success and logs them. The `webhook-client` is responsible for retrieving messages from the webhook_notifications table and sending them to the Prime (this endpoint in our testing case) via an mTLS connection.
+  This endpoint receives a notification that matches the webhook notification model. This is a test endpoint that represents a receiving server. In production, the Prime will set up a receiving endpoint. In testing, this server accepts notifications at this endpoint and simply responds with success and logs them. The `webhook-client` is responsible for retrieving messages from the webhook_notifications table and sending them to the Prime (this endpoint in our testing case) via an mTLS connection.
+
 */
 func (a *Client) ReceiveWebhookNotification(params *ReceiveWebhookNotificationParams, opts ...ClientOption) (*ReceiveWebhookNotificationOK, error) {
 	// TODO: Validate the params before sending

--- a/pkg/gen/supportmessages/m_t_o_service_item_model_type.go
+++ b/pkg/gen/supportmessages/m_t_o_service_item_model_type.go
@@ -17,12 +17,13 @@ import (
 // MTOServiceItemModelType Describes all model sub-types for a MTOServiceItem model.
 //
 // Using this list, choose the correct modelType in the dropdown, corresponding to the service item type.
-//   - DOFSIT, DOASIT - MTOServiceItemOriginSIT
-//   - DDFSIT, DDASIT - MTOServiceItemDestSIT
-//   - DOSHUT, DDSHUT - MTOServiceItemShuttle
-//   - DCRT, DUCRT - MTOServiceItemDomesticCrating
+//   * DOFSIT, DOASIT - MTOServiceItemOriginSIT
+//   * DDFSIT, DDASIT - MTOServiceItemDestSIT
+//   * DOSHUT, DDSHUT - MTOServiceItemShuttle
+//   * DCRT, DUCRT - MTOServiceItemDomesticCrating
 //
 // The documentation will then update with the supported fields.
+//
 //
 // swagger:model MTOServiceItemModelType
 type MTOServiceItemModelType string

--- a/pkg/gen/supportmessages/re_service_code.go
+++ b/pkg/gen/supportmessages/re_service_code.go
@@ -19,6 +19,7 @@ import (
 //
 // Documentation of all the service items will be provided.
 //
+//
 // swagger:model ReServiceCode
 type ReServiceCode string
 


### PR DESCRIPTION
## Summary

When branching off the latest changes in main/master, if I run

```shell
rm .server_generate.stamp .swagger_build.stamp && make server_generate
```

I get 486 files changed. Based on spot checking a few, they seem to be whitespace differences. Interestingly, they seem to be undoing the whitespace differences that #9191 made.

I checked my `go-swagger` version and it is the latest version:
![image](https://user-images.githubusercontent.com/35938642/194433342-a3073c9c-d25c-4037-985b-5d9d1cc3a7ff.png)

I saw the [thread Drew started about the differences between `go-swagger` from `nix` vs `brew`](https://ustcdp3.slack.com/archives/CP6PTUPQF/p1664206972401619) and I wonder if that's what this is. I'm using `nix` for my dependencies.

Interestingly, I had to commit the 486 files without running `pre-commit` because otherwise it (using `go fmt`) updated a bunch of the generated files, leaving them back how they were, leaving only 32 files changed (1 is not a gen file). Ideally we wouldn't have to generate the files and then have them fixed by `go fmt` though.

This PR has both commits, [one just after running the gen command](https://github.com/transcom/mymove/pull/9319/commits/d84f2b6f771e158a4b4041f6fbfd8bce4c4c3d5e), and [one after running the files though `go fmt`](https://github.com/transcom/mymove/pull/9319/commits/1513954a57d79a8f5e0242f5a2e5deb7a25d773c). The net result being the [32 file changes being shown in the PR](https://github.com/transcom/mymove/pull/9320/files).