### PR TITLE
MB-8426: searching by move code is case inensitive

### DIFF
--- a/pkg/services/move/move_searcher.go
+++ b/pkg/services/move/move_searcher.go
@@ -112,7 +112,7 @@ func dodIDFilter(dodID *string) QueryOption {
 func locatorFilter(locator *string) QueryOption {
 	return func(query *pop.Query) {
 		if locator != nil {
-			query.Where("moves.locator = ?", *locator)
+			query.Where("moves.locator = ?", strings.ToUpper(*locator))
 		}
 	}
 }

--- a/pkg/services/order/order_fetcher.go
+++ b/pkg/services/order/order_fetcher.go
@@ -264,7 +264,7 @@ func dodIDFilter(dodID *string) QueryOption {
 func locatorFilter(locator *string) QueryOption {
 	return func(query *pop.Query) {
 		if locator != nil {
-			query.Where("moves.locator = ?", *locator)
+			query.Where("moves.locator = ?", strings.ToUpper(*locator))
 		}
 	}
 }

--- a/pkg/services/payment_request/payment_request_list_fetcher.go
+++ b/pkg/services/payment_request/payment_request_list_fetcher.go
@@ -254,7 +254,7 @@ func dodIDFilter(dodID *string) QueryOption {
 func locatorFilter(locator *string) QueryOption {
 	return func(query *pop.Query) {
 		if locator != nil {
-			query.Where("moves.locator = ?", *locator)
+			query.Where("moves.locator = ?", strings.ToUpper(*locator))
 		}
 	}
 }


### PR DESCRIPTION
## [Jira ticket](https://dp3.atlassian.net/browse/MB-8426) for this change

## Summary

This updates our query on move code so that it is always uppercase regardless of what is passed to the endpoint/handler.


## Setup to Run Your Code

- spin up the office client locally (or on experimental)

## Verification Steps for Reviewers

- [ ] search for a move code in any of the queues (TOO/TIO), the search should be case insensitive (e.g. evlrpt return same as EVLRPT as EvlRpt)

### Backend

- [ ] Code follows the guidelines for [Logging](https://transcom.github.io/mymove-docs/docs/dev/contributing/backend/Backend-Programming-Guide#logging)
- [ ] The requirements listed in [Querying the Database Safely](https://transcom.github.io/mymove-docs/docs/dev/contributing/backend/Backend-Programming-Guide/#querying-the-database-safely) have been satisfied.
