### PR TITLE
MB-14374 Remove value from ppm_shipment_status enum (NEEDS_CLOSE_OUT)

### DIFF
--- a/migrations/app/migrations_manifest.txt
+++ b/migrations/app/migrations_manifest.txt
@@ -765,3 +765,4 @@
 20221020162508_rename_pro_gear_weight_document_columns.up.sql
 20221020202612_create-and-modify-move-history-triggers-for-multiple-tables.up.sql
 20221021145115_ppm_closeout_status.up.sql
+20221031150502_ppm_closeout_status_remove_needs_close_out.up.sql

--- a/migrations/app/schema/20221031150502_ppm_closeout_status_remove_needs_close_out.up.sql
+++ b/migrations/app/schema/20221031150502_ppm_closeout_status_remove_needs_close_out.up.sql
@@ -1,0 +1,15 @@
+--- rename existing enum
+ALTER TYPE ppm_shipment_status RENAME TO ppm_shipment_status_temp;
+
+-- create a new enum without the value we're looking to remove (NEEDS_CLOSE_OUT)
+CREATE TYPE ppm_shipment_status AS ENUM('DRAFT', 'SUBMITTED', 'WAITING_ON_CUSTOMER', 'NEEDS_ADVANCE_APPROVAL', 'NEEDS_PAYMENT_APPROVAL', 'PAYMENT_APPROVED');
+
+-- Remove references to the old value from the ppm_shipments table (there probably aren't any, but this is for safety)
+UPDATE ppm_shipments set status = 'NEEDS_PAYMENT_APPROVAL' WHERE status = 'NEEDS_CLOSE_OUT';
+
+-- alter the ppm shipments status column to use the new enum
+ALTER TABLE ppm_shipments ALTER COLUMN status TYPE ppm_shipment_status USING status::text::ppm_shipment_status;
+
+-- get rid of the temp type
+DROP TYPE ppm_shipment_status_temp
+

--- a/pkg/models/ppm_shipment.go
+++ b/pkg/models/ppm_shipment.go
@@ -28,8 +28,6 @@ const (
 	PPMShipmentStatusNeedsPaymentApproval PPMShipmentStatus = "NEEDS_PAYMENT_APPROVAL"
 	// PPMShipmentStatusPaymentApproved captures enum value "PAYMENT_APPROVED"
 	PPMShipmentStatusPaymentApproved PPMShipmentStatus = "PAYMENT_APPROVED"
-	// PPMShipmentStatusNeedsCloseOut captures enum value "NEEDS_CLOSE_OUT"
-	PPMShipmentStatusNeedsCloseOut PPMShipmentStatus = "NEEDS_CLOSE_OUT"
 )
 
 // PPMAdvanceStatus represents the status of an advance that can be approved, edited or rejected by a SC

--- a/pkg/services/mto_shipment/validation_test.go
+++ b/pkg/services/mto_shipment/validation_test.go
@@ -291,7 +291,6 @@ func (suite *MTOShipmentServiceSuite) TestDeleteValidations() {
 			models.PPMShipmentStatusNeedsAdvanceApproval: true,
 			models.PPMShipmentStatusNeedsPaymentApproval: true,
 			models.PPMShipmentStatusPaymentApproved:      true,
-			models.PPMShipmentStatusNeedsCloseOut:        true,
 		}
 
 		for status, allowed := range testCases {


### PR DESCRIPTION
## [Jira ticket](https://dp3.atlassian.net/browse/MB-14374) for this change

## Summary

This removes the NEEDS_CLOSE_OUT status we added previously for the ppm_shipment_status enum on ppm_shipment. It turned out there were already statuses to handle what we needed.

### Approach

For safety reasons it seemed best to go ahead and go about this the following way:
1. Rename the current thing
2. Create a replacement type
3. Make sure we don't have any of the old values in the DB (we shouldn't but just in case)
4. Apply the new type to the status field on the table
5. Drop the old type

Let me know if there's a different way we should go about it.


## Verification Steps for Author

These are to be checked by the author.

- [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
- [ ] Request review from a member of a different team.
- [ ] Have the Jira acceptance criteria been met for this change?

## Verification Steps for Reviewers

These are to be checked by a reviewer.

<!-- Fill out the next sections as you see fit, these are just suggestions. -->

### Frontend

- [ ] User facing changes have been reviewed by design.
- [ ] There are no aXe warnings for UI.
- [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
- [ ] There are no new console errors in the browser devtools
- [ ] There are no new console errors in the test output
- [ ] If this PR adds a new component to Storybook, it ensures the component is fully responsive, OR if it is intentionally not, a wrapping div using the `officeApp` class or custom `min-width` styling is used to hide any states the would not be visible to the user.

### Backend

- [ ] Code follows the guidelines for [Logging](https://transcom.github.io/mymove-docs/docs/dev/contributing/backend/Backend-Programming-Guide#logging)
- [ ] The requirements listed in [Querying the Database Safely](https://transcom.github.io/mymove-docs/docs/dev/contributing/backend/Backend-Programming-Guide/#querying-the-database-safely) have been satisfied.

### Database

#### Any new migrations/schema changes:

- [ ] Follows our guidelines for [Zero-Downtime Deploys](https://transcom.github.io/mymove-docs/docs/dev/contributing/database/Database-Migrations#zero-downtime-migrations)
- [ ] Have been communicated to #g-database
- [ ] Secure migrations have been tested following the instructions in our [docs](https://transcom.github.io/mymove-docs/docs/dev/contributing/database/Database-Migrations#secure-migrations)

## Screenshots
