### PR TITLE
Filter additional test users from the customer local login

### DIFF
--- a/pkg/models/user.go
+++ b/pkg/models/user.go
@@ -218,7 +218,7 @@ func FetchAppUserIdentities(db *pop.Connection, appname auth.Application, limit 
 				sm.middle_name AS sm_middle
 			FROM service_members as sm
 			JOIN users on sm.user_id = users.id
-			WHERE users.login_gov_email != 'first.last@login.gov.test'
+			WHERE users.login_gov_email NOT IN ('first.last@login.gov.test', 'needscloseout@ppm.closeout', '1needscloseout@ppm.closeout', '2needcloseout@ppm.closeout', 'needscloseout@ppmHHG.closeout')
 			ORDER BY users.created_at LIMIT $1`
 	}
 

--- a/pkg/testdatagen/scenario/shared.go
+++ b/pkg/testdatagen/scenario/shared.go
@@ -1455,7 +1455,7 @@ func createSubmittedMoveWithPPMShipment(appCtx appcontext.AppContext, userUpload
 
 func createMoveWithCloseOut(appCtx appcontext.AppContext, userUploader *uploader.UserUploader, locator string, branch models.ServiceMemberAffiliation) {
 	userID := uuid.Must(uuid.NewV4())
-	email := fmt.Sprintf("needscloseout+%s@ppm.closeout", strings.ToLower(branch.String()))
+	email := "needscloseout@ppm.closeout"
 	loginGovUUID := uuid.Must(uuid.NewV4())
 	submittedAt := time.Now()
 
@@ -1518,7 +1518,7 @@ func createMoveWithCloseOut(appCtx appcontext.AppContext, userUploader *uploader
 
 func createMoveWithCloseOutandNonCloseOut(appCtx appcontext.AppContext, userUploader *uploader.UserUploader, locator string, branch models.ServiceMemberAffiliation) {
 	userID := uuid.Must(uuid.NewV4())
-	email := fmt.Sprintf("1needscloseout+%s@ppm.closeout", strings.ToLower(branch.String()))
+	email := "1needscloseout@ppm.closeout"
 	loginGovUUID := uuid.Must(uuid.NewV4())
 	submittedAt := time.Now()
 
@@ -1597,7 +1597,7 @@ func createMoveWithCloseOutandNonCloseOut(appCtx appcontext.AppContext, userUplo
 
 func createMoveWith2CloseOuts(appCtx appcontext.AppContext, userUploader *uploader.UserUploader, locator string, branch models.ServiceMemberAffiliation) {
 	userID := uuid.Must(uuid.NewV4())
-	email := fmt.Sprintf("2needcloseout+%s@ppm.closeout", strings.ToLower(branch.String()))
+	email := "2needcloseout@ppm.closeout"
 	loginGovUUID := uuid.Must(uuid.NewV4())
 	submittedAt := time.Now()
 
@@ -1676,7 +1676,7 @@ func createMoveWith2CloseOuts(appCtx appcontext.AppContext, userUploader *upload
 
 func createMoveWithCloseOutandHHG(appCtx appcontext.AppContext, userUploader *uploader.UserUploader, locator string, branch models.ServiceMemberAffiliation) {
 	userID := uuid.Must(uuid.NewV4())
-	email := fmt.Sprintf("needscloseout+%s@ppmHHG.closeout", strings.ToLower(branch.String()))
+	email := "needscloseout@ppmHHG.closeout"
 	loginGovUUID := uuid.Must(uuid.NewV4())
 	submittedAt := time.Now()
 

--- a/pkg/testdatagen/scenario/shared.go
+++ b/pkg/testdatagen/scenario/shared.go
@@ -1455,7 +1455,7 @@ func createSubmittedMoveWithPPMShipment(appCtx appcontext.AppContext, userUpload
 
 func createMoveWithCloseOut(appCtx appcontext.AppContext, userUploader *uploader.UserUploader, locator string, branch models.ServiceMemberAffiliation) {
 	userID := uuid.Must(uuid.NewV4())
-	email := "needscloseout@ppm.closeout"
+	email := fmt.Sprintf("needscloseout+%s@ppm.closeout", strings.ToLower(branch.String()))
 	loginGovUUID := uuid.Must(uuid.NewV4())
 	submittedAt := time.Now()
 
@@ -1518,7 +1518,7 @@ func createMoveWithCloseOut(appCtx appcontext.AppContext, userUploader *uploader
 
 func createMoveWithCloseOutandNonCloseOut(appCtx appcontext.AppContext, userUploader *uploader.UserUploader, locator string, branch models.ServiceMemberAffiliation) {
 	userID := uuid.Must(uuid.NewV4())
-	email := "1needscloseout@ppm.closeout"
+	email := fmt.Sprintf("1needscloseout+%s@ppm.closeout", strings.ToLower(branch.String()))
 	loginGovUUID := uuid.Must(uuid.NewV4())
 	submittedAt := time.Now()
 
@@ -1597,7 +1597,7 @@ func createMoveWithCloseOutandNonCloseOut(appCtx appcontext.AppContext, userUplo
 
 func createMoveWith2CloseOuts(appCtx appcontext.AppContext, userUploader *uploader.UserUploader, locator string, branch models.ServiceMemberAffiliation) {
 	userID := uuid.Must(uuid.NewV4())
-	email := "2needcloseout@ppm.closeout"
+	email := fmt.Sprintf("2needcloseout+%s@ppm.closeout", strings.ToLower(branch.String()))
 	loginGovUUID := uuid.Must(uuid.NewV4())
 	submittedAt := time.Now()
 
@@ -1676,7 +1676,7 @@ func createMoveWith2CloseOuts(appCtx appcontext.AppContext, userUploader *upload
 
 func createMoveWithCloseOutandHHG(appCtx appcontext.AppContext, userUploader *uploader.UserUploader, locator string, branch models.ServiceMemberAffiliation) {
 	userID := uuid.Must(uuid.NewV4())
-	email := "needscloseout@ppmHHG.closeout"
+	email := fmt.Sprintf("needscloseout+%s@ppmHHG.closeout", strings.ToLower(branch.String()))
 	loginGovUUID := uuid.Must(uuid.NewV4())
 	submittedAt := time.Now()
 


### PR DESCRIPTION
## Summary

This removes the users associated with the following emails: `needscloseout@ppm.closeout`, `1needscloseout@ppm.closeout`, `2needcloseout@ppm.closeout`, `needscloseout@ppmHHG.closeout` from the local login for the customer app, because they are used primarily to create data for the office application.

## Setup to Run Your Code

<details>
<summary>💻 You will need to use three separate terminals to test this locally.</summary>

##### Terminal 1

Update your local dev seed data

```sh
 make db_dev_e2e_populate
```

##### Terminal 2

Start the UI locally.

```sh
make client_run
```

##### Terminal 3

Start the Go server locally.

```sh
make server_run
```

</details>

## Screenshots
### Before
![image](https://user-images.githubusercontent.com/84742904/202307146-5c5d0aaf-0674-44cd-b796-f1637f87f301.png)
### After
You should no longer see those users
