### PR TITLE
[MB-14480] Move history should only show one entry for excess weight notification dismissal

### DIFF
--- a/src/constants/MoveHistory/EventTemplates/AcknowledgeExcessWeightRisk/acknowledgeExcessWeightRisk.jsx
+++ b/src/constants/MoveHistory/EventTemplates/AcknowledgeExcessWeightRisk/acknowledgeExcessWeightRisk.jsx
@@ -9,5 +9,7 @@ export default {
   eventName: o.acknowledgeExcessWeightRisk,
   tableName: t.moves,
   getEventNameDisplay: () => 'Updated move',
-  getDetails: () => <> Dismissed excess weight alert </>,
+  getDetails: (historyRecord) => (
+    <>{historyRecord?.changedValues?.excess_weight_acknowledged_at ? 'Dismissed excess weight alert' : '-'} </>
+  ),
 };

--- a/src/constants/MoveHistory/EventTemplates/AcknowledgeExcessWeightRisk/acknowledgeExcessWeightRisk.test.jsx
+++ b/src/constants/MoveHistory/EventTemplates/AcknowledgeExcessWeightRisk/acknowledgeExcessWeightRisk.test.jsx
@@ -14,11 +14,19 @@ describe('when given an Acknowledge excess weight risk history record', () => {
     const result = getTemplate(historyRecord);
     expect(result).toMatchObject(e);
   });
-
-  it('renders the proper message in the details column', () => {
+  it('renders the default details in the details column when excess risk key is not present ', () => {
     const template = getTemplate(historyRecord);
-
     render(template.getDetails(historyRecord));
+    expect(screen.getByText('-')).toBeInTheDocument();
+  });
+
+  it('renders the proper message in the details column when excess_weight_acknowledged_at is present ', () => {
+    const newHistoryRecord = {
+      ...historyRecord,
+      changedValues: { excess_weight_acknowledged_at: 'this would usually be a time value' },
+    };
+    const template = getTemplate(newHistoryRecord);
+    render(template.getDetails(newHistoryRecord));
     expect(screen.getByText('Dismissed excess weight alert')).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## [Jira ticket](https://dp3.atlassian.net/browse/MB-14480) for this change

## Summary

This PR removes the duplicate dismiss weight move event and replaces it with blank details inline with the decision to not make a template for change of status noted in Confluence document on [Move statuses in PO9](https://dp3.atlassian.net/wiki/spaces/MT/pages/1917091841/Move+statuses+in+PO9).


### Setup to Run Your Code

<details>
<summary>💻 You will need to use three separate terminals to test this locally.</summary>

##### Terminal 1

Start the UI locally.

```sh
make client_run
```

##### Terminal 3

Start the Go server locally.

```sh
make server_run
```

</details>

### Additional steps

<!-- Fill out the next section as you see fit, these are just suggestions. -->

1. Find a new move as the TOO and submit a HHG shipment
2. Log in as the prime to update the shipment estimated weight. Use a value that’s ridiculous like 21,000. That should trigger the excess weight qualified at.
3. Log back in as TOO, locate the move and go to move task order.
4. There should be a notification of that states the move is at risk for being overweight. Click the x to dismiss it.
5. Go to move history. There should only be one entry for dismissing the weight risk.


## Screenshot
**Before**
<img width="1494" alt="Screen Shot 2022-11-18 at 3 15 36 PM" src="https://user-images.githubusercontent.com/28371460/202809194-09016e70-bbde-4c0b-b4bc-f7c085d5334c.png">

**After**
<img width="1470" alt="Screen Shot 2022-11-18 at 3 14 33 PM" src="https://user-images.githubusercontent.com/28371460/202809246-b141d830-2b05-41c9-b411-acffcfe0d34d.png">

