### PR TITLE
MB-13491 Allow/handle no destination address for both HHG and NTSR using destination duty location zip

### DIFF
--- a/src/components/ConfirmationModals/EvaluationReportConfirmationModal.jsx
+++ b/src/components/ConfirmationModals/EvaluationReportConfirmationModal.jsx
@@ -42,6 +42,7 @@ export const EvaluationReportConfirmationModal = ({
   mtoShipments,
   className,
   bordered,
+  destinationDutyLocationPostalCode,
 }) => (
   <Modal className={classnames(styles.evaluationReportModal, className)}>
     {modalTopRightClose && <ModalClose handleClick={() => modalTopRightClose()} data-testid="modalCloseButtonTop" />}
@@ -54,6 +55,7 @@ export const EvaluationReportConfirmationModal = ({
       evaluationReport={evaluationReport}
       reportViolations={reportViolations}
       bordered={bordered}
+      destinationDutyLocationPostalCode={destinationDutyLocationPostalCode}
     />
     {modalActions}
   </Modal>
@@ -71,6 +73,7 @@ EvaluationReportConfirmationModal.propTypes = {
   className: PropTypes.string,
   bordered: PropTypes.bool,
   modalActions: PropTypes.element,
+  destinationDutyLocationPostalCode: PropTypes.string,
 };
 
 EvaluationReportConfirmationModal.defaultProps = {
@@ -81,6 +84,7 @@ EvaluationReportConfirmationModal.defaultProps = {
   className: null,
   bordered: false,
   modalActions: null,
+  destinationDutyLocationPostalCode: 'bbbblank',
 };
 
 EvaluationReportConfirmationModal.displayName = 'EvaluationReportConfirmationModal';

--- a/src/components/ConfirmationModals/EvaluationReportConfirmationModal.jsx
+++ b/src/components/ConfirmationModals/EvaluationReportConfirmationModal.jsx
@@ -84,7 +84,7 @@ EvaluationReportConfirmationModal.defaultProps = {
   className: null,
   bordered: false,
   modalActions: null,
-  destinationDutyLocationPostalCode: 'bbbblank',
+  destinationDutyLocationPostalCode: '',
 };
 
 EvaluationReportConfirmationModal.displayName = 'EvaluationReportConfirmationModal';

--- a/src/components/Office/DefinitionLists/NTSRShipmentInfoList.jsx
+++ b/src/components/Office/DefinitionLists/NTSRShipmentInfoList.jsx
@@ -178,7 +178,7 @@ const NTSRShipmentInfoList = ({
   const destinationAddressElement = (
     <div className={destinationAddressElementFlags.classes}>
       <dt>Delivery address</dt>
-      <dd data-testid="destinationAddress">{formatAddress(destinationAddress)}</dd>
+      <dd data-testid="destinationAddress">{destinationAddress ? formatAddress(destinationAddress) : '—'}</dd>
     </div>
   );
 

--- a/src/components/Office/DefinitionLists/ShipmentInfoList.jsx
+++ b/src/components/Office/DefinitionLists/ShipmentInfoList.jsx
@@ -183,7 +183,7 @@ const ShipmentInfoList = ({
   const destinationAddressElement = (
     <div className={destinationAddressElementFlags.classes}>
       <dt>Destination address</dt>
-      <dd data-testid="destinationAddress">{formatAddress(destinationAddress)}</dd>
+      <dd data-testid="destinationAddress">{destinationAddress ? formatAddress(destinationAddress) : '—'}</dd>
     </div>
   );
 

--- a/src/components/Office/DefinitionLists/ShipmentInfoListSelector.jsx
+++ b/src/components/Office/DefinitionLists/ShipmentInfoListSelector.jsx
@@ -18,6 +18,7 @@ const ShipmentInfoListSelector = ({
   neverShow,
   shipmentType,
   isForEvaluationReport,
+  destinationDutyLocationPostalCode,
 }) => {
   switch (shipmentType) {
     case SHIPMENT_OPTIONS.PPM:
@@ -44,6 +45,7 @@ const ShipmentInfoListSelector = ({
           shipmentType={shipmentType}
           showWhenCollapsed={showWhenCollapsed}
           isForEvaluationReport={isForEvaluationReport}
+          destinationDutyLocationPostalCode={destinationDutyLocationPostalCode}
         />
       );
     case SHIPMENT_OPTIONS.NTSR:
@@ -56,6 +58,7 @@ const ShipmentInfoListSelector = ({
           errorIfMissing={errorIfMissing}
           showWhenCollapsed={showWhenCollapsed}
           isForEvaluationReport={isForEvaluationReport}
+          destinationDutyLocationPostalCode={destinationDutyLocationPostalCode}
         />
       );
     case SHIPMENT_OPTIONS.NTS:
@@ -79,6 +82,7 @@ const ShipmentInfoListSelector = ({
           shipmentType={shipmentType}
           isExpanded={isExpanded}
           isForEvaluationReport={isForEvaluationReport}
+          destinationDutyLocationPostalCode={destinationDutyLocationPostalCode}
         />
       );
   }
@@ -101,6 +105,7 @@ ShipmentInfoListSelector.propTypes = {
     SHIPMENT_OPTIONS.PPM,
   ]),
   isForEvaluationReport: PropTypes.bool,
+  destinationDutyLocationPostalCode: PropTypes.string,
 };
 
 ShipmentInfoListSelector.defaultProps = {
@@ -112,6 +117,7 @@ ShipmentInfoListSelector.defaultProps = {
   showWhenCollapsed: [],
   neverShow: [],
   isForEvaluationReport: false,
+  destinationDutyLocationPostalCode: '',
 };
 
 export default ShipmentInfoListSelector;

--- a/src/components/Office/DefinitionLists/ShipmentInfoListSelector.jsx
+++ b/src/components/Office/DefinitionLists/ShipmentInfoListSelector.jsx
@@ -117,7 +117,7 @@ ShipmentInfoListSelector.defaultProps = {
   showWhenCollapsed: [],
   neverShow: [],
   isForEvaluationReport: false,
-  destinationDutyLocationPostalCode: '',
+  destinationDutyLocationPostalCode: 'silselect',
 };
 
 export default ShipmentInfoListSelector;

--- a/src/components/Office/DefinitionLists/ShipmentInfoListSelector.jsx
+++ b/src/components/Office/DefinitionLists/ShipmentInfoListSelector.jsx
@@ -117,7 +117,7 @@ ShipmentInfoListSelector.defaultProps = {
   showWhenCollapsed: [],
   neverShow: [],
   isForEvaluationReport: false,
-  destinationDutyLocationPostalCode: 'silselect',
+  destinationDutyLocationPostalCode: '',
 };
 
 export default ShipmentInfoListSelector;

--- a/src/components/Office/EvaluationForm/EvaluationForm.jsx
+++ b/src/components/Office/EvaluationForm/EvaluationForm.jsx
@@ -23,7 +23,14 @@ import { formatDateForSwagger } from 'shared/dates';
 import EVALUATION_REPORT_TYPE from 'constants/evaluationReports';
 import { CustomerShape, EvaluationReportShape, ShipmentShape } from 'types';
 
-const EvaluationForm = ({ evaluationReport, reportViolations, mtoShipments, customerInfo, grade }) => {
+const EvaluationForm = ({
+  evaluationReport,
+  reportViolations,
+  mtoShipments,
+  customerInfo,
+  grade,
+  destinationDutyLocationPostalCode,
+}) => {
   const { moveCode, reportId } = useParams();
   const history = useHistory();
   const location = useLocation();
@@ -330,6 +337,7 @@ const EvaluationForm = ({ evaluationReport, reportViolations, mtoShipments, cust
         mtoShipments={mtoShipments}
         modalActions={submitModalActions}
         bordered
+        destinationDutyLocationPostalCode={destinationDutyLocationPostalCode}
       />
 
       <Formik
@@ -620,10 +628,12 @@ EvaluationForm.propTypes = {
   mtoShipments: PropTypes.arrayOf(ShipmentShape),
   customerInfo: CustomerShape.isRequired,
   grade: PropTypes.string.isRequired,
+  destinationDutyLocationPostalCode: PropTypes.string,
 };
 
 EvaluationForm.defaultProps = {
   mtoShipments: null,
+  destinationDutyLocationPostalCode: '',
 };
 
 export default EvaluationForm;

--- a/src/components/Office/EvaluationForm/EvaluationForm.jsx
+++ b/src/components/Office/EvaluationForm/EvaluationForm.jsx
@@ -628,12 +628,11 @@ EvaluationForm.propTypes = {
   mtoShipments: PropTypes.arrayOf(ShipmentShape),
   customerInfo: CustomerShape.isRequired,
   grade: PropTypes.string.isRequired,
-  destinationDutyLocationPostalCode: PropTypes.string,
+  destinationDutyLocationPostalCode: PropTypes.string.isRequired,
 };
 
 EvaluationForm.defaultProps = {
   mtoShipments: null,
-  destinationDutyLocationPostalCode: '',
 };
 
 export default EvaluationForm;

--- a/src/components/Office/EvaluationReportPreview/EvaluationReportPreview.jsx
+++ b/src/components/Office/EvaluationReportPreview/EvaluationReportPreview.jsx
@@ -26,6 +26,7 @@ const EvaluationReportPreview = ({
   moveCode,
   customerInfo,
   grade,
+  destinationDutyLocationPostalCode,
 }) => {
   const isShipment = evaluationReport.type === EVALUATION_REPORT_TYPE.SHIPMENT;
   const hasViolations = reportViolations && reportViolations.length > 0;
@@ -98,6 +99,7 @@ const EvaluationReportPreview = ({
                       shipmentId={mtoShipment.id}
                       displayInfo={shipmentDisplayInfo(mtoShipment)}
                       shipmentType={mtoShipment.shipmentType}
+                      destinationDutyLocationPostalCode={destinationDutyLocationPostalCode}
                     />
                   </div>
                 ))}
@@ -223,11 +225,13 @@ EvaluationReportPreview.propTypes = {
   moveCode: PropTypes.string.isRequired,
   customerInfo: CustomerShape.isRequired,
   grade: PropTypes.string.isRequired,
+  destinationDutyLocationPostalCode: PropTypes.string,
 };
 
 EvaluationReportPreview.defaultProps = {
   mtoShipments: null,
   reportViolations: null,
+  destinationDutyLocationPostalCode: '',
 };
 
 export default EvaluationReportPreview;

--- a/src/components/Office/EvaluationReportShipmentDisplay/EvaluationReportShipmentDisplay.jsx
+++ b/src/components/Office/EvaluationReportShipmentDisplay/EvaluationReportShipmentDisplay.jsx
@@ -112,7 +112,7 @@ const EvaluationReportShipmentDisplay = ({
 
 EvaluationReportShipmentDisplay.propTypes = {
   shipmentId: PropTypes.string.isRequired,
-  destinationDutyLocationPostalCode: PropTypes.string.isRequired,
+  destinationDutyLocationPostalCode: PropTypes.string,
   shipmentType: PropTypes.oneOf([
     SHIPMENT_OPTIONS.HHG,
     SHIPMENT_OPTIONS.HHG_SHORTHAUL_DOMESTIC,
@@ -180,6 +180,7 @@ EvaluationReportShipmentDisplay.propTypes = {
 
 EvaluationReportShipmentDisplay.defaultProps = {
   shipmentType: SHIPMENT_OPTIONS.HHG,
+  destinationDutyLocationPostalCode: '',
   allowApproval: true,
   ordersLOA: {
     tac: '',

--- a/src/components/Office/EvaluationReportShipmentDisplay/EvaluationReportShipmentDisplay.jsx
+++ b/src/components/Office/EvaluationReportShipmentDisplay/EvaluationReportShipmentDisplay.jsx
@@ -27,6 +27,7 @@ const EvaluationReportShipmentDisplay = ({
   errorIfMissing,
   showWhenCollapsed,
   neverShow,
+  destinationDutyLocationPostalCode,
 }) => {
   const containerClasses = classnames(styles.container, { [styles.noIcon]: !allowApproval });
   const [isExpanded, setIsExpanded] = useState(true);
@@ -79,7 +80,7 @@ const EvaluationReportShipmentDisplay = ({
             <h6 className={classnames(styles.ntsHeaderTextField, styles.ntsHeaderTextRight)}>Delivery address</h6>
           </div>
         )}
-        {isExpanded && (displayInfo.pickupAddress || displayInfo.destinationAddress) && (
+        {isExpanded && (
           <div className={styles.shipmentAddresses}>
             <div className={classnames(styles.shipmentAddressTextFields, styles.shipmentAddressLeft)}>
               {pickupAddressString || '—'}
@@ -87,7 +88,9 @@ const EvaluationReportShipmentDisplay = ({
             <div className={styles.shipmentAddressArrow}>
               <FontAwesomeIcon icon="arrow-right" />
             </div>
-            <div className={styles.shipmentAddressTextFields}>{destinationAddressString || '—'}</div>
+            <div className={styles.shipmentAddressTextFields}>
+              {destinationAddressString || destinationDutyLocationPostalCode}
+            </div>
           </div>
         )}
         <ShipmentInfoListSelector
@@ -100,6 +103,7 @@ const EvaluationReportShipmentDisplay = ({
           showWhenCollapsed={showWhenCollapsed}
           neverShow={neverShow}
           isForEvaluationReport
+          destinationDutyLocationPostalCode={destinationDutyLocationPostalCode}
         />
       </ShipmentContainer>
     </div>
@@ -108,6 +112,7 @@ const EvaluationReportShipmentDisplay = ({
 
 EvaluationReportShipmentDisplay.propTypes = {
   shipmentId: PropTypes.string.isRequired,
+  destinationDutyLocationPostalCode: PropTypes.string.isRequired,
   shipmentType: PropTypes.oneOf([
     SHIPMENT_OPTIONS.HHG,
     SHIPMENT_OPTIONS.HHG_SHORTHAUL_DOMESTIC,

--- a/src/components/Office/EvaluationReportShipmentInfo/EvaluationReportShipmentInfo.jsx
+++ b/src/components/Office/EvaluationReportShipmentInfo/EvaluationReportShipmentInfo.jsx
@@ -12,7 +12,13 @@ import { ORDERS_BRANCH_OPTIONS, ORDERS_RANK_OPTIONS } from 'constants/orders';
 import { shipmentTypeLabels } from 'content/shipments';
 import EvaluationReportShipmentDisplay from 'components/Office/EvaluationReportShipmentDisplay/EvaluationReportShipmentDisplay';
 
-const EvaluationReportShipmentInfo = ({ shipments, report, customerInfo, grade }) => {
+const EvaluationReportShipmentInfo = ({
+  shipments,
+  report,
+  customerInfo,
+  grade,
+  destinationDutyLocationPostalCode,
+}) => {
   const shipmentDisplayInfo = (shipment) => ({
     ...shipment,
     heading: shipmentTypeLabels[shipment.shipmentType],
@@ -62,6 +68,7 @@ const EvaluationReportShipmentInfo = ({ shipments, report, customerInfo, grade }
                   shipmentId={shipment.id}
                   displayInfo={shipmentDisplayInfo(shipment)}
                   shipmentType={shipment.shipmentType}
+                  destinationDutyLocationPostalCode={destinationDutyLocationPostalCode}
                 />
               </div>
             ))}
@@ -80,6 +87,7 @@ EvaluationReportShipmentInfo.propTypes = {
   shipments: PropTypes.arrayOf(PropTypes.object).isRequired,
   customerInfo: PropTypes.object.isRequired,
   grade: PropTypes.string.isRequired,
+  destinationDutyLocationPostalCode: PropTypes.string.isRequired,
 };
 
 export default EvaluationReportShipmentInfo;

--- a/src/components/Office/EvaluationReportTable/EvaluationReportShipmentInfo.jsx
+++ b/src/components/Office/EvaluationReportTable/EvaluationReportShipmentInfo.jsx
@@ -4,6 +4,7 @@ import { Button } from '@trussworks/react-uswds';
 import { useMutation, queryCache } from 'react-query';
 import { useHistory, useParams } from 'react-router-dom';
 import classnames from 'classnames';
+import PropTypes from 'prop-types';
 
 import styles from './EvaluationReportShipmentInfo.module.scss';
 
@@ -16,7 +17,7 @@ import { SHIPMENT_EVALUATION_REPORTS } from 'constants/queryKeys';
 import Restricted from 'components/Restricted/Restricted';
 import { permissionTypes } from 'constants/permissions';
 
-const EvaluationReportShipmentInfo = ({ shipment }) => {
+const EvaluationReportShipmentInfo = ({ shipment, destinationDutyLocationPostalCode }) => {
   const { moveCode } = useParams();
   const history = useHistory();
 
@@ -48,7 +49,9 @@ const EvaluationReportShipmentInfo = ({ shipment }) => {
     case SHIPMENT_OPTIONS.HHG_SHORTHAUL_DOMESTIC:
       heading = 'HHG';
       pickupAddress = formatEvaluationReportShipmentAddress(shipment.pickupAddress);
-      destinationAddress = formatEvaluationReportShipmentAddress(shipment.destinationAddress);
+      destinationAddress = shipment?.destinationAddress
+        ? formatEvaluationReportShipmentAddress(shipment.destinationAddress)
+        : destinationDutyLocationPostalCode;
       shipmentAccentStyle = styles.hhgShipmentType;
       break;
     case SHIPMENT_OPTIONS.NTS:
@@ -60,7 +63,9 @@ const EvaluationReportShipmentInfo = ({ shipment }) => {
     case SHIPMENT_OPTIONS.NTSR:
       heading = 'NTS-Release';
       pickupAddress = shipment?.storageFacility ? shipment.storageFacility.facilityName : '';
-      destinationAddress = formatEvaluationReportShipmentAddress(shipment.destinationAddress);
+      destinationAddress = shipment?.destinationAddress
+        ? formatEvaluationReportShipmentAddress(shipment.destinationAddress)
+        : destinationDutyLocationPostalCode;
       shipmentAccentStyle = styles.ntsrShipmentType;
       break;
     case SHIPMENT_OPTIONS.PPM:
@@ -96,6 +101,7 @@ const EvaluationReportShipmentInfo = ({ shipment }) => {
 };
 EvaluationReportShipmentInfo.propTypes = {
   shipment: ShipmentShape.isRequired,
+  destinationDutyLocationPostalCode: PropTypes.string.isRequired,
 };
 
 export default EvaluationReportShipmentInfo;

--- a/src/components/Office/EvaluationReportTable/EvaluationReportTable.jsx
+++ b/src/components/Office/EvaluationReportTable/EvaluationReportTable.jsx
@@ -22,6 +22,7 @@ const EvaluationReportTable = ({
   setIsDeleteModalOpen,
   deleteReport,
   isDeleteModalOpen,
+  destinationDutyLocationPostalCode,
 }) => {
   const location = useLocation();
   const [isViewReportModalVisible, setIsViewReportModalVisible] = useState(false);
@@ -109,6 +110,7 @@ const EvaluationReportTable = ({
           moveCode={moveCode}
           customerInfo={customerInfo}
           grade={grade}
+          destinationDutyLocationPostalCode={destinationDutyLocationPostalCode}
           mtoShipments={shipments}
           reportViolations={reportToView.ReportViolations}
           modalActions={
@@ -155,11 +157,13 @@ EvaluationReportTable.propTypes = {
   setReportToDelete: PropTypes.func.isRequired,
   deleteReport: PropTypes.func.isRequired,
   isDeleteModalOpen: PropTypes.bool.isRequired,
+  destinationDutyLocationPostalCode: PropTypes.string,
 };
 
 EvaluationReportTable.defaultProps = {
   reports: [],
   shipments: null,
+  destinationDutyLocationPostalCode: 'table',
 };
 
 export default EvaluationReportTable;

--- a/src/components/Office/EvaluationReportTable/EvaluationReportTable.jsx
+++ b/src/components/Office/EvaluationReportTable/EvaluationReportTable.jsx
@@ -163,7 +163,7 @@ EvaluationReportTable.propTypes = {
 EvaluationReportTable.defaultProps = {
   reports: [],
   shipments: null,
-  destinationDutyLocationPostalCode: 'table',
+  destinationDutyLocationPostalCode: '',
 };
 
 export default EvaluationReportTable;

--- a/src/components/Office/EvaluationReportTable/ShipmentEvaluationReports.jsx
+++ b/src/components/Office/EvaluationReportTable/ShipmentEvaluationReports.jsx
@@ -18,13 +18,17 @@ const ShipmentEvaluationReports = ({
   setIsDeleteModalOpen,
   deleteReport,
   isDeleteModalOpen,
+  destinationDutyLocationPostalCode,
 }) => {
   const sortedShipments = shipments.sort((a, b) => moment(a.createdAt) - moment(b.createdAt));
 
   const shipmentRows = sortedShipments.map((shipment) => {
     return (
       <div key={shipment.id} className={styles.shipmentRow}>
-        <EvaluationReportShipmentInfo shipment={shipment} />
+        <EvaluationReportShipmentInfo
+          shipment={shipment}
+          destinationDutyLocationPostalCode={destinationDutyLocationPostalCode}
+        />
         <EvaluationReportTable
           moveCode={moveCode}
           reports={reports.filter((r) => r.shipmentID === shipment.id)}
@@ -55,6 +59,7 @@ ShipmentEvaluationReports.propTypes = {
   moveCode: PropTypes.string.isRequired,
   customerInfo: CustomerShape.isRequired,
   grade: PropTypes.string.isRequired,
+  destinationDutyLocationPostalCode: PropTypes.string.isRequired,
 };
 ShipmentEvaluationReports.defaultProps = {
   reports: [],

--- a/src/components/Office/EvaluationReportTable/ShipmentEvaluationReports.jsx
+++ b/src/components/Office/EvaluationReportTable/ShipmentEvaluationReports.jsx
@@ -40,6 +40,7 @@ const ShipmentEvaluationReports = ({
           setIsDeleteModalOpen={setIsDeleteModalOpen}
           isDeleteModalOpen={isDeleteModalOpen}
           deleteReport={deleteReport}
+          destinationDutyLocationPostalCode={destinationDutyLocationPostalCode}
         />
       </div>
     );

--- a/src/components/Office/EvaluationViolationsForm/EvaluationViolationsForm.jsx
+++ b/src/components/Office/EvaluationViolationsForm/EvaluationViolationsForm.jsx
@@ -458,13 +458,12 @@ EvaluationViolationsForm.propTypes = {
   reportViolations: PropTypes.arrayOf(ReportViolationShape),
   customerInfo: CustomerShape.isRequired,
   mtoShipments: PropTypes.arrayOf(ShipmentShape),
-  destinationDutyLocationPostalCode: PropTypes.string,
+  destinationDutyLocationPostalCode: PropTypes.string.isRequired,
 };
 
 EvaluationViolationsForm.defaultProps = {
   mtoShipments: null,
   reportViolations: null,
-  destinationDutyLocationPostalCode: '',
 };
 
 export default EvaluationViolationsForm;

--- a/src/components/Office/EvaluationViolationsForm/EvaluationViolationsForm.jsx
+++ b/src/components/Office/EvaluationViolationsForm/EvaluationViolationsForm.jsx
@@ -20,7 +20,14 @@ import { MILMOVE_LOG_LEVEL, milmoveLog } from 'utils/milmoveLog';
 import { EvaluationReportShape, ReportViolationShape, PWSViolationShape, CustomerShape, ShipmentShape } from 'types';
 import { formatDateForSwagger } from 'shared/dates';
 
-const EvaluationViolationsForm = ({ violations, evaluationReport, reportViolations, customerInfo, mtoShipments }) => {
+const EvaluationViolationsForm = ({
+  violations,
+  evaluationReport,
+  reportViolations,
+  customerInfo,
+  mtoShipments,
+  destinationDutyLocationPostalCode,
+}) => {
   const { moveCode, reportId } = useParams();
   const history = useHistory();
 
@@ -237,6 +244,7 @@ const EvaluationViolationsForm = ({ violations, evaluationReport, reportViolatio
         modalActions={submitModalActions}
         reportViolations={reportViolations}
         bordered
+        destinationDutyLocationPostalCode={destinationDutyLocationPostalCode}
       />
       <Formik
         initialValues={getInitialValues()}
@@ -450,11 +458,13 @@ EvaluationViolationsForm.propTypes = {
   reportViolations: PropTypes.arrayOf(ReportViolationShape),
   customerInfo: CustomerShape.isRequired,
   mtoShipments: PropTypes.arrayOf(ShipmentShape),
+  destinationDutyLocationPostalCode: PropTypes.string,
 };
 
 EvaluationViolationsForm.defaultProps = {
   mtoShipments: null,
   reportViolations: null,
+  destinationDutyLocationPostalCode: '',
 };
 
 export default EvaluationViolationsForm;

--- a/src/pages/Office/EvaluationReport/EvaluationReport.jsx
+++ b/src/pages/Office/EvaluationReport/EvaluationReport.jsx
@@ -17,7 +17,7 @@ import QaeReportHeader from 'components/Office/QaeReportHeader/QaeReportHeader';
 import LoadingPlaceholder from 'shared/LoadingPlaceholder';
 import SomethingWentWrong from 'shared/SomethingWentWrong';
 
-const EvaluationReport = ({ customerInfo, grade }) => {
+const EvaluationReport = ({ customerInfo, grade, destinationDutyLocationPostalCode }) => {
   const { reportId } = useParams();
   const { evaluationReport, reportViolations, mtoShipments, isLoading, isError } =
     useEvaluationReportShipmentListQueries(reportId);
@@ -45,6 +45,7 @@ const EvaluationReport = ({ customerInfo, grade }) => {
             grade={grade}
             shipments={mtoShipmentsToShow}
             report={evaluationReport}
+            destinationDutyLocationPostalCode={destinationDutyLocationPostalCode}
           />
         )}
         <EvaluationForm
@@ -62,6 +63,7 @@ const EvaluationReport = ({ customerInfo, grade }) => {
 EvaluationReport.propTypes = {
   customerInfo: CustomerShape.isRequired,
   grade: PropTypes.string.isRequired,
+  destinationDutyLocationPostalCode: PropTypes.string.isRequired,
 };
 
 export default EvaluationReport;

--- a/src/pages/Office/EvaluationReport/EvaluationReport.jsx
+++ b/src/pages/Office/EvaluationReport/EvaluationReport.jsx
@@ -54,6 +54,7 @@ const EvaluationReport = ({ customerInfo, grade, destinationDutyLocationPostalCo
           grade={grade}
           customerInfo={customerInfo}
           mtoShipments={mtoShipments}
+          destinationDutyLocationPostalCode={destinationDutyLocationPostalCode}
         />
       </GridContainer>
     </div>

--- a/src/pages/Office/EvaluationReports/EvaluationReports.jsx
+++ b/src/pages/Office/EvaluationReports/EvaluationReports.jsx
@@ -21,7 +21,7 @@ import { milmoveLog, MILMOVE_LOG_LEVEL } from 'utils/milmoveLog';
 import Restricted from 'components/Restricted/Restricted';
 import { permissionTypes } from 'constants/permissions';
 
-const EvaluationReports = ({ customerInfo, grade }) => {
+const EvaluationReports = ({ customerInfo, grade, destinationDutyLocationPostalCode }) => {
   const { moveCode } = useParams();
   const location = useLocation();
   const history = useHistory();
@@ -118,6 +118,7 @@ const EvaluationReports = ({ customerInfo, grade }) => {
               moveCode={moveCode}
               customerInfo={customerInfo}
               grade={grade}
+              destinationDutyLocationPostalCode={destinationDutyLocationPostalCode}
               shipments={shipments}
               emptyText="No QAE reports have been submitted for counseling."
               setReportToDelete={setReportToDelete}
@@ -135,6 +136,7 @@ const EvaluationReports = ({ customerInfo, grade }) => {
               moveCode={moveCode}
               customerInfo={customerInfo}
               grade={grade}
+              destinationDutyLocationPostalCode={destinationDutyLocationPostalCode}
               emptyText="No QAE reports have been submitted for this shipment"
               setReportToDelete={setReportToDelete}
               setIsDeleteModalOpen={setIsDeleteModalOpen}
@@ -151,6 +153,7 @@ const EvaluationReports = ({ customerInfo, grade }) => {
 EvaluationReports.propTypes = {
   customerInfo: CustomerShape.isRequired,
   grade: PropTypes.string.isRequired,
+  destinationDutyLocationPostalCode: PropTypes.string.isRequired,
 };
 
 export default EvaluationReports;

--- a/src/pages/Office/EvaluationViolations/EvaluationViolations.jsx
+++ b/src/pages/Office/EvaluationViolations/EvaluationViolations.jsx
@@ -12,7 +12,7 @@ import { useEvaluationReportShipmentListQueries, usePWSViolationsQueries } from 
 import QaeReportHeader from 'components/Office/QaeReportHeader/QaeReportHeader';
 import EvaluationViolationsForm from 'components/Office/EvaluationViolationsForm/EvaluationViolationsForm';
 
-const EvaluationViolations = ({ customerInfo }) => {
+const EvaluationViolations = ({ customerInfo, destinationDutyLocationPostalCode }) => {
   const { reportId } = useParams();
 
   const { evaluationReport, reportViolations, mtoShipments } = useEvaluationReportShipmentListQueries(reportId);
@@ -29,6 +29,7 @@ const EvaluationViolations = ({ customerInfo }) => {
           reportViolations={reportViolations}
           customerInfo={customerInfo}
           mtoShipments={mtoShipments}
+          destinationDutyLocationPostalCode={destinationDutyLocationPostalCode}
         />
       </GridContainer>
     </div>

--- a/src/pages/Office/TXOMoveInfo/TXOMoveInfo.jsx
+++ b/src/pages/Office/TXOMoveInfo/TXOMoveInfo.jsx
@@ -133,7 +133,7 @@ const TXOMoveInfo = () => {
             <EvaluationReports
               customerInfo={customerData}
               grade={order.grade}
-              destinationDutyLocationPostalCode={order.destinationDutyLocation.address.postalCode}
+              destinationDutyLocationPostalCode={order?.destinationDutyLocation?.address?.postalCode}
             />
           </Route>
 
@@ -142,7 +142,7 @@ const TXOMoveInfo = () => {
               <EvaluationReport
                 customerInfo={customerData}
                 grade={order.grade}
-                destinationDutyLocationPostalCode={order.destinationDutyLocation.address.postalCode}
+                destinationDutyLocationPostalCode={order?.destinationDutyLocation?.address?.postalCode}
               />
             </Restricted>
           </Route>
@@ -150,7 +150,7 @@ const TXOMoveInfo = () => {
           <Route path={qaeCSRRoutes.EVALUATION_VIOLATIONS_PATH} exact>
             <EvaluationViolations
               customerInfo={customerData}
-              destinationDutyLocationPostalCode={order.destinationDutyLocation.address.postalCode}
+              destinationDutyLocationPostalCode={order?.destinationDutyLocation?.address?.postalCode}
             />
           </Route>
 

--- a/src/pages/Office/TXOMoveInfo/TXOMoveInfo.jsx
+++ b/src/pages/Office/TXOMoveInfo/TXOMoveInfo.jsx
@@ -139,7 +139,11 @@ const TXOMoveInfo = () => {
 
           <Route path={qaeCSRRoutes.EVALUATION_REPORT_PATH} exact>
             <Restricted to={permissionTypes.updateEvaluationReport} fallback={<Forbidden />}>
-              <EvaluationReport customerInfo={customerData} grade={order.grade} />
+              <EvaluationReport
+                customerInfo={customerData}
+                grade={order.grade}
+                destinationDutyLocationPostalCode={order.destinationDutyLocation.address.postalCode}
+              />
             </Restricted>
           </Route>
 

--- a/src/pages/Office/TXOMoveInfo/TXOMoveInfo.jsx
+++ b/src/pages/Office/TXOMoveInfo/TXOMoveInfo.jsx
@@ -130,7 +130,11 @@ const TXOMoveInfo = () => {
           </Route>
 
           <Route path={qaeCSRRoutes.EVALUATION_REPORTS_PATH} exact>
-            <EvaluationReports customerInfo={customerData} grade={order.grade} />
+            <EvaluationReports
+              customerInfo={customerData}
+              grade={order.grade}
+              destinationDutyLocationPostalCode={order.destinationDutyLocation.address.postalCode}
+            />
           </Route>
 
           <Route path={qaeCSRRoutes.EVALUATION_REPORT_PATH} exact>

--- a/src/pages/Office/TXOMoveInfo/TXOMoveInfo.jsx
+++ b/src/pages/Office/TXOMoveInfo/TXOMoveInfo.jsx
@@ -148,7 +148,10 @@ const TXOMoveInfo = () => {
           </Route>
 
           <Route path={qaeCSRRoutes.EVALUATION_VIOLATIONS_PATH} exact>
-            <EvaluationViolations customerInfo={customerData} />
+            <EvaluationViolations
+              customerInfo={customerData}
+              destinationDutyLocationPostalCode={order.destinationDutyLocation.address.postalCode}
+            />
           </Route>
 
           <Route path="/moves/:moveCode/history" exact>

--- a/src/pages/Office/TXOMoveInfo/TXOMoveInfo.test.jsx
+++ b/src/pages/Office/TXOMoveInfo/TXOMoveInfo.test.jsx
@@ -88,6 +88,9 @@ const basicUseTXOMoveInfoQueriesValue = {
     },
     destinationDutyLocation: {
       name: 'JB Lewis-McChord',
+      address: {
+        postalCode: '94535',
+      },
     },
     report_by_date: '2018-08-01',
   },


### PR DESCRIPTION
…inationDutyLocation

## [Jira ticket](https://dp3.atlassian.net/browse/MB-13491?atlOrigin=eyJpIjoiZjczNGVkZTczYmM2NGQ3N2EwOGFlZmRkMjRjYzQxNTUiLCJwIjoiaiJ9) for this change

## Summary

Bug was found where user would gets Oops page when there wasn't  a destination address for HHG and NTSR when they clicked QA reports tab. Now this no longer happens and the QA page loads and displays as expected, because the backup for this is the DDL postal code.

Additional work done to display this DDL zip only for HHG and NTSR when that's the only available address information. This was done many places: the view after submit, main report confirmation, violation report confirmation modal, and anywhere in an individual report (either form, either type, etc).



## Setup to Run Your Code

<details>
<summary>💻 You will need to use three separate terminals to test this locally.</summary>

##### Terminal 1

Start the Storybook locally.

```sh
make storybook
```

##### Terminal 2

Start the UI locally.

```sh
make client_run
```

##### Terminal 3

Start the Go server locally.

```sh
make server_run
```

</details>

### Additional steps

<!-- Fill out the next section as you see fit, these are just suggestions. -->

1. To test you can either create a customer move with a zip only destination address first.
 
Or you can take an existing HHG or NTSR move in dev database and edit the record to not have a destination address (null out mto_shipments.destination_address_id) 

2. Then login as a QAE/CSR and check that the QA main page loads as expected/no longer the Oops error page. I also checked that you can edit, view submitted, etc the specific report with the zip only address if you'd like to double check that too. 
3. Now, when applicable, displays DDL postal code in view, eval confirmation, and violation confirmation modals as well as  when creating/editing a report. This is in Move information (at the tops of these forms and modals under 'delivery address')


## Verification Steps for Author

These are to be checked by the author.

- [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
- [ ] Request review from a member of a different team.
- [ ] Have the Jira acceptance criteria been met for this change?

## Verification Steps for Reviewers

These are to be checked by a reviewer.

<!-- Fill out the next sections as you see fit, these are just suggestions. -->

### Frontend

- [ ] User facing changes have been reviewed by design.
- [ ] There are no aXe warnings for UI.
- [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
- [ ] There are no new console errors in the browser devtools
- [ ] There are no new console errors in the test output
- [ ] If this PR adds a new component to Storybook, it ensures the component is fully responsive, OR if it is intentionally not, a wrapping div using the `officeApp` class or custom `min-width` styling is used to hide any states the would not be visible to the user.

### Backend

- [ ] Code follows the guidelines for [Logging](https://transcom.github.io/mymove-docs/docs/dev/contributing/backend/Backend-Programming-Guide#logging)
- [ ] The requirements listed in [Querying the Database Safely](https://transcom.github.io/mymove-docs/docs/dev/contributing/backend/Backend-Programming-Guide/#querying-the-database-safely) have been satisfied.

### Database

#### Any new migrations/schema changes:

- [ ] Follows our guidelines for [Zero-Downtime Deploys](https://transcom.github.io/mymove-docs/docs/dev/contributing/database/Database-Migrations#zero-downtime-migrations)
- [ ] Have been communicated to #g-database
- [ ] Secure migrations have been tested following the instructions in our [docs](https://transcom.github.io/mymove-docs/docs/dev/contributing/database/Database-Migrations#secure-migrations)

## Screenshots
