### PR TITLE
[MB-12340] changed test assertion to fall within 2000 microsecond range

### DIFF
--- a/pkg/services/move_history/move_history_fetcher_test.go
+++ b/pkg/services/move_history/move_history_fetcher_test.go
@@ -285,7 +285,8 @@ func (suite *MoveHistoryServiceSuite) TestMoveFetcher() {
 				suite.Equal(*order.DepartmentIndicator, changedData["department_indicator"])
 
 				//changedData["amended_orders_acknowledged_at"] is being converted from a string to a formatted time.Time type
-				changedDataTimeStamp, _ := time.Parse("2006-01-02T15:04:05.000000", changedData["amended_orders_acknowledged_at"].(string))
+				layout := "2006-01-02T15:04:05.000000"
+				changedDataTimeStamp, _ := time.Parse(layout, changedData["amended_orders_acknowledged_at"].(string))
 				//We assert if it falls within a range starting at the original order.AmendedOrdersAcknowledgedAt time and ending with a added 2000 microsecond buffer
 				suite.WithinRange(changedDataTimeStamp, *order.AmendedOrdersAcknowledgedAt, order.AmendedOrdersAcknowledgedAt.Add(2000*time.Microsecond))
 

--- a/pkg/services/move_history/move_history_fetcher_test.go
+++ b/pkg/services/move_history/move_history_fetcher_test.go
@@ -287,8 +287,14 @@ func (suite *MoveHistoryServiceSuite) TestMoveFetcher() {
 				//changedData["amended_orders_acknowledged_at"] is being converted from a string to a formatted time.Time type
 				layout := "2006-01-02T15:04:05.000000"
 				changedDataTimeStamp, _ := time.Parse(layout, changedData["amended_orders_acknowledged_at"].(string))
+
+				d := 1000 * time.Nanosecond
+				suite.Logger().Sugar().Info("order.AmendedOrdersAcknowledgedAt TRUNCATED")
+				suite.Logger().Sugar().Info(order.AmendedOrdersAcknowledgedAt.Truncate(d))
+				suite.Logger().Sugar().Info("order.AmendedOrdersAcknowledgedAt TRUNCATED WITH ADDED MICROSECONDS")
+				suite.Logger().Sugar().Info(order.AmendedOrdersAcknowledgedAt.Add(2000 * time.Microsecond).Truncate(d))
 				//We assert if it falls within a range starting at the original order.AmendedOrdersAcknowledgedAt time and ending with a added 2000 microsecond buffer
-				suite.WithinRange(changedDataTimeStamp, *order.AmendedOrdersAcknowledgedAt, order.AmendedOrdersAcknowledgedAt.Add(2000*time.Microsecond))
+				suite.WithinRange(changedDataTimeStamp, order.AmendedOrdersAcknowledgedAt.Truncate(d), order.AmendedOrdersAcknowledgedAt.Add(2000*time.Microsecond).Truncate(d))
 
 				// rank/grade is also on orders
 				suite.Equal(*order.Grade, changedData["grade"])

--- a/pkg/services/move_history/move_history_fetcher_test.go
+++ b/pkg/services/move_history/move_history_fetcher_test.go
@@ -287,12 +287,8 @@ func (suite *MoveHistoryServiceSuite) TestMoveFetcher() {
 				//changedData["amended_orders_acknowledged_at"] is being converted from a string to a formatted time.Time type
 				layout := "2006-01-02T15:04:05.000000"
 				changedDataTimeStamp, _ := time.Parse(layout, changedData["amended_orders_acknowledged_at"].(string))
-
+				//CircleCi seems to add on nanoseconds to the tested time stamps so this is being used with Truncate to shave those nanoseconds off
 				d := 1000 * time.Nanosecond
-				suite.Logger().Sugar().Info("order.AmendedOrdersAcknowledgedAt TRUNCATED")
-				suite.Logger().Sugar().Info(order.AmendedOrdersAcknowledgedAt.Truncate(d))
-				suite.Logger().Sugar().Info("order.AmendedOrdersAcknowledgedAt TRUNCATED WITH ADDED MICROSECONDS")
-				suite.Logger().Sugar().Info(order.AmendedOrdersAcknowledgedAt.Add(2000 * time.Microsecond).Truncate(d))
 				//We assert if it falls within a range starting at the original order.AmendedOrdersAcknowledgedAt time and ending with a added 2000 microsecond buffer
 				suite.WithinRange(changedDataTimeStamp, order.AmendedOrdersAcknowledgedAt.Truncate(d), order.AmendedOrdersAcknowledgedAt.Add(2000*time.Microsecond).Truncate(d))
 

--- a/pkg/services/move_history/move_history_fetcher_test.go
+++ b/pkg/services/move_history/move_history_fetcher_test.go
@@ -287,10 +287,7 @@ func (suite *MoveHistoryServiceSuite) TestMoveFetcher() {
 				//changedData["amended_orders_acknowledged_at"] is being converted from a string to a formatted time.Time type
 				changedDataTimeStamp, _ := time.Parse("2006-01-02T15:04:05.000000", changedData["amended_orders_acknowledged_at"].(string))
 				//We assert if it falls within a range starting at the original order.AmendedOrdersAcknowledgedAt time and ending with a added 2 microsecond buffer
-				suite.WithinRange(changedDataTimeStamp, *order.AmendedOrdersAcknowledgedAt, order.AmendedOrdersAcknowledgedAt.Add(2*time.Microsecond))
-
-				//TODO: make a better comparison test for time
-				// suite.Equal(order.AmendedOrdersAcknowledgedAt.Format("2006-01-02T15:04:05.000000"), changedData["amended_orders_acknowledged_at"])
+				suite.WithinRange(changedDataTimeStamp, *order.AmendedOrdersAcknowledgedAt, order.AmendedOrdersAcknowledgedAt.Add(2000*time.Microsecond))
 
 				// rank/grade is also on orders
 				suite.Equal(*order.Grade, changedData["grade"])

--- a/pkg/services/move_history/move_history_fetcher_test.go
+++ b/pkg/services/move_history/move_history_fetcher_test.go
@@ -286,7 +286,7 @@ func (suite *MoveHistoryServiceSuite) TestMoveFetcher() {
 
 				//changedData["amended_orders_acknowledged_at"] is being converted from a string to a formatted time.Time type
 				changedDataTimeStamp, _ := time.Parse("2006-01-02T15:04:05.000000", changedData["amended_orders_acknowledged_at"].(string))
-				//We assert if it falls within a range starting at the original order.AmendedOrdersAcknowledgedAt time and ending with a added 2 microsecond buffer
+				//We assert if it falls within a range starting at the original order.AmendedOrdersAcknowledgedAt time and ending with a added 2000 microsecond buffer
 				suite.WithinRange(changedDataTimeStamp, *order.AmendedOrdersAcknowledgedAt, order.AmendedOrdersAcknowledgedAt.Add(2000*time.Microsecond))
 
 				// rank/grade is also on orders

--- a/pkg/services/move_history/move_history_fetcher_test.go
+++ b/pkg/services/move_history/move_history_fetcher_test.go
@@ -285,16 +285,8 @@ func (suite *MoveHistoryServiceSuite) TestMoveFetcher() {
 				suite.Equal(*order.DepartmentIndicator, changedData["department_indicator"])
 
 				//changedData["amended_orders_acknowledged_at"] is being converted from a string to a formatted time.Time type
-				layout := "2006-01-02T15:04:05.000000000"
+				layout := "2006-01-02T15:04:05.000000"
 				changedDataTimeStamp, _ := time.Parse(layout, changedData["amended_orders_acknowledged_at"].(string))
-				suite.Logger().Sugar().Info("STAMP 1 HERE")
-				suite.Logger().Sugar().Info(changedDataTimeStamp)
-				layout2 := "2006-01-0215:04:05.000000"
-				changedDataTimeStamp2, _ := time.Parse(layout2, changedData["amended_orders_acknowledged_at"].(string))
-				suite.Logger().Sugar().Info("STAMP 2 HERE")
-				suite.Logger().Sugar().Info(changedDataTimeStamp2)
-				suite.Logger().Sugar().Info("STAMP WITH ADDED MS HERE")
-				suite.Logger().Sugar().Info(order.AmendedOrdersAcknowledgedAt.Add(2000 * time.Microsecond))
 				//We assert if it falls within a range starting at the original order.AmendedOrdersAcknowledgedAt time and ending with a added 2000 microsecond buffer
 				suite.WithinRange(changedDataTimeStamp, *order.AmendedOrdersAcknowledgedAt, order.AmendedOrdersAcknowledgedAt.Add(2000*time.Microsecond))
 

--- a/pkg/services/move_history/move_history_fetcher_test.go
+++ b/pkg/services/move_history/move_history_fetcher_test.go
@@ -283,8 +283,14 @@ func (suite *MoveHistoryServiceSuite) TestMoveFetcher() {
 				suite.Equal(*order.NtsTAC, changedData["nts_tac"])
 				suite.Equal(*order.NtsSAC, changedData["nts_sac"])
 				suite.Equal(*order.DepartmentIndicator, changedData["department_indicator"])
+
+				//changedData["amended_orders_acknowledged_at"] is being converted from a string to a formatted time.Time type
+				changedDataTimeStamp, _ := time.Parse("2006-01-02T15:04:05.000000", changedData["amended_orders_acknowledged_at"].(string))
+				//We assert if it falls within a range starting at the original order.AmendedOrdersAcknowledgedAt time and ending with a added 2 microsecond buffer
+				suite.WithinRange(changedDataTimeStamp, *order.AmendedOrdersAcknowledgedAt, order.AmendedOrdersAcknowledgedAt.Add(2*time.Microsecond))
+
 				//TODO: make a better comparison test for time
-				//suite.Equal(order.AmendedOrdersAcknowledgedAt.Format("2006-01-02T15:04:05.000000"), changedData["amended_orders_acknowledged_at"])
+				// suite.Equal(order.AmendedOrdersAcknowledgedAt.Format("2006-01-02T15:04:05.000000"), changedData["amended_orders_acknowledged_at"])
 
 				// rank/grade is also on orders
 				suite.Equal(*order.Grade, changedData["grade"])

--- a/pkg/services/move_history/move_history_fetcher_test.go
+++ b/pkg/services/move_history/move_history_fetcher_test.go
@@ -285,8 +285,16 @@ func (suite *MoveHistoryServiceSuite) TestMoveFetcher() {
 				suite.Equal(*order.DepartmentIndicator, changedData["department_indicator"])
 
 				//changedData["amended_orders_acknowledged_at"] is being converted from a string to a formatted time.Time type
-				layout := "2006-01-02T15:04:05.000000"
+				layout := "2006-01-02T15:04:05.000000000"
 				changedDataTimeStamp, _ := time.Parse(layout, changedData["amended_orders_acknowledged_at"].(string))
+				suite.Logger().Sugar().Info("STAMP 1 HERE")
+				suite.Logger().Sugar().Info(changedDataTimeStamp)
+				layout2 := "2006-01-0215:04:05.000000"
+				changedDataTimeStamp2, _ := time.Parse(layout2, changedData["amended_orders_acknowledged_at"].(string))
+				suite.Logger().Sugar().Info("STAMP 2 HERE")
+				suite.Logger().Sugar().Info(changedDataTimeStamp2)
+				suite.Logger().Sugar().Info("STAMP WITH ADDED MS HERE")
+				suite.Logger().Sugar().Info(order.AmendedOrdersAcknowledgedAt.Add(2000 * time.Microsecond))
 				//We assert if it falls within a range starting at the original order.AmendedOrdersAcknowledgedAt time and ending with a added 2000 microsecond buffer
 				suite.WithinRange(changedDataTimeStamp, *order.AmendedOrdersAcknowledgedAt, order.AmendedOrdersAcknowledgedAt.Add(2000*time.Microsecond))
 


### PR DESCRIPTION
## [Jira ticket](https://dp3.atlassian.net/browse/MB-12340) for this change

## Summary

I thought of three potential approaches and will include some thoughts for each:

1. Hard coding the date:
    - Seemed like the simplest solution, but, when digging in it seemed like it might be more trouble than its worth since the datagen function uses `time.Now()` to generate a dateTime and this might just end up breaking other tests using that same function.

2. Changing the `suite.Equal()` assertion to `suite.GreaterOrEqual()`:
    - This would assert that the timestamp is equal while still passing if it happens to be greater by a microsecond BUT it won't account for egregious differences, which may be something we want to capture and tend to if it were to happen. 

3. Using `suite.WithinRange()` (my chosen approach for this PR):
    - This asserts whether or not the given timestamp falls within a certain range. I set up the assertion so the range begins at the time we are comparing it against and ending the range with a 2000 microsecond buffer. This way it can properly assert if it is equal while providing a bit of wiggle room incase it were to be ahead by a few microseconds. This approach was also informed a bit by [this article](https://michaeljswart.com/2022/02/five-ways-time-makes-unit-tests-flaky/) and the conversation from the original [PR](https://github.com/transcom/mymove/pull/8486/files#diff-2aaf788a6f0f8978cc3c4b19155cd99a084d553a2d49c70add1fcba5e6dcaf60L161) and more specifically a comment left by Roger suggesting an approach along these lines.

<img width="775" alt="Screen Shot 2022-10-20 at 9 03 50 PM" src="https://user-images.githubusercontent.com/111928238/197109232-8950a4aa-1c74-4cd6-9a22-b5cc682dcf32.png">


## Setup to Run Your Code

<details>
<summary>💻 You will need to use two separate terminals to test this locally.</summary>


##### Terminal 1

Start the Go server locally.

```sh
make server_run
```

##### Terminal 2

Run the Go tests.

```sh
make server_test
```

or

Run the test in the specific file (`-count=1` ensures it fully reruns instead of using cached results if running test back to back).

```sh
go test ./pkg/services/move_history -v -count=1
```


</details>

## Verification Steps for Author

These are to be checked by the author.

- [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
- [ ] Request review from a member of a different team.
- [ ] Have the Jira acceptance criteria been met for this change?

## Verification Steps for Reviewers

These are to be checked by a reviewer.

<!-- Fill out the next sections as you see fit, these are just suggestions. -->

### Backend

- [ ] Code follows the guidelines for [Logging](https://transcom.github.io/mymove-docs/docs/dev/contributing/backend/Backend-Programming-Guide#logging)
- [ ] The requirements listed in [Querying the Database Safely](https://transcom.github.io/mymove-docs/docs/dev/contributing/backend/Backend-Programming-Guide/#querying-the-database-safely) have been satisfied.
