### PR TITLE
MB-14477 - Fix swagger error for current address etag

### DIFF
--- a/pkg/gen/ghcapi/embedded_spec.go
+++ b/pkg/gen/ghcapi/embedded_spec.go
@@ -8102,7 +8102,11 @@ func init() {
           "$ref": "#/definitions/BackupContact"
         },
         "current_address": {
-          "$ref": "#/definitions/Address"
+          "allOf": [
+            {
+              "$ref": "#/definitions/Address"
+            }
+          ]
         },
         "email": {
           "type": "string",
@@ -18113,7 +18117,11 @@ func init() {
           "$ref": "#/definitions/BackupContact"
         },
         "current_address": {
-          "$ref": "#/definitions/Address"
+          "allOf": [
+            {
+              "$ref": "#/definitions/Address"
+            }
+          ]
         },
         "email": {
           "type": "string",

--- a/pkg/gen/ghcmessages/update_customer_payload.go
+++ b/pkg/gen/ghcmessages/update_customer_payload.go
@@ -23,7 +23,9 @@ type UpdateCustomerPayload struct {
 	BackupContact *BackupContact `json:"backup_contact,omitempty"`
 
 	// current address
-	CurrentAddress *Address `json:"current_address,omitempty"`
+	CurrentAddress struct {
+		Address
+	} `json:"current_address,omitempty"`
 
 	// email
 	// Pattern: ^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$
@@ -100,17 +102,6 @@ func (m *UpdateCustomerPayload) validateCurrentAddress(formats strfmt.Registry) 
 		return nil
 	}
 
-	if m.CurrentAddress != nil {
-		if err := m.CurrentAddress.Validate(formats); err != nil {
-			if ve, ok := err.(*errors.Validation); ok {
-				return ve.ValidateName("current_address")
-			} else if ce, ok := err.(*errors.CompositeError); ok {
-				return ce.ValidateName("current_address")
-			}
-			return err
-		}
-	}
-
 	return nil
 }
 
@@ -173,17 +164,6 @@ func (m *UpdateCustomerPayload) contextValidateBackupContact(ctx context.Context
 }
 
 func (m *UpdateCustomerPayload) contextValidateCurrentAddress(ctx context.Context, formats strfmt.Registry) error {
-
-	if m.CurrentAddress != nil {
-		if err := m.CurrentAddress.ContextValidate(ctx, formats); err != nil {
-			if ve, ok := err.(*errors.Validation); ok {
-				return ve.ValidateName("current_address")
-			} else if ce, ok := err.(*errors.CompositeError); ok {
-				return ce.ValidateName("current_address")
-			}
-			return err
-		}
-	}
 
 	return nil
 }

--- a/pkg/handlers/ghcapi/customer_test.go
+++ b/pkg/handlers/ghcapi/customer_test.go
@@ -48,22 +48,25 @@ func (suite *HandlerSuite) TestUpdateCustomerHandler() {
 	officeUser.User.Roles = append(officeUser.User.Roles, roles.Role{
 		RoleType: roles.RoleTypeServicesCounselor,
 	})
+
 	body := &ghcmessages.UpdateCustomerPayload{
 		LastName:  "Newlastname",
 		FirstName: "Newfirstname",
 		Phone:     handlers.FmtString("123-455-3399"),
-		CurrentAddress: &ghcmessages.Address{
-			StreetAddress1: handlers.FmtString("123 New Street"),
-			City:           handlers.FmtString("Newcity"),
-			State:          handlers.FmtString("MA"),
-			PostalCode:     handlers.FmtString("12345"),
-		},
 		BackupContact: &ghcmessages.BackupContact{
 			Name:  handlers.FmtString("New Backup Contact"),
 			Phone: handlers.FmtString("445-345-1212"),
 			Email: handlers.FmtString("newbackup@mail.com"),
 		},
 	}
+	currentAddress := ghcmessages.Address{
+		StreetAddress1: handlers.FmtString("123 New Street"),
+		City:           handlers.FmtString("Newcity"),
+		State:          handlers.FmtString("MA"),
+		PostalCode:     handlers.FmtString("12345"),
+	}
+	body.CurrentAddress.Address = currentAddress
+
 	customer := testdatagen.MakeExtendedServiceMember(suite.DB(), testdatagen.Assertions{})
 	request := httptest.NewRequest("PATCH", "/orders/{customerID}", nil)
 	request = suite.AuthenticateOfficeRequest(request, officeUser)

--- a/pkg/handlers/ghcapi/internal/payloads/payload_to_model.go
+++ b/pkg/handlers/ghcapi/internal/payloads/payload_to_model.go
@@ -48,19 +48,20 @@ func MTOAgentsModel(mtoAgents *ghcmessages.MTOAgents) *models.MTOAgents {
 // CustomerToServiceMember transforms UpdateCustomerPayload to ServiceMember model
 func CustomerToServiceMember(payload ghcmessages.UpdateCustomerPayload) models.ServiceMember {
 
-	var address models.Address
-	if payload.CurrentAddress != nil {
-		address = models.Address{
-			ID:             uuid.FromStringOrNil(payload.CurrentAddress.ID.String()),
-			StreetAddress1: *payload.CurrentAddress.StreetAddress1,
-			StreetAddress2: payload.CurrentAddress.StreetAddress2,
-			StreetAddress3: payload.CurrentAddress.StreetAddress3,
-			City:           *payload.CurrentAddress.City,
-			State:          *payload.CurrentAddress.State,
-			PostalCode:     *payload.CurrentAddress.PostalCode,
-			Country:        payload.CurrentAddress.Country,
-		}
-	}
+	// var address models.Address
+	// if payload.CurrentAddress != nil {
+	// 	address = models.Address{
+	// 		ID:             uuid.FromStringOrNil(payload.CurrentAddress.ID.String()),
+	// 		StreetAddress1: *payload.CurrentAddress.StreetAddress1,
+	// 		StreetAddress2: payload.CurrentAddress.StreetAddress2,
+	// 		StreetAddress3: payload.CurrentAddress.StreetAddress3,
+	// 		City:           *payload.CurrentAddress.City,
+	// 		State:          *payload.CurrentAddress.State,
+	// 		PostalCode:     *payload.CurrentAddress.PostalCode,
+	// 		Country:        payload.CurrentAddress.Country,
+	// 	}
+	// }
+	address := AddressModel(&payload.CurrentAddress.Address)
 
 	var backupContacts []models.BackupContact
 	if payload.BackupContact != nil {
@@ -72,7 +73,7 @@ func CustomerToServiceMember(payload ghcmessages.UpdateCustomerPayload) models.S
 	}
 
 	return models.ServiceMember{
-		ResidentialAddress: &address,
+		ResidentialAddress: address,
 		BackupContacts:     backupContacts,
 		FirstName:          &payload.FirstName,
 		LastName:           &payload.LastName,

--- a/pkg/handlers/ghcapi/internal/payloads/payload_to_model.go
+++ b/pkg/handlers/ghcapi/internal/payloads/payload_to_model.go
@@ -47,20 +47,6 @@ func MTOAgentsModel(mtoAgents *ghcmessages.MTOAgents) *models.MTOAgents {
 
 // CustomerToServiceMember transforms UpdateCustomerPayload to ServiceMember model
 func CustomerToServiceMember(payload ghcmessages.UpdateCustomerPayload) models.ServiceMember {
-
-	// var address models.Address
-	// if payload.CurrentAddress != nil {
-	// 	address = models.Address{
-	// 		ID:             uuid.FromStringOrNil(payload.CurrentAddress.ID.String()),
-	// 		StreetAddress1: *payload.CurrentAddress.StreetAddress1,
-	// 		StreetAddress2: payload.CurrentAddress.StreetAddress2,
-	// 		StreetAddress3: payload.CurrentAddress.StreetAddress3,
-	// 		City:           *payload.CurrentAddress.City,
-	// 		State:          *payload.CurrentAddress.State,
-	// 		PostalCode:     *payload.CurrentAddress.PostalCode,
-	// 		Country:        payload.CurrentAddress.Country,
-	// 	}
-	// }
 	address := AddressModel(&payload.CurrentAddress.Address)
 
 	var backupContacts []models.BackupContact

--- a/swagger-def/ghc.yaml
+++ b/swagger-def/ghc.yaml
@@ -2893,7 +2893,8 @@ definitions:
         example: David
         x-nullable: true
       current_address:
-        $ref: 'definitions/Address.yaml'
+        allOf:
+          - $ref: 'definitions/Address.yaml'
       backup_contact:
         $ref: '#/definitions/BackupContact'
   Entitlements:

--- a/swagger/ghc.yaml
+++ b/swagger/ghc.yaml
@@ -3007,7 +3007,8 @@ definitions:
         example: David
         x-nullable: true
       current_address:
-        $ref: '#/definitions/Address'
+        allOf:
+          - $ref: '#/definitions/Address'
       backup_contact:
         $ref: '#/definitions/BackupContact'
   Entitlements:


### PR DESCRIPTION
## [Jira ticket](https://dp3.atlassian.net/browse/MB-14477) for this change

## Summary

OpenAPI has trouble reconciling some validations without using "allOf" so the spec has been changed for UpdateCustomerPayload to match that of other payloads (e.g. UpdateShipment).

## Setup to Run Your Code

<details>
<summary>💻 You will need to use three separate terminals to test this locally.</summary>

##### Terminal 1

Start the Storybook locally.

```sh
make storybook
```

##### Terminal 2

Start the UI locally.

```sh
make client_run
```

##### Terminal 3

Start the Go server locally.

```sh
make server_run
```

</details>

### Additional steps

<!-- Fill out the next section as you see fit, these are just suggestions. -->

1. Log into the office app as services counselor
2. Choose any move
3. Scroll down page and click "Edit customer info"
4. Change a field on the address section
5. Click "save"
6. Validate that the save was successful

## Verification Steps for Author

These are to be checked by the author.

- [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
- [ ] Request review from a member of a different team.
- [ ] Have the Jira acceptance criteria been met for this change?

## Verification Steps for Reviewers

These are to be checked by a reviewer.

<!-- Fill out the next sections as you see fit, these are just suggestions. -->

### Frontend

- [ ] User facing changes have been reviewed by design.
- [ ] There are no aXe warnings for UI.
- [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/main/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
- [ ] There are no new console errors in the browser devtools
- [ ] There are no new console errors in the test output
- [ ] If this PR adds a new component to Storybook, it ensures the component is fully responsive, OR if it is intentionally not, a wrapping div using the `officeApp` class or custom `min-width` styling is used to hide any states the would not be visible to the user.

### Backend

- [ ] Code follows the guidelines for [Logging](https://transcom.github.io/mymove-docs/docs/dev/contributing/backend/Backend-Programming-Guide#logging)
- [ ] The requirements listed in [Querying the Database Safely](https://transcom.github.io/mymove-docs/docs/dev/contributing/backend/Backend-Programming-Guide/#querying-the-database-safely) have been satisfied.

