### PR TITLE
[ on-call ] Modified the docker tag creation to cut off the branch name at 100 chars

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -521,7 +521,7 @@ commands:
             #         the tag name to 100 characters. Docker tags can be a maximum of 128 characters
             #         and this leaves some room for a prefix.
             docker_tag_from_branch_name=${CIRCLE_BRANCH//+([^A-Za-z0-9-.])/-}
-            docker_tag_shortened_name=${DOCKER_TAG_FROM_BRANCH_NAME:0:100}
+            docker_tag_shortened_name=${docker_tag_from_branch_name:0:100}
 
             docker tag << parameters.image_name >>:<< parameters.tag >> ${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/<< parameters.repo >>:git-branch-${docker_tag_shortened_name}
             docker push ${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/<< parameters.repo >>:git-branch-${docker_tag_shortened_name}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -510,17 +510,21 @@ commands:
             docker load -i images/<< parameters.image_name >>
       - run:
           name: 'Tag and push docker image'
-          # Docker tags can only be 128 chars long,
-          # so we will shorten the branch name in the following command
-          # to a nice round 100 to leave room for a prefix.
+
           command: |
             aws ecr get-login-password --region $AWS_DEFAULT_REGION | docker login --username AWS --password-stdin ${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com
             docker tag << parameters.image_name >>:<< parameters.tag >> ${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/<< parameters.repo >>:git-${CIRCLE_SHA1}
             docker push ${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/<< parameters.repo >>:git-${CIRCLE_SHA1}
-            SHORTENED_BRANCH=${CIRCLE_BRANCH:0:100}
             shopt -s extglob
-            docker tag << parameters.image_name >>:<< parameters.tag >> ${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/<< parameters.repo >>:git-branch-${SHORTENED_BRANCH//+([^A-Za-z0-9-.])/-}
-            docker push ${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/<< parameters.repo >>:git-branch-${SHORTENED_BRANCH//+([^A-Za-z0-9-.])/-}
+
+            # README: We are going to replace any unwanted characters with dashes then truncate
+            #         the tag name to 100 characters. Docker tags can be a maximum of 128 characters
+            #         and this leaves some room for a prefix.
+            docker_tag_from_branch_name=${CIRCLE_BRANCH//+([^A-Za-z0-9-.])/-}
+            docker_tag_shortened_name=${DOCKER_TAG_FROM_BRANCH_NAME:0:100}
+
+            docker tag << parameters.image_name >>:<< parameters.tag >> ${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/<< parameters.repo >>:git-branch-${docker_tag_shortened_name}
+            docker push ${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/<< parameters.repo >>:git-branch-${docker_tag_shortened_name}
       - run:
           name: 'Record ECR Image Digest'
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -515,8 +515,8 @@ commands:
             docker tag << parameters.image_name >>:<< parameters.tag >> ${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/<< parameters.repo >>:git-${CIRCLE_SHA1}
             docker push ${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/<< parameters.repo >>:git-${CIRCLE_SHA1}
             shopt -s extglob
-            docker tag << parameters.image_name >>:<< parameters.tag >> ${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/<< parameters.repo >>:git-branch-${CIRCLE_BRANCH//+([^A-Za-z0-9-.])/-}
-            docker push ${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/<< parameters.repo >>:git-branch-${CIRCLE_BRANCH//+([^A-Za-z0-9-.])/-}
+            docker tag << parameters.image_name >>:<< parameters.tag >> ${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/<< parameters.repo >>:git-branch-${CIRCLE_BRANCH[0,100]//+([^A-Za-z0-9-.])/-}
+            docker push ${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/<< parameters.repo >>:git-branch-${CIRCLE_BRANCH[0,100]//+([^A-Za-z0-9-.])/-}
       - run:
           name: 'Record ECR Image Digest'
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -510,13 +510,17 @@ commands:
             docker load -i images/<< parameters.image_name >>
       - run:
           name: 'Tag and push docker image'
+          # Docker tags can only be 128 chars long,
+          # so we will shorten the branch name in the following command
+          # to a nice round 100 to leave room for a prefix.
           command: |
             aws ecr get-login-password --region $AWS_DEFAULT_REGION | docker login --username AWS --password-stdin ${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com
             docker tag << parameters.image_name >>:<< parameters.tag >> ${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/<< parameters.repo >>:git-${CIRCLE_SHA1}
             docker push ${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/<< parameters.repo >>:git-${CIRCLE_SHA1}
+            SHORTENED_BRANCH=${CIRCLE_BRANCH:0:100}
             shopt -s extglob
-            docker tag << parameters.image_name >>:<< parameters.tag >> ${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/<< parameters.repo >>:git-branch-${CIRCLE_BRANCH[0,100]//+([^A-Za-z0-9-.])/-}
-            docker push ${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/<< parameters.repo >>:git-branch-${CIRCLE_BRANCH[0,100]//+([^A-Za-z0-9-.])/-}
+            docker tag << parameters.image_name >>:<< parameters.tag >> ${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/<< parameters.repo >>:git-branch-${SHORTENED_BRANCH//+([^A-Za-z0-9-.])/-}
+            docker push ${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/<< parameters.repo >>:git-branch-${SHORTENED_BRANCH//+([^A-Za-z0-9-.])/-}
       - run:
           name: 'Record ECR Image Digest'
           command: |


### PR DESCRIPTION
## This issue came up while I was on call, in reference to [this thread in slack](https://ustcdp3.slack.com/archives/CP4U2NKRT/p1666985510127409).

## Summary

Docker tag names can be a maximum of 128 characters. [See docs here.](https://docs.docker.com/engine/reference/commandline/tag/) However, Github branch names can be longer than that. We are using the branch name to create our tags and, as you can see in the slack thread, an error will be thrown when the tag name is too long. Another compounding issue is that we have a process where we can create branches using JIRA, which uses the ticket titles to create the name. These have a tendency to create longer branch names.

This change truncates the branch name to a maximum of 100 characters, allowing for up to 28 characters of prefix text. Currently, we are using 11 characters (`git-branch-`).

## Setup to Run Your Code

The code is changing the config.yaml file for the CircleCI deployments. I made the branch name super long to test it. You can check the CircleCI workflow for this PR to verify that the push_app_gov_dev and push_task_gov_dev pass. You can rerun to verify this as well. Also you can check our AWS ECR for the tag names that get created and verify that the tag name is cut off at the appropriate spot. You can see it in the screen shot below.


## Screenshots


![image](https://user-images.githubusercontent.com/110134470/199325067-eb96b0b1-c23a-4a8c-bb29-626130764825.png)
