### PR TITLE
[ on-call ] Upgrade PSQL to 12.11 for the application

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,34 +30,34 @@ references:
   #
   # In addition, it's common practice to disable acceptance tests and
   # ignore tests for dp3 deploys. See the branch settings below.
-  dp3-branch: &dp3-branch placeholder_branch_name
+  dp3-branch: &dp3-branch rogeruiz/oncall/upgrade-psql-12.11
   # MUST BE ONE OF: loadtest, demo, exp.
   # These are used to pull in env vars so the spelling matters!
-  dp3-env: &dp3-env placeholder_env
+  dp3-env: &dp3-env exp
 
   # set acceptance-branch to the branch you want to ENABLE acceptance
   # tests, or `placeholder_branch_name` if you don't want to run them
-  acceptance-branch: &acceptance-branch placeholder_branch_name
+  acceptance-branch: &acceptance-branch rogeruiz/oncall/upgrade-psql-12.11
 
   # set integration-ignore-branch to the branch if you want to IGNORE
   # integration tests, or `placeholder_branch_name` if you do want to
   # run them
-  integration-ignore-branch: &integration-ignore-branch placeholder_branch_name
+  integration-ignore-branch: &integration-ignore-branch rogeruiz/oncall/upgrade-psql-12.11
 
   # set integration-mtls-ignore-branch to the branch if you want to
   # IGNORE mtls integration tests, or `placeholder_branch_name` if you
   # do want to run them
-  integration-mtls-ignore-branch: &integration-mtls-ignore-branch placeholder_branch_name
+  integration-mtls-ignore-branch: &integration-mtls-ignore-branch rogeruiz/oncall/upgrade-psql-12.11
 
   # set client-ignore-branch to the branch if you want to IGNORE
   # client tests, or `placeholder_branch_name` if you do want to run
   # them
-  client-ignore-branch: &client-ignore-branch placeholder_branch_name
+  client-ignore-branch: &client-ignore-branch rogeruiz/oncall/upgrade-psql-12.11
 
   # set server-ignore-branch to the branch if you want to IGNORE
   # server tests, or `placeholder_branch_name` if you do want to run
   # them
-  server-ignore-branch: &server-ignore-branch placeholder_branch_name
+  server-ignore-branch: &server-ignore-branch rogeruiz/oncall/upgrade-psql-12.11
 
 executors:
   av_medium:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,34 +30,34 @@ references:
   #
   # In addition, it's common practice to disable acceptance tests and
   # ignore tests for dp3 deploys. See the branch settings below.
-  dp3-branch: &dp3-branch rogeruiz/oncall/upgrade-psql-12.11
+  dp3-branch: &dp3-branch placeholder_branch_name
   # MUST BE ONE OF: loadtest, demo, exp.
   # These are used to pull in env vars so the spelling matters!
-  dp3-env: &dp3-env exp
+  dp3-env: &dp3-env placeholder_env
 
   # set acceptance-branch to the branch you want to ENABLE acceptance
   # tests, or `placeholder_branch_name` if you don't want to run them
-  acceptance-branch: &acceptance-branch rogeruiz/oncall/upgrade-psql-12.11
+  acceptance-branch: &acceptance-branch placeholder_branch_name
 
   # set integration-ignore-branch to the branch if you want to IGNORE
   # integration tests, or `placeholder_branch_name` if you do want to
   # run them
-  integration-ignore-branch: &integration-ignore-branch rogeruiz/oncall/upgrade-psql-12.11
+  integration-ignore-branch: &integration-ignore-branch placeholder_branch_name
 
   # set integration-mtls-ignore-branch to the branch if you want to
   # IGNORE mtls integration tests, or `placeholder_branch_name` if you
   # do want to run them
-  integration-mtls-ignore-branch: &integration-mtls-ignore-branch rogeruiz/oncall/upgrade-psql-12.11
+  integration-mtls-ignore-branch: &integration-mtls-ignore-branch placeholder_branch_name
 
   # set client-ignore-branch to the branch if you want to IGNORE
   # client tests, or `placeholder_branch_name` if you do want to run
   # them
-  client-ignore-branch: &client-ignore-branch rogeruiz/oncall/upgrade-psql-12.11
+  client-ignore-branch: &client-ignore-branch placeholder_branch_name
 
   # set server-ignore-branch to the branch if you want to IGNORE
   # server tests, or `placeholder_branch_name` if you do want to run
   # them
-  server-ignore-branch: &server-ignore-branch rogeruiz/oncall/upgrade-psql-12.11
+  server-ignore-branch: &server-ignore-branch placeholder_branch_name
 
 executors:
   av_medium:

--- a/Makefile
+++ b/Makefile
@@ -4,9 +4,6 @@ DB_NAME_TEST = test_db
 DB_DOCKER_CONTAINER_DEV = milmove-db-dev
 DB_DOCKER_CONTAINER_DEPLOYED_MIGRATIONS = milmove-db-deployed-migrations
 DB_DOCKER_CONTAINER_TEST = milmove-db-test
-# README: The version of the postgres container should match production as
-# closely as possible.
-# https://github.com/transcom/terraform-aws-app-environment/tree/main/database/main.tf#68
 DB_DOCKER_CONTAINER_IMAGE = postgres:12.11
 REDIS_DOCKER_CONTAINER_IMAGE = redis:5.0.6
 REDIS_DOCKER_CONTAINER = milmove-redis

--- a/Makefile
+++ b/Makefile
@@ -4,9 +4,9 @@ DB_NAME_TEST = test_db
 DB_DOCKER_CONTAINER_DEV = milmove-db-dev
 DB_DOCKER_CONTAINER_DEPLOYED_MIGRATIONS = milmove-db-deployed-migrations
 DB_DOCKER_CONTAINER_TEST = milmove-db-test
-# The version of the postgres container should match production as closely
-# as possible.
-# https://github.com/transcom/transcom-infrasec-com/blob/c32c45078f29ea6fd58b0c246f994dbea91be372/transcom-com-legacy/app-prod/main.tf#L62
+# README: The version of the postgres container should match production as
+# closely as possible.
+# https://github.com/transcom/terraform-aws-app-environment/tree/main/database/main.tf#68
 DB_DOCKER_CONTAINER_IMAGE = postgres:12.11
 REDIS_DOCKER_CONTAINER_IMAGE = redis:5.0.6
 REDIS_DOCKER_CONTAINER = milmove-redis

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ DB_DOCKER_CONTAINER_TEST = milmove-db-test
 # The version of the postgres container should match production as closely
 # as possible.
 # https://github.com/transcom/transcom-infrasec-com/blob/c32c45078f29ea6fd58b0c246f994dbea91be372/transcom-com-legacy/app-prod/main.tf#L62
-DB_DOCKER_CONTAINER_IMAGE = postgres:12.7
+DB_DOCKER_CONTAINER_IMAGE = postgres:12.11
 REDIS_DOCKER_CONTAINER_IMAGE = redis:5.0.6
 REDIS_DOCKER_CONTAINER = milmove-redis
 TASKS_DOCKER_CONTAINER = tasks


### PR DESCRIPTION
## Summary

This will help run the tests before I deploy this to EXP for further
testing.

We're trying to validate that upgrading RDS to version 12.11 will not affect
application engineering engineers in any way besides having to restart their
local Docker containers to get the new versions.
