### PR TITLE
MB-14448 Fix flaky QAE cypress tests

### DIFF
--- a/cypress/integration/office/qaecsr/qaeFlows.js
+++ b/cypress/integration/office/qaecsr/qaeFlows.js
@@ -76,7 +76,7 @@ const submitReportFromPreview = () => {
     .should(($el) => {
       expect(Cypress.dom.isDetached($el)).to.eq(false);
     })
-    .click();
+    .click({ force: true });
 
   // Wait for the submit
   cy.wait(['@submitEvaluationReport']);

--- a/cypress/integration/office/qaecsr/qaeFlows.js
+++ b/cypress/integration/office/qaecsr/qaeFlows.js
@@ -267,7 +267,7 @@ describe('Quality Evaluation Report', () => {
     });
 
     // Create new report, fill out all conditional fields on 1st page fields, on second page select correct violations to display/fill out date fields, serious violations = true, submit
-    it('can complete an evaluation report with all field populated, including conditionally displayed fields', () => {
+    it('can complete an evaluation report with all fields populated, including conditionally displayed fields', () => {
       // Create a new shipment report
       createShipmentReport();
 

--- a/cypress/integration/office/qaecsr/qaeFlows.js
+++ b/cypress/integration/office/qaecsr/qaeFlows.js
@@ -71,8 +71,12 @@ const openSubmissionPreview = (isViolationsPage) => {
 };
 
 const submitReportFromPreview = () => {
-  // Click submit button in the modal
-  cy.get('[data-testid="modalSubmitButton"]').click();
+  // Click submit button in the modal (waits for button to be attached to DOM before clicking)
+  cy.get('[data-testid="modalSubmitButton"]')
+    .should(($el) => {
+      expect(Cypress.dom.isDetached($el)).to.eq(false);
+    })
+    .click();
 
   // Wait for the submit
   cy.wait(['@submitEvaluationReport']);


### PR DESCRIPTION
## [Jira ticket](https://dp3.atlassian.net/browse/MB-14448) for this change

## Summary

This PR fixes a flaky click in a QAE cypress tests. The button click causing flakiness is the submit button in the QAE eval report submit preview model. Sometimes, due to the timing of a re-rending (I think),  the submit button would get clicked while not attached to the DOM. I was able to fix by adding a 'guard' to the click call. The guard has cypress wait until the submit button is attached to the DOM before clicking. This seems to have resolved the test flakiness both locally and in circle but we will of course want to keep an eye on it after merging to make sure it does not continue to be flaky. 

##  To validate

This PR only touches cypress files, no application code. To validate, please run the cypress tests and ensure that they all pass (especially the `qaeFlows.js` file). 
