### PR TITLE
[MB-14323, MB-14296, MB-14208] audit history table migrations

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,10 +30,10 @@ references:
   #
   # In addition, it's common practice to disable acceptance tests and
   # ignore tests for dp3 deploys. See the branch settings below.
-  dp3-branch: &dp3-branch placeholder_branch_name
+  dp3-branch: &dp3-branch mmayo/audit-history-table-migrations
   # MUST BE ONE OF: loadtest, demo, exp.
   # These are used to pull in env vars so the spelling matters!
-  dp3-env: &dp3-env placeholder_env
+  dp3-env: &dp3-env exp
 
   # set acceptance-branch to the branch you want to ENABLE acceptance
   # tests, or `placeholder_branch_name` if you don't want to run them
@@ -42,22 +42,22 @@ references:
   # set integration-ignore-branch to the branch if you want to IGNORE
   # integration tests, or `placeholder_branch_name` if you do want to
   # run them
-  integration-ignore-branch: &integration-ignore-branch placeholder_branch_name
+  integration-ignore-branch: &integration-ignore-branch mmayo/audit-history-table-migrations
 
   # set integration-mtls-ignore-branch to the branch if you want to
   # IGNORE mtls integration tests, or `placeholder_branch_name` if you
   # do want to run them
-  integration-mtls-ignore-branch: &integration-mtls-ignore-branch placeholder_branch_name
+  integration-mtls-ignore-branch: &integration-mtls-ignore-branch mmayo/audit-history-table-migrations
 
   # set client-ignore-branch to the branch if you want to IGNORE
   # client tests, or `placeholder_branch_name` if you do want to run
   # them
-  client-ignore-branch: &client-ignore-branch placeholder_branch_name
+  client-ignore-branch: &client-ignore-branch mmayo/audit-history-table-migrations
 
   # set server-ignore-branch to the branch if you want to IGNORE
   # server tests, or `placeholder_branch_name` if you do want to run
   # them
-  server-ignore-branch: &server-ignore-branch placeholder_branch_name
+  server-ignore-branch: &server-ignore-branch mmayo/audit-history-table-migrations
 
 executors:
   av_medium:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,10 +30,10 @@ references:
   #
   # In addition, it's common practice to disable acceptance tests and
   # ignore tests for dp3 deploys. See the branch settings below.
-  dp3-branch: &dp3-branch mmayo/audit-history-table-migrations
+  dp3-branch: &dp3-branch placeholder_branch_name
   # MUST BE ONE OF: loadtest, demo, exp.
   # These are used to pull in env vars so the spelling matters!
-  dp3-env: &dp3-env exp
+  dp3-env: &dp3-env placeholder_env
 
   # set acceptance-branch to the branch you want to ENABLE acceptance
   # tests, or `placeholder_branch_name` if you don't want to run them
@@ -42,22 +42,22 @@ references:
   # set integration-ignore-branch to the branch if you want to IGNORE
   # integration tests, or `placeholder_branch_name` if you do want to
   # run them
-  integration-ignore-branch: &integration-ignore-branch mmayo/audit-history-table-migrations
+  integration-ignore-branch: &integration-ignore-branch placeholder_branch_name
 
   # set integration-mtls-ignore-branch to the branch if you want to
   # IGNORE mtls integration tests, or `placeholder_branch_name` if you
   # do want to run them
-  integration-mtls-ignore-branch: &integration-mtls-ignore-branch mmayo/audit-history-table-migrations
+  integration-mtls-ignore-branch: &integration-mtls-ignore-branch placeholder_branch_name
 
   # set client-ignore-branch to the branch if you want to IGNORE
   # client tests, or `placeholder_branch_name` if you do want to run
   # them
-  client-ignore-branch: &client-ignore-branch mmayo/audit-history-table-migrations
+  client-ignore-branch: &client-ignore-branch placeholder_branch_name
 
   # set server-ignore-branch to the branch if you want to IGNORE
   # server tests, or `placeholder_branch_name` if you do want to run
   # them
-  server-ignore-branch: &server-ignore-branch mmayo/audit-history-table-migrations
+  server-ignore-branch: &server-ignore-branch placeholder_branch_name
 
 executors:
   av_medium:

--- a/migrations/app/migrations_manifest.txt
+++ b/migrations/app/migrations_manifest.txt
@@ -761,3 +761,4 @@
 20220927210523_remove-gidjin-cac.up.sql
 20221006031146_add_status_and_reason_to_weight_ticket.up.sql
 20221014194001_rename_weighing_fees_to_weighing_fee.up.sql
+20221020202612_create-and-modify-move-history-triggers-for-multiple-tables.up.sql

--- a/migrations/app/schema/20221020202612_create-and-modify-move-history-triggers-for-multiple-tables.up.sql
+++ b/migrations/app/schema/20221020202612_create-and-modify-move-history-triggers-for-multiple-tables.up.sql
@@ -1,0 +1,165 @@
+-- Modifying existing move history triggers to ignore most of the fk ids
+SELECT add_audit_history_table(
+    target_table := 'moves',
+    audit_rows := BOOLEAN 't',
+    audit_query_text := BOOLEAN 't',
+    ignored_cols := ARRAY[
+        'created_at',
+        'updated_at',
+        'orders_id',
+        'contractor_id',
+        'excess_weight_upload_id'
+    ]
+);
+SELECT add_audit_history_table(
+	target_table := 'mto_agents',
+	audit_rows := BOOLEAN 't',
+	audit_query_text := BOOLEAN 't',
+	ignored_cols := ARRAY[
+	   	'created_at',
+	   	'updated_at',
+	   	'mto_shipment_id'
+	]
+);
+SELECT add_audit_history_table(
+	target_table := 'mto_service_item_customer_contacts',
+	audit_rows := BOOLEAN 't',
+	audit_query_text := BOOLEAN 't',
+	ignored_cols := ARRAY[
+		'created_at',
+		'updated_at',
+		'mto_service_item_id'
+	]
+);
+SELECT add_audit_history_table(
+	target_table := 'mto_service_item_dimensions',
+	audit_rows := BOOLEAN 't',
+	audit_query_text := BOOLEAN 't',
+	ignored_cols := ARRAY[
+		'created_at',
+		'updated_at',
+		'mto_service_item_id'
+	]
+);
+SELECT add_audit_history_table(
+	target_table := 'mto_service_items',
+	audit_rows := BOOLEAN 't',
+	audit_query_text := BOOLEAN 't',
+	ignored_cols := ARRAY[
+		'created_at',
+		'updated_at',
+		'move_id',
+		'mto_shipment_id',
+		're_service_id',
+		'sit_destination_final_address_id',
+		'sit_origin_hhg_original_address_id',
+		'sit_origin_hhg_actual_address_id'
+   	]
+);
+SELECT add_audit_history_table(
+	target_table := 'mto_shipments',
+	audit_rows := BOOLEAN 't',
+	audit_query_text := BOOLEAN 't',
+	ignored_cols := ARRAY[
+		'created_at',
+		'updated_at',
+		'destination_address_id',
+		'secondary_pickup_address_id',
+		'secondary_delivery_address_id',
+		'pickup_address_id',
+		'move_id',
+		'storage_facility_id'
+	]
+);
+SELECT add_audit_history_table(
+	target_table := 'orders',
+	audit_rows := BOOLEAN 't',
+	audit_query_text := BOOLEAN 't',
+	ignored_cols := ARRAY[
+		'created_at',
+		'updated_at',
+		'service_member_id',
+		'uploaded_orders_id',
+		'entitlement_id',
+		'uploaded_amended_orders_id',
+		'origin_duty_location_id',
+		'new_duty_location_id'
+	]
+);
+SELECT add_audit_history_table(
+	target_table := 'payment_requests',
+	audit_rows := BOOLEAN 't',
+	audit_query_text := BOOLEAN 't',
+	ignored_cols := ARRAY[
+		'created_at',
+		'updated_at',
+		'move_id'
+	] -- recalculation_of_payment_request_id is another fk but it is utilized to display supplemental information
+);
+SELECT add_audit_history_table(
+	target_table := 'proof_of_service_docs',
+	audit_rows := BOOLEAN 't',
+	audit_query_text := BOOLEAN 't',
+	ignored_cols := ARRAY[
+		'created_at',
+		'updated_at',
+		'payment_request_id'
+	]
+);
+SELECT add_audit_history_table(
+	target_table := 'reweighs',
+	audit_rows := BOOLEAN 't',
+	audit_query_text := BOOLEAN 't',
+	ignored_cols := ARRAY[
+		'created_at',
+		'updated_at',
+		'shipment_id'
+	]
+);
+SELECT add_audit_history_table(
+	target_table := 'service_members',
+	audit_rows := BOOLEAN 't',
+	audit_query_text := BOOLEAN 't',
+	ignored_cols := ARRAY[
+		'created_at',
+		'updated_at',
+		'user_id',
+		'residential_address_id',
+		'backup_mailing_address_id'
+	] -- duty_location_id is another fk but it is utilized to display supplemental information
+);
+SELECT add_audit_history_table(
+	target_table := 'storage_facilities',
+	audit_rows := BOOLEAN 't',
+	audit_query_text := BOOLEAN 't',
+	ignored_cols := ARRAY[
+		'created_at',
+		'updated_at',
+		'address_id'
+	]
+);
+
+-- These following two are newly added move history triggers
+SELECT add_audit_history_table(
+	target_table := 'backup_contacts',
+	audit_rows := BOOLEAN 't',
+	audit_query_text := BOOLEAN 't',
+	ignored_cols := ARRAY[
+		'created_at',
+		'updated_at',
+		'service_member_id'
+	]
+);
+SELECT add_audit_history_table(
+	target_table := 'moves',
+	audit_rows := BOOLEAN 't',
+	audit_query_text := BOOLEAN 't',
+	ignored_cols := ARRAY[
+		'created_at',
+		'updated_at',
+		'document_id',
+		'uploader_id',
+		'upload_id'
+	]
+);
+

--- a/migrations/app/schema/20221020202612_create-and-modify-move-history-triggers-for-multiple-tables.up.sql
+++ b/migrations/app/schema/20221020202612_create-and-modify-move-history-triggers-for-multiple-tables.up.sql
@@ -81,7 +81,8 @@ SELECT add_audit_history_table(
 		'service_member_id',
 		'uploaded_orders_id',
 		'entitlement_id',
-		'uploaded_amended_orders_id'
+		'uploaded_amended_orders_id',
+	    'grade'
 	] -- origin_duty_location_id and new_duty_location_id are fks but are utilized to display supplemental information
 );
 SELECT add_audit_history_table(

--- a/migrations/app/schema/20221020202612_create-and-modify-move-history-triggers-for-multiple-tables.up.sql
+++ b/migrations/app/schema/20221020202612_create-and-modify-move-history-triggers-for-multiple-tables.up.sql
@@ -81,10 +81,8 @@ SELECT add_audit_history_table(
 		'service_member_id',
 		'uploaded_orders_id',
 		'entitlement_id',
-		'uploaded_amended_orders_id',
-		'origin_duty_location_id',
-		'new_duty_location_id'
-	]
+		'uploaded_amended_orders_id'
+	] -- origin_duty_location_id and new_duty_location_id are fks but are utilized to display supplemental information
 );
 SELECT add_audit_history_table(
 	target_table := 'payment_requests',
@@ -151,7 +149,7 @@ SELECT add_audit_history_table(
 	]
 );
 SELECT add_audit_history_table(
-	target_table := 'moves',
+	target_table := 'user_uploads',
 	audit_rows := BOOLEAN 't',
 	audit_query_text := BOOLEAN 't',
 	ignored_cols := ARRAY[

--- a/pkg/services/move_history/move_history_fetcher_test.go
+++ b/pkg/services/move_history/move_history_fetcher_test.go
@@ -286,9 +286,6 @@ func (suite *MoveHistoryServiceSuite) TestMoveFetcher() {
 				//TODO: make a better comparison test for time
 				//suite.Equal(order.AmendedOrdersAcknowledgedAt.Format("2006-01-02T15:04:05.000000"), changedData["amended_orders_acknowledged_at"])
 
-				// rank/grade is also on orders
-				suite.Equal(*order.Grade, changedData["grade"])
-
 				// test context as well
 				context := removeEscapeJSONtoArray(historyRecord.Context)[0]
 				suite.Equal(order.OriginDutyLocation.Name, context["origin_duty_location_name"])

--- a/src/constants/MoveHistory/EventTemplates/CreateOrders/createOrders.jsx
+++ b/src/constants/MoveHistory/EventTemplates/CreateOrders/createOrders.jsx
@@ -6,11 +6,13 @@ import o from 'constants/MoveHistory/UIDisplay/Operations';
 import LabeledDetails from 'pages/Office/MoveHistory/LabeledDetails';
 
 const formatChangedValues = (historyRecord) => {
-  let newChangedValues;
+  let newChangedValues = {
+    ...historyRecord.changedValues,
+  };
 
   if (historyRecord.context) {
     newChangedValues = {
-      ...historyRecord.changedValues,
+      ...newChangedValues,
       ...historyRecord.context[0],
     };
   }

--- a/src/constants/MoveHistory/EventTemplates/UpdateAllowances/updateAllowanceServiceMemberByTOO.jsx
+++ b/src/constants/MoveHistory/EventTemplates/UpdateAllowances/updateAllowanceServiceMemberByTOO.jsx
@@ -9,7 +9,7 @@ export default {
   action: a.UPDATE,
   eventName: o.updateAllowance,
   tableName: t.service_members,
-  getEventNameDisplay: () => 'Updated service member',
+  getEventNameDisplay: () => 'Updated profile',
   getDetails: (historyRecord) => {
     return <LabeledDetails historyRecord={historyRecord} />;
   },

--- a/src/constants/MoveHistory/EventTemplates/UpdateAllowances/updateAllowanceServiceMemberByTOO.test.jsx
+++ b/src/constants/MoveHistory/EventTemplates/UpdateAllowances/updateAllowanceServiceMemberByTOO.test.jsx
@@ -10,7 +10,7 @@ describe('When a TOO updates shipping allowances', () => {
     action: 'UPDATE',
     eventName: o.updateAllowance,
     tableName: t.service_members,
-    eventNameDisplay: 'Updated service member',
+    eventNameDisplay: 'Updated profile',
     changedValues: {
       affiliation: 'AIR_FORCE',
       rank: 'E_2',

--- a/src/constants/MoveHistory/EventTemplates/updateAllowanceServiceMemberByCounselor.js
+++ b/src/constants/MoveHistory/EventTemplates/updateAllowanceServiceMemberByCounselor.js
@@ -8,5 +8,5 @@ export default {
   eventName: o.counselingUpdateAllowance,
   tableName: t.service_members,
   detailsType: d.LABELED,
-  getEventNameDisplay: () => 'Updated service member',
+  getEventNameDisplay: () => 'Updated profile',
 };

--- a/src/constants/MoveHistory/EventTemplates/updateAllowanceServiceMemberByCounselor.test.js
+++ b/src/constants/MoveHistory/EventTemplates/updateAllowanceServiceMemberByCounselor.test.js
@@ -10,7 +10,7 @@ describe('When a service counselor updates shipping allowances', () => {
     eventName: o.counselingUpdateAllowance,
     tableName: t.service_members,
     detailsType: d.LABELED,
-    eventNameDisplay: 'Updated service member',
+    eventNameDisplay: 'Updated profile',
     changedValues: {
       affiliation: 'AIR_FORCE',
       rank: 'E_2',


### PR DESCRIPTION
## JIRA tickets for this change [MB-14323](https://dp3.atlassian.net/browse/MB-14323) [MB-14296](https://dp3.atlassian.net/browse/MB-14296) [MB-14208](https://dp3.atlassian.net/browse/MB-14208)
 
## Summary
This PR is grouping the migrations together for multiple issues. 

MB-14323: We are adding to the ignored_cols array for multiple to remove duplicate entries on the move history table when a new item is added. 
Note that this will remove these ids from being tracked in the `changed_values` column of the audit history table. There are some foreign keys that need to be tracked, mostly with duty locations, so I omitted those from the ignored columns and commented that in the migration file. 
Second Note: this migration file looks bigger than it is. I decided to change the formatting of how we typically use the `add_audit_history_table` function in order to make it easier to see all of the ignored columns and make appropriate comments.

MB-14208: We are adding a the `user_uploads` table to be tracked on the audit history table. 

MB-14296: We are adding the `backup_contacts` table to be tracked on the audit history table.



## Setup to Run Your Code

<details>
<summary>💻 You will need to use two separate terminals to test this locally.</summary>

##### Terminal 1

Start the UI locally.

```sh
make client_run
```

##### Terminal 2

Start the Go server locally.

```sh
make server_run
```

</details>

### Additional steps

<!-- Fill out the next section as you see fit, these are just suggestions. -->

1. Access the milmove app as a service member.
2. Go through the process of creating a move (Make sure you use the correct GBLOC, Fort McCoy is a duty station that will show up easily for our normal local dev patterns)
3. When you create the shipment do not add a secondary pickup or a secondary delivery address
4. 🛑 Don't submit the move yet
5. Go back and edit address to add a secondary pickup address
6. 🛑 Don't submit the move yet
7. Go back again to edit address to add a secondary delivery address
8. Sign and submit the move.
9. Log into the office app as a services counselor and view the move history for the move just created.
10. You should see the secondary addresses displayed as their own rows on the move history table, but not any accompanying empty rows for the id being attached to the shipment.
11. You will NOT see any entries currently for the `user_uploads` or the `backup_contacts`, since the query has not been modified. But if you are running this locally you should see entries on a db viewer for both the orders upload and the creation of the backup contacts when you went through the creation of the move.

## Verification Steps for Author

These are to be checked by the author.

- [ ] Have the Jira acceptance criteria been met for this change?

## Screenshots
BEFORE:
![image](https://user-images.githubusercontent.com/110134470/197251396-ecfee8d2-8df5-4035-b40c-b3d8cd7f9001.png)

AFTER
![image](https://user-images.githubusercontent.com/110134470/197251266-82a73d4c-d58c-4c35-a174-121286785416.png)


DB view of audit history table featuring backup_contacts and user_upload entries:
![image](https://user-images.githubusercontent.com/110134470/197245045-c54c1d27-7cd9-4d06-b964-f14bc93a5aeb.png)

