### PR TITLE
MB-14390 Delete Report Bug

### DIFF
--- a/migrations/app/migrations_manifest.txt
+++ b/migrations/app/migrations_manifest.txt
@@ -765,3 +765,4 @@
 20221020162508_rename_pro_gear_weight_document_columns.up.sql
 20221020202612_create-and-modify-move-history-triggers-for-multiple-tables.up.sql
 20221021145115_ppm_closeout_status.up.sql
+20221028220508_remove_deleted_at_column_from_evaluation_reports.up.sql

--- a/migrations/app/schema/20221028220508_remove_deleted_at_column_from_evaluation_reports.up.sql
+++ b/migrations/app/schema/20221028220508_remove_deleted_at_column_from_evaluation_reports.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE evaluation_reports DROP COLUMN IF EXISTS deleted_at;

--- a/pkg/gen/ghcapi/embedded_spec.go
+++ b/pkg/gen/ghcapi/embedded_spec.go
@@ -508,18 +508,18 @@ func init() {
         ]
       },
       "delete": {
-        "description": "Soft deletes an evaluation report by ID",
+        "description": "Deletes an evaluation report by ID",
         "produces": [
           "application/json"
         ],
         "tags": [
           "evaluationReports"
         ],
-        "summary": "Soft deletes an evaluation report by ID",
+        "summary": "Deletes an evaluation report by ID",
         "operationId": "deleteEvaluationReport",
         "responses": {
           "204": {
-            "description": "Successfully soft deleted the report"
+            "description": "Successfully deleted the report"
           },
           "400": {
             "$ref": "#/responses/InvalidRequest"
@@ -9520,18 +9520,18 @@ func init() {
         ]
       },
       "delete": {
-        "description": "Soft deletes an evaluation report by ID",
+        "description": "Deletes an evaluation report by ID",
         "produces": [
           "application/json"
         ],
         "tags": [
           "evaluationReports"
         ],
-        "summary": "Soft deletes an evaluation report by ID",
+        "summary": "Deletes an evaluation report by ID",
         "operationId": "deleteEvaluationReport",
         "responses": {
           "204": {
-            "description": "Successfully soft deleted the report"
+            "description": "Successfully deleted the report"
           },
           "400": {
             "description": "The request payload is invalid",

--- a/pkg/gen/ghcapi/ghcoperations/evaluation_reports/delete_evaluation_report.go
+++ b/pkg/gen/ghcapi/ghcoperations/evaluation_reports/delete_evaluation_report.go
@@ -32,9 +32,9 @@ func NewDeleteEvaluationReport(ctx *middleware.Context, handler DeleteEvaluation
 /*
 	DeleteEvaluationReport swagger:route DELETE /evaluation-reports/{reportID} evaluationReports deleteEvaluationReport
 
-# Soft deletes an evaluation report by ID
+# Deletes an evaluation report by ID
 
-Soft deletes an evaluation report by ID
+Deletes an evaluation report by ID
 */
 type DeleteEvaluationReport struct {
 	Context *middleware.Context

--- a/pkg/gen/ghcapi/ghcoperations/evaluation_reports/delete_evaluation_report_responses.go
+++ b/pkg/gen/ghcapi/ghcoperations/evaluation_reports/delete_evaluation_report_responses.go
@@ -17,7 +17,7 @@ import (
 const DeleteEvaluationReportNoContentCode int = 204
 
 /*
-DeleteEvaluationReportNoContent Successfully soft deleted the report
+DeleteEvaluationReportNoContent Successfully deleted the report
 
 swagger:response deleteEvaluationReportNoContent
 */

--- a/pkg/models/evaluation_report.go
+++ b/pkg/models/evaluation_report.go
@@ -58,7 +58,6 @@ type EvaluationReport struct {
 	ObservedPickupSpreadEndDate   *time.Time                      `json:"observed_pickup_spread_end_date" db:"observed_pickup_spread_end_date"`
 	ObservedDeliveryDate          *time.Time                      `json:"observed_delivery_date" db:"observed_delivery_date"`
 	SubmittedAt                   *time.Time                      `json:"submitted_at" db:"submitted_at"`
-	DeletedAt                     *time.Time                      `db:"deleted_at"`
 	CreatedAt                     time.Time                       `json:"created_at" db:"created_at"`
 	UpdatedAt                     time.Time                       `json:"updated_at" db:"updated_at"`
 	ReportViolations              ReportViolations                `json:"report_violation,omitempty" fk_id:"report_id" has_many:"report_violation"`

--- a/pkg/services/evaluation_report/evaluation_report_creator_test.go
+++ b/pkg/services/evaluation_report/evaluation_report_creator_test.go
@@ -29,7 +29,6 @@ func (suite *EvaluationReportSuite) TestEvaluationReportCreator() {
 		suite.NotNil(createdEvaluationReport.ShipmentID)
 		suite.NotNil(createdEvaluationReport.CreatedAt)
 		suite.NotNil(createdEvaluationReport.UpdatedAt)
-		suite.Nil(createdEvaluationReport.DeletedAt)
 		suite.Nil(createdEvaluationReport.SubmittedAt)
 	})
 

--- a/pkg/services/evaluation_report/evaluation_report_deleter.go
+++ b/pkg/services/evaluation_report/evaluation_report_deleter.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/transcom/mymove/pkg/appcontext"
 	"github.com/transcom/mymove/pkg/apperror"
-	"github.com/transcom/mymove/pkg/db/utilities"
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/services"
 )
@@ -22,7 +21,7 @@ func NewEvaluationReportDeleter() services.EvaluationReportDeleter {
 
 func (o evaluationReportDeleter) DeleteEvaluationReport(appCtx appcontext.AppContext, reportID uuid.UUID) error {
 	var report models.EvaluationReport
-	err := appCtx.DB().Scope(utilities.ExcludeDeletedScope()).Find(&report, reportID)
+	err := appCtx.DB().Find(&report, reportID)
 	if err != nil {
 		switch err {
 		case sql.ErrNoRows:
@@ -41,14 +40,20 @@ func (o evaluationReportDeleter) DeleteEvaluationReport(appCtx appcontext.AppCon
 	}
 
 	transactionError := appCtx.NewTransaction(func(txnAppCtx appcontext.AppContext) error {
-		err := utilities.SoftDestroy(appCtx.DB(), &report)
+		// Delete existing report_violations for this report
+		existingReportViolations := models.ReportViolations{}
+		err := appCtx.DB().Where("report_id in (?)", reportID).All(&existingReportViolations)
 		if err != nil {
-			switch err.Error() {
-			case "error updating model":
-				return apperror.NewUnprocessableEntityError("while updating model")
-			default:
-				return apperror.NewInternalServerError("failed attempt to soft delete model")
-			}
+			return apperror.NewQueryError("EvaluationReport", err, "Unable to find existing report violations to remove")
+		}
+		err = appCtx.DB().Destroy(&existingReportViolations)
+		if err != nil {
+			return apperror.NewQueryError("EvaluationReport", err, "failed to delete existing report violations")
+		}
+
+		err = appCtx.DB().Destroy(&report)
+		if err != nil {
+			return apperror.NewQueryError("EvaluationReport", err, "failed to delete report")
 		}
 		return nil
 	})

--- a/pkg/services/evaluation_report/evaluation_report_deleter_test.go
+++ b/pkg/services/evaluation_report/evaluation_report_deleter_test.go
@@ -37,8 +37,8 @@ func (suite *EvaluationReportSuite) TestEvaluationReportDeleter() {
 		suite.NoError(deleter.DeleteEvaluationReport(appCtx, report.ID))
 		var dbReport models.EvaluationReport
 		err := suite.DB().Find(&dbReport, report.ID)
-		suite.NoError(err)
-		suite.NotNil(dbReport.DeletedAt)
+		suite.Error(err)
+		suite.IsType(apperror.NotFoundError{}, err)
 	})
 
 	suite.Run("Returns an error when delete non-existent report", func() {
@@ -49,19 +49,5 @@ func (suite *EvaluationReportSuite) TestEvaluationReportDeleter() {
 		suite.Error(err)
 		suite.IsType(apperror.NotFoundError{}, err)
 
-	})
-
-	suite.Run("Returns an error when attempting to delete an already deleted report", func() {
-		deleter, report, appCtx := setupTestData()
-
-		suite.NoError(deleter.DeleteEvaluationReport(appCtx, report.ID))
-		var dbReport models.EvaluationReport
-		err := suite.DB().Find(&dbReport, report.ID)
-		suite.NoError(err)
-		suite.NotNil(dbReport.DeletedAt)
-
-		err = deleter.DeleteEvaluationReport(appCtx, report.ID)
-		suite.Error(err)
-		suite.IsType(apperror.NotFoundError{}, err)
 	})
 }

--- a/pkg/services/evaluation_report/evaluation_report_deleter_test.go
+++ b/pkg/services/evaluation_report/evaluation_report_deleter_test.go
@@ -1,6 +1,8 @@
 package evaluationreport
 
 import (
+	"database/sql"
+
 	"github.com/gofrs/uuid"
 
 	"github.com/transcom/mymove/pkg/appcontext"
@@ -40,7 +42,7 @@ func (suite *EvaluationReportSuite) TestEvaluationReportDeleter() {
 		var dbReport models.EvaluationReport
 		err := suite.DB().Find(&dbReport, report.ID)
 		suite.Error(err)
-		suite.Equal(err.Error(), "sql: no rows in result set")
+		suite.Equal(sql.ErrNoRows, err)
 	})
 
 	suite.Run("Returns an error when delete non-existent report", func() {

--- a/pkg/services/evaluation_report/evaluation_report_deleter_test.go
+++ b/pkg/services/evaluation_report/evaluation_report_deleter_test.go
@@ -35,10 +35,12 @@ func (suite *EvaluationReportSuite) TestEvaluationReportDeleter() {
 		deleter, report, appCtx := setupTestData()
 
 		suite.NoError(deleter.DeleteEvaluationReport(appCtx, report.ID))
+
+		// Should not be able to find the deleted report
 		var dbReport models.EvaluationReport
 		err := suite.DB().Find(&dbReport, report.ID)
 		suite.Error(err)
-		suite.IsType(apperror.NotFoundError{}, err)
+		suite.Equal(err.Error(), "sql: no rows in result set")
 	})
 
 	suite.Run("Returns an error when delete non-existent report", func() {

--- a/pkg/services/evaluation_report/evaluation_report_fetcher.go
+++ b/pkg/services/evaluation_report/evaluation_report_fetcher.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/transcom/mymove/pkg/appcontext"
 	"github.com/transcom/mymove/pkg/apperror"
-	"github.com/transcom/mymove/pkg/db/utilities"
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/services"
 )
@@ -28,7 +27,6 @@ func (f *evaluationReportFetcher) FetchEvaluationReports(appCtx appcontext.AppCo
 	}
 
 	err := appCtx.DB().
-		Scope(utilities.ExcludeDeletedScope()).
 		EagerPreload("Move", "OfficeUser", "ReportViolations", "ReportViolations.Violation").
 		Where("move_id = ?", moveID).
 		Where("type = ?", reportType).
@@ -44,8 +42,8 @@ func (f *evaluationReportFetcher) FetchEvaluationReports(appCtx appcontext.AppCo
 
 func (f *evaluationReportFetcher) FetchEvaluationReportByID(appCtx appcontext.AppContext, reportID uuid.UUID, officeUserID uuid.UUID) (*models.EvaluationReport, error) {
 	var report models.EvaluationReport
-	// Get the report by its ID, but don't return it if it's been soft-deleted.
-	err := appCtx.DB().Scope(utilities.ExcludeDeletedScope()).EagerPreload("Move", "OfficeUser").Find(&report, reportID)
+	// Get the report by its ID
+	err := appCtx.DB().EagerPreload("Move", "OfficeUser").Find(&report, reportID)
 	if err != nil {
 		switch err {
 		case sql.ErrNoRows:

--- a/pkg/services/evaluation_report/evaluation_report_fetcher_test.go
+++ b/pkg/services/evaluation_report/evaluation_report_fetcher_test.go
@@ -84,29 +84,6 @@ func (suite *EvaluationReportSuite) TestFetchEvaluationReportList() {
 		suite.NoError(err)
 		suite.Empty(reports)
 	})
-	suite.Run("deleted reports should not be included", func() {
-		fetcher := NewEvaluationReportFetcher()
-		move := testdatagen.MakeDefaultMove(suite.DB())
-		officeUser := testdatagen.MakeOfficeUser(suite.DB(), testdatagen.Assertions{})
-		testdatagen.MakeEvaluationReport(suite.DB(), testdatagen.Assertions{
-			EvaluationReport: models.EvaluationReport{
-				MoveID:       move.ID,
-				OfficeUserID: officeUser.ID,
-				DeletedAt:    swag.Time(time.Now()),
-			},
-		})
-		testdatagen.MakeEvaluationReport(suite.DB(), testdatagen.Assertions{
-			EvaluationReport: models.EvaluationReport{
-				MoveID:       move.ID,
-				OfficeUserID: officeUser.ID,
-				SubmittedAt:  swag.Time(time.Now()),
-				DeletedAt:    swag.Time(time.Now()),
-			},
-		})
-		reports, err := fetcher.FetchEvaluationReports(suite.AppContextForTest(), models.EvaluationReportTypeCounseling, move.ID, officeUser.ID)
-		suite.NoError(err)
-		suite.Empty(reports)
-	})
 	suite.Run("fetch counseling reports should only return counseling reports", func() {
 		fetcher := NewEvaluationReportFetcher()
 		move := testdatagen.MakeDefaultMove(suite.DB())

--- a/pkg/services/evaluation_report/evaluation_report_updater.go
+++ b/pkg/services/evaluation_report/evaluation_report_updater.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/transcom/mymove/pkg/appcontext"
 	"github.com/transcom/mymove/pkg/apperror"
-	"github.com/transcom/mymove/pkg/db/utilities"
 	"github.com/transcom/mymove/pkg/etag"
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/services"
@@ -26,7 +25,7 @@ func NewEvaluationReportUpdater() services.EvaluationReportUpdater {
 
 func (u evaluationReportUpdater) UpdateEvaluationReport(appCtx appcontext.AppContext, evaluationReport *models.EvaluationReport, officeUserID uuid.UUID, eTag string) error {
 	var originalReport models.EvaluationReport
-	err := appCtx.DB().Scope(utilities.ExcludeDeletedScope()).Find(&originalReport, evaluationReport.ID)
+	err := appCtx.DB().Find(&originalReport, evaluationReport.ID)
 	if err != nil {
 		switch err {
 		case sql.ErrNoRows:
@@ -57,20 +56,20 @@ func (u evaluationReportUpdater) UpdateEvaluationReport(appCtx appcontext.AppCon
 		existingReportViolations := models.ReportViolations{}
 		err = appCtx.DB().Where("report_id = ?", evaluationReport.ID).All(&existingReportViolations)
 		if err != nil {
-			return err
+			return apperror.NewQueryError("EvaluationReport", err, "Unable to find existing report violations")
 		}
 		// Delete the existing reportViolations
 		if len(existingReportViolations) > 0 {
 			err = appCtx.DB().Destroy(existingReportViolations)
 			if err != nil {
-				return err
+				return apperror.NewQueryError("EvaluationReport", err, "failed to delete existing report violations")
 			}
 		}
 	}
 
 	verrs, err := appCtx.DB().ValidateAndSave(evaluationReport)
 	if err != nil {
-		return err
+		return apperror.NewQueryError("EvaluationReport", err, "failed to save the evaluation report")
 	}
 	if verrs.HasAny() {
 		return apperror.NewInvalidInputError(evaluationReport.ID, err, verrs, "")
@@ -82,7 +81,7 @@ func (u evaluationReportUpdater) UpdateEvaluationReport(appCtx appcontext.AppCon
 // sharing with others.
 func (u evaluationReportUpdater) SubmitEvaluationReport(appCtx appcontext.AppContext, evaluationReportID uuid.UUID, officeUserID uuid.UUID, eTag string) error {
 	var originalReport models.EvaluationReport
-	err := appCtx.DB().Scope(utilities.ExcludeDeletedScope()).Find(&originalReport, evaluationReportID)
+	err := appCtx.DB().Find(&originalReport, evaluationReportID)
 	if err != nil {
 		switch err {
 		case sql.ErrNoRows:

--- a/pkg/services/evaluation_report/evaluation_report_updater_test.go
+++ b/pkg/services/evaluation_report/evaluation_report_updater_test.go
@@ -268,22 +268,6 @@ func (suite EvaluationReportSuite) TestUpdateEvaluationReport() {
 		err := updater.UpdateEvaluationReport(suite.AppContextForTest(), &report, report.OfficeUserID, etag.GenerateEtag(report.UpdatedAt))
 		suite.Error(err)
 	})
-	suite.Run("updating a deleted report should fail", func() {
-		// Create a report
-		originalReport := testdatagen.MakeEvaluationReport(suite.DB(), testdatagen.Assertions{
-			EvaluationReport: models.EvaluationReport{
-				DeletedAt: swag.Time(time.Now()),
-			},
-		})
-
-		report := originalReport
-		report.Remarks = swag.String("spectacular packing job!!")
-
-		// Attempt to update the report
-		err := updater.UpdateEvaluationReport(suite.AppContextForTest(), &report, report.OfficeUserID, etag.GenerateEtag(report.UpdatedAt))
-		suite.Error(err)
-		suite.IsType(apperror.NotFoundError{}, err)
-	})
 	suite.Run("updating a report with a bad ETag should fail", func() {
 		// Create a report
 		originalReport := testdatagen.MakeEvaluationReport(suite.DB(), testdatagen.Assertions{

--- a/swagger-def/ghc.yaml
+++ b/swagger-def/ghc.yaml
@@ -2071,8 +2071,8 @@ paths:
         '500':
           $ref: '#/responses/ServerError'
     delete:
-      summary: Soft deletes an evaluation report by ID
-      description: Soft deletes an evaluation report by ID
+      summary: Deletes an evaluation report by ID
+      description: Deletes an evaluation report by ID
       operationId: deleteEvaluationReport
       x-permissions:
         - delete.evaluationReport
@@ -2082,7 +2082,7 @@ paths:
         - application/json
       responses:
         '204':
-          description: Successfully soft deleted the report
+          description: Successfully deleted the report
         '400':
           $ref: '#/responses/InvalidRequest'
         '403':

--- a/swagger/ghc.yaml
+++ b/swagger/ghc.yaml
@@ -2119,8 +2119,8 @@ paths:
         '500':
           $ref: '#/responses/ServerError'
     delete:
-      summary: Soft deletes an evaluation report by ID
-      description: Soft deletes an evaluation report by ID
+      summary: Deletes an evaluation report by ID
+      description: Deletes an evaluation report by ID
       operationId: deleteEvaluationReport
       x-permissions:
         - delete.evaluationReport
@@ -2130,7 +2130,7 @@ paths:
         - application/json
       responses:
         '204':
-          description: Successfully soft deleted the report
+          description: Successfully deleted the report
         '400':
           $ref: '#/responses/InvalidRequest'
         '403':


### PR DESCRIPTION
## [Jira ticket](https://dp3.atlassian.net/browse/MB-14390) for this change

## Summary

This PR fixes[ a bug](https://dp3.atlassian.net/browse/MB-14390) around deleting evaluation reports. The core of the issue related to using a mix of soft and hard deletion for evaluation reports and report violations (association between a report and a violation). To fix this I changed both to use real/hard deletion as there was no need to retain all states of draft reports. 

## Setup to Run Your Code

<details>
<summary>💻 You will need to use three separate terminals to test this locally.</summary>

##### Terminal 1

Start the Storybook locally.

```sh
make storybook
```

##### Terminal 2

Start the UI locally.

```sh
make client_run
```

##### Terminal 3

Start the Go server locally.

```sh
make server_run
```

</details>

## To Validate
- [ ] Evaluation reports without violations associated can be deleted
- [ ] Evaluation reports with violations associated can be deleted
- [ ] Violations selected or unselected are retained when using the 'save draft' button.

https://user-images.githubusercontent.com/62263329/199317466-12d1809a-9914-4a44-adfa-b1dbb015faf8.mov



## Video
