### PR TITLE
Fix ready to merge label since master has been renamed to main

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,13 +1,13 @@
 queue_rules:
   - name: default
     conditions:
-      - "label=ready-to-merge"
+      - 'label=ready-to-merge'
 
 pull_request_rules:
   - name: merge using the merge queue
     conditions:
-      - base=master
-      - "label=ready-to-merge"
+      - base=main
+      - 'label=ready-to-merge'
     actions:
       queue:
         name: default

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,13 +1,13 @@
 queue_rules:
   - name: default
     conditions:
-      - 'label=ready-to-merge'
+      - "label=ready-to-merge"
 
 pull_request_rules:
   - name: merge using the merge queue
     conditions:
       - base=main
-      - 'label=ready-to-merge'
+      - "label=ready-to-merge"
     actions:
       queue:
         name: default


### PR DESCRIPTION
## [Jira ticket](tbd) for this change

## Summary

I noticed that the ready to merge label got broken when the branch got renamed to main. 
Ideally, this should fix the label and I think I should be able to use this PR as a test.