### PR TITLE
[MB-14458] move history should show full address after updating a single field

### DIFF
--- a/src/constants/MoveHistory/EventTemplates/UpdateAddress/createAddress.jsx
+++ b/src/constants/MoveHistory/EventTemplates/UpdateAddress/createAddress.jsx
@@ -2,7 +2,6 @@ import React from 'react';
 
 import { formatMoveHistoryFullAddress } from 'utils/formatters';
 import a from 'constants/MoveHistory/Database/Actions';
-import o from 'constants/MoveHistory/UIDisplay/Operations';
 import t from 'constants/MoveHistory/Database/Tables';
 import LabeledDetails from 'pages/Office/MoveHistory/LabeledDetails';
 import ADDRESS_TYPE from 'constants/MoveHistory/Database/AddressTypes';
@@ -26,7 +25,7 @@ const formatChangedValues = (historyRecord) => {
 
 export default {
   action: a.INSERT,
-  eventName: o.updateMTOShipment,
+  eventName: '*',
   tableName: t.addresses,
   getEventNameDisplay: () => 'Updated address',
   getDetails: (historyRecord) => <LabeledDetails historyRecord={formatChangedValues(historyRecord)} />,

--- a/src/constants/MoveHistory/EventTemplates/UpdateAddress/createAddress.jsx
+++ b/src/constants/MoveHistory/EventTemplates/UpdateAddress/createAddress.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 
 import { formatMoveHistoryFullAddress } from 'utils/formatters';
 import a from 'constants/MoveHistory/Database/Actions';
+import o from 'constants/MoveHistory/UIDisplay/Operations';
 import t from 'constants/MoveHistory/Database/Tables';
 import LabeledDetails from 'pages/Office/MoveHistory/LabeledDetails';
 import ADDRESS_TYPE from 'constants/MoveHistory/Database/AddressTypes';
@@ -25,7 +26,7 @@ const formatChangedValues = (historyRecord) => {
 
 export default {
   action: a.INSERT,
-  eventName: '*',
+  eventName: o.updateMTOShipment,
   tableName: t.addresses,
   getEventNameDisplay: () => 'Updated address',
   getDetails: (historyRecord) => <LabeledDetails historyRecord={formatChangedValues(historyRecord)} />,

--- a/src/constants/MoveHistory/EventTemplates/UpdateAddress/createAddress.test.jsx
+++ b/src/constants/MoveHistory/EventTemplates/UpdateAddress/createAddress.test.jsx
@@ -3,8 +3,6 @@ import { render, screen } from '@testing-library/react';
 import getTemplate from 'constants/MoveHistory/TemplateManager';
 import createAddress from 'constants/MoveHistory/EventTemplates/UpdateAddress/createAddress';
 import ADDRESS_TYPE from 'constants/MoveHistory/Database/AddressTypes';
-import a from 'constants/MoveHistory/Database/Actions';
-import t from 'constants/MoveHistory/Database/Tables';
 
 const LABEL = {
   backupMailingAddress: 'Backup mailing address',
@@ -17,9 +15,9 @@ const LABEL = {
 
 describe('when given an insert with address table history record', () => {
   const historyRecord = {
-    action: a.INSERT,
-    eventName: '',
-    tableName: t.addresses,
+    action: 'INSERT',
+    eventName: 'updateMTOShipment',
+    tableName: 'addresses',
   };
   const changedValues = {
     city: 'Beverly Hills',

--- a/src/constants/MoveHistory/EventTemplates/UpdateAddress/updateAddress.jsx
+++ b/src/constants/MoveHistory/EventTemplates/UpdateAddress/updateAddress.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 
 import a from 'constants/MoveHistory/Database/Actions';
 import t from 'constants/MoveHistory/Database/Tables';
+import o from 'constants/MoveHistory/UIDisplay/Operations';
 import LabeledDetails from 'pages/Office/MoveHistory/LabeledDetails';
 import { formatMoveHistoryFullAddress } from 'utils/formatters';
 import ADDRESS_TYPE from 'constants/MoveHistory/Database/AddressTypes';
@@ -9,7 +10,12 @@ import { getMtoShipmentLabel } from 'utils/formatMtoShipment';
 
 const formatChangedValues = (historyRecord) => {
   const { context, changedValues, oldValues } = historyRecord;
-  const address = formatMoveHistoryFullAddress(changedValues);
+  // order is important here, please keep oldValues first in the addressValues object
+  const addressValues = {
+    ...oldValues,
+    ...changedValues,
+  };
+  const address = formatMoveHistoryFullAddress(addressValues);
 
   const addressType = context.filter((contextObject) => contextObject.address_type)[0].address_type;
   const addressLabel = ADDRESS_TYPE[addressType];
@@ -21,8 +27,8 @@ const formatChangedValues = (historyRecord) => {
     state: oldValues.state,
     postal_code: oldValues.postal_code,
     [addressLabel]: address,
-    ...changedValues,
     ...getMtoShipmentLabel(historyRecord),
+    ...changedValues,
   };
 
   return { ...historyRecord, changedValues: newChangedValues };
@@ -30,7 +36,7 @@ const formatChangedValues = (historyRecord) => {
 
 export default {
   action: a.UPDATE,
-  eventName: '*',
+  eventName: o.patchServiceMember,
   tableName: t.addresses,
   getEventNameDisplay: () => 'Updated address',
   getDetails: (historyRecord) => <LabeledDetails historyRecord={formatChangedValues(historyRecord)} />,

--- a/src/constants/MoveHistory/EventTemplates/UpdateAddress/updateAddress.jsx
+++ b/src/constants/MoveHistory/EventTemplates/UpdateAddress/updateAddress.jsx
@@ -2,7 +2,6 @@ import React from 'react';
 
 import a from 'constants/MoveHistory/Database/Actions';
 import t from 'constants/MoveHistory/Database/Tables';
-import o from 'constants/MoveHistory/UIDisplay/Operations';
 import LabeledDetails from 'pages/Office/MoveHistory/LabeledDetails';
 import { formatMoveHistoryFullAddress } from 'utils/formatters';
 import ADDRESS_TYPE from 'constants/MoveHistory/Database/AddressTypes';
@@ -36,7 +35,7 @@ const formatChangedValues = (historyRecord) => {
 
 export default {
   action: a.UPDATE,
-  eventName: o.patchServiceMember,
+  eventName: '*',
   tableName: t.addresses,
   getEventNameDisplay: () => 'Updated address',
   getDetails: (historyRecord) => <LabeledDetails historyRecord={formatChangedValues(historyRecord)} />,

--- a/src/constants/MoveHistory/EventTemplates/UpdateAddress/updateAddress.jsx
+++ b/src/constants/MoveHistory/EventTemplates/UpdateAddress/updateAddress.jsx
@@ -27,8 +27,8 @@ const formatChangedValues = (historyRecord) => {
     state: oldValues.state,
     postal_code: oldValues.postal_code,
     [addressLabel]: address,
-    ...getMtoShipmentLabel(historyRecord),
     ...changedValues,
+    ...getMtoShipmentLabel(historyRecord),
   };
 
   return { ...historyRecord, changedValues: newChangedValues };

--- a/src/constants/MoveHistory/EventTemplates/UpdateAddress/updateAddress.test.jsx
+++ b/src/constants/MoveHistory/EventTemplates/UpdateAddress/updateAddress.test.jsx
@@ -95,4 +95,30 @@ describe('when given a Update basic service item address history record', () => 
       },
     );
   });
+
+  describe('should display the whole address when only one field was updated', () => {
+    const updatedHistoryRecord = {
+      action: 'UPDATE',
+      eventName: 'patchServiceMember',
+      tableName: 'addresses',
+      oldValues: {
+        city: 'los angeles',
+        postal_code: '90210',
+        state: 'CA',
+        street_address_1: '123 sesame st',
+      },
+      changedValues: { street_address_1: '1234 New Ave' },
+      context: [{ address_type: 'residentialAddress' }],
+    };
+    const updatedTemplate = getTemplate(updatedHistoryRecord);
+
+    it.each([['Current mailing address', ': 1234 New Ave, los angeles, CA 90210']])(
+      'Label `%s` should have the full address `%s`',
+      async (label, value) => {
+        render(updatedTemplate.getDetails(updatedHistoryRecord));
+        expect(screen.getByText(label)).toBeInTheDocument();
+        expect(screen.getByText(value)).toBeInTheDocument();
+      },
+    );
+  });
 });

--- a/src/constants/MoveHistory/EventTemplates/UpdateAddress/updateAddress.test.jsx
+++ b/src/constants/MoveHistory/EventTemplates/UpdateAddress/updateAddress.test.jsx
@@ -1,8 +1,6 @@
 import { render, screen } from '@testing-library/react';
 
 import getTemplate from 'constants/MoveHistory/TemplateManager';
-import a from 'constants/MoveHistory/Database/Actions';
-import t from 'constants/MoveHistory/Database/Tables';
 import updateAddress from 'constants/MoveHistory/EventTemplates/UpdateAddress/updateAddress';
 import ADDRESS_TYPE from 'constants/MoveHistory/Database/AddressTypes';
 import { shipmentTypes } from 'constants/shipments';
@@ -19,9 +17,9 @@ const LABEL = {
 
 describe('when given a Update basic service item address history record', () => {
   const historyRecord = {
-    action: a.UPDATE,
-    eventName: '',
-    tableName: t.addresses,
+    action: 'UPDATE',
+    eventName: 'patchServiceMember',
+    tableName: 'addresses',
     oldValues: {
       city: 'Beverly Hills',
       postal_code: '90211',
@@ -50,7 +48,7 @@ describe('when given a Update basic service item address history record', () => 
     it.each(Object.keys(ADDRESS_TYPE).map((type) => [type, newAddress]))(
       'for label %s it displays the proper details value %s',
       async (type, value) => {
-        // add the address type and new valuei in changeValues
+        // add the address type and new value in changedValues
         const newChangedValues = { ...changedValues, [type]: newAddress };
         // set the address type in context
         const context = [{ address_type: type }];


### PR DESCRIPTION
## [Jira ticket](https://dp3.atlassian.net/browse/MB-14458) for this change

## Summary

Full address now renders and I added a test case to check its rendered when only one field is updated

## Setup to Run Your Code

<details>
<summary>💻 You will need to use two separate terminals to test this locally.</summary>

##### Terminal 1

Start the UI locally.

```sh
make client_run
```

##### Terminal 2

Start the Go server locally.

```sh
make server_run
```

</details>

### Additional steps

<!-- Fill out the next section as you see fit, these are just suggestions. -->

Update any address
1. Login as a customer
2. Click review move button at bottom
3. Click edit on the profile
4. Edit a single field of the address

View change in move history
1. Login as a office user
2. Find move by move code and click on it to view
3. Navigate to the move history tab/page
4. Find entry for the address updated

## Verification Steps for Author

These are to be checked by the author.

- [x] Have the Jira acceptance criteria been met for this change?

## Verification Steps for Reviewers

These are to be checked by a reviewer.

<!-- Fill out the next sections as you see fit, these are just suggestions. -->

### Frontend

- [ ] User facing changes have been reviewed by design.
- [ ] There are no aXe warnings for UI.
- [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/main/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
- [ ] There are no new console errors in the browser devtools
- [ ] There are no new console errors in the test output
- [ ] If this PR adds a new component to Storybook, it ensures the component is fully responsive, OR if it is intentionally not, a wrapping div using the `officeApp` class or custom `min-width` styling is used to hide any states the would not be visible to the user.

## Screenshots
Before:
<img width="1330" alt="image" src="https://user-images.githubusercontent.com/111928238/201181973-c17faf92-d845-4fa3-8d76-ab82aea9cca9.png">

After:
<img width="1328" alt="image" src="https://user-images.githubusercontent.com/111928238/201182065-55bd91ea-4fba-4d41-ae4e-30d882d17b53.png">
