### PR TITLE
MB-14316 Violations and serious incident cells show no data until radio buttons are selected

### DIFF
--- a/src/components/Office/EvaluationReportTable/EvaluationReportTable.jsx
+++ b/src/components/Office/EvaluationReportTable/EvaluationReportTable.jsx
@@ -70,8 +70,12 @@ const EvaluationReportTable = ({
         </td>
         <td className={styles.dateSubmittedColumn}>{report.submittedAt && formatCustomerDate(report.submittedAt)}</td>
         <td className={styles.locationColumn}>{formatEvaluationReportLocation(report.location)}</td>
-        <td className={styles.violationsColumn}>{violations}</td>
-        <td className={styles.seriousIncidentColumn}>{seriousIncident}</td>
+        <td data-testid="violation-column" className={styles.violationsColumn}>
+          {violations}
+        </td>
+        <td data-testid="incident-column" className={styles.seriousIncidentColumn}>
+          {seriousIncident}
+        </td>
         <td className={styles.viewReportColumn}>
           {report.submittedAt && (
             <Button

--- a/src/components/Office/EvaluationReportTable/EvaluationReportTable.jsx
+++ b/src/components/Office/EvaluationReportTable/EvaluationReportTable.jsx
@@ -45,6 +45,24 @@ const EvaluationReportTable = ({
   };
 
   const row = (report) => {
+    let violations;
+    let seriousIncident;
+
+    if (report.violationsObserved) {
+      violations = 'Yes';
+    } else if (report.violationsObserved === false) {
+      violations = 'No';
+    } else {
+      violations = '';
+    }
+
+    if (report.seriousIncident) {
+      seriousIncident = 'Yes';
+    } else if (report.seriousIncident === false) {
+      seriousIncident = 'No';
+    } else {
+      seriousIncident = '';
+    }
     return (
       <tr key={report.id}>
         <td className={styles.reportIDColumn}>
@@ -52,8 +70,8 @@ const EvaluationReportTable = ({
         </td>
         <td className={styles.dateSubmittedColumn}>{report.submittedAt && formatCustomerDate(report.submittedAt)}</td>
         <td className={styles.locationColumn}>{formatEvaluationReportLocation(report.location)}</td>
-        <td className={styles.violationsColumn}>{report.violationsObserved ? 'Yes' : 'No'}</td>
-        <td className={styles.seriousIncidentColumn}>{report.seriousIncident ? 'Yes' : 'No'}</td>
+        <td className={styles.violationsColumn}>{violations}</td>
+        <td className={styles.seriousIncidentColumn}>{seriousIncident}</td>
         <td className={styles.viewReportColumn}>
           {report.submittedAt && (
             <Button

--- a/src/components/Office/EvaluationReportTable/EvaluationReportTable.test.jsx
+++ b/src/components/Office/EvaluationReportTable/EvaluationReportTable.test.jsx
@@ -22,6 +22,16 @@ const draftReport = {
   submittedAt: null,
   type: 'SHIPMENT',
   violationsObserved: true,
+};
+
+const blankReport = {
+  id: '3g9d18a8-7688-428d-be8e-3f3c59a0ae5e',
+  location: null,
+  moveID: 'aa1bbbdc-1710-4831-aa41-e35ebedff5cd',
+  shipmentID: 'a46825dd-cf90-442b-96de-c5075ea2f1bf',
+  submittedAt: null,
+  type: 'SHIPMENT',
+  violationsObserved: undefined,
   seriousIncident: undefined,
 };
 
@@ -79,7 +89,7 @@ describe('EvaluationReportTable', () => {
       <MockProviders>
         <EvaluationReportTable
           reports={[draftReport]}
-          emptyText="no reports for this"
+          emptyText=""
           shipments={[]}
           moveCode="FAKEIT"
           grade="E_4"
@@ -95,16 +105,34 @@ describe('EvaluationReportTable', () => {
     expect(screen.getByText('Date submitted')).toBeInTheDocument();
     expect(screen.getByText('Location')).toBeInTheDocument();
     expect(screen.getByText('Violations')).toBeInTheDocument();
-    expect(screen.getByTestId('violation-column')).toHaveTextContent('Yes');
     expect(screen.getByText('Serious Incident')).toBeInTheDocument();
-    expect(screen.getByTestId('incident-column')).toHaveTextContent('');
-    expect(screen.queryByText('no reports for this')).not.toBeInTheDocument();
-
     expect(screen.getByTestId('tag')).toHaveTextContent('DRAFT');
 
     expect(screen.getByText('#QA-1F9D1')).toBeInTheDocument();
     expect(screen.getByRole('link', { name: 'Edit report' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Delete' })).toBeInTheDocument();
+  });
+  it('does not show undefined values in table', () => {
+    render(
+      <MockProviders>
+        <EvaluationReportTable
+          reports={[blankReport]}
+          emptyText="no reports for this"
+          shipments={[]}
+          moveCode="FAKEIT"
+          grade="E_4"
+          customerInfo={customerInfo}
+          deleteReport={jest.fn()}
+          setReportToDelete={jest.fn()}
+          setIsDeleteModalOpen={jest.fn()}
+          isDeleteModalOpen={false}
+        />
+      </MockProviders>,
+    );
+    expect(screen.getByText('Violations')).toBeInTheDocument();
+    expect(screen.getByTestId('violation-column')).toHaveTextContent('');
+    expect(screen.getByText('Serious Incident')).toBeInTheDocument();
+    expect(screen.getByTestId('incident-column')).toHaveTextContent('');
   });
   it('renders table with a submitted report', () => {
     render(

--- a/src/components/Office/EvaluationReportTable/EvaluationReportTable.test.jsx
+++ b/src/components/Office/EvaluationReportTable/EvaluationReportTable.test.jsx
@@ -22,6 +22,7 @@ const draftReport = {
   submittedAt: null,
   type: 'SHIPMENT',
   violationsObserved: true,
+  seriousIncident: undefined,
 };
 
 const customerInfo = {
@@ -94,7 +95,9 @@ describe('EvaluationReportTable', () => {
     expect(screen.getByText('Date submitted')).toBeInTheDocument();
     expect(screen.getByText('Location')).toBeInTheDocument();
     expect(screen.getByText('Violations')).toBeInTheDocument();
+    expect(screen.getByTestId('violation-column')).toHaveTextContent('Yes');
     expect(screen.getByText('Serious Incident')).toBeInTheDocument();
+    expect(screen.getByTestId('incident-column')).toHaveTextContent('');
     expect(screen.queryByText('no reports for this')).not.toBeInTheDocument();
 
     expect(screen.getByTestId('tag')).toHaveTextContent('DRAFT');


### PR DESCRIPTION
…buttons are selected

## [Jira ticket](https://dp3.atlassian.net/browse/MB-14316?atlOrigin=eyJpIjoiMGFmODdiNDcxOTg5NDE2MTkxNWRhOTUxY2I5NWU2ZTQiLCJwIjoiaiJ9) for this change

## Summary

On quality assurance reports page, violations and serious incidents showed as “no”, even if these sections haven't been filled out in the report yet. Now it shows a blank/no data until either yes or no is selected.

## Setup to Run Your Code

<details>
<summary>💻 You will need to use three separate terminals to test this locally.</summary>

##### Terminal 1

Start the Storybook locally.

```sh
make storybook
```

##### Terminal 2

Start the UI locally.

```sh
make client_run
```

##### Terminal 3

Start the Go server locally.

```sh
make server_run
```

</details>

### Additional steps

<!-- Fill out the next section as you see fit, these are just suggestions. -->

1.  Login as a QAE
2. Go to QA tab. You may have to create and/or modify reports to cover all scenarios. See my screenshot to see possible scenarios so you can test yourself.

## Verification Steps for Author

These are to be checked by the author.

- [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
- [ ] Request review from a member of a different team.
- [ ] Have the Jira acceptance criteria been met for this change?

## Verification Steps for Reviewers

These are to be checked by a reviewer.

<!-- Fill out the next sections as you see fit, these are just suggestions. -->

### Frontend

- [ ] User facing changes have been reviewed by design.
- [ ] There are no aXe warnings for UI.
- [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
- [ ] There are no new console errors in the browser devtools
- [ ] There are no new console errors in the test output
- [ ] If this PR adds a new component to Storybook, it ensures the component is fully responsive, OR if it is intentionally not, a wrapping div using the `officeApp` class or custom `min-width` styling is used to hide any states the would not be visible to the user.

### Backend

- [ ] Code follows the guidelines for [Logging](https://transcom.github.io/mymove-docs/docs/dev/contributing/backend/Backend-Programming-Guide#logging)
- [ ] The requirements listed in [Querying the Database Safely](https://transcom.github.io/mymove-docs/docs/dev/contributing/backend/Backend-Programming-Guide/#querying-the-database-safely) have been satisfied.

### Database

#### Any new migrations/schema changes:

- [ ] Follows our guidelines for [Zero-Downtime Deploys](https://transcom.github.io/mymove-docs/docs/dev/contributing/database/Database-Migrations#zero-downtime-migrations)
- [ ] Have been communicated to #g-database
- [ ] Secure migrations have been tested following the instructions in our [docs](https://transcom.github.io/mymove-docs/docs/dev/contributing/database/Database-Migrations#secure-migrations)

## Screenshots
![Screen Shot 2022-10-28 at 10 40 49 AM](https://user-images.githubusercontent.com/108361430/198663974-310f20e1-9dac-4b9d-a771-8996654c5f28.png)
