### PR TITLE
MB-14373 Testing after removing v6 and keep 7.8.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,6 @@
     "react-router-tabs": "^1.1.1",
     "react-select": "^5.6.0",
     "react-table": "^7.8.0",
-    "react-table-6": "^6.11.0",
     "react-tabs": "^4.2.1",
     "reduce-reducers": "^1.0.4",
     "redux": "^4.2.0",

--- a/src/scenes/Office/QueueTable.jsx
+++ b/src/scenes/Office/QueueTable.jsx
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import { withRouter } from 'react-router';
-import ReactTable from 'react-table-6';
+import ReactTable from 'react-table';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import { get } from 'lodash';
@@ -11,7 +11,6 @@ import { SHIPMENT_OPTIONS } from 'shared/constants';
 import { defaultColumns } from './queueTableColumns';
 
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import 'react-table-6/react-table.css';
 
 class QueueTable extends Component {
   constructor() {

--- a/src/scenes/Office/QueueTable.test.js
+++ b/src/scenes/Office/QueueTable.test.js
@@ -6,7 +6,7 @@ import configureMockStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
 
 import QueueTable from './QueueTable';
-import ReactTable from 'react-table-6';
+import ReactTable from 'react-table';
 import store from 'shared/store';
 import { mount } from 'enzyme/build';
 import { SHIPMENT_OPTIONS } from 'shared/constants';

--- a/yarn.lock
+++ b/yarn.lock
@@ -7711,7 +7711,7 @@ classlist-polyfill@1.0.3:
   resolved "https://registry.yarnpkg.com/classlist-polyfill/-/classlist-polyfill-1.0.3.tgz#7cd5a9207c8d6932f592fdeaa6b45352ed71690d"
   integrity sha512-bDLDUsSg5LYFWsc2hphtG6ulyaCFSupdEBU3wxNECKWHnyPVvY8EB9Wbt9DzWkstWclFZhDaZK/VnEK/DmqE/Q==
 
-classnames@^2.2.3, classnames@^2.2.5, classnames@^2.3.2, classnames@~2.3.1:
+classnames@^2.2.3, classnames@^2.3.2, classnames@~2.3.1:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.3.2.tgz#351d813bf0137fcc6a76a16b88208d2560a0d924"
   integrity sha512-CSbhY4cFEJRe6/GQzIk5qXZ4Jeg5pcsP7b5peFSDpffpe1cqjASH/n9UTjBwOp6XpMSTwQ8Za2K5V02ueA7Tmw==
@@ -17826,13 +17826,6 @@ react-sizeme@^3.0.1:
     invariant "^2.2.4"
     shallowequal "^1.1.0"
     throttle-debounce "^3.0.1"
-
-react-table-6@^6.11.0:
-  version "6.11.0"
-  resolved "https://registry.yarnpkg.com/react-table-6/-/react-table-6-6.11.0.tgz#727de5d9f0357a35816a1bbc2e9c9868f8c5b2c4"
-  integrity sha512-zO24J+1Qg2AHxtSNMfHeGW1dxFcmLJQrAeLJyCAENdNdwJt+YolDDtJEBdZlukon7rZeAdB3d5gUH6eb9Dn5Ug==
-  dependencies:
-    classnames "^2.2.5"
 
 react-table@^7.8.0:
   version "7.8.0"


### PR DESCRIPTION
## [Jira ticket](https://dp3.atlassian.net/browse/MB-14373) for this change

## Summary

I read through everything I saw on this, including MB 1989 and all of the discussion (from those comments and in slack). It was reported a while back that upgrading to v7 would likely result in filtering problems. When I remove 6, I didn't notice this and these queues function fine on version 7.8.0  First video is with 6/current, second is just 7. 

I do see there are some test fails that we'll need to do a ticket for to resolve these. (ex. `renderedRoute` is now empty, many tests failing due to invalid element type). So 7 does seem to change things like this, but it's not seeming to change functionality of filters in table queues.

Also on a separate topic: I tried different ways to test case sensitivity in general, and partial matches as TTV was discussing this in a recent planning. You can see some of that in the videos, in case it's helpful for future filtering refinement.

## Setup to Run Your Code

<details>
<summary>💻 You will need to use three separate terminals to test this locally.</summary>

##### Terminal 1

Start the Storybook locally.

```sh
make storybook
```

##### Terminal 2

Start the UI locally.

```sh
make client_run
```

##### Terminal 3

Start the Go server locally.

```sh
make server_run
```

</details>

### Additional steps

1. Test thoroughly first with the current setup (with versions 6 7) so you know what the expected functionality is.
2. Test this branch with v6 removed. Login as a TIo/TOO/SC so that you can test as each to be certain (videos are just as 
    SC, but tested in all to be safe and I can provide more videos if desired).
3. Try all different ways to test these queues, all table functionality. 
       Ex. Filters with on blur and enter, test both; test with things you know will result and those that won't; Multiple 
       selections, pagination functionality, etc, etc.
4. Note any differences

## Verification Steps for Author

These are to be checked by the author.

- [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
- [ ] Request review from a member of a different team.
- [ ] Have the Jira acceptance criteria been met for this change?

## Verification Steps for Reviewers

These are to be checked by a reviewer.

<!-- Fill out the next sections as you see fit, these are just suggestions. -->

### Frontend

- [ ] User facing changes have been reviewed by design.
- [ ] There are no aXe warnings for UI.
- [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
- [ ] There are no new console errors in the browser devtools
- [ ] There are no new console errors in the test output
- [ ] If this PR adds a new component to Storybook, it ensures the component is fully responsive, OR if it is intentionally not, a wrapping div using the `officeApp` class or custom `min-width` styling is used to hide any states the would not be visible to the user.

### Backend

- [ ] Code follows the guidelines for [Logging](https://transcom.github.io/mymove-docs/docs/dev/contributing/backend/Backend-Programming-Guide#logging)
- [ ] The requirements listed in [Querying the Database Safely](https://transcom.github.io/mymove-docs/docs/dev/contributing/backend/Backend-Programming-Guide/#querying-the-database-safely) have been satisfied.

### Database

#### Any new migrations/schema changes:

- [ ] Follows our guidelines for [Zero-Downtime Deploys](https://transcom.github.io/mymove-docs/docs/dev/contributing/database/Database-Migrations#zero-downtime-migrations)
- [ ] Have been communicated to #g-database
- [ ] Secure migrations have been tested following the instructions in our [docs](https://transcom.github.io/mymove-docs/docs/dev/contributing/database/Database-Migrations#secure-migrations)

## Screenshots

https://user-images.githubusercontent.com/108361430/200017856-7cedb267-c1aa-45c2-918f-0c820d195c82.mov




https://user-images.githubusercontent.com/108361430/200017950-6a79c976-324d-4752-883b-3d5b486ae3d9.mov

