### PR TITLE
Removing the orders.*.move.mil TLS healthcheck

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1649,7 +1649,7 @@ jobs:
       - tls_vars_stg
       - deploy_app_client_tls_steps:
           compare_host: gex.stg.move.mil
-          health_check_hosts: gex.stg.move.mil,orders.stg.move.mil
+          health_check_hosts: gex.stg.move.mil
           ecr_env: stg
 
   # `deploy_stg_webhook_client` deploys the webhook client to stg
@@ -1717,7 +1717,7 @@ jobs:
       - tls_vars_prd
       - deploy_app_client_tls_steps:
           compare_host: gex.move.mil
-          health_check_hosts: gex.move.mil,orders.move.mil
+          health_check_hosts: gex.move.mil
           ecr_env: prd
 
 workflows:


### PR DESCRIPTION
## There is no Jira ticket associated with this change.

## Summary

We no longer have certificates that validate against these DNS names, so
we are removing them from our TLS health checks.

We are removing this health check. 

