### PR TITLE
MB-12744 QAE/CSR Search Form Fix and Styling Updates

### DIFF
--- a/cypress/integration/office/qaecsr/moveSearchFlows.js
+++ b/cypress/integration/office/qaecsr/moveSearchFlows.js
@@ -77,7 +77,7 @@ describe('QAE/CSR Move Search', () => {
     // Verify results table contents
     cy.get('tbody > tr').as('results');
     cy.get('@results').should('have.length', 1); // Page size of 20 in table
-    cy.get('@results').first().contains(name); // Should have leo in name
+    cy.get('@results').first().contains(name); // Should have QAECSRTestFirst in name
 
     // Click result to navigate to move details page
     cy.get('@results').first().click();

--- a/cypress/integration/office/qaecsr/moveSearchFlows.js
+++ b/cypress/integration/office/qaecsr/moveSearchFlows.js
@@ -64,7 +64,7 @@ describe('QAE/CSR Move Search', () => {
   });
 
   it('is able to search by customer name', () => {
-    const name = 'Leo';
+    const name = 'QAECSRTestFirst';
 
     // Type dodID into search bar and select DOD ID as search type
     cy.get('[type="radio"]').check('customerName', { force: true });
@@ -76,8 +76,8 @@ describe('QAE/CSR Move Search', () => {
 
     // Verify results table contents
     cy.get('tbody > tr').as('results');
-    cy.get('@results').should('have.length', 20); // Page size of 20 in table
-    cy.get('@results').first().contains(name);
+    cy.get('@results').should('have.length', 1); // Page size of 20 in table
+    cy.get('@results').first().contains(name); // Should have leo in name
 
     // Click result to navigate to move details page
     cy.get('@results').first().click();
@@ -92,6 +92,7 @@ describe('QAE/CSR Move Search', () => {
     cy.wait(['@getSearchResults']);
 
     // Verify no results
-    cy.get('[data-testid=table-queue] > h1').contains('Results (0)');
+    cy.get('[data-testid=table-queue] > h2').contains('Results (0)');
+    cy.get('[data-testid=table-queue] > p').contains('No results found.');
   });
 });

--- a/pkg/testdatagen/scenario/shared.go
+++ b/pkg/testdatagen/scenario/shared.go
@@ -6542,7 +6542,8 @@ func createUserWithLocatorAndDODID(appCtx appcontext.AppContext, locator string,
 			ProvidesServicesCounseling: true,
 		},
 		ServiceMember: models.ServiceMember{
-			Edipi: swag.String(dodID),
+			Edipi:     swag.String(dodID),
+			FirstName: swag.String("QAECSRTestFirst"),
 		},
 	})
 	move := testdatagen.MakeMove(db, testdatagen.Assertions{

--- a/src/components/MoveSearchForm/MoveSearchForm.jsx
+++ b/src/components/MoveSearchForm/MoveSearchForm.jsx
@@ -38,7 +38,7 @@ const MoveSearchForm = ({ onSubmit }) => {
             onSubmit={formik.handleSubmit}
             role="search"
           >
-            <p>What do you want to search for?</p>
+            <legend className="usa-label">What do you want to search for?</legend>
             <div role="group" className={formStyles.radioGroup}>
               <Field
                 as={Radio}
@@ -68,11 +68,19 @@ const MoveSearchForm = ({ onSubmit }) => {
                 label="Customer Name"
               />
             </div>
-            <div className={classnames(styles.searchBar)}>
-              <TextField id="searchText" className="usa-search__input" label="Search" name="searchText" type="search" />
-              <Button className={classnames(styles.searchButton)} type="submit" disabled={!formik.isValid}>
-                Search
-              </Button>
+            <div className={styles.searchBar}>
+              <TextField
+                id="searchText"
+                className="usa-search__input"
+                label={<legend className="usa-label">Search</legend>}
+                name="searchText"
+                type="search"
+                button={
+                  <Button className={styles.searchButton} type="submit" disabled={!formik.isValid}>
+                    Search
+                  </Button>
+                }
+              />
             </div>
           </Form>
         );

--- a/src/components/MoveSearchForm/MoveSearchForm.module.scss
+++ b/src/components/MoveSearchForm/MoveSearchForm.module.scss
@@ -5,38 +5,49 @@
 .MoveSearchForm {
   @include u-padding-y(3);
   @include u-padding-x(4);
-  @include u-margin-x(1);
   @include u-bg('white');
   @include u-radius(4px);
   border: 1px solid $border-color;
+  max-width: none !important;
 
+  :global(.usa-radio) {
+    @include u-margin-left(0);
+    @include u-margin-right(2);
+  }
+  :global(.usa-radio__label) {
+    font-size: 15px;
+    line-height: 23px;
+  }
+  :global(.usa-radio__input) + :global(.usa-radio__label::before) {
+    box-shadow: 0 0 0 2px $base, inset 0 0 0 2px white;
+  }
   :global(.usa-radio__input:checked) + :global(.usa-radio__label::before) {
     background-color: $link;
-    box-shadow:0 0 0 2px $link, inset 0 0 0 2px white;
+    box-shadow: 0 0 0 2px $link, inset 0 0 0 2px white;
   }
-  p {
-    font-weight: 700;
-    font-size: 13px;
-    line-height: 16px;
-    color: $base-darker;
-    @include u-margin-top(0);
-    @include u-margin-bottom(1);
+
+  legend {
+    @include u-margin(0);
   }
 
   .searchBar {
     @include u-margin-top(2);
     display: flex;
-    label {
-      @include u-margin-top(0);
+    @include u-margin-top(2);
+    :global(.usa-form-group) {
+      @include u-margin(0);
+    }
+    legend {
       @include u-margin-bottom(1);
-      line-height: 16px;
     }
   }
+
   .searchButton {
     height: 43px;
-    align-self: flex-end;
+    width: 99px;
     border-bottom-left-radius: 0;
     border-top-left-radius: 0;
+    @include u-margin(0 !important);
     background-color: $link;
   }
   .searchButton:hover {

--- a/src/components/Table/SearchResultsTable.jsx
+++ b/src/components/Table/SearchResultsTable.jsx
@@ -1,5 +1,4 @@
 import React, { useState, useEffect, useMemo } from 'react';
-import { GridContainer } from '@trussworks/react-uswds';
 import { useTable, useFilters, usePagination, useSortBy } from 'react-table';
 import PropTypes from 'prop-types';
 
@@ -212,31 +211,35 @@ const SearchResultsTable = (props) => {
   if (isError) return <SomethingWentWrong />;
 
   return (
-    <GridContainer data-testid="table-queue" containerSize="widescreen" className={styles.SearchResultsTable}>
-      <h1>{`${title} (${totalCount})`}</h1>
-      <div className={styles.tableContainer}>
-        <Table
-          showFilters={showFilters}
-          showPagination={showPagination}
-          handleClick={handleClick}
-          gotoPage={gotoPage}
-          setPageSize={setPageSize}
-          nextPage={nextPage}
-          previousPage={previousPage}
-          getTableProps={getTableProps}
-          getTableBodyProps={getTableBodyProps}
-          headerGroups={headerGroups}
-          rows={rows}
-          prepareRow={prepareRow}
-          canPreviousPage={canPreviousPage}
-          canNextPage={canNextPage}
-          pageIndex={pageIndex}
-          pageSize={pageSize}
-          pageCount={pageCount}
-          pageOptions={pageOptions}
-        />
-      </div>
-    </GridContainer>
+    <div data-testid="table-queue" className={styles.SearchResultsTable}>
+      <h2>{`${title} (${totalCount})`}</h2>
+      {totalCount > 0 ? (
+        <div className={styles.tableContainer}>
+          <Table
+            showFilters={showFilters}
+            showPagination={showPagination}
+            handleClick={handleClick}
+            gotoPage={gotoPage}
+            setPageSize={setPageSize}
+            nextPage={nextPage}
+            previousPage={previousPage}
+            getTableProps={getTableProps}
+            getTableBodyProps={getTableBodyProps}
+            headerGroups={headerGroups}
+            rows={rows}
+            prepareRow={prepareRow}
+            canPreviousPage={canPreviousPage}
+            canNextPage={canNextPage}
+            pageIndex={pageIndex}
+            pageSize={pageSize}
+            pageCount={pageCount}
+            pageOptions={pageOptions}
+          />
+        </div>
+      ) : (
+        <p>No results found.</p>
+      )}
+    </div>
   );
 };
 

--- a/src/components/Table/SearchResultsTable.module.scss
+++ b/src/components/Table/SearchResultsTable.module.scss
@@ -10,17 +10,18 @@
   flex: auto;
 
   p {
-    @include u-margin-x(1.5);
+    @include u-margin(0);
+    @include u-padding-left(0.5);
   }
 
   h2 {
-    @include u-margin-top(29px);
-    @include u-margin-x(1.5);
+    @include u-margin-top(4);
+    @include u-margin-bottom(2);
+    @include u-padding-left(0.5);
   }
 
   .tableContainer {
     flex: auto;
-
     @include u-margin-top(1);
     width: 100%;
     overflow-x: auto;

--- a/src/components/form/fields/TextField/TextField.jsx
+++ b/src/components/form/fields/TextField/TextField.jsx
@@ -33,6 +33,7 @@ const TextField = ({
   errorClassName,
   isDisabled,
   display,
+  button,
   ...inputProps
 }) => {
   const [fieldProps, metaProps] = useField({ name, validate, type });
@@ -66,6 +67,8 @@ const TextField = ({
         <Textarea id={id} name={name} disabled={isDisabled} {...fieldProps} {...inputProps} />
       )}
       {/* eslint-enable react/jsx-props-no-spreading */}
+
+      {button || null}
     </FormGroup>
   );
 };
@@ -85,6 +88,7 @@ TextField.propTypes = {
   errorMessage: PropTypes.string,
   errorClassName: PropTypes.string,
   isDisabled: PropTypes.bool,
+  button: PropTypes.node,
 };
 
 TextField.defaultProps = {
@@ -99,6 +103,7 @@ TextField.defaultProps = {
   errorClassName: '',
   isDisabled: false,
   display: 'input',
+  button: undefined,
 };
 
 export default TextField;

--- a/src/components/form/fields/TextField/TextField.test.jsx
+++ b/src/components/form/fields/TextField/TextField.test.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { render } from '@testing-library/react';
 import { useField } from 'formik'; // package will be auto mocked
+import userEvent from '@testing-library/user-event';
 
 import TextField from './TextField';
 
@@ -47,6 +48,33 @@ describe('TextField component', () => {
     );
 
     expect(queryByLabelText('First Name')).toHaveClass('myCustomInputClass');
+  });
+
+  it('can include a trailing button', () => {
+    useField.mockReturnValue([{}, {}]);
+
+    const mockOnButtonClick = jest.fn();
+    const { getByTestId } = render(
+      <TextField
+        name="testName"
+        id="testId"
+        label="testLabel"
+        button={
+          <button type="button" data-testid="testButton" onClick={mockOnButtonClick}>
+            Test button
+          </button>
+        }
+      />,
+    );
+
+    // Verify button is shown
+    expect(getByTestId('testButton')).toBeInTheDocument();
+    expect(getByTestId('testButton')).toHaveTextContent('Test button');
+
+    // Click the button
+    expect(mockOnButtonClick).not.toHaveBeenCalled();
+    userEvent.click(getByTestId('testButton'));
+    expect(mockOnButtonClick).toHaveBeenCalled();
   });
 
   describe('with an error message', () => {

--- a/src/pages/Office/QAECSRMoveSearch/QAECSRMoveSearch.jsx
+++ b/src/pages/Office/QAECSRMoveSearch/QAECSRMoveSearch.jsx
@@ -1,6 +1,5 @@
 import React, { useCallback, useState } from 'react';
 import { withRouter } from 'react-router-dom';
-import { GridContainer } from '@trussworks/react-uswds';
 
 import styles from './QAECSRMoveSearch.module.scss';
 
@@ -38,7 +37,7 @@ const QAECSRMoveSearch = ({ history }) => {
 
   return (
     <div className={styles.QAECSRMoveSearchWrapper}>
-      <GridContainer data-testid="move-search" containerSize="widescreen" className={styles.QAECSRMoveSearchPage}>
+      <div data-testid="move-search" className={styles.QAECSRMoveSearchPage}>
         <h1>Search for a move</h1>
         <MoveSearchForm onSubmit={onSubmit} />
         {searchHappened && (
@@ -56,7 +55,7 @@ const QAECSRMoveSearch = ({ history }) => {
             customerName={search.customerName}
           />
         )}
-      </GridContainer>
+      </div>
     </div>
   );
 };

--- a/src/pages/Office/QAECSRMoveSearch/QAECSRMoveSearch.module.scss
+++ b/src/pages/Office/QAECSRMoveSearch/QAECSRMoveSearch.module.scss
@@ -4,16 +4,8 @@
 
 .QAECSRMoveSearchPage {
   @include u-padding-y(3);
-  @include u-padding-x(3);
-
-  h1, h2, h3 {
-    color: $mm-blue;
-    @include u-margin-x(1);
-  }
-
-  h1 {
-    font-size: 40px;
-  }
+  @include u-padding-x(4);
+  width: 100%;
 }
 
 .QAECSRMoveSearchWrapper {


### PR DESCRIPTION
## [Jira ticket](https://dp3.atlassian.net/browse/MB-12744) for this change

## Summary

This PR updates the styling/html related to the QAE/CSR move search to be consistent every time a users visits the page. Previously going back to the search page after the initial viewing resulted in funky styling.

While investigating this styling issue I noticed a few parts of the search page/form that differed from the designs. Since I was tweaking styling anyways it felt natural to fix these design discrepancies as well. 

Designs: https://www.figma.com/file/5AhuEkaH3bJVrtffU3wp22/Milmove-Office-App?node-id=227%3A10746

## What does this PR change?
- All visible changes in this PR apply only to the QAE/CSR Search/Results page (home page when logged in as a qaecsr user).
- Most changes are padding/margin updates (compare w/ designs: https://www.figma.com/file/5AhuEkaH3bJVrtffU3wp22/Milmove-Office-App?node-id=227%3A10746). 
- Changed the behavior of 'no search results' a little bit (empty table -> no results message).
- Swapped out a few components with other components/html elements that came with some styling for free and generally tried to simplify the styling as much as possible. 
- 'Fixed' the weird styling behavior on page revisit by tweaking some existing styles, removing `GridContainer`, and in a few cases using `!important` to force a style to not be overridden.
-  Added the ability to pass a `button` prop to a `textField` to allow buttons (or any html/component) to be displayed after a `textField` but still inside of its `formGroup`.  Having this button outside the `formGroup` causes a number of pain points when getting the validation warning to look correct, this was the most elegant way avoid that pain I could think of. 

## Validation/Testing
- [ ] The QAE/CSR move page should function as before (search input/results behavior, validation, etc)
- [ ] Searches that return no results show 'No results found.'
- [ ] The search form looks the same after clicking on a search result and going back to the search form.
- [ ] The search form and results match the designs.

## Setup to Run Your Code

<details>
<summary>💻 You will need to use three separate terminals to test this locally.</summary>

##### Terminal 1

Start the Storybook locally.

```sh
make storybook
```

##### Terminal 2

Start the UI locally.

```sh
make client_run
```

##### Terminal 3

Start the Go server locally.

```sh
make server_run
```

</details>

## Video
https://user-images.githubusercontent.com/62263329/195916347-ed962318-acae-4ba2-9fff-92ad83a153ef.mov

