### PR TITLE
MB-13956: Updates github workflow to pass necessary parameter to actions/checkout

### DIFF
--- a/.github/workflows/go-auto-approve.yml
+++ b/.github/workflows/go-auto-approve.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v3.1.0
+        with:
+          fetch-depth: 0
         if: github.actor == 'dependabot[bot]' || github.actor == 'dependabot-preview[bot]'
       - name: reattach HEAD to Head Ref
         # b/c checkout action leaves in detached head state https://github.com/actions/checkout/issues/6
@@ -56,4 +58,4 @@ jobs:
         uses: hmarr/auto-approve-action@v2.4.0
         if: github.actor == 'dependabot[bot]' && contains(github.event.pull_request.labels.*.name, 'dependencies')
         with:
-          github-token: "${{ secrets.GITHUB_TOKEN }}"
+          github-token: '${{ secrets.GITHUB_TOKEN }}'


### PR DESCRIPTION
## [Jira ticket](https://dp3.atlassian.net/browse/MB-13956) for this change

## Summary

This pull request updates the `go-auto-approve.yml` GitHub workflow to pass `fetch-depth: 0` as a parameter into the `checkout` action, which resolves an issue that was introduced when the action's version was updated from v1 to v3.1 as a part of #9290. 

This particular workflow runs whenever dependabot creates a pull request that updates the go packages; it should run `go mod tidy` after checking out the active branch, but was failing at the first step because the updated version of the `checkout` action no longer fetches the entire dependency tree by default, and so wasn't able to find the active branch. Passing `fetch-depth: 0` as a parameter essentially returns the action's behavior to the original and resolves the issue.

An example of this action working correctly can be seen [in this check](https://github.com/transcom/mymove/actions/runs/3251781046/jobs/5337227286) on a now-closed experimental draft pull request. Note: in order to get the workflow to run the configuration from the active branch instead of the base branch, the experimental PR set the event target to `pull_request` instead of `pull_request_target`. _This_ pull request does not change this event target.