### PR TITLE
MB-14226 auth logging improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -162,7 +162,7 @@ client_deps: .check_hosts.stamp .check_node_version.stamp .client_deps.stamp ## 
 	scripts/copy-swagger-ui
 	touch .client_deps.stamp
 
-.client_build.stamp: .check_node_version.stamp $(wildcard src/**/*)
+.client_build.stamp: .check_node_version.stamp $(shell find src -type f)
 	yarn build
 	touch .client_build.stamp
 
@@ -263,30 +263,30 @@ bin/health-checker: cmd/health-checker
 bin/iws: cmd/iws
 	go build -ldflags "$(LDFLAGS)" -o bin/iws ./cmd/iws/iws.go
 
-PKG_GOSRC := $(wildcard pkg/**/*.go)
+PKG_GOSRC := $(shell find pkg -name '*.go')
 
-bin/milmove: $(wildcard cmd/milmove/**/*.go) $(PKG_GOSRC)
+bin/milmove: $(shell find cmd/milmove -name '*.go') $(PKG_GOSRC)
 	go build -gcflags="$(GOLAND_GC_FLAGS) $(GC_FLAGS)" -asmflags=-trimpath=$(GOPATH) -ldflags "$(LDFLAGS) $(WEBSERVER_LDFLAGS)" -o bin/milmove ./cmd/milmove
 
-bin/milmove-tasks: $(wildcard cmd/milmove-tasks/**/*.go) $(PKG_GOSRC)
+bin/milmove-tasks: $(shell find cmd/milmove-tasks -name '*.go') $(PKG_GOSRC)
 	go build -ldflags "$(LDFLAGS) $(WEBSERVER_LDFLAGS)" -o bin/milmove-tasks ./cmd/milmove-tasks
 
-bin/prime-api-client: $(wildcard cmd/prime-api-client/**/*.go) $(PKG_GOSRC)
+bin/prime-api-client: $(shell find cmd/prime-api-client -name '*.go') $(PKG_GOSRC)
 	go build -ldflags "$(LDFLAGS)" -o bin/prime-api-client ./cmd/prime-api-client
 
-bin/webhook-client: $(wildcard cmd/webhook-client/**/*.go) $(PKG_GOSRC)
+bin/webhook-client: $(shell find cmd/webhook-client -name '*.go') $(PKG_GOSRC)
 	go build -ldflags "$(LDFLAGS)" -o bin/webhook-client ./cmd/webhook-client
 
-bin/read-alb-logs: $(wildcard cmd/read-alb-logs/**/*.go) $(PKG_GOSRC)
+bin/read-alb-logs: $(shell find cmd/read-alb-logs -name '*.go') $(PKG_GOSRC)
 	go build -ldflags "$(LDFLAGS)" -o bin/read-alb-logs ./cmd/read-alb-logs
 
-bin/send-to-gex: $(wildcard cmd/send-to-gex/**/*.go) $(PKG_GOSRC)
+bin/send-to-gex: $(shell find cmd/send-to-gex -name '*.go') $(PKG_GOSRC)
 	go build -ldflags "$(LDFLAGS)" -o bin/send-to-gex ./cmd/send-to-gex
 
-bin/tls-checker: $(wildcard cmd/tls-checker/**/*.go) $(PKG_GOSRC)
+bin/tls-checker: $(shell find cmd/tls-checker -name '*.go') $(PKG_GOSRC)
 	go build -ldflags "$(LDFLAGS)" -o bin/tls-checker ./cmd/tls-checker
 
-bin/generate-payment-request-edi: $(wildcard cmd/generate-payment-request-edi/**/*.go) $(PKG_GOSRC)
+bin/generate-payment-request-edi: $(shell find cmd/generate-payment-request-edi -name '*.go') $(PKG_GOSRC)
 	go build -ldflags "$(LDFLAGS)" -o bin/generate-payment-request-edi ./cmd/generate-payment-request-edi
 
 pkg/assets/assets.go:
@@ -1141,6 +1141,10 @@ prune_volumes:  ## Prune docker volumes
 
 .PHONY: prune
 prune: prune_images prune_containers prune_volumes ## Prune docker containers, images, and volumes
+
+.PHONY: clean_server
+clean_server:
+	rm -f bin/milmove
 
 .PHONY: clean
 clean: ## Clean all generated files

--- a/pkg/auth/cookie.go
+++ b/pkg/auth/cookie.go
@@ -175,13 +175,13 @@ func SessionCookieMiddleware(globalLogger *zap.Logger, appnames ApplicationServe
 			obj := sessionManager.Get(r.Context(), "session")
 			session, ok := obj.(Session)
 			if ok {
-				logger.Info("Existing session", zap.Any("session", session))
+				logger.Info("Existing session", zap.Any("session.appname", session.ApplicationName))
 			} else {
 				session = Session{
 					ApplicationName: app,
 					Hostname:        strings.ToLower(hostname),
 				}
-				logger.Info("Creating new session", zap.Any("session", session))
+				logger.Info("Creating new session", zap.Any("session.appname", session.ApplicationName))
 			}
 
 			// And update the cookie. May get over-ridden later

--- a/pkg/handlers/authentication/auth.go
+++ b/pkg/handlers/authentication/auth.go
@@ -277,7 +277,9 @@ func authenticateUser(ctx context.Context, appCtx appcontext.AppContext, session
 		appCtx.Logger().Error("Updating user's current session ID", zap.Error(updateErr))
 		return updateErr
 	}
-	appCtx.Logger().Info("Logged in", zap.Any("session", appCtx.Session()))
+	appCtx.Logger().Info("Logged in",
+		zap.Any("session.UserID", appCtx.Session().UserID),
+		zap.Any("session.appname", appCtx.Session().ApplicationName))
 
 	return nil
 }

--- a/pkg/handlers/authentication/auth.go
+++ b/pkg/handlers/authentication/auth.go
@@ -238,6 +238,7 @@ func authenticateUser(ctx context.Context, appCtx appcontext.AppContext, session
 		appCtx.Logger().Error("Failed to write new user session to store", zap.Error(err))
 		return err
 	}
+	appCtx.Logger().Info("User authenticated with new session", zap.String("new_session_id", sessionID))
 	sessionManager.Put(ctx, "session", appCtx.Session())
 
 	user, err := currentUser(appCtx)

--- a/pkg/handlers/authentication/auth.go
+++ b/pkg/handlers/authentication/auth.go
@@ -635,7 +635,7 @@ func (h CallbackHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	openIDSession, err := fetchToken(
 		appCtx.Logger(),
 		r.URL.Query().Get("code"),
-		provider.ClientKey,
+		provider.ClientKey(),
 		h.loginGovProvider)
 	if err != nil {
 		appCtx.Logger().Error("Reading openIDSession from login.gov", zap.Error(err))

--- a/pkg/handlers/authentication/auth.go
+++ b/pkg/handlers/authentication/auth.go
@@ -665,13 +665,23 @@ func (h CallbackHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	appCtx.Logger().Info("New Login", zap.String("OID_User", openIDUser.UserID), zap.String("OID_Email", openIDUser.Email), zap.String("Host", appCtx.Session().Hostname))
 
 	userIdentity, err := models.FetchUserIdentity(appCtx.DB(), openIDUser.UserID)
-	if err == nil { // Someone we know already
-		authorizeKnownUser(appCtx, userIdentity, h, w, r, landingURL.String())
-		appCtx.Logger().Info("Authorized and known user detected", zap.String("OID_User", openIDUser.UserID), zap.String("OID_Email", openIDUser.Email))
+	if err == nil {
+		// In this case, we found an existing user associated with the
+		// unique login.gov UUID (aka OID_User, aka openIDUser.UserID,
+		// aka models.User.login_gov_uuid)
+		appCtx.Logger().Info("Known user: found by login.gov OID_User, checking authorization", zap.String("OID_User", openIDUser.UserID), zap.String("OID_Email", openIDUser.Email), zap.String("user.id", userIdentity.ID.String()), zap.String("user.login_gov_email", userIdentity.Email))
+		ok := authorizeKnownUser(appCtx, userIdentity, h, w, r, landingURL.String())
+		appCtx.Logger().Info("Known user authorization", zap.Bool("authorized", ok), zap.String("OID_User", openIDUser.UserID), zap.String("OID_Email", openIDUser.Email))
 		return
-	} else if err == models.ErrFetchNotFound { // Never heard of them so far
-		authorizeUnknownUser(appCtx, openIDUser, h, w, r, landingURL.String())
-		appCtx.Logger().Error("Unknown user detected", zap.Error(err))
+	} else if err == models.ErrFetchNotFound { // Never heard of them
+		// so far In this case, we can't find an existing user
+		// associated with the unique login.gov UUID (aka OID_User,
+		// aka openIDUser.UserID, aka models.User.login_gov_uuid).
+		// The authorizeUnknownUser method tries to find a user record
+		// with a matching email address
+		appCtx.Logger().Info("Unknown user: not found by login.gov OID_User, associating email and checking authorization", zap.String("OID_User", openIDUser.UserID), zap.String("OID_Email", openIDUser.Email))
+		ok := authorizeUnknownUser(appCtx, openIDUser, h, w, r, landingURL.String())
+		appCtx.Logger().Info("Unknown user authorization", zap.Bool("authorized", ok), zap.String("OID_User", openIDUser.UserID), zap.String("OID_Email", openIDUser.Email))
 		return
 	} else {
 		appCtx.Logger().Error("Error loading Identity.", zap.Error(err))
@@ -680,14 +690,14 @@ func (h CallbackHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-var authorizeKnownUser = func(appCtx appcontext.AppContext, userIdentity *models.UserIdentity, h CallbackHandler, w http.ResponseWriter, r *http.Request, lURL string) {
+var authorizeKnownUser = func(appCtx appcontext.AppContext, userIdentity *models.UserIdentity, h CallbackHandler, w http.ResponseWriter, r *http.Request, lURL string) bool {
 	if !userIdentity.Active {
 		appCtx.Logger().Error("Inactive user requesting authentication",
 			zap.String("application_name", string(appCtx.Session().ApplicationName)),
 			zap.String("hostname", appCtx.Session().Hostname),
 			zap.String("user_id", appCtx.Session().UserID.String()))
-		http.Error(w, http.StatusText(403), http.StatusForbidden)
-		return
+		http.Error(w, "User unauthorized", http.StatusForbidden)
+		return false
 	}
 	appCtx.Session().Roles = append(appCtx.Session().Roles, userIdentity.Roles...)
 	appCtx.Session().Permissions = getPermissionsForUser(appCtx, userIdentity.ID)
@@ -700,8 +710,8 @@ var authorizeKnownUser = func(appCtx appcontext.AppContext, userIdentity *models
 	if appCtx.Session().IsOfficeApp() {
 		if userIdentity.OfficeActive != nil && !*userIdentity.OfficeActive {
 			appCtx.Logger().Error("Office user is deactivated", zap.String("userID", appCtx.Session().UserID.String()))
-			http.Error(w, http.StatusText(403), http.StatusForbidden)
-			return
+			http.Error(w, "Office User Unauthorized", http.StatusForbidden)
+			return false
 		}
 		if userIdentity.OfficeUserID != nil {
 			appCtx.Session().OfficeUserID = *(userIdentity.OfficeUserID)
@@ -710,12 +720,12 @@ var authorizeKnownUser = func(appCtx appcontext.AppContext, userIdentity *models
 			officeUser, err := models.FetchOfficeUserByEmail(appCtx.DB(), appCtx.Session().Email)
 			if err == models.ErrFetchNotFound {
 				appCtx.Logger().Error("Non-office user authenticated at office site", zap.String("userID", appCtx.Session().UserID.String()))
-				http.Error(w, http.StatusText(403), http.StatusForbidden)
-				return
+				http.Error(w, "Office User Unauthorized", http.StatusForbidden)
+				return false
 			} else if err != nil {
 				appCtx.Logger().Error("Checking for office user", zap.String("userID", appCtx.Session().UserID.String()), zap.Error(err))
 				http.Error(w, http.StatusText(500), http.StatusInternalServerError)
-				return
+				return false
 			}
 			appCtx.Session().OfficeUserID = officeUser.ID
 			officeUser.UserID = &userIdentity.ID
@@ -723,7 +733,7 @@ var authorizeKnownUser = func(appCtx appcontext.AppContext, userIdentity *models
 			if err != nil {
 				appCtx.Logger().Error("Updating office user", zap.String("userID", appCtx.Session().UserID.String()), zap.Error(err))
 				http.Error(w, http.StatusText(500), http.StatusInternalServerError)
-				return
+				return false
 			}
 		}
 	}
@@ -731,8 +741,8 @@ var authorizeKnownUser = func(appCtx appcontext.AppContext, userIdentity *models
 	if appCtx.Session().IsAdminApp() {
 		if userIdentity.AdminUserActive != nil && !*userIdentity.AdminUserActive {
 			appCtx.Logger().Error("Admin user is deactivated", zap.String("userID", appCtx.Session().UserID.String()))
-			http.Error(w, http.StatusText(403), http.StatusForbidden)
-			return
+			http.Error(w, "Admin User Unauthorized", http.StatusForbidden)
+			return false
 		}
 		if userIdentity.AdminUserID != nil {
 			appCtx.Session().AdminUserID = *(userIdentity.AdminUserID)
@@ -748,12 +758,12 @@ var authorizeKnownUser = func(appCtx appcontext.AppContext, userIdentity *models
 
 			if err != nil && errors.Cause(err).Error() == models.RecordNotFoundErrorString {
 				appCtx.Logger().Error("No admin user found", zap.String("userID", appCtx.Session().UserID.String()))
-				http.Error(w, http.StatusText(403), http.StatusForbidden)
-				return
+				http.Error(w, "Admin User Unauthorized", http.StatusForbidden)
+				return false
 			} else if err != nil {
 				appCtx.Logger().Error("Checking for admin user", zap.String("userID", appCtx.Session().UserID.String()), zap.Error(err))
 				http.Error(w, http.StatusText(500), http.StatusInternalServerError)
-				return
+				return false
 			}
 
 			appCtx.Session().AdminUserID = adminUser.ID
@@ -763,13 +773,13 @@ var authorizeKnownUser = func(appCtx appcontext.AppContext, userIdentity *models
 			if err != nil {
 				appCtx.Logger().Error("Updating admin user", zap.String("userID", appCtx.Session().UserID.String()), zap.Error(err))
 				http.Error(w, http.StatusText(500), http.StatusInternalServerError)
-				return
+				return false
 			}
 
 			if verrs != nil {
 				appCtx.Logger().Error("Admin user validation errors", zap.String("userID", appCtx.Session().UserID.String()), zap.Error(verrs))
 				http.Error(w, http.StatusText(500), http.StatusInternalServerError)
-				return
+				return false
 			}
 		}
 	}
@@ -782,13 +792,14 @@ var authorizeKnownUser = func(appCtx appcontext.AppContext, userIdentity *models
 	if authError != nil {
 		appCtx.Logger().Error("Authenticating user", zap.Error(authError))
 		http.Error(w, http.StatusText(500), http.StatusInternalServerError)
-		return
+		return false
 	}
 
 	http.Redirect(w, r, lURL, http.StatusTemporaryRedirect)
+	return true
 }
 
-var authorizeUnknownUser = func(appCtx appcontext.AppContext, openIDUser goth.User, h CallbackHandler, w http.ResponseWriter, r *http.Request, lURL string) {
+var authorizeUnknownUser = func(appCtx appcontext.AppContext, openIDUser goth.User, h CallbackHandler, w http.ResponseWriter, r *http.Request, lURL string) bool {
 	var officeUser *models.OfficeUser
 	var user *models.User
 	var err error
@@ -799,18 +810,25 @@ var authorizeUnknownUser = func(appCtx appcontext.AppContext, openIDUser goth.Us
 	if appCtx.Session().IsOfficeApp() { // Look to see if we have OfficeUser with this email address
 		officeUser, err = models.FetchOfficeUserByEmail(conn, appCtx.Session().Email)
 		if err == models.ErrFetchNotFound {
-			appCtx.Logger().Error("No Office user found", zap.String("userID", appCtx.Session().UserID.String()))
-			http.Error(w, http.StatusText(403), http.StatusForbidden)
-			return
+			appCtx.Logger().Error("Unauthorized: No Office user found",
+				zap.String("OID_User", openIDUser.UserID),
+				zap.String("OID_Email", openIDUser.Email))
+			http.Error(w, "Office User Unauthorized", http.StatusForbidden)
+			return false
 		} else if err != nil {
-			appCtx.Logger().Error("Checking for office user", zap.String("userID", appCtx.Session().UserID.String()), zap.Error(err))
+			appCtx.Logger().Error("Authorization checking for office user",
+				zap.String("OID_User", openIDUser.UserID),
+				zap.String("OID_Email", openIDUser.Email),
+				zap.Error(err))
 			http.Error(w, http.StatusText(500), http.StatusInternalServerError)
-			return
+			return false
 		}
 		if !officeUser.Active {
-			appCtx.Logger().Error("Office user is deactivated", zap.String("userID", appCtx.Session().UserID.String()))
-			http.Error(w, http.StatusText(403), http.StatusForbidden)
-			return
+			appCtx.Logger().Error("Unauthorized: Office user deactivated",
+				zap.String("OID_User", openIDUser.UserID),
+				zap.String("OID_Email", openIDUser.Email))
+			http.Error(w, "Office User Unauthorized", http.StatusForbidden)
+			return false
 		}
 		user = &officeUser.User
 	}
@@ -824,18 +842,25 @@ var authorizeUnknownUser = func(appCtx appcontext.AppContext, openIDUser goth.Us
 		err = queryBuilder.FetchOne(appCtx, &adminUser, filters)
 
 		if err != nil && errors.Cause(err).Error() == models.RecordNotFoundErrorString {
-			appCtx.Logger().Error("No admin user found", zap.String("userID", appCtx.Session().UserID.String()))
-			http.Error(w, http.StatusText(403), http.StatusForbidden)
-			return
+			appCtx.Logger().Error("Unauthorized: No admin user found",
+				zap.String("OID_User", openIDUser.UserID),
+				zap.String("OID_Email", openIDUser.Email))
+			http.Error(w, "Admin User Unauthorized", http.StatusForbidden)
+			return false
 		} else if err != nil {
-			appCtx.Logger().Error("Checking for admin user", zap.String("userID", appCtx.Session().UserID.String()), zap.Error(err))
+			appCtx.Logger().Error("Authorization checking for admin user",
+				zap.String("OID_User", openIDUser.UserID),
+				zap.String("OID_Email", openIDUser.Email),
+				zap.Error(err))
 			http.Error(w, http.StatusText(500), http.StatusInternalServerError)
-			return
+			return false
 		}
 		if !adminUser.Active {
-			appCtx.Logger().Error("Admin user is deactivated", zap.String("userID", appCtx.Session().UserID.String()))
-			http.Error(w, http.StatusText(403), http.StatusForbidden)
-			return
+			appCtx.Logger().Error("Unauthorized: Admin user deactivated",
+				zap.String("OID_User", openIDUser.UserID),
+				zap.String("OID_Email", openIDUser.Email))
+			http.Error(w, "Admin User Unauthorized", http.StatusForbidden)
+			return false
 		}
 		user = &adminUser.User
 	}
@@ -874,17 +899,22 @@ var authorizeUnknownUser = func(appCtx appcontext.AppContext, openIDUser goth.Us
 		if smVerrs.HasAny() || smErr != nil {
 			appCtx.Logger().Error("Error creating service member for user", zap.Error(smErr))
 			http.Error(w, http.StatusText(500), http.StatusInternalServerError)
-			return
+			return false
 		}
 		appCtx.Session().ServiceMemberID = newServiceMember.ID
 	} else {
+		appCtx.Logger().Error("Authorization associating login.gov UUID with user",
+			zap.String("OID_User", openIDUser.UserID),
+			zap.String("OID_Email", openIDUser.Email),
+			zap.String("user.id", user.ID.String()),
+		)
 		err = models.UpdateUserLoginGovUUID(appCtx.DB(), user, openIDUser.UserID)
 	}
 
 	if err != nil {
-		appCtx.Logger().Error("Error updating/creating user", zap.Error(err))
+		appCtx.Logger().Error("Authorization error updating/creating user", zap.Error(err))
 		http.Error(w, http.StatusText(500), http.StatusInternalServerError)
-		return
+		return false
 	}
 
 	appCtx.Session().UserID = user.ID
@@ -902,10 +932,11 @@ var authorizeUnknownUser = func(appCtx appcontext.AppContext, openIDUser goth.Us
 	if authError != nil {
 		appCtx.Logger().Error("Authenticate user", zap.Error(authError))
 		http.Error(w, http.StatusText(500), http.StatusInternalServerError)
-		return
+		return false
 	}
 
 	http.Redirect(w, r, lURL, http.StatusTemporaryRedirect)
+	return true
 }
 
 func fetchToken(logger *zap.Logger, code string, clientID string, loginGovProvider LoginGovProvider) (*openidConnect.Session, error) {

--- a/pkg/handlers/authentication/login_gov.go
+++ b/pkg/handlers/authentication/login_gov.go
@@ -21,7 +21,30 @@ const milProviderName = "milProvider"
 const officeProviderName = "officeProvider"
 const adminProviderName = "adminProvider"
 
-func getLoginGovProviderForRequest(r *http.Request) (*openidConnect.Provider, error) {
+type MilMoveLoginGovProvider interface {
+	Name() string
+	SetName(name string)
+	BeginAuth(state string) (goth.Session, error)
+	FetchUser(goth.Session) (goth.User, error)
+	ClientKey() string
+}
+
+type milMoveLoginGovProviderWrapper struct {
+	*openidConnect.Provider
+}
+
+func (w *milMoveLoginGovProviderWrapper) ClientKey() string {
+	return w.Provider.ClientKey
+}
+
+func wrapGothProvider(provider goth.Provider) MilMoveLoginGovProvider {
+	if openidProvider, ok := provider.(*openidConnect.Provider); ok {
+		return &milMoveLoginGovProviderWrapper{openidProvider}
+	}
+	return provider.(MilMoveLoginGovProvider)
+}
+
+func getLoginGovProviderForRequest(r *http.Request) (MilMoveLoginGovProvider, error) {
 	session := auth.SessionFromRequestContext(r)
 	providerName := milProviderName
 	if session.IsOfficeApp() {
@@ -33,7 +56,18 @@ func getLoginGovProviderForRequest(r *http.Request) (*openidConnect.Provider, er
 	if err != nil {
 		return nil, err
 	}
-	return gothProvider.(*openidConnect.Provider), nil
+	return wrapGothProvider(gothProvider), nil
+}
+
+func SetLoginGovProviders(milProvider MilMoveLoginGovProvider,
+	officeProvider MilMoveLoginGovProvider,
+	adminProvider MilMoveLoginGovProvider) {
+	milProvider.SetName(milProviderName)
+	officeProvider.SetName(officeProviderName)
+	adminProvider.SetName(adminProviderName)
+	goth.UseProviders(milProvider.(goth.Provider),
+		officeProvider.(goth.Provider),
+		adminProvider.(goth.Provider))
 }
 
 // LoginGovProvider facilitates generating URLs and parameters for interfacing with Login.gov
@@ -70,20 +104,19 @@ func (p LoginGovProvider) RegisterProvider(milHostname string, milClientID strin
 		p.logger.Error("getting open_id provider", zap.String("host", milHostname), zap.Error(err))
 		return err
 	}
-	milProvider.SetName(milProviderName)
 	officeProvider, err := p.getOpenIDProvider(officeHostname, officeClientID, callbackProtocol, callbackPort)
 	if err != nil {
 		p.logger.Error("getting open_id provider", zap.String("host", officeHostname), zap.Error(err))
 		return err
 	}
-	officeProvider.SetName(officeProviderName)
 	adminProvider, err := p.getOpenIDProvider(adminHostname, adminClientID, callbackProtocol, callbackPort)
 	if err != nil {
 		p.logger.Error("getting open_id provider", zap.String("host", adminHostname), zap.Error(err))
 		return err
 	}
-	adminProvider.SetName(adminProviderName)
-	goth.UseProviders(milProvider, officeProvider, adminProvider)
+	SetLoginGovProviders(wrapGothProvider(milProvider),
+		wrapGothProvider(officeProvider),
+		wrapGothProvider(adminProvider))
 	return nil
 }
 

--- a/pkg/handlers/routing/routing_init.go
+++ b/pkg/handlers/routing/routing_init.go
@@ -122,6 +122,7 @@ func InitRouting(appCtx appcontext.AppContext, redisPool *redis.Pool,
 	// are added, but the resulting http.Handlers execute in "normal" order
 	// (i.e., the http.Handler returned by the first Middleware added gets
 	// called first).
+	site.Use(auth.SessionIDMiddleware(routingConfig.HandlerConfig.AppNames(), routingConfig.HandlerConfig.GetSessionManagers()))
 	site.Use(middleware.Trace(appCtx.Logger())) // injects trace id into the context
 	site.Use(middleware.ContextLogger("milmove_trace_id", appCtx.Logger()))
 	site.Use(middleware.Recovery(appCtx.Logger()))

--- a/pkg/middleware/context_logger.go
+++ b/pkg/middleware/context_logger.go
@@ -5,6 +5,7 @@ import (
 
 	"go.uber.org/zap"
 
+	"github.com/transcom/mymove/pkg/auth"
 	"github.com/transcom/mymove/pkg/logging"
 	"github.com/transcom/mymove/pkg/trace"
 )
@@ -17,6 +18,11 @@ func ContextLogger(field string, original *zap.Logger) func(next http.Handler) h
 			logs := original.With(zap.String("host", r.Host))
 			if id := trace.FromContext(ctx); !id.IsNil() {
 				logs = logs.With(zap.String(field, id.String()))
+			}
+			// log the sessionID so we can track requests from the
+			// same user across time
+			if sessionID := auth.SessionIDFromContext(ctx); sessionID != "" {
+				logs = logs.With(zap.String("session_id", sessionID))
 			}
 			ctx = logging.NewContext(ctx, logs)
 			next.ServeHTTP(w, r.WithContext(ctx))


### PR DESCRIPTION
## [Jira ticket](https://dp3.atlassian.net/browse/MB-14226) for this change

## Summary

Improve logging in our auth flow to help us track down bugs, particularly the dreaded 403 Forbidden bug. As part of this add the sessionid to our logs so we can track user requests over time.

## Setup to Run Your Code

##### Terminal 1

Start the UI locally.

```sh
make client_run
```

##### Terminal 2

Start the Go server locally.

```sh
make server_run
```

Log in using login.gov. See the logs.

### Backend

- [ ] Code follows the guidelines for [Logging](https://transcom.github.io/mymove-docs/docs/dev/contributing/backend/Backend-Programming-Guide#logging)

