### PR TITLE
[MB-14420] Add a certificate validity check to circleCI workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1764,7 +1764,9 @@ workflows:
       - pre_deps_golang
 
       - pre_deps_yarn
-
+      
+      - check_tls_certificate_prd
+      
       - check_generated_code:
           requires:
             - pre_deps_golang
@@ -1776,7 +1778,6 @@ workflows:
           filters:
             branches:
               only: main
-
       - pre_test:
           requires:
             - pre_deps_golang

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -729,6 +729,31 @@ jobs:
       - run: scripts/check-generated-code pkg/gen/ $(find . -type d -name "*mocks" -exec echo -n '{} ' \;)
       - announce_failure
 
+  # `check_tls_certificate_env` is used to confirm that the certificate-key pair match
+  check_tls_certificate_prd:
+    executor: av_medium
+    steps:
+      - checkout
+      - tls_vars_prd
+      - run: scripts/check-tls-pair ${TLS_KEY} ${TLS_CERT}
+      - announce_failure
+  
+  check_tls_certificate_stg:
+    executor: av_medium
+    steps:
+      - checkout
+      - tls_vars_stg
+      - run: scripts/check-tls-pair ${TLS_KEY} ${TLS_CERT}
+      - announce_failure
+
+  check_tls_certificate_dp3:
+    executor: av_medium
+    steps:
+      - checkout
+      - tls_vars_dp3
+      - run: scripts/check-tls-pair ${TLS_KEY} ${TLS_CERT}
+      - announce_failure
+
   # `anti_virus` uses virus detection software to scan the source code
   anti_virus:
     executor: av_medium

--- a/scripts/check-tls-pair
+++ b/scripts/check-tls-pair
@@ -1,0 +1,19 @@
+#! /usr/bin/env bash
+#
+#   check-tls-pair confirms that the TLS cert and key pair are a match.
+#   This will allow us to trigger a failure quickly instead of finding out that the keypair doesn't work 30 minutes into the deploy.
+#
+set -eu -o pipefail
+
+key=$1
+cert=$2
+
+KEY_FILE=$(echo $1 | base64 --decode)
+CERT_FILE=$(echo $2 | base64 --decode)
+
+key_mod=$(openssl rsa -noout -modulus -in ${KEY_FILE} | openssl md5)
+cert_mod=$(openssl x509 -noout -modulus -in ${CERT_FILE} | openssl md5)
+
+if [ key_mod != cert_mod ]; then
+  exit 1
+fi


### PR DESCRIPTION
The motivation here is to shorten the feedback loop from updating a certificate to knowing whether its valid or not in the CircleCI workflow.