### PR TITLE
MB-12540: Integration tests for PPM expense submission

### DIFF
--- a/cypress/integration/milmove/ppms/expenses.js
+++ b/cypress/integration/milmove/ppms/expenses.js
@@ -10,7 +10,7 @@ describe('Expenses', function () {
   });
   beforeEach(() => {
     cy.intercept('GET', '**/internal/moves/**/mto_shipments').as('getShipment');
-    cy.intercept('POST', '**/internal/uploads**').as('uploadFile');
+    cy.intercept('POST', '**/internal/ppm-shipments/**/uploads**').as('uploadFile');
   });
   const viewportType = [
     { viewport: 'desktop', isMobile: false, userId: '146c2665-5b8a-4653-8434-9a4460de30b5' }, // movingExpensePPM@ppm.approved

--- a/cypress/integration/milmove/ppms/expenses.js
+++ b/cypress/integration/milmove/ppms/expenses.js
@@ -2,7 +2,6 @@ import {
   navigateFromCloseoutReviewPageToExpensesPage,
   setMobileViewport,
   signInAndNavigateToPPMReviewPage,
-  signInAndNavigateToWeightTicketPage,
 } from '../../../support/ppmCustomerShared';
 
 describe('Expenses', function () {
@@ -11,6 +10,7 @@ describe('Expenses', function () {
   });
   beforeEach(() => {
     cy.intercept('GET', '**/internal/moves/**/mto_shipments').as('getShipment');
+    cy.intercept('POST', '**/internal/uploads**').as('uploadFile');
   });
   const viewportType = [
     { viewport: 'desktop', isMobile: false, userId: '146c2665-5b8a-4653-8434-9a4460de30b5' }, // movingExpensePPM@ppm.approved
@@ -32,10 +32,20 @@ describe('Expenses', function () {
       cy.get('input[name="paidWithGTCC"][value="true"]').click({ force: true });
       cy.get('input[name="amount"]').type('675.99');
 
-      // TODO: Add receipt document upload when integrated
+      cy.upload_file('.receiptDocument.filepond--root', 'sampleWeightTicket.jpg');
+      cy.wait('@uploadFile');
 
       cy.get('input[name="sitStartDate"]').type('14 Aug 2022').blur();
       cy.get('input[name="sitEndDate"]').type('20 Aug 2022').blur();
+
+      cy.get('button').contains('Save & Continue').should('be.enabled').click();
+      cy.location().should((loc) => {
+        expect(loc.pathname).to.match(/^\/moves\/[^/]+\/shipments\/[^/]+\/review/);
+      });
+
+      cy.contains('Cloud storage');
+      cy.contains('dt', 'Days in storage:');
+      cy.contains('dd', '7');
     });
 
     it(`edit expense page loads - ${viewport}`, () => {
@@ -65,6 +75,13 @@ describe('Expenses', function () {
 
       cy.get('input[name="missingReceipt"]').as('missingReceipt').should('not.be.checked');
       cy.get('@missingReceipt').click({ force: true });
+
+      cy.get('button').contains('Save & Continue').should('be.enabled').click();
+      cy.location().should((loc) => {
+        expect(loc.pathname).to.match(/^\/moves\/[^/]+\/shipments\/[^/]+\/review/);
+      });
+
+      cy.contains('PA Turnpike EZ-Pass');
     });
   });
 });

--- a/src/pages/MyMove/PPM/Closeout/Expenses/Expenses.jsx
+++ b/src/pages/MyMove/PPM/Closeout/Expenses/Expenses.jsx
@@ -14,7 +14,12 @@ import ExpenseForm from 'components/Customer/PPM/Closeout/ExpenseForm/ExpenseFor
 import { selectExpenseAndIndexById, selectMTOShipmentById } from 'store/entities/selectors';
 import { customerRoutes, generalRoutes } from 'constants/routes';
 import LoadingPlaceholder from 'shared/LoadingPlaceholder';
-import { createUploadForDocument, createMovingExpense, deleteUpload, patchMovingExpense } from 'services/internalApi';
+import {
+  createUploadForPPMDocument,
+  createMovingExpense,
+  deleteUpload,
+  patchMovingExpense,
+} from 'services/internalApi';
 import { updateMTOShipment } from 'store/entities/actions';
 import { formatDateForSwagger } from 'shared/dates';
 import { convertDollarsToCents } from 'shared/utils';
@@ -58,7 +63,7 @@ const Expenses = () => {
   const handleCreateUpload = async (fieldName, file, setFieldTouched) => {
     const documentId = currentExpense[`${fieldName}Id`];
 
-    createUploadForDocument(file, documentId)
+    createUploadForPPMDocument(mtoShipment.ppmShipment.id, documentId, file)
       .then((upload) => {
         mtoShipment.ppmShipment.movingExpenses[currentIndex][fieldName].uploads.push(upload);
         dispatch(updateMTOShipment(mtoShipment));

--- a/src/pages/MyMove/PPM/Closeout/Expenses/Expenses.test.jsx
+++ b/src/pages/MyMove/PPM/Closeout/Expenses/Expenses.test.jsx
@@ -31,7 +31,7 @@ jest.mock('react-router-dom', () => ({
 jest.mock('services/internalApi', () => ({
   ...jest.requireActual('services/internalApi'),
   createMovingExpense: jest.fn(),
-  createUploadForDocument: jest.fn(),
+  createUploadForPPMDocument: jest.fn(),
   deleteUpload: jest.fn(),
   patchMovingExpense: jest.fn(),
 }));


### PR DESCRIPTION
## [Jira ticket](https://dp3.atlassian.net/browse/MB-12540) for this change

## Summary

This pull request completes the integration tests for PPM expenses submission, including the since-added capability of uploading a receipt document and verifying that a newly-created or edited expense record saves correctly.

## Setup to Run Your Code

Run the integration test client locally:

```sh
make e2e_test_fresh
```

### Additional steps

In an instance running on your machine, run the `mymove/expenses.js` integration test suite. Verify that all four tests in that suite pass.

Alternatively, you can view the `integration_tests_milmove` workflow step on CircleCI for this pull request and verify that these (and all other) tests pass.

## Verification Steps for Author

These are to be checked by the author.

- [ ] Request review from a member of a different team.
- [ ] Have the Jira acceptance criteria been met for this change?