### PR TITLE
MB-13792 Minor qaecsr cleanup

### DIFF
--- a/cypress/integration/office/qaecsr/qaeFlows.js
+++ b/cypress/integration/office/qaecsr/qaeFlows.js
@@ -252,7 +252,7 @@ describe('Quality Evaluation Report', () => {
         cy.get('dd').contains('Data review');
         cy.get('dd').contains('Origin');
         cy.get('dd').contains('1 hr 15 min');
-        cy.get('dd').contains('no');
+        cy.get('dd').contains('No');
         cy.get('dd').contains('This is a test evaluation report');
       });
 
@@ -306,7 +306,7 @@ describe('Quality Evaluation Report', () => {
 
       // Veryify preview has correct sections/headers
       cy.contains('Move information').should('exist');
-      cy.contains('yes').should('exist');
+      cy.contains('Yes').should('exist');
 
       cy.get('h1').contains('Shipment report');
       cy.get('h2').contains('Evaluation report').parent().as('report');

--- a/src/components/Office/EvaluationReportPreview/EvaluationReportPreview.jsx
+++ b/src/components/Office/EvaluationReportPreview/EvaluationReportPreview.jsx
@@ -193,7 +193,7 @@ const EvaluationReportPreview = ({
               <>
                 <div className={classnames(descriptionListStyles.row)}>
                   <dt className={styles.violationsLabel}>Serious incident</dt>
-                  <dd className={styles.violationsRemarks}>{showIncidentDescription ? 'yes' : 'no'}</dd>
+                  <dd className={styles.violationsRemarks}>{showIncidentDescription ? 'Yes' : 'No'}</dd>
                 </div>
                 {showIncidentDescription && (
                   <div className={classnames(descriptionListStyles.row)}>

--- a/src/components/Office/EvaluationViolationsForm/EvaluationViolationsForm.jsx
+++ b/src/components/Office/EvaluationViolationsForm/EvaluationViolationsForm.jsx
@@ -26,6 +26,7 @@ const EvaluationViolationsForm = ({
   reportViolations,
   customerInfo,
   mtoShipments,
+  grade,
   destinationDutyLocationPostalCode,
 }) => {
   const { moveCode, reportId } = useParams();
@@ -241,7 +242,7 @@ const EvaluationViolationsForm = ({
         evaluationReport={evaluationReport}
         moveCode={moveCode}
         customerInfo={customerInfo}
-        grade={customerInfo.grade}
+        grade={grade}
         mtoShipments={mtoShipments}
         modalActions={submitModalActions}
         reportViolations={reportViolations}
@@ -466,6 +467,7 @@ EvaluationViolationsForm.propTypes = {
   reportViolations: PropTypes.arrayOf(ReportViolationShape),
   customerInfo: CustomerShape.isRequired,
   mtoShipments: PropTypes.arrayOf(ShipmentShape),
+  grade: PropTypes.string.isRequired,
   destinationDutyLocationPostalCode: PropTypes.string.isRequired,
 };
 

--- a/src/pages/Office/EvaluationViolations/EvaluationViolations.jsx
+++ b/src/pages/Office/EvaluationViolations/EvaluationViolations.jsx
@@ -8,6 +8,8 @@ import styles from '../TXOMoveInfo/TXOTab.module.scss';
 
 import evaluationViolationsStyles from './EvaluationViolations.module.scss';
 
+import LoadingPlaceholder from 'shared/LoadingPlaceholder';
+import SomethingWentWrong from 'shared/SomethingWentWrong';
 import { useEvaluationReportShipmentListQueries, usePWSViolationsQueries } from 'hooks/queries';
 import QaeReportHeader from 'components/Office/QaeReportHeader/QaeReportHeader';
 import EvaluationViolationsForm from 'components/Office/EvaluationViolationsForm/EvaluationViolationsForm';
@@ -15,8 +17,16 @@ import EvaluationViolationsForm from 'components/Office/EvaluationViolationsForm
 const EvaluationViolations = ({ customerInfo, destinationDutyLocationPostalCode }) => {
   const { reportId } = useParams();
 
-  const { evaluationReport, reportViolations, mtoShipments } = useEvaluationReportShipmentListQueries(reportId);
-  const { violations } = usePWSViolationsQueries();
+  const { evaluationReport, reportViolations, mtoShipments, isLoading, isError } =
+    useEvaluationReportShipmentListQueries(reportId);
+  const { violations, isLoading: isViolationsLoading, isError: isViolationsError } = usePWSViolationsQueries();
+
+  if (isLoading || isViolationsLoading) {
+    return <LoadingPlaceholder />;
+  }
+  if (isError || isViolationsError) {
+    return <SomethingWentWrong />;
+  }
 
   return (
     <div className={classnames(styles.tabContent, evaluationViolationsStyles.tabContent)}>

--- a/src/pages/Office/EvaluationViolations/EvaluationViolations.jsx
+++ b/src/pages/Office/EvaluationViolations/EvaluationViolations.jsx
@@ -14,7 +14,7 @@ import { useEvaluationReportShipmentListQueries, usePWSViolationsQueries } from 
 import QaeReportHeader from 'components/Office/QaeReportHeader/QaeReportHeader';
 import EvaluationViolationsForm from 'components/Office/EvaluationViolationsForm/EvaluationViolationsForm';
 
-const EvaluationViolations = ({ customerInfo, destinationDutyLocationPostalCode }) => {
+const EvaluationViolations = ({ customerInfo, grade, destinationDutyLocationPostalCode }) => {
   const { reportId } = useParams();
 
   const { evaluationReport, reportViolations, mtoShipments, isLoading, isError } =
@@ -39,6 +39,7 @@ const EvaluationViolations = ({ customerInfo, destinationDutyLocationPostalCode 
           reportViolations={reportViolations}
           customerInfo={customerInfo}
           mtoShipments={mtoShipments}
+          grade={grade}
           destinationDutyLocationPostalCode={destinationDutyLocationPostalCode}
         />
       </GridContainer>

--- a/src/pages/Office/TXOMoveInfo/TXOMoveInfo.jsx
+++ b/src/pages/Office/TXOMoveInfo/TXOMoveInfo.jsx
@@ -150,6 +150,7 @@ const TXOMoveInfo = () => {
           <Route path={qaeCSRRoutes.EVALUATION_VIOLATIONS_PATH} exact>
             <EvaluationViolations
               customerInfo={customerData}
+              grade={order.grade}
               destinationDutyLocationPostalCode={order?.destinationDutyLocation?.address?.postalCode}
             />
           </Route>

--- a/src/types/reportViolation.js
+++ b/src/types/reportViolation.js
@@ -1,12 +1,12 @@
 import PropTypes from 'prop-types';
 
-import { EvaluationReportShape } from './evaluationReport';
+import { PWSViolationShape } from './pwsViolation';
 
 export const ReportViolationShape = PropTypes.shape({
   id: PropTypes.string,
   reportId: PropTypes.string,
   violationId: PropTypes.string,
-  violation: EvaluationReportShape,
+  violation: PWSViolationShape,
 });
 
 export default {


### PR DESCRIPTION
## [Jira ticket](https://dp3.atlassian.net/browse/MB-13792) for this change

## Summary

This PR bundles a few small fixes/cleanup items within the QAE/CSR work. These all seemed too small to be worth the overhead of individual PRs.

## Included Fixes: 
* Fix serious incidents field on report preview to be capitalized `Yes`/`No` (previously  `yes`/`no`)
* Add loading/error states to the second page of the QAE eval report form
* Fix the `ReportViolationShape` type to use the correct sub-shape for violation
* Pass the `grade` value though the second page of the eval form

## Setup to Run Your Code

<details>
<summary>💻 You will need to use three separate terminals to test this locally.</summary>

##### Terminal 1

Start the Storybook locally.

```sh
make storybook
```

##### Terminal 2

Start the UI locally.

```sh
make client_run
```

##### Terminal 3

Start the Go server locally.

```sh
make server_run
```

</details>

## To Validate/Test
- [ ] Yes/No value shown on the eval report submission preview for 'Serious Incident' is capitalized
- [ ] Grade is shown on the eval report submission preview from both form pages to access the preview (with and w/out violations)
- [ ] No console warnings are shown when creating, previewing, or submitting eval reports
