### PR TITLE
MB-14347 Add closeout office column to moves

### DIFF
--- a/migrations/app/migrations_manifest.txt
+++ b/migrations/app/migrations_manifest.txt
@@ -767,3 +767,4 @@
 20221021145115_ppm_closeout_status.up.sql
 20221028220508_remove_deleted_at_column_from_evaluation_reports.up.sql
 20221031150502_ppm_closeout_status_remove_needs_close_out.up.sql
+20221104180553_add_closeout_office_move_association.up.sql

--- a/migrations/app/schema/20221104180553_add_closeout_office_move_association.up.sql
+++ b/migrations/app/schema/20221104180553_add_closeout_office_move_association.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE moves ADD COLUMN closeout_office_id uuid REFERENCES transportation_offices(id);

--- a/migrations/app/schema/20221104180553_add_closeout_office_move_association.up.sql
+++ b/migrations/app/schema/20221104180553_add_closeout_office_move_association.up.sql
@@ -1,1 +1,3 @@
 ALTER TABLE moves ADD COLUMN closeout_office_id uuid REFERENCES transportation_offices(id);
+
+COMMENT on COLUMN moves.closeout_office_id IS 'The ID of the assiociated transportation office that is the closeout office for a move.';

--- a/migrations/app/schema/20221104180553_add_closeout_office_move_association.up.sql
+++ b/migrations/app/schema/20221104180553_add_closeout_office_move_association.up.sql
@@ -1,3 +1,3 @@
 ALTER TABLE moves ADD COLUMN closeout_office_id uuid REFERENCES transportation_offices(id);
 
-COMMENT on COLUMN moves.closeout_office_id IS 'The ID of the assiociated transportation office that is the closeout office for a move.';
+COMMENT on COLUMN moves.closeout_office_id IS 'The ID of the associated transportation office that is the closeout office for a move.';

--- a/pkg/models/move.go
+++ b/pkg/models/move.go
@@ -132,6 +132,7 @@ func (m *Move) Validate(tx *pop.Connection) (*validate.Errors, error) {
 		&validators.StringIsPresent{Field: string(m.Status), Name: "Status"},
 		&OptionalTimeIsPresent{Field: m.ExcessWeightQualifiedAt, Name: "ExcessWeightQualifiedAt"},
 		&OptionalUUIDIsPresent{Field: m.ExcessWeightUploadID, Name: "ExcessWeightUploadID"},
+		&OptionalUUIDIsPresent{Field: m.CloseoutOfficeID, Name: "CloseoutOfficeID"},
 	), nil
 }
 

--- a/pkg/models/move.go
+++ b/pkg/models/move.go
@@ -110,6 +110,8 @@ type Move struct {
 	FinancialReviewRemarks       *string                   `db:"financial_review_remarks"`
 	ShipmentGBLOC                MoveToGBLOCs              `has_many:"move_to_gbloc" fk_id:"move_id"`
 	OriginDutyLocationGBLOC      OriginDutyLocationToGBLOC `has_one:"origin_duty_location_to_gbloc" fk_id:"move_id"`
+	CloseoutOfficeID             *uuid.UUID                `db:"closeout_office_id"`
+	CloseoutOffice               *TransportationOffice     `belongs_to:"transportation_offices" fk_id:"closeout_office_id"`
 }
 
 // MoveOptions is used when creating new moves based on parameters

--- a/pkg/testdatagen/scenario/subscenarios.go
+++ b/pkg/testdatagen/scenario/subscenarios.go
@@ -83,6 +83,7 @@ func subScenarioPPMCloseOut(appCtx appcontext.AppContext, userUploader *uploader
 
 		// PPM Closeout
 		createMovesForEachBranch(appCtx, userUploader)
+		createMoveWithCloseoutOffice(appCtx, userUploader)
 	}
 }
 


### PR DESCRIPTION
## [Jira ticket](https://dp3.atlassian.net/browse/MB-14347) for this change

## Summary

This PR adds a field to the Move table to allow association of a closeout office. It also includes test data (in devseed) to create a move with this field populated (Move Locator = `CLSOFF`). 

Note: This story calls out not to name this field anything with the word 'location' in it. I went with `closeoutOffice` since the type of this field is a transportation office. Please let me know if anyone has opinions on this naming, I am happy to rename it if anyone feels strongly about it. 

## Testing/Validation
There are no changes visible in the app UI, this will be more of a code/db change type review. There is test data that can be loaded that will populate this new field in the database (see move w/ locator `CSLOFF`)
<img width="1163" alt="Screenshot 2022-11-07 at 2 40 18 PM" src="https://user-images.githubusercontent.com/62263329/200438585-d70430cf-4ced-4038-9276-fae42d799337.png">


## To Verify
- [ ] New migration adds new column as expected
- [ ] Move model is updated to include CloseoutOffice 
- [ ] Test data is present with the new field populated
