### PR TITLE
MB-14424: Fixes issue with non-deterministic date causing Happo diffs

### DIFF
--- a/src/pages/MyMove/Home/index.stories.jsx
+++ b/src/pages/MyMove/Home/index.stories.jsx
@@ -160,8 +160,8 @@ const propsForCloseoutCompletePPMShipment = {
       id: 'abcd1234-0000-0000-0000-000000000000',
       ppmShipment: {
         status: ppmShipmentStatuses.NEEDS_PAYMENT_APPROVAL,
-        approvedAt: '2022-11-25',
-        submittedAt: '2022-11-21',
+        approvedAt: '2022-11-21',
+        submittedAt: '2022-11-25',
       },
     }),
   ],

--- a/src/pages/MyMove/Home/index.stories.jsx
+++ b/src/pages/MyMove/Home/index.stories.jsx
@@ -158,7 +158,11 @@ const propsForCloseoutCompletePPMShipment = {
   mtoShipments: [
     createPPMShipmentWithFinalIncentive({
       id: 'abcd1234-0000-0000-0000-000000000000',
-      ppmShipment: { status: ppmShipmentStatuses.NEEDS_PAYMENT_APPROVAL },
+      ppmShipment: {
+        status: ppmShipmentStatuses.NEEDS_PAYMENT_APPROVAL,
+        approvedAt: '2022-11-25',
+        submittedAt: '2022-11-21',
+      },
     }),
   ],
   move: {


### PR DESCRIPTION
## [Jira ticket](https://dp3.atlassian.net/browse/MB-14424) for this change

## Summary

This pull request updates the calls to generate mock data in src/pages/MyMove/Home/index.stories.jsx from the PPM Shipment factory, specifically to hard-code `submittedAt` and `approvedAt` dates on the resulting shipment.

These values were being procedurally generated based on the current date; as these values are displayed in the `PPM Closeout Finished` story, it was therefore causing unnecessary Happo diffs when unrelated parts of the code were modified.

https://github.com/orgs/transcom/teams/truss-design: There is no functionality change to the application's behavior, just a small change to the code that presents data to Storybook. Note that Happo should cite these changes as diffs in this pull request, but this PR should fix the problem in future branches.

## Setup to Run Your Code

Start the Storybook locally.

```sh
make storybook
```

### Additional steps

1. In Storybook, view the `PPM Closeout Finished` story in Customer Components -> Pages -> Home.
2. Verify that the "PPM approved" and "PPM documentation submitted" values are set to "21 Nov 2022" and "25 Nov 2022" respectively. **Update:** Dates swapped, in response to code review feedback.

