### PR TITLE
[MB-12401] removed clientQuery from move history request

### DIFF
--- a/pkg/gen/ghcapi/embedded_spec.go
+++ b/pkg/gen/ghcapi/embedded_spec.go
@@ -5889,11 +5889,6 @@ func init() {
           "additionalProperties": true,
           "x-nullable": true
         },
-        "clientQuery": {
-          "description": "Record the text of the client query that triggered the audit event",
-          "type": "string",
-          "x-nullable": true
-        },
         "context": {
           "type": "array",
           "items": {
@@ -15387,11 +15382,6 @@ func init() {
           "description": "A list of (changed/updated) MoveAuditHistoryItem's for a record after the change.",
           "type": "object",
           "additionalProperties": true,
-          "x-nullable": true
-        },
-        "clientQuery": {
-          "description": "Record the text of the client query that triggered the audit event",
-          "type": "string",
           "x-nullable": true
         },
         "context": {

--- a/pkg/gen/ghcmessages/move_audit_history.go
+++ b/pkg/gen/ghcmessages/move_audit_history.go
@@ -37,9 +37,6 @@ type MoveAuditHistory struct {
 	// A list of (changed/updated) MoveAuditHistoryItem's for a record after the change.
 	ChangedValues interface{} `json:"changedValues,omitempty"`
 
-	// Record the text of the client query that triggered the audit event
-	ClientQuery *string `json:"clientQuery,omitempty"`
-
 	// context
 	Context []map[string]string `json:"context"`
 

--- a/pkg/handlers/ghcapi/internal/payloads/model_to_payload.go
+++ b/pkg/handlers/ghcapi/internal/payloads/model_to_payload.go
@@ -256,7 +256,6 @@ func MoveAuditHistory(logger *zap.Logger, auditHistory models.AuditHistory) *ghc
 		ActionTstampTx:       strfmt.DateTime(auditHistory.ActionTstampTx),
 		ChangedValues:        removeEscapeJSONtoObject(logger, auditHistory.ChangedData),
 		OldValues:            removeEscapeJSONtoObject(logger, auditHistory.OldData),
-		ClientQuery:          auditHistory.ClientQuery,
 		EventName:            auditHistory.EventName,
 		ID:                   strfmt.UUID(auditHistory.ID.String()),
 		ObjectID:             handlers.FmtUUIDPtr(auditHistory.ObjectID),

--- a/pkg/handlers/ghcapi/move_history_test.go
+++ b/pkg/handlers/ghcapi/move_history_test.go
@@ -20,7 +20,6 @@ import (
 func getMoveHistoryForTest() models.MoveHistory {
 	localUUID := uuid.Must(uuid.NewV4())
 	transactionID := int64(3281)
-	clientQuery := "UPDATE \"orders\" AS orders SET \"amended_orders_acknowledged_at\" = $1, \"department_indicator\" = $2, \"entitlement_id\" = $3, \"grade\" = $4, \"has_dependents\" = $5, \"issue_date\" = $6, \"new_duty_location_id\" = $7, \"nts_sac\" = $8, \"nts_tac\" = $9, \"orders_number\" = $10, \"orders_type\" = $11, \"orders_type_detail\" = $12, \"origin_duty_location_id\" = $13, \"report_by_date\" = $14, \"sac\" = $15, \"service_member_id\" = $16, \"spouse_has_pro_gear\" = $17, \"status\" = $18, \"tac\" = $19, \"updated_at\" = $20, \"uploaded_amended_orders_id\" = $21, \"uploaded_orders_id\" = $22 WHERE orders.id = $23"
 	eventName := "apiEndpoint"
 	oldData := `{\"updated_at\": \"2022-03-08T19:08:44.664709\", \"postal_code\": \"90213\"}`
 	changedData := `{\"updated_at\": \"2022-03-08T19:08:44.664709\", \"postal_code\": \"90213\"}`
@@ -38,7 +37,6 @@ func getMoveHistoryForTest() models.MoveHistory {
 				ObjectID:        &localUUID,
 				SessionUserID:   &localUUID,
 				TransactionID:   &transactionID,
-				ClientQuery:     &clientQuery,
 				Action:          "U",
 				EventName:       &eventName,
 				OldData:         &oldData,
@@ -98,11 +96,9 @@ func (suite *HandlerSuite) TestMockGetMoveHistoryHandler() {
 		suite.Equal(maudit.SchemaName, paudit.SchemaName)
 		suite.Equal(maudit.TableName, paudit.TableName)
 		suite.Equal(maudit.RelID, paudit.RelID)
-		suite.Equal(maudit.ClientQuery, paudit.ClientQuery)
 		suite.Equal(maudit.Action, paudit.Action)
 		suite.Equal(maudit.EventName, paudit.EventName)
 		suite.Equal(maudit.StatementOnly, paudit.StatementOnly)
-
 		swaggerTimeFormat := "2006-01-02T15:04:05.99Z07:00"
 		suite.Equal(maudit.ActionTstampTx.Format(swaggerTimeFormat), time.Time(paudit.ActionTstampTx).Format(swaggerTimeFormat))
 		suite.Equal(maudit.ActionTstampStm.Format(swaggerTimeFormat), time.Time(paudit.ActionTstampStm).Format(swaggerTimeFormat))

--- a/swagger-def/ghc.yaml
+++ b/swagger-def/ghc.yaml
@@ -3132,10 +3132,6 @@ definitions:
         description: Identifier of transaction that made the change. May wrap, but unique paired with action_tstamp_tx.
         type: integer
         x-nullable: true
-      clientQuery:
-        description: Record the text of the client query that triggered the audit event
-        type: string
-        x-nullable: true
       action:
         description: Action type; I = insert, D = delete, U = update, T = truncate
         type: string

--- a/swagger/ghc.yaml
+++ b/swagger/ghc.yaml
@@ -3246,10 +3246,6 @@ definitions:
           paired with action_tstamp_tx.
         type: integer
         x-nullable: true
-      clientQuery:
-        description: Record the text of the client query that triggered the audit event
-        type: string
-        x-nullable: true
       action:
         description: Action type; I = insert, D = delete, U = update, T = truncate
         type: string


### PR DESCRIPTION
## [Jira ticket](https://dp3.atlassian.net/browse/MB-12401) for this change

## Summary
Removing clientQuery from historyRecord; queries should not be returned for the application for users.

## Setup to Run Your Code

<details>
<summary>💻 You will need to use two separate terminals to test this locally.</summary>


##### Terminal 1

Start the Go server locally.

```sh
make server_run
```

##### Terminal 2

Start the office client..

```sh
make office_client_run
```

</details>

### Additional steps

<!-- Fill out the next section as you see fit, these are just suggestions. -->

1. If you are met with a swagger error when starting up the server; running the command `make swagger_generate` should resolve it
2. Login as an office user and navigate to the move history page
3. Click the react query icon in the bottom left and check the history record to verify clientQuery is no longer included

## Verification Steps for Author

These are to be checked by the author.

- [x] Have the Jira acceptance criteria been met for this change?

## Verification Steps for Reviewers

These are to be checked by a reviewer.

<!-- Fill out the next sections as you see fit, these are just suggestions. -->

### Frontend

- [ ] User facing changes have been reviewed by design.
- [ ] There are no aXe warnings for UI.
- [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
- [ ] There are no new console errors in the browser devtools
- [ ] There are no new console errors in the test output
- [ ] If this PR adds a new component to Storybook, it ensures the component is fully responsive, OR if it is intentionally not, a wrapping div using the `officeApp` class or custom `min-width` styling is used to hide any states the would not be visible to the user.

### Backend

- [ ] Code follows the guidelines for [Logging](https://transcom.github.io/mymove-docs/docs/dev/contributing/backend/Backend-Programming-Guide#logging)
- [ ] The requirements listed in [Querying the Database Safely](https://transcom.github.io/mymove-docs/docs/dev/contributing/backend/Backend-Programming-Guide/#querying-the-database-safely) have been satisfied.

## Screenshots
Before: 
![image](https://user-images.githubusercontent.com/111928238/196230231-3f644b3f-bdeb-46e3-8dce-d95faab704a3.png)

After:

<img width="1248" alt="Screen Shot 2022-10-17 at 9 22 08 AM" src="https://user-images.githubusercontent.com/111928238/196232432-6d1fafa2-2e9a-435d-a3ce-7f01aa29e2b9.png">


