### PR TITLE
[MB-14464] Update milmove-cypress hash to latest one, now with Cypress 8.5.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ references:
   circleci-docker: &circleci-docker milmove/circleci-docker:milmove-app-94a41a022a48dab1c05b932734b472922260f3c0
 
   # the cypress image to use
-  cypress: &cypress milmove/circleci-docker:milmove-cypress-f678d1c6a5e2085f733f5408b7affd628f9f3576
+  cypress: &cypress milmove/circleci-docker:milmove-cypress-e44706ef28d1cad04ee6ebf45b2316d825991af7
 
   # https://circleci.com/docs/2.0/databases/#optimizing-postgres-images
   postgres: &postgres cimg/postgres:12.7

--- a/cypress/Dockerfile.cypress
+++ b/cypress/Dockerfile.cypress
@@ -1,4 +1,4 @@
-FROM milmove/circleci-docker:milmove-cypress-f678d1c6a5e2085f733f5408b7affd628f9f3576
+FROM milmove/circleci-docker:milmove-cypress-e44706ef28d1cad04ee6ebf45b2316d825991af7
 
 # use the WORKDIR from the CI image
 # hadolint ignore=DL3045


### PR DESCRIPTION
## [Jira ticket](https://dp3.atlassian.net/browse/MB-14464) for this change

## Summary

First, reference [this circleci-docker PR](https://github.com/transcom/circleci-docker/pull/325).  This MilMove PR is just trying to get MilMove on the latest `milmove-cypress` image with a downgraded Cypress (8.5.0).  We're currently on the same version, but we're getting there by using a circleci-docker hash from back in April because cypress was updated after that to 9.x and 10.x in circleci-docker independently of MilMove (which ideally shouldn't have happened).  As a result, updating other dependencies from the `milmove-cypress` image becomes more difficult.  So this just tries to get everything on the latest main branches back in sync.

This also includes some other dependencies that have been updated in the `milmove-cypress` image since April, but we've not been using because of the old hash reference.

## Setup to Run Your Code

<details>
<summary>💻 You will need to use three separate terminals to test this locally.</summary>

##### Terminal 1

Start the Storybook locally.

```sh
make storybook
```

##### Terminal 2

Start the UI locally.

```sh
make client_run
```

##### Terminal 3

Start the Go server locally.

```sh
make server_run
```

</details>

### Additional steps

Just make sure all E2E tests pass.

## Verification Steps for Author

These are to be checked by the author.

- [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
- [ ] Request review from a member of a different team.
- [ ] Have the Jira acceptance criteria been met for this change?
