### PR TITLE
MB-13897 Fix race conditions in GHC rate engine importer

### DIFF
--- a/cmd/ghc-pricing-parser/main.go
+++ b/cmd/ghc-pricing-parser/main.go
@@ -130,17 +130,13 @@ func main() {
 
 	// Open the spreadsheet
 	printDivider("Loading")
-	spinner, err := pterm.DefaultSpinner.Start(fmt.Sprintf("Loading file: %s", params.XlsxFilename))
-	if err != nil {
-		logger.Fatal("Failed to create pterm spinner", zap.Error(err))
-	}
+	pterm.Println(pterm.BgGray.Sprint(fmt.Sprintf("Loading file %s", params.XlsxFilename)))
 
 	params.XlsxFile, err = xlsx.OpenFile(params.XlsxFilename)
 	if err != nil {
-		spinner.Fail()
 		logger.Fatal("Failed to open file", zap.String("XlsxFilename", params.XlsxFilename), zap.Error(err))
 	}
-	spinner.Success()
+	pterm.Println(pterm.BgGray.Sprint(fmt.Sprintf("Finished loading file %s", params.XlsxFilename)))
 
 	// Now kick off the parsing
 	printDivider("Parsing")

--- a/pkg/parser/pricing/parse.go
+++ b/pkg/parser/pricing/parse.go
@@ -429,15 +429,11 @@ func process(appCtx appcontext.AppContext, xlsxDataSheets []XlsxDataSheetInfo, p
 					processDescription = *p.description
 				}
 
-				spinner, err := pterm.DefaultSpinner.Start(fmt.Sprintf("Processing section: %s", processDescription))
-				if err != nil {
-					appCtx.Logger().Fatal("Failed to create pterm spinner", zap.Error(err))
-				}
+				pterm.Println(pterm.BgGray.Sprint(fmt.Sprintf("Processing section %s", processDescription)))
 
 				callFunc := *p.process
 				slice, err := callFunc(appCtx, params, sheetIndex)
 				if err != nil {
-					spinner.Fail()
 					appCtx.Logger().Error("process error", zap.String("description", description), zap.Error(err))
 					return errors.Wrapf(err, "process error for sheet index: %d with description: %s", sheetIndex, description)
 				}
@@ -445,16 +441,14 @@ func process(appCtx appcontext.AppContext, xlsxDataSheets []XlsxDataSheetInfo, p
 				if params.SaveToFile {
 					filename := xlsxDataSheets[sheetIndex].generateOutputFilename(sheetIndex, params.RunTime, p.adtlSuffix)
 					if err := createCSV(appCtx, filename, slice); err != nil {
-						spinner.Fail()
 						return errors.Wrapf(err, "Could not create CSV for sheet index: %d with description: %s", sheetIndex, description)
 					}
 				}
 				if err := tableFromSliceCreator.CreateTableFromSlice(appCtx, slice); err != nil {
-					spinner.Fail()
 					return errors.Wrapf(err, "Could not create table for sheet index: %d with description: %s", sheetIndex, description)
 				}
 
-				spinner.Success()
+				pterm.Println(pterm.BgGray.Sprint(fmt.Sprintf("Finished processing section %s", processDescription)))
 			} else {
 				appCtx.Logger().Info("No process function", zap.Int("sheet index", sheetIndex), zap.String("description", description), zap.Int("method index", methodIndex))
 			}

--- a/pkg/services/ghcimport/ghc_rateengine_importer.go
+++ b/pkg/services/ghcimport/ghc_rateengine_importer.go
@@ -52,18 +52,14 @@ func (gre *GHCRateEngineImporter) runImports(appCtx appcontext.AppContext) error
 	}
 
 	for _, importer := range importers {
-		spinner, err := pterm.DefaultSpinner.Start(importer.action)
-		if err != nil {
-			return fmt.Errorf("failed to create pterm spinner: %w", err)
-		}
+		pterm.Println(pterm.BgGray.Sprint(importer.action))
 
-		err = importer.importFunction(appCtx)
+		err := importer.importFunction(appCtx)
 		if err != nil {
-			spinner.Fail()
 			return fmt.Errorf("importer failed: %s: %w", importer.action, err)
 		}
 
-		spinner.Success()
+		pterm.Println(pterm.BgGray.Sprint(fmt.Sprintf("Finished %s", importer.action)))
 	}
 
 	return nil


### PR DESCRIPTION
## [Jira ticket](https://dp3.atlassian.net/browse/MB-13897) for this change

## Summary

I removed all the spinner related code since it was generating race conditions when I turned the -race flag on for Go. 
Go does run the tests in parallel, so I suspect that it wasn't really an issue. I decided to fix it anyways since I think putting in the fix is easier than proving why the code isn't vulnerable. 

This is related to [PR for the related ADR](https://github.com/transcom/mymove-docs/pull/233)

## Setup to Run Your Code

<details>
<summary>💻 You will need to use three separate terminals to test this locally.</summary>


##### Terminal 1

Start the UI locally.

```sh
make client_run
```

##### Terminal 2

Start the Go server locally.

```sh
make server_run
```

</details>

### Additional steps

<!-- Fill out the next section as you see fit, these are just suggestions. -->

1. Make sure everything works as expected.

## Verification Steps for Author

These are to be checked by the author.

- [ ] Request review from a member of a different team.
- [ ] Have the Jira acceptance criteria been met for this change?

## Verification Steps for Reviewers

These are to be checked by a reviewer.

<!-- Fill out the next sections as you see fit, these are just suggestions. -->

### Backend

- [ ] Code follows the guidelines for [Logging](https://transcom.github.io/mymove-docs/docs/dev/contributing/backend/Backend-Programming-Guide#logging)
- [ ] The requirements listed in [Querying the Database Safely](https://transcom.github.io/mymove-docs/docs/dev/contributing/backend/Backend-Programming-Guide/#querying-the-database-safely) have been satisfied.
