### PR TITLE
MB-13792 Cleanup selected/preview violations styling

### DIFF
--- a/src/components/Office/EvaluationReportPreview/EvaluationReportPreview.jsx
+++ b/src/components/Office/EvaluationReportPreview/EvaluationReportPreview.jsx
@@ -3,8 +3,6 @@ import * as PropTypes from 'prop-types';
 import { Grid } from '@trussworks/react-uswds';
 import classnames from 'classnames';
 
-import SelectedViolation from '../EvaluationViolationsForm/SelectedViolation/SelectedViolation';
-
 import styles from './EvaluationReportPreview.module.scss';
 
 import descriptionListStyles from 'styles/descriptionList.module.scss';
@@ -175,12 +173,12 @@ const EvaluationReportPreview = ({
               {hasViolations ? (
                 <dd className={styles.violationsRemarks}>
                   {reportViolations.map((reportViolation) => (
-                    <SelectedViolation
-                      className={styles.violationsList}
-                      key={`${reportViolation.id}-violation`}
-                      violation={reportViolation.violation}
-                      isReadOnly
-                    />
+                    <div className={styles.violation} key={`${reportViolation.id}-violation`}>
+                      <h5>{`${reportViolation?.violation?.paragraphNumber} ${reportViolation?.violation?.title}`}</h5>
+                      <p>
+                        <small>{reportViolation?.violation?.requirementSummary}</small>
+                      </p>
+                    </div>
                   ))}
                 </dd>
               ) : (

--- a/src/components/Office/EvaluationReportPreview/EvaluationReportPreview.module.scss
+++ b/src/components/Office/EvaluationReportPreview/EvaluationReportPreview.module.scss
@@ -68,11 +68,13 @@
   @include u-margin-top(2);
 }
 
-.qaeRemarks, .violationsRemarks  {
+.qaeRemarks,
+.violationsRemarks {
   width: 75%;
 }
 
-.qaeRemarksLabel, .violationsLabel  {
+.qaeRemarksLabel,
+.violationsLabel {
   width: 25%;
 }
 
@@ -81,13 +83,15 @@
   @include u-margin-top(6);
 }
 
-div > h5 {
-  padding-left: 18px;
-  margin-left: 20px;
-  margin-top: 8px !important;
-  margin-bottom: 4px !important;
-}
+.violation {
+  @include u-padding-x(2);
+  @include u-padding-y(1);
+  border: 1px solid $base-light;
+  border-radius: 2px;
+  max-width: 648px;
+  margin-bottom: -1px;
 
-div > p {
-  padding-bottom: 6px;
+  p {
+    padding-top: 4px;
+  }
 }

--- a/src/components/Office/EvaluationViolationsForm/SelectedViolation/SelectedViolation.jsx
+++ b/src/components/Office/EvaluationViolationsForm/SelectedViolation/SelectedViolation.jsx
@@ -1,9 +1,12 @@
 import React from 'react';
+import * as PropTypes from 'prop-types';
 import { Button } from '@trussworks/react-uswds';
 
 import styles from './SelectedViolation.module.scss';
 
-const SelectedViolation = ({ violation, unselectViolation, isReadOnly }) => {
+import { PWSViolationShape } from 'types';
+
+const SelectedViolation = ({ violation, unselectViolation }) => {
   if (!violation) {
     return null;
   }
@@ -13,16 +16,23 @@ const SelectedViolation = ({ violation, unselectViolation, isReadOnly }) => {
       <div className={styles.grow}>
         <h5>{`${violation.paragraphNumber} ${violation.title}`}</h5>
         <p>
-          <small> {violation.requirementSummary}</small>
+          <small>{violation.requirementSummary}</small>
         </p>
       </div>
-      {!isReadOnly && (
-        <Button type="button" unstyled onClick={() => unselectViolation(violation.id)} role="button">
-          Remove
-        </Button>
-      )}
+      <Button type="button" unstyled onClick={() => unselectViolation(violation.id)} role="button">
+        Remove
+      </Button>
     </div>
   );
+};
+
+SelectedViolation.propTypes = {
+  violation: PWSViolationShape,
+  unselectViolation: PropTypes.func.isRequired,
+};
+
+SelectedViolation.defaultProps = {
+  violation: null,
 };
 
 export default SelectedViolation;

--- a/src/components/Office/EvaluationViolationsForm/SelectedViolation/SelectedViolation.test.jsx
+++ b/src/components/Office/EvaluationViolationsForm/SelectedViolation/SelectedViolation.test.jsx
@@ -34,13 +34,6 @@ describe('SelectedViolation', () => {
     expect(screen.getByRole('button', { name: 'Remove' })).toBeInTheDocument();
   });
 
-  it('renders the violation content in preview without remove button', async () => {
-    render(<SelectedViolation violation={mockViolation} isReadOnly />);
-
-    // remove button should not display when read only is true
-    expect(screen.queryByRole('button', { name: 'Remove' })).not.toBeInTheDocument();
-  });
-
   it('removes the violation from selected when remove is clicked', async () => {
     render(<SelectedViolation violation={mockViolation} unselectViolation={mockUnselectViolation} />);
 


### PR DESCRIPTION
## [Jira ticket](https://dp3.atlassian.net/browse/MB-13792) for this change

## Summary

This PR fixes the somewhat inconsistent styling issue around selected violations. Currently we are using the same component with styling overrides for both the selected violations in the eval report form and in the report preview. This resulted in some competing styles causing layout/spacing issues. I took what felt like the simplest route to fix (dont re-use selected violation component) and was able to simplify and clean up the styling quite a bit as a result.

Note: I realized as I got into this that the styles being removed in this PR were unintentionally effecting a lot of other components in the app. See my below comment and the happo diffs for more detail on this. It is resolved by the changes in this PR. From an eng perspective, I think the learning here is we need to be careful not to add any generic css selectors that are not inside a class or we could end up causing unintended effects to other components/pages (again, see below comment for more).  

## Setup to Run Your Code

<details>
<summary>💻 You will need to use three separate terminals to test this locally.</summary>

##### Terminal 1

Start the Storybook locally.

```sh
make storybook
```

##### Terminal 2

Start the UI locally.

```sh
make client_run
```

##### Terminal 3

Start the Go server locally.

```sh
make server_run
```

</details>

## To Test/Validate
After login and navigation to the second page of a evaluation form (violations page): 
- [ ] Can select violations
- [ ] Selected violations are displayed and match designs
- [ ] On report preview, selected violations are displayed and match designs. 

## Video

https://user-images.githubusercontent.com/62263329/196496797-efed0be0-9f0f-466a-b080-88286f2ffd7e.mov


