### PR TITLE
MB-13877 factory.BuildUser added as new version of testdatagen.makeUser

### DIFF
--- a/pkg/appcontext-linter/appctx.go
+++ b/pkg/appcontext-linter/appctx.go
@@ -75,6 +75,7 @@ func checkIfPackageCanBeSkipped(packageName string) bool {
 		"testdatagen":  true,
 		"testingsuite": true,
 		"utilities":    true,
+		"factory":      true,
 	}
 
 	return allowedPackages[packageName]

--- a/pkg/db/utilities/utilities_test.go
+++ b/pkg/db/utilities/utilities_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	"github.com/transcom/mymove/pkg/db/utilities"
+	"github.com/transcom/mymove/pkg/factory"
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/services/mocks"
 	"github.com/transcom/mymove/pkg/testdatagen"
@@ -37,7 +38,7 @@ func (suite *UtilitiesSuite) TestSoftDestroy_NotModel() {
 
 func (suite *UtilitiesSuite) TestSoftDestroy_ModelWithoutDeletedAtWithoutAssociations() {
 	//model without deleted_at with no associations
-	user := testdatagen.MakeDefaultUser(suite.DB())
+	user := factory.BuildDefaultUser(suite.DB())
 
 	err := utilities.SoftDestroy(suite.DB(), &user)
 

--- a/pkg/factory/factory_test.go
+++ b/pkg/factory/factory_test.go
@@ -1,0 +1,369 @@
+package factory
+
+import (
+	"testing"
+	"time"
+
+	"github.com/go-openapi/swag"
+	"github.com/gofrs/uuid"
+	"github.com/stretchr/testify/suite"
+
+	"github.com/transcom/mymove/pkg/models"
+	"github.com/transcom/mymove/pkg/testingsuite"
+)
+
+type MakerSuite struct {
+	*testingsuite.PopTestSuite
+}
+
+func TestMakerSuite(t *testing.T) {
+
+	ts := &MakerSuite{
+		PopTestSuite: testingsuite.NewPopTestSuite(testingsuite.CurrentPackage(), testingsuite.WithPerTestTransaction()),
+	}
+	suite.Run(t, ts)
+	ts.PopTestSuite.TearDown()
+}
+
+func (suite *MakerSuite) TestElevateCustomization() {
+
+	suite.Run("Customization converted ", func() {
+
+		customEmail := "leospaceman123@example.com"
+		streetAddress := "235 Prospect Valley Road SE"
+
+		customizationList :=
+			[]Customization{
+				{
+					Model: models.User{LoginGovEmail: customEmail},
+					Type:  User,
+				},
+				{
+					Model: models.Address{StreetAddress1: streetAddress},
+					Type:  Addresses.ResidentialAddress,
+				},
+			}
+		tempCustoms := convertCustomizationInList(customizationList, Addresses.ResidentialAddress, Address)
+		// Nothing wrong with customizations
+		tempCustoms, err := validateCustomizations(tempCustoms)
+		suite.NoError(err)
+		// Customization has new type
+		suite.Equal(Address, tempCustoms[1].Type)
+		// Old customization list is unchanged
+		suite.Equal(Addresses.ResidentialAddress, customizationList[1].Type)
+	})
+}
+
+// getTraitActiveArmy is a custom Trait
+func getTraitActiveArmy() []Customization {
+	army := models.AffiliationARMY
+	return []Customization{
+		{
+			Model: models.User{
+				LoginGovEmail:         "trait@army.mil",
+				CurrentAdminSessionID: "my-session-id",
+			},
+			Type: User,
+		},
+		{
+			Model: models.ServiceMember{
+				Affiliation: &army,
+			},
+			Type: ServiceMember,
+		},
+	}
+}
+
+func (suite *MakerSuite) TestMergeCustomization() {
+
+	suite.Run("Customizations and traits merged into result", func() {
+		// Under test:       mergeCustomization, which merges traits and customizations
+		// Set up:           Create a customization without a matching trait, and traits with no customizations
+		// Expected outcome: All should exist in the result list
+		streetAddress := "235 Prospect Valley Road SE"
+		result := mergeCustomization(
+			// Address customization
+			[]Customization{
+				{
+					Model: models.Address{
+						StreetAddress1: streetAddress,
+					},
+					Type: Address,
+				},
+			},
+			// User and ServiceMember customization
+			[]Trait{
+				getTraitActiveArmy,
+			},
+		)
+		suite.Len(result, 3)
+		_, custom := findCustomWithIdx(result, Address)
+		suite.NotNil(custom)
+		address := custom.Model.(models.Address)
+		suite.Equal(streetAddress, address.StreetAddress1)
+
+		// Check that User customization from trait is available
+		_, custom = findCustomWithIdx(result, User)
+		suite.NotNil(custom)
+		user := custom.Model.(models.User)
+		suite.Equal("trait@army.mil", user.LoginGovEmail)
+		// Check that ServiceMember customization from trait is available
+		_, custom = findCustomWithIdx(result, ServiceMember)
+		suite.NotNil(custom)
+	})
+
+	suite.Run("Customization should override traits", func() {
+		// Under test:       mergeCustomization, which merges traits and customizations
+		// Set up:           Create a customization with a user email and a trait with a user email
+		// Expected outcome: Customization should override the trait email
+		//                   If an object exists and no customization, it should become a customization
+		uuidval := uuid.Must(uuid.NewV4())
+		result := mergeCustomization(
+			[]Customization{
+				{
+					Model: models.User{
+						LoginGovUUID:  &uuidval,
+						LoginGovEmail: "custom@army.mil",
+					},
+					Type: User,
+				},
+			},
+			[]Trait{
+				getTraitActiveArmy,
+			},
+		)
+		userModel := result[0].Model.(models.User)
+		// Customization email should be used
+		suite.Equal("custom@army.mil", userModel.LoginGovEmail)
+		// But other fields could come from trait
+		suite.Equal("my-session-id", userModel.CurrentAdminSessionID)
+
+	})
+
+}
+
+func (suite *MakerSuite) TestMergeInterfaces() {
+	// Under test:       mergeInterfaces, wrapper function for calling mergeModels
+	// Set up:           Create two interface types and call mergeInterfaces
+	// Expected outcome: Underlying model should contain fields from both models.
+	//                   user1 fields should overwrite user2 fields
+	user1 := models.User{
+		LoginGovEmail: "user1@example.com",
+		Active:        true,
+	}
+	uuidNew := uuid.Must(uuid.NewV4())
+	user2 := models.User{
+		LoginGovEmail: "user2@example.com",
+		LoginGovUUID:  &uuidNew,
+	}
+
+	result := mergeInterfaces(user2, user1)
+	user := result.(models.User)
+	// user1 email should overwrite user2 email
+	suite.Equal(user1.LoginGovEmail, user.LoginGovEmail)
+	// All other fields set in interfaces should persist
+	suite.Equal(user1.Active, user.Active)
+	suite.Equal(user2.LoginGovUUID, user.LoginGovUUID)
+}
+
+func (suite *MakerSuite) TestHasID() {
+	suite.Run("True if ID is provided", func() {
+		// Under test:       hasIDs, uses reflection to check if a model has a populated ID
+		// Set up:           Test a model with an id
+		// Expected outcome: True
+		testid := uuid.Must(uuid.NewV4())
+		result := hasID(models.ServiceMember{
+			ID: testid,
+		})
+		suite.True(result)
+	})
+
+	suite.Run("False if no id", func() {
+		// Under test:       hasIDs
+		// Set up:           Test a model with no id
+		// Expected outcome: False
+		result := hasID(models.ServiceMember{})
+		suite.False(result)
+	})
+
+	suite.Run("False if nil id", func() {
+		// Under test:       hasIDs
+		// Set up:           Test a model with a nil id
+		// Expected outcome: False
+		result := hasID(models.ServiceMember{
+			ID: uuid.Nil,
+		})
+		suite.False(result)
+	})
+}
+
+func (suite *MakerSuite) TestNestedModelsCheck() {
+	suite.Run("Must not call with pointer", func() {
+		// Under test:       checkNestedModels, uses reflection to check if other models are nested
+		// Set up:           Call with a pointer, instead of a struct
+		// Expected outcome: Error
+
+		c := Customization{
+			Model: models.ServiceMember{},
+			Type:  ServiceMember,
+		}
+		err := checkNestedModels(&c)
+		suite.Error(err)
+		suite.Contains(err.Error(), "received a pointer")
+	})
+
+	suite.Run("Must not have missing model", func() {
+		// Under test:       checkNestedModels
+		// Set up:           Call with a struct that doesn't contain the main model
+		// Expected outcome: Error
+		c := Customization{
+			Type: ServiceMember,
+		}
+		err := checkNestedModels(c)
+		suite.Error(err)
+		suite.Contains(err.Error(), "must contain a model")
+	})
+
+	suite.Run("Customization contains nested model", func() {
+		// Under test:       checkNestedModels
+		// Set up:           Call with a struct that contains a nested model
+		// Expected outcome: Error
+		user, err := BuildUser(suite.DB(), nil, nil)
+		suite.NoError(err)
+		c := Customization{
+			Model: models.ServiceMember{
+				User: user,
+			},
+			Type: ServiceMember,
+		}
+		err = checkNestedModels(c)
+		suite.Error(err)
+		suite.Contains(err.Error(), "no nested models")
+
+	})
+	suite.Run("Customization contains ptr to nested model", func() {
+		// Under test:       checkNestedModels
+		// Set up:           Call with a struct with nested address
+		// Expected outcome: Error
+		resiAddress := models.Address{
+			StreetAddress1: "142 E Barrel Hoop Circle #4A",
+		}
+		c := Customization{
+			Model: models.ServiceMember{
+				ResidentialAddress: &resiAddress,
+			},
+			Type: ServiceMember,
+		}
+		err := checkNestedModels(c)
+		suite.Error(err)
+		suite.Contains(err.Error(), "no nested models")
+
+	})
+	suite.Run("Customization allows all other fields", func() {
+		// Under test:       checkNestedModels
+		// Set up:           Call with a struct with fields populated but no nested model
+		// Expected outcome: No Error
+		navy := models.AffiliationNAVY
+		testid := uuid.Must(uuid.NewV4())
+		edipi := RandomEdipi()
+		timestamp := time.Now()
+		rank := models.ServiceMemberRankE4
+		name := "Riley Baker"
+		phone := "555-777-9929"
+
+		c := Customization{
+			Model: models.ServiceMember{
+				ID:                     uuid.Must(uuid.NewV4()),
+				CreatedAt:              timestamp,
+				UpdatedAt:              timestamp,
+				UserID:                 testid,
+				Edipi:                  &edipi,
+				Affiliation:            &navy,
+				Rank:                   &rank,
+				FirstName:              &name,
+				MiddleName:             &name,
+				LastName:               &name,
+				Suffix:                 &name,
+				Telephone:              &phone,
+				SecondaryTelephone:     &phone,
+				PersonalEmail:          &name,
+				PhoneIsPreferred:       swag.Bool(true),
+				EmailIsPreferred:       swag.Bool(false),
+				ResidentialAddressID:   &testid,
+				BackupMailingAddressID: &testid,
+				DutyLocationID:         &testid,
+			},
+			Type: ServiceMember,
+		}
+		err := checkNestedModels(c)
+		suite.NoError(err)
+
+	})
+
+}
+
+func (suite *MakerSuite) TestValidateCustomizations() {
+	suite.Run("Control obj added if missing", func() {
+		customs := getTraitActiveArmy()
+		suite.Len(customs, 2)
+
+		customs, err := validateCustomizations(customs)
+		suite.Nil(err)
+		suite.Len(customs, 3)
+		_, controlCustom := findCustomWithIdx(customs, control)
+		suite.NotNil(controlCustom)
+	})
+
+	suite.Run("Control obj not added if not missing", func() {
+		customs := getTraitActiveArmy()
+		customs = append(customs, Customization{
+			Model: controlObject{},
+			Type:  control,
+		})
+		suite.Len(customs, 3)
+
+		customs, err := validateCustomizations(customs)
+		suite.Len(customs, 3)
+		suite.NoError(err)
+		_, controlCustom := findCustomWithIdx(customs, control)
+		suite.NotNil(controlCustom)
+	})
+
+	suite.Run("Pass if customizations not repeated", func() {
+		customs := getTraitActiveArmy()
+		customs = append(customs, Customization{
+			Model: models.Address{},
+			Type:  Addresses.ResidentialAddress,
+		},
+			Customization{
+				Model: models.Address{},
+				Type:  Addresses.PickupAddress,
+			},
+		)
+		suite.Len(customs, 4)
+
+		customs, err := validateCustomizations(customs)
+		suite.Len(customs, 5)
+		suite.NoError(err)
+		_, controlCustom := findCustomWithIdx(customs, control)
+		suite.NotNil(controlCustom)
+	})
+	suite.Run("Error if duplicate customization is used", func() {
+		customs := getTraitActiveArmy()
+		customs = append(customs, Customization{
+			Model: models.User{},
+			Type:  User,
+		})
+		suite.Len(customs, 3)
+
+		customs, err := validateCustomizations(customs)
+		suite.Len(customs, 4) // control object should be added
+		suite.ErrorContains(err, "Found more than one instance")
+
+		// Check that control object was updated
+		_, controlCustom := findCustomWithIdx(customs, control)
+		controller := (*controlCustom).Model.(controlObject)
+		suite.False(controller.isValid)
+	})
+
+}

--- a/pkg/factory/factory_test.go
+++ b/pkg/factory/factory_test.go
@@ -228,15 +228,14 @@ func (suite *MakerSuite) TestNestedModelsCheck() {
 		// Under test:       checkNestedModels
 		// Set up:           Call with a struct that contains a nested model
 		// Expected outcome: Error
-		user, err := BuildUser(suite.DB(), nil, nil)
-		suite.NoError(err)
+		user := BuildUser(suite.DB(), nil, nil)
 		c := Customization{
 			Model: models.ServiceMember{
 				User: user,
 			},
 			Type: &ServiceMember,
 		}
-		err = checkNestedModels(c)
+		err := checkNestedModels(c)
 		suite.Error(err)
 		suite.Contains(err.Error(), "no nested models")
 
@@ -326,30 +325,19 @@ func (suite *MakerSuite) TestDefaultTypes() {
 			suite.NotNil(c.Type)
 		}
 	})
-	suite.Run("Default types unknown", func() {
+	suite.Run("Error if type is unknown", func() {
 		// TESTCASE SCENARIO
-		// Under test:       setDefaultTypes
-		// Set up:           Pass customizations
-		//                   [0] Known model in map
-		//                   [1] Unknown model in map
-		// Expected outcome: Type is nil on unknown model
-		customs := []Customization{
-			{
-				Model: models.Address{
-					StreetAddress1: "string",
-				},
-			},
-			{
-				Model: models.MoveHistory{
-					Locator: "rock",
-				},
+		// Under test:       assignType
+		// Set up:           Create a customization with a type that isn't supported
+		// Expected outcome: Error
+		custom := Customization{
+			Model: models.MoveHistory{
+				Locator: "rock",
 			},
 		}
-		suite.Len(customs, 2)
-		setDefaultTypes(customs)
-
-		suite.NotNil(customs[0].Type)
-		suite.Nil(customs[1].Type)
+		err := assignType(&custom)
+		suite.Error(err)
+		suite.ErrorContains(err, "models.MoveHistory")
 	})
 }
 func (suite *MakerSuite) TestSetupCustomizations() {

--- a/pkg/factory/shared.go
+++ b/pkg/factory/shared.go
@@ -99,7 +99,6 @@ func assignType(custom *Customization) error {
 		return fmt.Errorf("Customization.Model field had type %v - should contain a struct", mv.Kind())
 	}
 	// Get the model type and find the default type
-	fmt.Println("assigning type:", defaultTypesMap[mv.Type().String()])
 	typestring, ok := defaultTypesMap[mv.Type().String()]
 	if ok {
 		custom.Type = &typestring
@@ -158,7 +157,7 @@ func setupCustomizations(customs []Customization, traits []Trait) []Customizatio
 
 }
 
-// uniqueCustomizations
+// uniqueCustomizations ensures there's only one customization per type.
 // Requirement: All customizations should already have a type assigned.
 func uniqueCustomizations(customs []Customization) ([]Customization, error) {
 	// validate that there are no repeat CustomTypes

--- a/pkg/factory/shared.go
+++ b/pkg/factory/shared.go
@@ -155,7 +155,7 @@ func setupCustomizations(customs []Customization, traits []Trait) []Customizatio
 	// Merge customizations with traits
 	customs = mergeCustomization(customs, traits)
 	// Ensure unique customizations
-	customs, err := uniqueCustomizations(customs)
+	err := isUnique(customs)
 	if err != nil {
 		controller.isValid = false
 		log.Panic(err)
@@ -166,9 +166,9 @@ func setupCustomizations(customs []Customization, traits []Trait) []Customizatio
 
 }
 
-// uniqueCustomizations ensures there's only one customization per type.
+// isUnique ensures there's only one customization per type.
 // Requirement: All customizations should already have a type assigned.
-func uniqueCustomizations(customs []Customization) ([]Customization, error) {
+func isUnique(customs []Customization) error {
 	// validate that there are no repeat CustomTypes
 	m := make(map[CustomType]int)
 	for i, custom := range customs {
@@ -178,13 +178,13 @@ func uniqueCustomizations(customs []Customization) ([]Customization, error) {
 		// if custom type already exists
 		idx, exists := m[*custom.Type]
 		if exists {
-			return customs, fmt.Errorf("Found more than one instance of %s Customization at index %d and %d",
+			return fmt.Errorf("Found more than one instance of %s Customization at index %d and %d",
 				*custom.Type, idx, i)
 		}
 		// Add to hashmap
 		m[*custom.Type] = i
 	}
-	return customs, nil
+	return nil
 
 }
 

--- a/pkg/factory/shared.go
+++ b/pkg/factory/shared.go
@@ -1,0 +1,315 @@
+package factory
+
+import (
+	"fmt"
+	"log"
+	"reflect"
+	"strconv"
+	"strings"
+
+	"github.com/gobuffalo/pop/v6"
+
+	"github.com/transcom/mymove/pkg/random"
+	"github.com/transcom/mymove/pkg/testdatagen"
+)
+
+// Customization type is the building block for passing in customizations and traits
+type Customization struct {
+	Model     interface{}
+	Type      CustomType
+	ForceUUID bool
+}
+
+// CustomType is a string that represents what kind of customization it is
+type CustomType string
+
+// Model customizations will each have a "type" here
+// This does not have to match the model type but generally will
+// You can have CustomType like ResidentialAddress to define specifically
+// where this address will get created and nested
+const (
+	control       CustomType = "Control"
+	Address       CustomType = "Address"
+	User          CustomType = "User"
+	ServiceMember CustomType = "ServiceMember"
+)
+
+// Instead of nesting structs, we create specific CustomTypes here to give devs
+// a code-completion friendly way to select the right type
+type AddressesGroup struct {
+	PickupAddress            CustomType
+	DeliveryAddress          CustomType
+	SecondaryDeliveryAddress CustomType
+	ResidentialAddress       CustomType
+}
+
+var Addresses = AddressesGroup{
+	PickupAddress:            "PickupAddress",
+	DeliveryAddress:          "DeliveryAddress",
+	SecondaryDeliveryAddress: "SecondaryDeliveryAddress",
+	ResidentialAddress:       "ResidentialAddress",
+}
+
+type DimensionsGroup struct {
+	CrateDimension CustomType
+	ItemDimension  CustomType
+}
+
+var Dimensions = DimensionsGroup{
+	// MTOServiceItems may include:
+	CrateDimension: "CrateDimension",
+	ItemDimension:  "ItemDimension",
+}
+
+type DutyLocationsGroup struct {
+	OriginDutyLocation CustomType
+	NewDutyLocation    CustomType
+}
+
+var DutyLocations = DutyLocationsGroup{
+	// Orders may include:
+	OriginDutyLocation: "OriginDutyLocation",
+	NewDutyLocation:    "NewDutyLocation",
+}
+
+// Control is a struct used with CustomType Control to
+// set flags on overall behaviour and status of the customizations
+type controlObject struct {
+	isValid bool // has this set of customizations been validated
+	//stub    bool // if stub is false, only in-memory objects are created, not db
+}
+
+// Trait is a function that returns a set of customizations
+// Every Trait should start with GetTrait for discoverability
+type Trait func() []Customization
+
+// validateCustomizations
+func validateCustomizations(customs []Customization) ([]Customization, error) {
+	_, controlCustom := findCustomWithIdx(customs, control)
+
+	// if it does exist, and customization list has been validated already, return
+	if controlCustom != nil {
+		controls := controlCustom.Model.(controlObject)
+		if controls.isValid {
+			return customs, nil
+		}
+	} else {
+		// If control object does not exist, create
+		controlCustom = &Customization{
+			Model: controlObject{},
+			Type:  control,
+		}
+		customs = append(customs, *controlCustom)
+	}
+	controller := (*controlCustom).Model.(controlObject)
+	// validate that there are no repeat model types
+	m := make(map[CustomType]int)
+	for i, custom := range customs {
+		// if custom type already exists
+		idx, exists := m[custom.Type]
+		if exists {
+			controller.isValid = false
+			return customs, fmt.Errorf("Found more than one instance of %s Customization at index %d and %d",
+				custom.Type, idx, i)
+		}
+		// Add to hashmap
+		m[custom.Type] = i
+	}
+	// Store the validation result
+	controller.isValid = true
+	return customs, nil
+
+}
+
+// findCustomWithIdx is a helper function to find a customization of a specific type and its index
+func findCustomWithIdx(customs []Customization, customType CustomType) (int, *Customization) {
+	for i, custom := range customs {
+		if custom.Type == customType {
+			return i, &custom
+		}
+	}
+	return -1, nil
+}
+
+// toStructPtr takes an interface wrapping a struct and
+// returns an interface wrapping a pointer to the struct
+// For e.g. interface{}(models.User) → interface{}(*models.User)
+func toStructPtr(obj interface{}) interface{} {
+	vp := reflect.New(reflect.TypeOf(obj))
+	vp.Elem().Set(reflect.ValueOf(obj))
+	return vp.Interface()
+}
+
+// toInterfacePtr takes an interface wrapping a pointer to a struct and
+// returns an interface wrapping the struct
+// For e.g. interface{}(*models.User) → interface{}(models.User)
+func toInterfacePtr(obj interface{}) interface{} {
+	rv := reflect.ValueOf(obj).Elem()
+	return rv.Interface()
+}
+
+// mergeInterfaces transforms the interfaces to match what mergeModels expects
+func mergeInterfaces(model1 interface{}, model2 interface{}) interface{} {
+	// This wrapper function is needed because merge models expects the first
+	// model to be an interface containing a pointer to struct.
+	// This function converts
+	//    an interface containing the struct
+	//    → an interface containing a pointer to the struct
+	modelPtr := toStructPtr(model1)
+	testdatagen.MergeModels(modelPtr, model2)
+	model := toInterfacePtr(modelPtr)
+	return model
+}
+
+func hasID(model interface{}) bool {
+	mv := reflect.ValueOf(model)
+
+	// mv should be a model of type struct
+	if mv.Kind() != reflect.Struct || !strings.HasPrefix(mv.Type().String(), "models.") {
+		log.Panic("Expecting interface containing a model")
+	}
+
+	return !mv.FieldByName("ID").IsZero()
+}
+
+// mergeCustomization takes the original set of customizations
+// and merges with the traits.
+// The order of application is
+//   - Earlier traits override later traits in the trait list
+//   - Customizations override the traits
+//
+// So if you have [trait1, trait2] customization
+// and all three contain the same object:
+//   - trait 1 will override trait 2 (so start with the highest priority)
+//   - customization will override trait 2
+func mergeCustomization(customs []Customization, traits []Trait) []Customization {
+	// Get a list of traits, each could return a list of customizations
+	for _, trait := range traits {
+		traitCustomizations := trait()
+
+		// for each trait custom, merge or replace the one in user supplied customizations
+		for _, traitCustom := range traitCustomizations {
+			j, callerCustom := findCustomWithIdx(customs, traitCustom.Type)
+			if callerCustom != nil {
+				// If a customization has an ID, it means we use that precreated object
+				// Therefore we can't merge a trait with it, as those fields will not get
+				// updated.
+				if !hasID(callerCustom.Model) {
+					result := mergeInterfaces(traitCustom.Model, callerCustom.Model)
+					callerCustom.Model = result
+					customs[j] = *callerCustom
+				}
+			} else {
+				customs = append(customs, traitCustom)
+			}
+		}
+	}
+	return customs
+}
+
+// Helper function for when you need to elevate the type of customization from say
+// ResidentialAddress to Address before you call makeAddress
+// This is a little finicky because we want to be careful not to harm the existing list
+func convertCustomizationInList(customs []Customization, from CustomType, to CustomType) []Customization {
+	if _, custom := findCustomWithIdx(customs, to); custom != nil {
+		log.Panic(fmt.Errorf("A customization of type %s already exists", to))
+	}
+	if idx, custom := findCustomWithIdx(customs, from); custom != nil {
+		// Create a slice in new memory
+		var newCustoms []Customization
+		// Populate with copies of objects
+		newCustoms = append(newCustoms, customs...)
+		// Update the type
+		newCustoms[idx].Type = to
+		return newCustoms
+	}
+	log.Panic(fmt.Errorf("No customization of type %s found", from))
+	return nil
+}
+
+func findValidCustomization(customs []Customization, customType CustomType) *Customization {
+	_, custom := findCustomWithIdx(customs, customType)
+	if custom == nil {
+		return nil
+	}
+
+	// Else check that the customization is valid
+	if err := checkNestedModels(*custom); err != nil {
+		log.Panic(fmt.Errorf("Errors encountered in customization for %s: %w", custom.Type, err))
+	}
+	return custom
+}
+
+func checkNestedModels(c interface{}) error {
+
+	// c IS THE CUSTOMIZATION, SHOULD NOT BE A POINTER
+	// c SHOULD NOT BE A POINTER
+	if reflect.ValueOf(c).Kind() == reflect.Pointer {
+		return fmt.Errorf("function expects a struct, received a pointer")
+	}
+
+	// mv IS THE MODEL VALUE, SHOULD NOT BE EMPTY
+	mv := reflect.ValueOf(c).FieldByName("Model") // get the interface
+	if mv.IsNil() {
+		return fmt.Errorf("customization must contain a model")
+	}
+	mv = mv.Elem() // get the model from the interface
+
+	// mv SHOULD BE A STRUCT
+	if mv.Kind() == reflect.Struct {
+		numberOfFields := mv.NumField()
+		mt := mv.Type() // get the model type
+
+		// CHECK ALL FIELDS IN THE STRUCT
+		for i := 0; i < numberOfFields; i++ {
+			fieldName := mt.Field(i).Name
+			field := mv.Field(i)
+
+			// There are a couple conditions we want to check for
+			// - If a field is a struct that is a model, it should be empty
+			// - If a field is a pointer to struct, and that struct is a model it should be nil
+
+			// IF A FIELD IS A MODELS STRUCT - SHOULD BE EMPTY
+			ft := field.Type()
+			if field.Kind() == reflect.Struct && strings.HasPrefix(ft.String(), "models.") {
+				if !reflect.DeepEqual(field.Interface(), reflect.Zero(field.Type()).Interface()) {
+					return fmt.Errorf("%s cannot be populated, no nested models allowed", fieldName)
+				}
+			}
+
+			// IF A FIELD IS A POINTER TO A MODELS STRUCT - SHOULD ALSO BE EMPTY
+			if field.Kind() == reflect.Pointer {
+				nf := field.Elem()
+				if !field.IsNil() && nf.Kind() == reflect.Struct && strings.HasPrefix(nf.Type().String(), "models.") {
+					return fmt.Errorf("%s cannot be populated, no nested models allowed", fieldName)
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func mustCreate(db *pop.Connection, model interface{}, stub bool) {
+	if stub {
+		return
+	}
+
+	verrs, err := db.ValidateAndCreate(model)
+	if err != nil {
+		log.Panic(fmt.Errorf("Errors encountered saving %#v: %v", model, err))
+	}
+	if verrs.HasAny() {
+		log.Panic(fmt.Errorf("Validation errors encountered saving %#v: %v", model, verrs))
+	}
+}
+
+// RandomEdipi creates a random Edipi for a service member
+func RandomEdipi() string {
+	low := 1000000000
+	high := 9999999999
+	randInt, err := random.GetRandomIntAddend(low, high)
+	if err != nil {
+		log.Panicf("Failure to generate random Edipi %v", err)
+	}
+	return strconv.Itoa(low + int(randInt))
+}

--- a/pkg/factory/shared.go
+++ b/pkg/factory/shared.go
@@ -128,7 +128,10 @@ func setDefaultTypes(clist []Customization) {
 // setDefaultTypesTraits assigns types to all customizations in the traits
 //func setDefaultTypesTraits()
 
-// setupCustomizations prepares the customizations for the factory
+// setupCustomizations prepares the customizations customs for the factory
+// by applying and merging the traits.
+// customs is a slice that will be modified by setupCustomizations.
+//
 // - Ensures a control object has been created
 // - Assigns default types to all default customizations
 // - Merges customizations and traits

--- a/pkg/factory/shared.go
+++ b/pkg/factory/shared.go
@@ -34,8 +34,9 @@ var ServiceMember CustomType = "ServiceMember"
 
 // defaultTypesMap allows us to assign CustomTypes for most default types
 var defaultTypesMap = map[string]CustomType{
-	"models.Address": Address,
-	"models.User":    User,
+	"models.Address":       Address,
+	"models.User":          User,
+	"models.ServiceMember": ServiceMember,
 }
 
 // Instead of nesting structs, we create specific CustomTypes here to give devs
@@ -124,6 +125,9 @@ func setDefaultTypes(clist []Customization) {
 	}
 }
 
+// setDefaultTypesTraits assigns types to all customizations in the traits
+//func setDefaultTypesTraits()
+
 // setupCustomizations prepares the customizations for the factory
 // - Ensures a control object has been created
 // - Assigns default types to all default customizations
@@ -149,10 +153,7 @@ func setupCustomizations(customs []Customization, traits []Trait) []Customizatio
 	}
 
 	// If not valid:
-
-	// Make sure all customs have a proper type
-	setDefaultTypes(customs)
-	// Merge customizations with traits
+	// Merge customizations with traits (also sets default types)
 	customs = mergeCustomization(customs, traits)
 	// Ensure unique customizations
 	err := isUnique(customs)
@@ -252,8 +253,13 @@ func hasID(model interface{}) bool {
 //   - trait 1 will override trait 2 (so start with the highest priority)
 //   - customization will override trait 2
 func mergeCustomization(customs []Customization, traits []Trait) []Customization {
-	// Get a list of traits, each could return a list of customizations
+	// Make sure all customs have a proper type
+	setDefaultTypes(customs)
+
+	// Iterate list of traits, each could return a list of customizations
 	for _, trait := range traits {
+
+		// Get customizations and set default types
 		traitCustomizations := trait()
 		setDefaultTypes(traitCustomizations)
 

--- a/pkg/factory/shared_test.go
+++ b/pkg/factory/shared_test.go
@@ -506,9 +506,7 @@ func (suite *FactorySuite) TestValidateCustomizations() {
 			},
 		)
 		suite.Len(customs, 4)
-
-		customs, err := uniqueCustomizations(customs)
-		suite.Len(customs, 4)
+		err := isUnique(customs)
 		suite.NoError(err)
 	})
 	suite.Run("Error if duplicate customization is used", func() {
@@ -522,9 +520,7 @@ func (suite *FactorySuite) TestValidateCustomizations() {
 			Type:  &User,
 		})
 		suite.Len(customs, 3)
-
-		customs, err := uniqueCustomizations(customs)
-		suite.Len(customs, 3)
+		err := isUnique(customs)
 		suite.ErrorContains(err, "Found more than one instance")
 
 	})
@@ -556,7 +552,7 @@ func (suite *FactorySuite) TestElevateCustomization() {
 		// convert customization type from residentialAddress to Address
 		tempCustoms := convertCustomizationInList(customizationList, Addresses.ResidentialAddress, Address)
 		// Nothing wrong with customizations
-		tempCustoms, err := uniqueCustomizations(tempCustoms)
+		err := isUnique(tempCustoms)
 		suite.NoError(err)
 		// Customization has new type
 		suite.Equal(Address, *tempCustoms[1].Type)

--- a/pkg/factory/traits.go
+++ b/pkg/factory/traits.go
@@ -2,18 +2,6 @@ package factory
 
 import "github.com/transcom/mymove/pkg/models"
 
-// GetTraitActiveUser returns a customization to enable active on a user
-func GetTraitActiveUser() []Customization {
-	return []Customization{
-		{
-			Model: models.User{
-				Active: true,
-			},
-			Type: &User,
-		},
-	}
-}
-
 // GetTraitNavy is a sample GetTraitFunc
 func GetTraitNavy() []Customization {
 	navy := models.AffiliationNAVY

--- a/pkg/factory/traits.go
+++ b/pkg/factory/traits.go
@@ -1,0 +1,41 @@
+package factory
+
+import "github.com/transcom/mymove/pkg/models"
+
+// GetTraitActiveUser returns a customization to enable active on a user
+func GetTraitActiveUser() []Customization {
+	return []Customization{
+		{
+			Model: models.User{
+				Active: true,
+			},
+			Type: User,
+		},
+	}
+}
+
+// GetTraitNavy is a sample GetTraitFunc
+func GetTraitNavy() []Customization {
+	navy := models.AffiliationNAVY
+	return []Customization{
+		{
+			Model: models.ServiceMember{
+				Affiliation: &navy,
+			},
+			Type: ServiceMember,
+		},
+	}
+}
+
+// GetTraitArmy is a sample GetTraitFunc
+func GetTraitArmy() []Customization {
+	army := models.AffiliationARMY
+	return []Customization{
+		{
+			Model: models.ServiceMember{
+				Affiliation: &army,
+			},
+			Type: ServiceMember,
+		},
+	}
+}

--- a/pkg/factory/traits.go
+++ b/pkg/factory/traits.go
@@ -10,7 +10,6 @@ func GetTraitNavy() []Customization {
 			Model: models.ServiceMember{
 				Affiliation: &navy,
 			},
-			Type: &ServiceMember,
 		},
 	}
 }
@@ -23,7 +22,6 @@ func GetTraitArmy() []Customization {
 			Model: models.ServiceMember{
 				Affiliation: &army,
 			},
-			Type: &ServiceMember,
 		},
 	}
 }

--- a/pkg/factory/traits.go
+++ b/pkg/factory/traits.go
@@ -9,7 +9,7 @@ func GetTraitActiveUser() []Customization {
 			Model: models.User{
 				Active: true,
 			},
-			Type: User,
+			Type: &User,
 		},
 	}
 }
@@ -22,7 +22,7 @@ func GetTraitNavy() []Customization {
 			Model: models.ServiceMember{
 				Affiliation: &navy,
 			},
-			Type: ServiceMember,
+			Type: &ServiceMember,
 		},
 	}
 }
@@ -35,7 +35,7 @@ func GetTraitArmy() []Customization {
 			Model: models.ServiceMember{
 				Affiliation: &army,
 			},
-			Type: ServiceMember,
+			Type: &ServiceMember,
 		},
 	}
 }

--- a/pkg/factory/user_factory.go
+++ b/pkg/factory/user_factory.go
@@ -9,8 +9,7 @@ import (
 )
 
 // UserMaker is the base maker function to create a user
-// MYTODO Instead of error (not useful) can we return a list of the created objects?
-func BuildUser(db *pop.Connection, customs []Customization, traits []Trait) (models.User, error) {
+func BuildUser(db *pop.Connection, customs []Customization, traits []Trait) models.User {
 	customs = setupCustomizations(customs, traits)
 
 	// Find user assertion and convert to models user
@@ -31,8 +30,10 @@ func BuildUser(db *pop.Connection, customs []Customization, traits []Trait) (mod
 	// Overwrite values with those from assertions
 	testdatagen.MergeModels(&user, cUser)
 
-	// MYTODO: Add back stub functionality
-	mustCreate(db, &user, false)
+	// If db is false, it's a stub. No need to create in database
+	if db != nil {
+		mustCreate(db, &user)
+	}
 
-	return user, nil
+	return user
 }

--- a/pkg/factory/user_factory.go
+++ b/pkg/factory/user_factory.go
@@ -1,8 +1,6 @@
 package factory
 
 import (
-	"log"
-
 	"github.com/gobuffalo/pop/v6"
 	"github.com/gofrs/uuid"
 
@@ -13,11 +11,7 @@ import (
 // UserMaker is the base maker function to create a user
 // MYTODO Instead of error (not useful) can we return a list of the created objects?
 func BuildUser(db *pop.Connection, customs []Customization, traits []Trait) (models.User, error) {
-	customs = mergeCustomization(customs, traits)
-	customs, err := validateCustomizations(customs)
-	if err != nil {
-		log.Panic(err)
-	}
+	customs = setupCustomizations(customs, traits)
 
 	// Find user assertion and convert to models user
 	var cUser models.User

--- a/pkg/factory/user_factory.go
+++ b/pkg/factory/user_factory.go
@@ -9,6 +9,8 @@ import (
 )
 
 // UserMaker is the base maker function to create a user
+// customs is a slice that will be modified by setupCustomizations.
+// db can be set to nil to create a stubbed model that is not stored in DB.
 func BuildUser(db *pop.Connection, customs []Customization, traits []Trait) models.User {
 	customs = setupCustomizations(customs, traits)
 
@@ -39,6 +41,7 @@ func BuildUser(db *pop.Connection, customs []Customization, traits []Trait) mode
 }
 
 // BuildDefaultUser creates an active user
+// db can be set to nil to create a stubbed model that is not stored in DB.
 func BuildDefaultUser(db *pop.Connection) models.User {
 	return BuildUser(db, nil, []Trait{GetTraitActiveUser})
 }

--- a/pkg/factory/user_factory.go
+++ b/pkg/factory/user_factory.go
@@ -38,6 +38,7 @@ func BuildUser(db *pop.Connection, customs []Customization, traits []Trait) mode
 	return user
 }
 
+// BuildDefaultUser creates an active user
 func BuildDefaultUser(db *pop.Connection) models.User {
 	return BuildUser(db, nil, []Trait{GetTraitActiveUser})
 }

--- a/pkg/factory/user_factory.go
+++ b/pkg/factory/user_factory.go
@@ -37,3 +37,7 @@ func BuildUser(db *pop.Connection, customs []Customization, traits []Trait) mode
 
 	return user
 }
+
+func BuildDefaultUser(db *pop.Connection) models.User {
+	return BuildUser(db, nil, []Trait{GetTraitActiveUser})
+}

--- a/pkg/factory/user_factory.go
+++ b/pkg/factory/user_factory.go
@@ -54,7 +54,6 @@ func GetTraitActiveUser() []Customization {
 			Model: models.User{
 				Active: true,
 			},
-			Type: &User,
 		},
 	}
 }

--- a/pkg/factory/user_factory.go
+++ b/pkg/factory/user_factory.go
@@ -1,0 +1,44 @@
+package factory
+
+import (
+	"log"
+
+	"github.com/gobuffalo/pop/v6"
+	"github.com/gofrs/uuid"
+
+	"github.com/transcom/mymove/pkg/models"
+	"github.com/transcom/mymove/pkg/testdatagen"
+)
+
+// UserMaker is the base maker function to create a user
+// MYTODO Instead of error (not useful) can we return a list of the created objects?
+func BuildUser(db *pop.Connection, customs []Customization, traits []Trait) (models.User, error) {
+	customs = mergeCustomization(customs, traits)
+	customs, err := validateCustomizations(customs)
+	if err != nil {
+		log.Panic(err)
+	}
+
+	// Find user assertion and convert to models user
+	var cUser models.User
+	if result := findValidCustomization(customs, User); result != nil {
+		cUser = result.Model.(models.User)
+	}
+
+	// create user
+	// MYTODO: Add forceUUID functionality
+	loginGovUUID := uuid.Must(uuid.NewV4())
+	user := models.User{
+		LoginGovUUID:  &loginGovUUID,
+		LoginGovEmail: "first.last@login.gov.test",
+		Active:        false,
+	}
+
+	// Overwrite values with those from assertions
+	testdatagen.MergeModels(&user, cUser)
+
+	// MYTODO: Add back stub functionality
+	mustCreate(db, &user, false)
+
+	return user, nil
+}

--- a/pkg/factory/user_factory.go
+++ b/pkg/factory/user_factory.go
@@ -42,3 +42,19 @@ func BuildUser(db *pop.Connection, customs []Customization, traits []Trait) mode
 func BuildDefaultUser(db *pop.Connection) models.User {
 	return BuildUser(db, nil, []Trait{GetTraitActiveUser})
 }
+
+// ------------------------
+//      TRAITS
+// ------------------------
+
+// GetTraitActiveUser returns a customization to enable active on a user
+func GetTraitActiveUser() []Customization {
+	return []Customization{
+		{
+			Model: models.User{
+				Active: true,
+			},
+			Type: &User,
+		},
+	}
+}

--- a/pkg/factory/user_factory_test.go
+++ b/pkg/factory/user_factory_test.go
@@ -4,7 +4,7 @@ import (
 	"github.com/transcom/mymove/pkg/models"
 )
 
-func (suite *MakerSuite) TestUserMaker() {
+func (suite *FactorySuite) TestUserMaker() {
 	defaultEmail := "first.last@login.gov.test"
 	customEmail := "leospaceman123@example.com"
 	suite.Run("Successful creation of default user", func() {

--- a/pkg/factory/user_factory_test.go
+++ b/pkg/factory/user_factory_test.go
@@ -28,7 +28,6 @@ func (suite *MakerSuite) TestUserMaker() {
 				Model: models.User{
 					LoginGovEmail: customEmail,
 				},
-				Type: User,
 			},
 		}, nil)
 		suite.NoError(err)
@@ -61,7 +60,6 @@ func (suite *MakerSuite) TestUserMaker() {
 				Model: models.User{
 					LoginGovEmail: customEmail,
 				},
-				Type: User,
 			}}, []Trait{
 			GetTraitActiveUser,
 		})

--- a/pkg/factory/user_factory_test.go
+++ b/pkg/factory/user_factory_test.go
@@ -1,0 +1,73 @@
+package factory
+
+import (
+	"github.com/transcom/mymove/pkg/models"
+)
+
+func (suite *MakerSuite) TestUserMaker() {
+	defaultEmail := "first.last@login.gov.test"
+	customEmail := "leospaceman123@example.com"
+	suite.Run("Successful creation of default user", func() {
+		// Under test:      UserMaker
+		// Mocked:          None
+		// Set up:          Create a User with no customizations or traits
+		// Expected outcome:User should be created with default values
+
+		user, err := BuildUser(suite.DB(), nil, nil)
+		suite.NoError(err)
+		suite.Equal(defaultEmail, user.LoginGovEmail)
+		suite.False(user.Active)
+	})
+
+	suite.Run("Successful creation of user with customization", func() {
+		// Under test:      UserMaker
+		// Set up:          Create a User with a customized email and no trait
+		// Expected outcome:User should be created with email and inactive status
+		user, err := BuildUser(suite.DB(), []Customization{
+			{
+				Model: models.User{
+					LoginGovEmail: customEmail,
+				},
+				Type: User,
+			},
+		}, nil)
+		suite.NoError(err)
+		suite.Equal(customEmail, user.LoginGovEmail)
+		suite.False(user.Active)
+
+	})
+
+	suite.Run("Successful creation of user with trait", func() {
+		// Under test:      UserMaker
+		// Set up:          Create a User with a trait
+		// Expected outcome:User should be created with default email and active status
+
+		user, err := BuildUser(suite.DB(), nil,
+			[]Trait{
+				GetTraitActiveUser,
+			})
+		suite.NoError(err)
+		suite.Equal(defaultEmail, user.LoginGovEmail)
+		suite.True(user.Active)
+	})
+
+	suite.Run("Successful creation of user with both", func() {
+		// Under test:      UserMaker
+		// Set up:          Create a User with a customized email and active trait
+		// Expected outcome:User should be created with email and active status
+
+		user, err := BuildUser(suite.DB(), []Customization{
+			{
+				Model: models.User{
+					LoginGovEmail: customEmail,
+				},
+				Type: User,
+			}}, []Trait{
+			GetTraitActiveUser,
+		})
+		suite.NoError(err)
+		suite.Equal(customEmail, user.LoginGovEmail)
+		suite.True(user.Active)
+	})
+
+}

--- a/pkg/factory/user_factory_test.go
+++ b/pkg/factory/user_factory_test.go
@@ -4,11 +4,11 @@ import (
 	"github.com/transcom/mymove/pkg/models"
 )
 
-func (suite *FactorySuite) TestUserMaker() {
+func (suite *FactorySuite) TestBuildUser() {
 	defaultEmail := "first.last@login.gov.test"
 	customEmail := "leospaceman123@example.com"
 	suite.Run("Successful creation of default user", func() {
-		// Under test:      UserMaker
+		// Under test:      BuildUser
 		// Mocked:          None
 		// Set up:          Create a User with no customizations or traits
 		// Expected outcome:User should be created with default values
@@ -19,7 +19,7 @@ func (suite *FactorySuite) TestUserMaker() {
 	})
 
 	suite.Run("Successful creation of user with customization", func() {
-		// Under test:      UserMaker
+		// Under test:      BuildUser
 		// Set up:          Create a User with a customized email and no trait
 		// Expected outcome:User should be created with email and inactive status
 		user := BuildUser(suite.DB(), []Customization{
@@ -35,7 +35,7 @@ func (suite *FactorySuite) TestUserMaker() {
 	})
 
 	suite.Run("Successful creation of user with trait", func() {
-		// Under test:      UserMaker
+		// Under test:      BuildUser
 		// Set up:          Create a User with a trait
 		// Expected outcome:User should be created with default email and active status
 
@@ -48,7 +48,7 @@ func (suite *FactorySuite) TestUserMaker() {
 	})
 
 	suite.Run("Successful creation of user with both", func() {
-		// Under test:      UserMaker
+		// Under test:      BuildUser
 		// Set up:          Create a User with a customized email and active trait
 		// Expected outcome:User should be created with email and active status
 
@@ -65,7 +65,7 @@ func (suite *FactorySuite) TestUserMaker() {
 	})
 
 	suite.Run("Successful creation of stubbed user", func() {
-		// Under test:      UserMaker
+		// Under test:      BuildUser
 		// Set up:          Create a customized user, but don't pass in a db
 		// Expected outcome:User should be created with email and active status
 		//                  No user should be created in database
@@ -89,4 +89,29 @@ func (suite *FactorySuite) TestUserMaker() {
 		suite.Equal(precount, count)
 	})
 
+}
+
+func (suite *FactorySuite) TestBuildDefaultUser() {
+	defaultEmail := "first.last@login.gov.test"
+	suite.Run("Successful creation of default user", func() {
+		// Under test:      BuildDefaultUser
+		// Mocked:          None
+		// Set up:          Use helper function BuildDefaultUser
+		// Expected outcome:User should be created with GetTraitActiveUser
+
+		user := BuildDefaultUser(suite.DB())
+		suite.Equal(defaultEmail, user.LoginGovEmail)
+		suite.True(user.Active)
+	})
+
+	suite.Run("Successful creation of stubbed default user", func() {
+		// Under test:      BuildDefaultUser
+		// Mocked:          None
+		// Set up:          Use helper function BuildDefaultUser, but no db
+		// Expected outcome:User should be created with GetTraitActiveUser
+
+		user := BuildDefaultUser(nil)
+		suite.Equal(defaultEmail, user.LoginGovEmail)
+		suite.True(user.Active)
+	})
 }

--- a/pkg/factory/user_factory_test.go
+++ b/pkg/factory/user_factory_test.go
@@ -64,4 +64,29 @@ func (suite *MakerSuite) TestUserMaker() {
 		suite.True(user.Active)
 	})
 
+	suite.Run("Successful creation of stubbed user", func() {
+		// Under test:      UserMaker
+		// Set up:          Create a customized user, but don't pass in a db
+		// Expected outcome:User should be created with email and active status
+		//                  No user should be created in database
+		precount, err := suite.DB().Count(&models.User{})
+		suite.NoError(err)
+
+		user := BuildUser(nil, []Customization{
+			{
+				Model: models.User{
+					LoginGovEmail: customEmail,
+				},
+			}}, []Trait{
+			GetTraitActiveUser,
+		})
+
+		suite.Equal(customEmail, user.LoginGovEmail)
+		suite.True(user.Active)
+		// Count how many users are in the DB, no new users should have been created.
+		count, err := suite.DB().Count(&models.User{})
+		suite.NoError(err)
+		suite.Equal(precount, count)
+	})
+
 }

--- a/pkg/factory/user_factory_test.go
+++ b/pkg/factory/user_factory_test.go
@@ -13,8 +13,7 @@ func (suite *MakerSuite) TestUserMaker() {
 		// Set up:          Create a User with no customizations or traits
 		// Expected outcome:User should be created with default values
 
-		user, err := BuildUser(suite.DB(), nil, nil)
-		suite.NoError(err)
+		user := BuildUser(suite.DB(), nil, nil)
 		suite.Equal(defaultEmail, user.LoginGovEmail)
 		suite.False(user.Active)
 	})
@@ -23,14 +22,13 @@ func (suite *MakerSuite) TestUserMaker() {
 		// Under test:      UserMaker
 		// Set up:          Create a User with a customized email and no trait
 		// Expected outcome:User should be created with email and inactive status
-		user, err := BuildUser(suite.DB(), []Customization{
+		user := BuildUser(suite.DB(), []Customization{
 			{
 				Model: models.User{
 					LoginGovEmail: customEmail,
 				},
 			},
 		}, nil)
-		suite.NoError(err)
 		suite.Equal(customEmail, user.LoginGovEmail)
 		suite.False(user.Active)
 
@@ -41,11 +39,10 @@ func (suite *MakerSuite) TestUserMaker() {
 		// Set up:          Create a User with a trait
 		// Expected outcome:User should be created with default email and active status
 
-		user, err := BuildUser(suite.DB(), nil,
+		user := BuildUser(suite.DB(), nil,
 			[]Trait{
 				GetTraitActiveUser,
 			})
-		suite.NoError(err)
 		suite.Equal(defaultEmail, user.LoginGovEmail)
 		suite.True(user.Active)
 	})
@@ -55,7 +52,7 @@ func (suite *MakerSuite) TestUserMaker() {
 		// Set up:          Create a User with a customized email and active trait
 		// Expected outcome:User should be created with email and active status
 
-		user, err := BuildUser(suite.DB(), []Customization{
+		user := BuildUser(suite.DB(), []Customization{
 			{
 				Model: models.User{
 					LoginGovEmail: customEmail,
@@ -63,7 +60,6 @@ func (suite *MakerSuite) TestUserMaker() {
 			}}, []Trait{
 			GetTraitActiveUser,
 		})
-		suite.NoError(err)
 		suite.Equal(customEmail, user.LoginGovEmail)
 		suite.True(user.Active)
 	})

--- a/pkg/handlers/adminapi/users_test.go
+++ b/pkg/handlers/adminapi/users_test.go
@@ -30,12 +30,12 @@ import (
 	"github.com/transcom/mymove/pkg/services/pagination"
 	"github.com/transcom/mymove/pkg/services/query"
 	userservice "github.com/transcom/mymove/pkg/services/user"
-	"github.com/transcom/mymove/pkg/testdatagen"
 )
 
 func (suite *HandlerSuite) TestGetUserHandler() {
 	suite.Run("integration test ok response", func() {
-		user := testdatagen.MakeDefaultUser(suite.DB())
+		user := factory.BuildDefaultUser(suite.DB())
+
 		params := userop.GetUserParams{
 			HTTPRequest: suite.setupAuthenticatedRequest("GET", fmt.Sprintf("/users/%s", user.ID)),
 			UserID:      strfmt.UUID(user.ID.String()),
@@ -56,7 +56,7 @@ func (suite *HandlerSuite) TestGetUserHandler() {
 	})
 
 	suite.Run("unsuccessful response when fetch fails", func() {
-		user := testdatagen.MakeDefaultUser(suite.DB())
+		user := factory.BuildDefaultUser(suite.DB())
 		params := userop.GetUserParams{
 			HTTPRequest: suite.setupAuthenticatedRequest("GET", fmt.Sprintf("/users/%s", user.ID)),
 			UserID:      strfmt.UUID(user.ID.String()),
@@ -87,8 +87,8 @@ func (suite *HandlerSuite) TestIndexUsersHandler() {
 	// test that everything is wired up
 	suite.Run("integration test ok response", func() {
 		users := models.Users{
-			testdatagen.MakeDefaultUser(suite.DB()),
-			testdatagen.MakeDefaultUser(suite.DB()),
+			factory.BuildDefaultUser(suite.DB()),
+			factory.BuildDefaultUser(suite.DB()),
 		}
 		params := userop.IndexUsersParams{
 			HTTPRequest: suite.setupAuthenticatedRequest("GET", "/users"),

--- a/pkg/handlers/adminapi/users_test.go
+++ b/pkg/handlers/adminapi/users_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/gobuffalo/validate/v3"
 	"github.com/stretchr/testify/mock"
 
+	"github.com/transcom/mymove/pkg/factory"
 	userop "github.com/transcom/mymove/pkg/gen/adminapi/adminoperations/users"
 	"github.com/transcom/mymove/pkg/gen/adminmessages"
 	"github.com/transcom/mymove/pkg/handlers"
@@ -154,6 +155,19 @@ func (suite *HandlerSuite) TestUpdateUserHandler() {
 	adminSessionID := "admin-session"
 	officeSessionID := "office-session"
 
+	activeUserTrait := func() []factory.Customization {
+		return []factory.Customization{
+			{
+				Model: models.User{
+					CurrentMilSessionID:    milSessionID,
+					CurrentAdminSessionID:  adminSessionID,
+					CurrentOfficeSessionID: officeSessionID,
+					Active:                 true,
+				},
+			},
+		}
+	}
+
 	// Create a handler and service object instances to test
 	queryFilter := mocks.QueryFilter{}
 	newQueryFilter := newMockQueryFilterBuilder(&queryFilter)
@@ -184,15 +198,9 @@ func (suite *HandlerSuite) TestUpdateUserHandler() {
 
 		// Create a user that has multiple sessions
 		// and is labeled an Active user of the system
-		assertions := testdatagen.Assertions{
-			User: models.User{
-				CurrentMilSessionID:    milSessionID,
-				CurrentAdminSessionID:  adminSessionID,
-				CurrentOfficeSessionID: officeSessionID,
-				Active:                 true,
-			},
-		}
-		user := testdatagen.MakeUser(suite.DB(), assertions)
+		user := factory.BuildUser(suite.DB(), nil, []factory.Trait{
+			activeUserTrait,
+		})
 
 		params := userop.UpdateUserParams{
 			HTTPRequest: suite.setupAuthenticatedRequest("PUT", fmt.Sprintf("/users/%s", user.ID)),
@@ -228,13 +236,8 @@ func (suite *HandlerSuite) TestUpdateUserHandler() {
 		//			   *All* sessions are revoked because the user is deactivated.
 
 		// Create a fresh user to reset all values
-		user := testdatagen.MakeUser(suite.DB(), testdatagen.Assertions{
-			User: models.User{
-				CurrentMilSessionID:    milSessionID,
-				CurrentAdminSessionID:  adminSessionID,
-				CurrentOfficeSessionID: officeSessionID,
-				Active:                 true,
-			},
+		user := factory.BuildUser(suite.DB(), nil, []factory.Trait{
+			activeUserTrait,
 		})
 
 		// Create the update to revoke 2 sessions and deactivate the user
@@ -272,13 +275,8 @@ func (suite *HandlerSuite) TestUpdateUserHandler() {
 		//			   All sessions are revoked because the user is deactivated.
 
 		// Create a fresh user to reset all values
-		user := testdatagen.MakeUser(suite.DB(), testdatagen.Assertions{
-			User: models.User{
-				CurrentMilSessionID:    milSessionID,
-				CurrentAdminSessionID:  adminSessionID,
-				CurrentOfficeSessionID: officeSessionID,
-				Active:                 true,
-			},
+		user := factory.BuildUser(suite.DB(), nil, []factory.Trait{
+			activeUserTrait,
 		})
 
 		params := userop.UpdateUserParams{
@@ -314,17 +312,16 @@ func (suite *HandlerSuite) TestUpdateUserHandler() {
 		//
 
 		// Create a new user that is inactive but has session values
-		user := testdatagen.MakeUser(suite.DB(), testdatagen.Assertions{
-			User: models.User{
-				CurrentMilSessionID:    milSessionID,
-				CurrentAdminSessionID:  adminSessionID,
-				CurrentOfficeSessionID: officeSessionID,
-				Active:                 false,
+		user := factory.BuildUser(suite.DB(), []factory.Customization{
+			{
+				Model: models.User{
+					CurrentMilSessionID:    milSessionID,
+					CurrentAdminSessionID:  adminSessionID,
+					CurrentOfficeSessionID: officeSessionID,
+					Active:                 false,
+				},
 			},
-		})
-
-		// Manually update Active because of an issue with mergeModels in MakeUser
-		suite.DB().ValidateAndUpdate(&user)
+		}, nil)
 
 		params := userop.UpdateUserParams{
 			HTTPRequest: suite.setupAuthenticatedRequest("PUT", fmt.Sprintf("/users/%s", user.ID)),
@@ -357,13 +354,8 @@ func (suite *HandlerSuite) TestUpdateUserHandler() {
 		// 			   Err returned for RevokeUserSession
 
 		// Create a fresh user to reset all values
-		user := testdatagen.MakeUser(suite.DB(), testdatagen.Assertions{
-			User: models.User{
-				CurrentMilSessionID:    milSessionID,
-				CurrentAdminSessionID:  adminSessionID,
-				CurrentOfficeSessionID: officeSessionID,
-				Active:                 true,
-			},
+		user := factory.BuildUser(suite.DB(), nil, []factory.Trait{
+			activeUserTrait,
 		})
 
 		params := userop.UpdateUserParams{
@@ -407,13 +399,8 @@ func (suite *HandlerSuite) TestUpdateUserHandler() {
 		// 			   User sessions are revoked.
 
 		// Create a fresh user to reset all values
-		user := testdatagen.MakeUser(suite.DB(), testdatagen.Assertions{
-			User: models.User{
-				CurrentMilSessionID:    milSessionID,
-				CurrentAdminSessionID:  adminSessionID,
-				CurrentOfficeSessionID: officeSessionID,
-				Active:                 true,
-			},
+		user := factory.BuildUser(suite.DB(), nil, []factory.Trait{
+			activeUserTrait,
 		})
 
 		params := userop.UpdateUserParams{
@@ -461,13 +448,8 @@ func (suite *HandlerSuite) TestUpdateUserHandler() {
 		// 			   User sessions are not revoked.
 
 		// Create a fresh user to reset all values
-		user := testdatagen.MakeUser(suite.DB(), testdatagen.Assertions{
-			User: models.User{
-				CurrentMilSessionID:    milSessionID,
-				CurrentAdminSessionID:  adminSessionID,
-				CurrentOfficeSessionID: officeSessionID,
-				Active:                 true,
-			},
+		user := factory.BuildUser(suite.DB(), nil, []factory.Trait{
+			activeUserTrait,
 		})
 
 		params := userop.UpdateUserParams{

--- a/pkg/handlers/authentication/auth_test.go
+++ b/pkg/handlers/authentication/auth_test.go
@@ -19,6 +19,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/transcom/mymove/pkg/auth"
+	"github.com/transcom/mymove/pkg/factory"
 	"github.com/transcom/mymove/pkg/handlers"
 	"github.com/transcom/mymove/pkg/handlers/ghcapi"
 	"github.com/transcom/mymove/pkg/models"
@@ -655,7 +656,7 @@ func (suite *AuthSuite) TestAuthKnownSingleRoleAdmin() {
 }
 
 func (suite *AuthSuite) TestAuthKnownServiceMember() {
-	user := testdatagen.MakeDefaultUser(suite.DB())
+	user := factory.BuildDefaultUser(suite.DB())
 	userID := uuid.Must(uuid.NewV4())
 
 	userIdentity := models.UserIdentity{
@@ -906,7 +907,7 @@ func (suite *AuthSuite) TestAuthorizeUnknownUserOfficeNotFound() {
 }
 
 func (suite *AuthSuite) TestAuthorizeUnknownUserOfficeLogsIn() {
-	user := testdatagen.MakeDefaultUser(suite.DB())
+	user := factory.BuildDefaultUser(suite.DB())
 	// user is in office_users but has never logged into the app
 	officeUser := testdatagen.MakeOfficeUser(suite.DB(), testdatagen.Assertions{
 		OfficeUser: models.OfficeUser{
@@ -958,7 +959,7 @@ func (suite *AuthSuite) TestAuthorizeUnknownUserOfficeLogsIn() {
 }
 
 func (suite *AuthSuite) TestAuthorizeUnknownUserOfficeLogsInWithPermissions() {
-	user := testdatagen.MakeDefaultUser(suite.DB())
+	user := factory.BuildDefaultUser(suite.DB())
 	// user is in office_users but has never logged into the app
 	officeUser := testdatagen.MakeOfficeUser(suite.DB(), testdatagen.Assertions{
 		OfficeUser: models.OfficeUser{
@@ -1129,7 +1130,7 @@ func (suite *AuthSuite) TestAuthorizeKnownUserAdminNotFound() {
 }
 
 func (suite *AuthSuite) TestAuthorizeUnknownUserAdminLogsIn() {
-	user := testdatagen.MakeDefaultUser(suite.DB())
+	user := factory.BuildDefaultUser(suite.DB())
 	// user is in admin_users but has not logged into the app before
 	adminUser := testdatagen.MakeAdminUser(suite.DB(), testdatagen.Assertions{
 		AdminUser: models.AdminUser{
@@ -1180,7 +1181,7 @@ func (suite *AuthSuite) TestAuthorizeUnknownUserAdminLogsIn() {
 }
 
 func (suite *AuthSuite) TestLoginGovAuthenticatedRedirect() {
-	user := testdatagen.MakeDefaultUser(suite.DB())
+	user := factory.BuildDefaultUser(suite.DB())
 	// user is in office_users but has never logged into the app
 	officeUser := testdatagen.MakeOfficeUser(suite.DB(), testdatagen.Assertions{
 		OfficeUser: models.OfficeUser{
@@ -1223,7 +1224,7 @@ func (suite *AuthSuite) TestLoginGovAuthenticatedRedirect() {
 }
 
 func (suite *AuthSuite) TestAuthorizePrime() {
-	user := testdatagen.MakeDefaultUser(suite.DB())
+	user := factory.BuildDefaultUser(suite.DB())
 	clientCert := testdatagen.MakeDevClientCert(suite.DB(), testdatagen.Assertions{
 		ClientCert: models.ClientCert{
 			UserID: user.ID,

--- a/pkg/handlers/internalapi/service_members_test.go
+++ b/pkg/handlers/internalapi/service_members_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/go-openapi/swag"
 	"github.com/gofrs/uuid"
 
+	"github.com/transcom/mymove/pkg/factory"
 	servicememberop "github.com/transcom/mymove/pkg/gen/internalapi/internaloperations/service_members"
 	"github.com/transcom/mymove/pkg/gen/internalmessages"
 	"github.com/transcom/mymove/pkg/handlers"
@@ -29,7 +30,7 @@ import (
 
 func (suite *HandlerSuite) TestShowServiceMemberHandler() {
 	// Given: A servicemember and a user
-	user := testdatagen.MakeDefaultUser(suite.DB())
+	user := factory.BuildDefaultUser(suite.DB())
 
 	newServiceMember := testdatagen.MakeExtendedServiceMember(suite.DB(), testdatagen.Assertions{
 		ServiceMember: models.ServiceMember{
@@ -81,7 +82,7 @@ func (suite *HandlerSuite) TestShowServiceMemberWrongUser() {
 
 func (suite *HandlerSuite) TestSubmitServiceMemberHandlerNoValues() {
 	// Given: A logged-in user
-	user := testdatagen.MakeDefaultUser(suite.DB())
+	user := factory.BuildDefaultUser(suite.DB())
 
 	// When: a new ServiceMember is posted
 	newServiceMemberPayload := internalmessages.CreateServiceMemberPayload{}
@@ -128,7 +129,7 @@ func (suite *HandlerSuite) TestSubmitServiceMemberHandlerNoValues() {
 
 func (suite *HandlerSuite) TestSubmitServiceMemberHandlerAllValues() {
 	// Given: A logged-in user
-	user := testdatagen.MakeDefaultUser(suite.DB())
+	user := factory.BuildDefaultUser(suite.DB())
 
 	// When: a new ServiceMember is posted
 	newServiceMemberPayload := internalmessages.CreateServiceMemberPayload{
@@ -172,7 +173,7 @@ func (suite *HandlerSuite) TestSubmitServiceMemberHandlerAllValues() {
 
 func (suite *HandlerSuite) TestPatchServiceMemberHandler() {
 	// Given: a logged in user
-	user := testdatagen.MakeDefaultUser(suite.DB())
+	user := factory.BuildDefaultUser(suite.DB())
 
 	// TODO: add more fields to change
 	var origEdipi = "2342342344"
@@ -304,7 +305,7 @@ func (suite *HandlerSuite) TestPatchServiceMemberHandler() {
 
 func (suite *HandlerSuite) TestPatchServiceMemberHandlerSubmittedMove() {
 	// Given: a logged in user
-	user := testdatagen.MakeDefaultUser(suite.DB())
+	user := factory.BuildDefaultUser(suite.DB())
 
 	edipi := "2342342344"
 
@@ -471,8 +472,8 @@ func (suite *HandlerSuite) TestPatchServiceMemberHandlerSubmittedMove() {
 
 func (suite *HandlerSuite) TestPatchServiceMemberHandlerWrongUser() {
 	// Given: a logged in user
-	user := testdatagen.MakeDefaultUser(suite.DB())
-	user2 := testdatagen.MakeDefaultUser(suite.DB())
+	user := factory.BuildDefaultUser(suite.DB())
+	user2 := factory.BuildDefaultUser(suite.DB())
 
 	var origEdipi = "2342342344"
 	var newEdipi = "9999999999"
@@ -507,7 +508,7 @@ func (suite *HandlerSuite) TestPatchServiceMemberHandlerWrongUser() {
 
 func (suite *HandlerSuite) TestPatchServiceMemberHandlerNoServiceMember() {
 	// Given: a logged in user
-	user := testdatagen.MakeDefaultUser(suite.DB())
+	user := factory.BuildDefaultUser(suite.DB())
 
 	servicememberUUID := uuid.Must(uuid.NewV4())
 
@@ -537,7 +538,7 @@ func (suite *HandlerSuite) TestPatchServiceMemberHandlerNoServiceMember() {
 
 func (suite *HandlerSuite) TestPatchServiceMemberHandlerNoChange() {
 	// Given: a logged in user with a servicemember
-	user := testdatagen.MakeDefaultUser(suite.DB())
+	user := factory.BuildDefaultUser(suite.DB())
 
 	var origEdipi = "4444444444"
 	newServiceMember := models.ServiceMember{

--- a/pkg/handlers/routing/routing_init_test.go
+++ b/pkg/handlers/routing/routing_init_test.go
@@ -11,11 +11,11 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	"github.com/transcom/mymove/pkg/auth"
+	"github.com/transcom/mymove/pkg/factory"
 	"github.com/transcom/mymove/pkg/handlers"
 	"github.com/transcom/mymove/pkg/handlers/authentication"
 	"github.com/transcom/mymove/pkg/notifications"
 	"github.com/transcom/mymove/pkg/telemetry"
-	"github.com/transcom/mymove/pkg/testdatagen"
 	"github.com/transcom/mymove/pkg/testingsuite"
 )
 
@@ -99,7 +99,7 @@ func (suite *RoutingSuite) TestServeGHC() {
 	h, err := InitRouting(suite.AppContextForTest(), nil, rConfig, &telemetry.Config{})
 	suite.NoError(err)
 
-	user := testdatagen.MakeUser(suite.DB(), testdatagen.Assertions{})
+	user := factory.BuildUser(suite.DB(), nil, nil)
 
 	// make the request without auth
 	// getting auth working here in the test is a good bit more work.

--- a/pkg/models/service_member_test.go
+++ b/pkg/models/service_member_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/gofrs/uuid"
 
 	"github.com/transcom/mymove/pkg/auth"
+	"github.com/transcom/mymove/pkg/factory"
 	"github.com/transcom/mymove/pkg/gen/internalmessages"
 	. "github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/testdatagen"
@@ -85,8 +86,8 @@ func (suite *ModelSuite) TestIsProfileCompleteWithIncompleteSM() {
 }
 
 func (suite *ModelSuite) TestFetchServiceMemberForUser() {
-	user1 := testdatagen.MakeDefaultUser(suite.DB())
-	user2 := testdatagen.MakeDefaultUser(suite.DB())
+	user1 := factory.BuildDefaultUser(suite.DB())
+	user2 := factory.BuildDefaultUser(suite.DB())
 
 	firstName := "Oliver"
 	resAddress := testdatagen.MakeDefaultAddress(suite.DB())
@@ -128,7 +129,7 @@ func (suite *ModelSuite) TestFetchServiceMemberForUser() {
 }
 
 func (suite *ModelSuite) TestFetchServiceMemberNotForUser() {
-	user1 := testdatagen.MakeDefaultUser(suite.DB())
+	user1 := factory.BuildDefaultUser(suite.DB())
 
 	firstName := "Nino"
 	resAddress := testdatagen.MakeDefaultAddress(suite.DB())
@@ -151,7 +152,7 @@ func (suite *ModelSuite) TestFetchServiceMemberNotForUser() {
 func (suite *ModelSuite) TestFetchLatestOrders() {
 	setupTestData := func() (Order, *auth.Session) {
 
-		user := testdatagen.MakeDefaultUser(suite.DB())
+		user := factory.BuildDefaultUser(suite.DB())
 
 		serviceMember := testdatagen.MakeDefaultServiceMember(suite.DB())
 

--- a/pkg/models/user_test.go
+++ b/pkg/models/user_test.go
@@ -150,6 +150,17 @@ func (suite *ModelSuite) TestFetchUserIdentity() {
 	suite.NoError(suite.DB().Create(&rs))
 	customerRole := rs[0]
 	patUUID := uuid.Must(uuid.NewV4())
+	// pat, _ := factory.BuildUser(suite.DB(), []factory.Customization{
+	// 	{
+	// 		Model: models.User{
+	// 			LoginGovUUID: &patUUID,
+	// 			Active:       true,
+	// 			Roles:        []roles.Role{customerRole},
+	// 		},
+	// 		Type: CustomType.User,
+	// 	},
+	// }, nil)
+
 	pat := testdatagen.MakeUser(suite.DB(), testdatagen.Assertions{
 		User: User{
 			LoginGovUUID: &patUUID,

--- a/pkg/models/user_test.go
+++ b/pkg/models/user_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/transcom/mymove/pkg/auth"
 	"github.com/transcom/mymove/pkg/db/dberr"
+	"github.com/transcom/mymove/pkg/factory"
 	. "github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/models/roles"
 	userroles "github.com/transcom/mymove/pkg/services/users_roles"
@@ -150,24 +151,15 @@ func (suite *ModelSuite) TestFetchUserIdentity() {
 	suite.NoError(suite.DB().Create(&rs))
 	customerRole := rs[0]
 	patUUID := uuid.Must(uuid.NewV4())
-	// pat, _ := factory.BuildUser(suite.DB(), []factory.Customization{
-	// 	{
-	// 		Model: models.User{
-	// 			LoginGovUUID: &patUUID,
-	// 			Active:       true,
-	// 			Roles:        []roles.Role{customerRole},
-	// 		},
-	// 		Type: CustomType.User,
-	// 	},
-	// }, nil)
-
-	pat := testdatagen.MakeUser(suite.DB(), testdatagen.Assertions{
-		User: User{
-			LoginGovUUID: &patUUID,
-			Active:       true,
-			Roles:        []roles.Role{customerRole},
+	pat := factory.BuildUser(suite.DB(), []factory.Customization{
+		{
+			Model: User{
+				LoginGovUUID: &patUUID,
+				Active:       true,
+				Roles:        []roles.Role{customerRole},
+			},
 		},
-	})
+	}, nil)
 
 	identity, err = FetchUserIdentity(suite.DB(), pat.LoginGovUUID.String())
 	suite.Nil(err, "loading pat's identity")
@@ -176,13 +168,15 @@ func (suite *ModelSuite) TestFetchUserIdentity() {
 
 	tooRole := rs[1]
 	billyUUID := uuid.Must(uuid.NewV4())
-	billy := testdatagen.MakeUser(suite.DB(), testdatagen.Assertions{
-		User: User{
-			LoginGovUUID: &billyUUID,
-			Active:       true,
-			Roles:        []roles.Role{tooRole},
+	billy := factory.BuildUser(suite.DB(), []factory.Customization{
+		{
+			Model: User{
+				LoginGovUUID: &billyUUID,
+				Active:       true,
+				Roles:        []roles.Role{tooRole},
+			},
 		},
-	})
+	}, nil)
 
 	suite.DB().MigrationURL()
 	identity, err = FetchUserIdentity(suite.DB(), billy.LoginGovUUID.String())
@@ -268,11 +262,12 @@ func (suite *ModelSuite) TestFetchAppUserIdentities() {
 
 		// Create a user email that won't be filtered out of the devlocal user query w/ a default value of
 		// first.last@login.gov.test
-		user := testdatagen.MakeUser(suite.DB(), testdatagen.Assertions{
-			User: User{
-				LoginGovEmail: "test@example.com",
-			},
-		})
+		user := factory.BuildUser(suite.DB(), []factory.Customization{
+			{
+				Model: User{
+					LoginGovEmail: "test@example.com",
+				},
+			}}, nil)
 
 		testdatagen.MakeServiceMember(suite.DB(), testdatagen.Assertions{
 			ServiceMember: ServiceMember{

--- a/pkg/services/admin_user/admin_user_creator_test.go
+++ b/pkg/services/admin_user/admin_user_creator_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/transcom/mymove/pkg/appcontext"
 	"github.com/transcom/mymove/pkg/auth"
+	"github.com/transcom/mymove/pkg/factory"
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/notifications"
 	"github.com/transcom/mymove/pkg/notifications/mocks"
@@ -36,13 +37,14 @@ func (suite *AdminUserServiceSuite) TestCreateAdminUser() {
 	setupTestData := func() (models.User, models.AdminUser) {
 
 		loginGovUUID := uuid.Must(uuid.NewV4())
-		existingUser := testdatagen.MakeUser(suite.DB(), testdatagen.Assertions{
-			User: models.User{
-				LoginGovUUID:  &loginGovUUID,
-				LoginGovEmail: "spaceman+existing@leo.org",
-				Active:        true,
-			},
-		})
+		existingUser := factory.BuildUser(suite.DB(), []factory.Customization{
+			{
+				Model: models.User{
+					LoginGovUUID:  &loginGovUUID,
+					LoginGovEmail: "spaceman+existing@leo.org",
+					Active:        true,
+				},
+			}}, nil)
 
 		organization := testdatagen.MakeDefaultOrganization(suite.DB())
 		userInfo := models.AdminUser{

--- a/pkg/services/move_history/move_history_fetcher_test.go
+++ b/pkg/services/move_history/move_history_fetcher_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/transcom/mymove/pkg/apperror"
 	"github.com/transcom/mymove/pkg/etag"
+	"github.com/transcom/mymove/pkg/factory"
 	"github.com/transcom/mymove/pkg/gen/internalmessages"
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/models/roles"
@@ -387,7 +388,7 @@ func (suite *MoveHistoryServiceSuite) TestMoveFetcherWithFakeData() {
 	suite.Run("returns Audit History with session information", func() {
 		approvedMove := testdatagen.MakeAvailableMove(suite.DB())
 		fakeRole, _ := testdatagen.LookupOrMakeRoleByRoleType(suite.DB(), roles.RoleTypeTOO)
-		fakeUser := testdatagen.MakeUser(suite.DB(), testdatagen.Assertions{})
+		fakeUser := factory.BuildUser(suite.DB(), nil, nil)
 		_ = testdatagen.MakeUsersRoles(suite.DB(), testdatagen.Assertions{
 			User: fakeUser,
 			UsersRoles: models.UsersRoles{

--- a/pkg/services/office_user/office_user_creator_test.go
+++ b/pkg/services/office_user/office_user_creator_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/transcom/mymove/pkg/appcontext"
 	"github.com/transcom/mymove/pkg/auth"
+	"github.com/transcom/mymove/pkg/factory"
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/notifications"
 	"github.com/transcom/mymove/pkg/notifications/mocks"
@@ -35,13 +36,14 @@ func (suite *OfficeUserServiceSuite) TestCreateOfficeUser() {
 	queryBuilder := query.NewQueryBuilder()
 
 	loginGovUUID := uuid.Must(uuid.NewV4())
-	existingUser := testdatagen.MakeUser(suite.DB(), testdatagen.Assertions{
-		User: models.User{
-			LoginGovUUID:  &loginGovUUID,
-			LoginGovEmail: "spaceman+existing@leo.org",
-			Active:        true,
-		},
-	})
+	existingUser := factory.BuildUser(suite.DB(), []factory.Customization{
+		{
+			Model: models.User{
+				LoginGovUUID:  &loginGovUUID,
+				LoginGovEmail: "spaceman+existing@leo.org",
+				Active:        true,
+			},
+		}}, nil)
 
 	transportationOffice := testdatagen.MakeDefaultTransportationOffice(suite.DB())
 	userInfo := models.OfficeUser{

--- a/pkg/services/user/user_updater_test.go
+++ b/pkg/services/user/user_updater_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/transcom/mymove/pkg/appcontext"
 	"github.com/transcom/mymove/pkg/auth"
+	"github.com/transcom/mymove/pkg/factory"
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/notifications"
 	"github.com/transcom/mymove/pkg/notifications/mocks"
@@ -137,7 +138,7 @@ func (suite *UserServiceSuite) TestUserUpdater() {
 		//              A notification is sent to sys admins
 		appCtx := appcontext.NewAppContext(suite.DB(), suite.AppContextForTest().Logger(), &auth.Session{})
 		// Make an inactive user
-		user := testdatagen.MakeUser(suite.DB(), testdatagen.Assertions{})
+		user, _ := factory.BuildUser(suite.DB(), nil, nil)
 
 		mockSender := setUpMockNotificationSender()
 		updater := NewUserUpdater(builder, officeUserUpdater, adminUserUpdater, mockSender)
@@ -162,7 +163,11 @@ func (suite *UserServiceSuite) TestUserUpdater() {
 		//           	updateUser returns the active user
 		//              A notification is NOT sent to sys admins
 		appCtx := appcontext.NewAppContext(suite.DB(), suite.AppContextForTest().Logger(), &auth.Session{})
-		user := testdatagen.MakeDefaultUser(suite.DB()) // Default user is active
+		user, _ := factory.BuildUser(suite.DB(), nil,
+			[]factory.Trait{
+				factory.GetTraitActiveUser,
+			})
+
 		mockSender := setUpMockNotificationSender()
 		updater := NewUserUpdater(builder, officeUserUpdater, adminUserUpdater, mockSender)
 
@@ -187,7 +192,7 @@ func (suite *UserServiceSuite) TestUserUpdater() {
 		mockSender := setUpMockNotificationSender()
 		updater := NewUserUpdater(builder, officeUserUpdater, adminUserUpdater, mockSender)
 
-		user := testdatagen.MakeUser(suite.DB(), testdatagen.Assertions{}) // MakeUser makes an inactive user
+		user, _ := factory.BuildUser(suite.DB(), nil, nil)
 
 		user.Active = inactiveStatus
 		updatedUser, verr, err := updater.UpdateUser(appCtx, user.ID, &user)

--- a/pkg/services/user/user_updater_test.go
+++ b/pkg/services/user/user_updater_test.go
@@ -47,7 +47,7 @@ func (suite *UserServiceSuite) TestUserUpdater() {
 	suite.Run("Deactivate a user successfully", func() {
 		// This case should send an email to sys admins
 		appCtx := appcontext.NewAppContext(suite.DB(), suite.AppContextForTest().Logger(), &auth.Session{})
-		user := testdatagen.MakeDefaultUser(suite.DB())
+		user := factory.BuildDefaultUser(suite.DB())
 		mockSender := setUpMockNotificationSender()
 		updater := NewUserUpdater(builder, officeUserUpdater, adminUserUpdater, mockSender)
 

--- a/pkg/services/user/user_updater_test.go
+++ b/pkg/services/user/user_updater_test.go
@@ -138,7 +138,7 @@ func (suite *UserServiceSuite) TestUserUpdater() {
 		//              A notification is sent to sys admins
 		appCtx := appcontext.NewAppContext(suite.DB(), suite.AppContextForTest().Logger(), &auth.Session{})
 		// Make an inactive user
-		user, _ := factory.BuildUser(suite.DB(), nil, nil)
+		user := factory.BuildUser(suite.DB(), nil, nil)
 
 		mockSender := setUpMockNotificationSender()
 		updater := NewUserUpdater(builder, officeUserUpdater, adminUserUpdater, mockSender)
@@ -163,7 +163,7 @@ func (suite *UserServiceSuite) TestUserUpdater() {
 		//           	updateUser returns the active user
 		//              A notification is NOT sent to sys admins
 		appCtx := appcontext.NewAppContext(suite.DB(), suite.AppContextForTest().Logger(), &auth.Session{})
-		user, _ := factory.BuildUser(suite.DB(), nil,
+		user := factory.BuildUser(suite.DB(), nil,
 			[]factory.Trait{
 				factory.GetTraitActiveUser,
 			})
@@ -192,7 +192,7 @@ func (suite *UserServiceSuite) TestUserUpdater() {
 		mockSender := setUpMockNotificationSender()
 		updater := NewUserUpdater(builder, officeUserUpdater, adminUserUpdater, mockSender)
 
-		user, _ := factory.BuildUser(suite.DB(), nil, nil)
+		user := factory.BuildUser(suite.DB(), nil, nil)
 
 		user.Active = inactiveStatus
 		updatedUser, verr, err := updater.UpdateUser(appCtx, user.ID, &user)


### PR DESCRIPTION
## [Jira ticket](https://dp3.atlassian.net/browse/MB-13877) for this change

## Summary

This ticket adds a factory package with first function BuildUser intended to be an eventual replacement for testdatagen. 
* Created BuildUser and shared functions
* Created tests for all of those. 
* Replaced all makeUser and makeDefaultUser calls except those in
   * testdatagen
   * testdatagen/scenarios

Reason for not replacing all
* testdatagen make functions will slowly be deprecated as we keep going, so there's no need to replace them. The functions will eventually get deleted. Also there's no good way to "pass down assertions" from the old make functions to the new build functions. 
* testdatagen/scenarios *will* be updated but we intend to break that work down into tickets for our team. 
* Wanted to get the base code in and examples of how to replace so we can split up the work.

Please pay note to:
* Most functionality has been reviewed in a spike. 
* But new additions in this ticket are
   *  the `assignDefaultTypes` code and 
   * the `setupCustomizations` functions. 
* Those simplify usage for devs. Please give extra attention

## Setup to Run Your Code

`make server_test` should be enough. 

### Frontend

- No frontend changes

### Backend

- [x] Code follows the guidelines for [Logging](https://transcom.github.io/mymove-docs/docs/dev/contributing/backend/Backend-Programming-Guide#logging)
- [x] The requirements listed in [Querying the Database Safely](https://transcom.github.io/mymove-docs/docs/dev/contributing/backend/Backend-Programming-Guide/#querying-the-database-safely) have been satisfied.

### Database

#### Any new migrations/schema changes:

- No schema changes
