### PR TITLE
MB-14214 customer can enter pro gear details integration

### DIFF
--- a/pkg/handlers/internalapi/uploads.go
+++ b/pkg/handlers/internalapi/uploads.go
@@ -179,7 +179,7 @@ func (h CreatePPMUploadHandler) Handle(params ppmop.CreatePPMUploadParams) middl
 			documentID := uuid.FromStringOrNil(params.DocumentID.String())
 
 			// Fetch document to ensure user has access to it
-			document, docErr := models.FetchDocument(appCtx.DB(), appCtx.Session(), documentID, false)
+			document, docErr := models.FetchDocument(appCtx.DB(), appCtx.Session(), documentID, true)
 			if docErr != nil {
 				docNotFoundErr := fmt.Errorf("documentId %q was not found for this user", documentID)
 				return ppmop.NewCreatePPMUploadNotFound().WithPayload(payloads.ClientError(handlers.NotFoundMessage, docNotFoundErr.Error(), h.GetTraceIDFromRequest(params.HTTPRequest))), docNotFoundErr

--- a/src/components/Customer/PPM/Closeout/FinalCloseoutForm/FinalCloseoutForm.test.jsx
+++ b/src/components/Customer/PPM/Closeout/FinalCloseoutForm/FinalCloseoutForm.test.jsx
@@ -26,10 +26,7 @@ describe('FinalCloseoutForm component', () => {
 
     const weightTicket = createCompleteWeightTicket({ serviceMemberId }, { emptyWeight: 14000, fullWeight: 18000 });
     const movingExpense = createCompleteMovingExpense({ serviceMemberId }, { amount: 30000 });
-    const proGearWeightTicket = createCompleteProGearWeightTicket(
-      { serviceMemberId },
-      { emptyWeight: 14000, fullWeight: 16000 },
-    );
+    const proGearWeightTicket = createCompleteProGearWeightTicket({ serviceMemberId }, { weight: 1500 });
 
     const mtoShipment = createPPMShipmentWithFinalIncentive({
       ppmShipment: {
@@ -52,7 +49,7 @@ describe('FinalCloseoutForm component', () => {
     const findListItemWithText = prepListSearchForItem(screen.getAllByRole('listitem'));
 
     expect(findListItemWithText('4,000 lbs total net weight')).toBeInTheDocument();
-    expect(findListItemWithText('2,000 lbs of pro-gear')).toBeInTheDocument();
+    expect(findListItemWithText('1,500 lbs of pro-gear')).toBeInTheDocument();
     expect(findListItemWithText('$300.00 in expenses claimed')).toBeInTheDocument();
 
     expect(
@@ -74,10 +71,9 @@ describe('FinalCloseoutForm component', () => {
       createCompleteMovingExpense({ serviceMemberId }, fieldOverrides),
     );
 
-    const proGearWeightTickets = [
-      { emptyWeight: 15000, fullWeight: 15500 },
-      { emptyWeight: 15000, fullWeight: 16000 },
-    ].map((fieldOverrides) => createCompleteProGearWeightTicket({ serviceMemberId }, fieldOverrides));
+    const proGearWeightTickets = [{ weight: 750 }, { weight: 750 }].map((fieldOverrides) =>
+      createCompleteProGearWeightTicket({ serviceMemberId }, fieldOverrides),
+    );
 
     const mtoShipment = createPPMShipmentWithFinalIncentive({
       ppmShipment: {

--- a/src/components/Customer/PPM/Closeout/ProGearForm/ProGearForm.jsx
+++ b/src/components/Customer/PPM/Closeout/ProGearForm/ProGearForm.jsx
@@ -61,8 +61,10 @@ const ProGearForm = ({ proGear, setNumber, onSubmit, onBack, onCreateUpload, onU
                 <h2>Set {setNumber}</h2>
                 <FormGroup>
                   <Fieldset>
-                    <legend>Who does this pro-gear belongs to?</legend>
-                    <Hint className={ppmStyles.hint}>You have to separate yours and your spouse&apos;s pro-gear.</Hint>
+                    <label htmlFor="selfProGear" className={classnames('usa-label', styles.descriptionTextField)}>
+                      Who does this pro-gear belong to?
+                      <Hint className={styles.hint}>You have to separate yours and your spouse&apos;s pro-gear.</Hint>
+                    </label>
                     <Field
                       as={Radio}
                       id="ownerOfProGearSelf"
@@ -90,7 +92,7 @@ const ProGearForm = ({ proGear, setNumber, onSubmit, onBack, onCreateUpload, onU
                         label="Brief description of the pro-gear"
                         labelHint={
                           <Hint className={styles.hint}>
-                            Examples of pro-gear includes specialized apparel and government issued equipment. Check the{' '}
+                            Examples of pro-gear include specialized apparel and government&ndash;issued equipment.
                             {jtr} for examples of pro-gear.
                           </Hint>
                         }

--- a/src/components/Customer/PPM/Closeout/ProGearForm/ProGearForm.jsx
+++ b/src/components/Customer/PPM/Closeout/ProGearForm/ProGearForm.jsx
@@ -103,7 +103,7 @@ const ProGearForm = ({ proGear, setNumber, onSubmit, onBack, onCreateUpload, onU
                       name="belongsToSelf"
                       value="true"
                       checked={values.belongsToSelf === 'true'}
-                      data-testid="belongsToSelf"
+                      data-testid="selfProGear"
                     />
                     <Field
                       as={Radio}

--- a/src/components/Customer/PPM/Closeout/ProGearForm/ProGearForm.jsx
+++ b/src/components/Customer/PPM/Closeout/ProGearForm/ProGearForm.jsx
@@ -1,5 +1,5 @@
 import React, { createRef } from 'react';
-import { connect } from 'react-redux';
+import { useSelector } from 'react-redux';
 import * as Yup from 'yup';
 import { Field, Formik } from 'formik';
 import { func, number } from 'prop-types';
@@ -23,17 +23,10 @@ import MaskedTextField from 'components/form/fields/MaskedTextField/MaskedTextFi
 
 const documentRef = createRef();
 
-const ProGearForm = ({
-  proGear,
-  setNumber,
-  onSubmit,
-  onBack,
-  onCreateUpload,
-  onUploadComplete,
-  onUploadDelete,
-  proGearEntitlements,
-}) => {
+const ProGearForm = ({ proGear, setNumber, onSubmit, onBack, onCreateUpload, onUploadComplete, onUploadDelete }) => {
   const { belongsToSelf, document, weight, description, hasWeightTickets } = proGear || {};
+
+  const proGearEntitlements = useSelector((state) => selectProGearEntitlements(state));
 
   const validationSchema = Yup.object().shape({
     belongsToSelf: Yup.bool().required('Required'),
@@ -212,11 +205,4 @@ ProGearForm.defaultProps = {
   },
 };
 
-const mapStateToProps = (state) => {
-  const proGearEntitlements = selectProGearEntitlements(state);
-  return {
-    proGearEntitlements,
-  };
-};
-
-export default connect(mapStateToProps)(ProGearForm);
+export default ProGearForm;

--- a/src/components/Customer/PPM/Closeout/ProGearForm/ProGearForm.jsx
+++ b/src/components/Customer/PPM/Closeout/ProGearForm/ProGearForm.jsx
@@ -36,9 +36,6 @@ const ProGearForm = ({ proGear, setNumber, onSubmit, onBack, onCreateUpload, onU
       .required('Required')
       .min(1, 'Enter a weight greater than 0 lbs.')
       .when('belongsToSelf', (belongsToSelfField, schema) => {
-        if (belongsToSelfField === null) {
-          return schema;
-        }
         let maximum;
         if (belongsToSelfField) {
           maximum = proGearEntitlements.proGear;
@@ -77,13 +74,7 @@ const ProGearForm = ({ proGear, setNumber, onSubmit, onBack, onCreateUpload, onU
     <Formik initialValues={initialValues} validationSchema={validationSchema} onSubmit={onSubmit}>
       {({ isValid, isSubmitting, handleSubmit, values, ...formikProps }) => {
         const getEntitlement = () => {
-          if (values.belongsToSelf === null) {
-            return null;
-          }
-          if (values.belongsToSelf === 'true') {
-            return proGearEntitlements.proGear;
-          }
-          return proGearEntitlements.proGearSpouse;
+          return values.belongsToSelf === 'true' ? proGearEntitlements.proGear : proGearEntitlements.proGearSpouse;
         };
         return (
           <div className={classnames(ppmStyles.formContainer, styles.ProGearForm)}>

--- a/src/components/Customer/PPM/Closeout/ProGearForm/ProGearForm.jsx
+++ b/src/components/Customer/PPM/Closeout/ProGearForm/ProGearForm.jsx
@@ -3,8 +3,7 @@ import { useSelector } from 'react-redux';
 import * as Yup from 'yup';
 import { Field, Formik } from 'formik';
 import { func, number } from 'prop-types';
-import { Button, Form, Link, Radio } from '@trussworks/react-uswds';
-import { FormGroup } from '@material-ui/core';
+import { ErrorMessage, Button, Form, FormGroup, Link, Radio } from '@trussworks/react-uswds';
 import classnames from 'classnames';
 
 import { formatWeight } from 'utils/formatters';
@@ -61,7 +60,7 @@ const ProGearForm = ({ proGear, setNumber, onSubmit, onBack, onCreateUpload, onU
     document: document?.uploads || [],
     weight: weight ? `${weight}` : '',
     description: description ? `${description}` : '',
-    missingWeightTicket: hasWeightTickets === 'false',
+    missingWeightTicket: hasWeightTickets === false,
   };
 
   const jtr = (
@@ -81,11 +80,14 @@ const ProGearForm = ({ proGear, setNumber, onSubmit, onBack, onCreateUpload, onU
             <Form className={classnames(ppmStyles.form, styles.form)}>
               <SectionWrapper className={formStyles.formSection}>
                 <h2>Set {setNumber}</h2>
-                <FormGroup>
+                <FormGroup error={formikProps.touched?.belongsToSelf && formikProps.errors?.belongsToSelf}>
                   <Fieldset>
                     <label htmlFor="belongsToSelf" className={classnames('usa-label', styles.descriptionTextField)}>
                       Who does this pro-gear belong to?
                       <Hint className={styles.hint}>You have to separate yours and your spouse&apos;s pro-gear.</Hint>
+                      {formikProps.touched?.belongsToSelf && formikProps.errors?.belongsToSelf && (
+                        <ErrorMessage>{formikProps.errors?.belongsToSelf}</ErrorMessage>
+                      )}
                     </label>
                     <Field
                       as={Radio}

--- a/src/components/Customer/PPM/Closeout/ProGearForm/ProGearForm.jsx
+++ b/src/components/Customer/PPM/Closeout/ProGearForm/ProGearForm.jsx
@@ -48,7 +48,7 @@ const ProGearForm = ({ proGear, setNumber, onSubmit, onBack, onCreateUpload, onU
         return schema.max(maximum, `Pro gear weight must be less than or equal to ${formatWeight(maximum)}.`);
       }),
     description: Yup.string().required('Required'),
-    hasWeightTickets: Yup.string(),
+    missingWeightTicket: Yup.string().required(),
   });
 
   let proGearValue;

--- a/src/components/Customer/PPM/Closeout/ProGearForm/ProGearForm.jsx
+++ b/src/components/Customer/PPM/Closeout/ProGearForm/ProGearForm.jsx
@@ -20,6 +20,7 @@ import formStyles from 'styles/form.module.scss';
 import ppmStyles from 'components/Customer/PPM/PPM.module.scss';
 import SectionWrapper from 'components/Customer/SectionWrapper';
 import MaskedTextField from 'components/form/fields/MaskedTextField/MaskedTextField';
+import { uploadShape } from 'types/uploads';
 
 const documentRef = createRef();
 
@@ -30,10 +31,10 @@ const ProGearForm = ({ proGear, setNumber, onSubmit, onBack, onCreateUpload, onU
 
   const validationSchema = Yup.object().shape({
     belongsToSelf: Yup.bool().required('Required'),
-    document: Yup.object().nullable(),
+    document: Yup.array().of(uploadShape).min(1, 'At least one upload is required'),
     weight: Yup.number()
       .required('Required')
-      .min(0, 'Enter a weight 0 lbs or greater.')
+      .min(1, 'Enter a weight greater than 0 lbs.')
       .when('belongsToSelf', (belongsToSelfField, schema) => {
         if (belongsToSelfField === null) {
           return schema;

--- a/src/components/Customer/PPM/Closeout/ProGearForm/ProGearForm.module.scss
+++ b/src/components/Customer/PPM/Closeout/ProGearForm/ProGearForm.module.scss
@@ -1,6 +1,10 @@
 @import 'shared/styles/_basics';
 
 .ProGearForm {
+  :global(.usa-label) {
+    max-width: none;
+  }
+
   :global(.usa-select) {
     width: 50%;
   }
@@ -17,12 +21,13 @@
     @include u-margin-top('05');
     @include u-margin-bottom('05');
     font-weight: normal;
-    width: 100%
+    width: 100%;
+    max-width: none;
   }
 
   .form {
     .descriptionTextField {
-      width: 100%
+      width: 100%;
     }
   }
 

--- a/src/components/Customer/PPM/Closeout/ProGearForm/ProGearForm.stories.jsx
+++ b/src/components/Customer/PPM/Closeout/ProGearForm/ProGearForm.stories.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Grid, GridContainer } from '@trussworks/react-uswds';
 
+import { MockProviders } from 'testUtils';
 import ProGearForm from 'components/Customer/PPM/Closeout/ProGearForm/ProGearForm';
 
 export default {
@@ -8,13 +9,15 @@ export default {
   component: ProGearForm,
   decorators: [
     (Story) => (
-      <GridContainer>
-        <Grid row>
-          <Grid col desktop={{ col: 8, offset: 2 }}>
-            <Story />
+      <MockProviders>
+        <GridContainer>
+          <Grid row>
+            <Grid col desktop={{ col: 8, offset: 2 }}>
+              <Story />
+            </Grid>
           </Grid>
-        </Grid>
-      </GridContainer>
+        </GridContainer>
+      </MockProviders>
     ),
   ],
   argTypes: {

--- a/src/components/Customer/PPM/Closeout/ProGearForm/ProGearForm.test.jsx
+++ b/src/components/Customer/PPM/Closeout/ProGearForm/ProGearForm.test.jsx
@@ -29,9 +29,9 @@ beforeEach(() => {
 
 const proGearProps = {
   proGear: {
-    selfProGear: true,
+    belongsToSelf: true,
     document: [],
-    proGearWeight: 1,
+    weight: 1,
     description: 'Description',
     missingWeightTicket: '',
   },
@@ -39,7 +39,7 @@ const proGearProps = {
 
 const spouseProGearProps = {
   proGear: {
-    selfProGear: false,
+    belongsToSelf: false,
   },
 };
 
@@ -59,13 +59,13 @@ describe('ProGearForm component', () => {
       expect(screen.getByRole('button', { name: 'Save & Continue' })).toBeEnabled();
     });
 
-    it('does not select a radio when selfProGear is null', () => {
+    it('does not select a radio when belongsToSelf is null', () => {
       render(<ProGearForm {...defaultProps} />, { wrapper: MockProviders });
       expect(screen.getByLabelText('Me')).not.toBeChecked();
       expect(screen.getByLabelText('My spouse')).not.toBeChecked();
     });
 
-    it('selects "Me" radio when selfProGear is true', () => {
+    it('selects "Me" radio when belongsToSelf is true', () => {
       const { container } = render(<ProGearForm {...defaultProps} {...proGearProps} />, { wrapper: MockProviders });
       expect(screen.getByLabelText('Me')).toBeChecked();
       expect(screen.getByLabelText('My spouse')).not.toBeChecked();
@@ -73,7 +73,7 @@ describe('ProGearForm component', () => {
     });
     // TODO: Move test to WeightTicketUpload.test.jsx
     // it('populates form when weight ticket is missing', async () => {
-    //   render(<ProGearForm {...defaultProps} {...selfProGearProps} />);
+    //   render(<ProGearForm {...defaultProps} {...belongsToSelfProps} />);
     //   await waitFor(() => {
     //     expect(screen.getByLabelText("I don't have weight tickets")).toHaveDisplayValue('missingWeightTicket');
     //   });
@@ -82,7 +82,7 @@ describe('ProGearForm component', () => {
     //   ).toBeInTheDocument();
     // });
 
-    it('selects "My spouse" radio when selfProGear is false', () => {
+    it('selects "My spouse" radio when belongsToSelf is false', () => {
       render(
         <MockProviders initialState={testState}>
           <ProGearForm {...defaultProps} {...spouseProGearProps} />
@@ -93,13 +93,13 @@ describe('ProGearForm component', () => {
     });
   });
   describe('attaches button handler callbacks', () => {
-    it('calls the onSubmit callback with selfProGear set', async () => {
+    it('calls the onSubmit callback with belongsToSelf set', async () => {
       const expectedPayload = {
-        selfProGear: 'true',
+        belongsToSelf: 'true',
         document: [],
-        proGearWeight: '1',
+        weight: '1',
         description: 'Description',
-        missingWeightTicket: '',
+        missingWeightTicket: false,
       };
       render(<ProGearForm {...defaultProps} {...proGearProps} />, { wrapper: MockProviders });
 

--- a/src/components/Customer/PPM/Closeout/ProGearForm/ProGearForm.test.jsx
+++ b/src/components/Customer/PPM/Closeout/ProGearForm/ProGearForm.test.jsx
@@ -2,17 +2,35 @@ import React from 'react';
 import { render, waitFor, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
+import { MockProviders } from 'testUtils';
 import ProGearForm from 'components/Customer/PPM/Closeout/ProGearForm/ProGearForm';
 
 const defaultProps = {
   onBack: jest.fn(),
   onSubmit: jest.fn(),
+  onUploadComplete: jest.fn(),
+  onUploadDelete: jest.fn(),
+  onCreateUpload: jest.fn(),
 };
+
+const mockProGearEntitlements = {
+  proGear: 1234,
+  proGearSpouse: 987,
+};
+
+jest.mock('store/entities/selectors', () => ({
+  ...jest.requireActual('store/entities/selectors'),
+  selectProGearEntitlements: jest.fn().mockImplementation(() => mockProGearEntitlements),
+}));
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
 
 const proGearProps = {
   proGear: {
     selfProGear: true,
-    proGearDocument: [],
+    document: [],
     proGearWeight: 1,
     description: 'Description',
     missingWeightTicket: '',
@@ -25,13 +43,15 @@ const spouseProGearProps = {
   },
 };
 
+const testState = {};
+
 describe('ProGearForm component', () => {
   describe('displays form', () => {
     it('renders blank form on load with defaults', () => {
-      render(<ProGearForm {...defaultProps} />);
+      render(<ProGearForm {...defaultProps} />, { wrapper: MockProviders });
 
       expect(screen.getByRole('heading', { level: 2, name: 'Set 1' })).toBeInTheDocument();
-      expect(screen.getByText('Who does this pro-gear belongs to?')).toBeInstanceOf(HTMLLegendElement);
+      expect(screen.getByText('Who does this pro-gear belong to?')).toBeInstanceOf(HTMLLabelElement);
       expect(screen.getByLabelText('Me')).toBeInstanceOf(HTMLInputElement);
       expect(screen.getByLabelText('My spouse')).toBeInstanceOf(HTMLInputElement);
 
@@ -40,13 +60,13 @@ describe('ProGearForm component', () => {
     });
 
     it('does not select a radio when selfProGear is null', () => {
-      render(<ProGearForm {...defaultProps} />);
+      render(<ProGearForm {...defaultProps} />, { wrapper: MockProviders });
       expect(screen.getByLabelText('Me')).not.toBeChecked();
       expect(screen.getByLabelText('My spouse')).not.toBeChecked();
     });
 
     it('selects "Me" radio when selfProGear is true', () => {
-      const { container } = render(<ProGearForm {...defaultProps} {...proGearProps} />);
+      const { container } = render(<ProGearForm {...defaultProps} {...proGearProps} />, { wrapper: MockProviders });
       expect(screen.getByLabelText('Me')).toBeChecked();
       expect(screen.getByLabelText('My spouse')).not.toBeChecked();
       expect(container).toHaveTextContent("You have to separate yours and your spouse's pro-gear.");
@@ -63,12 +83,11 @@ describe('ProGearForm component', () => {
     // });
 
     it('selects "My spouse" radio when selfProGear is false', () => {
-      render(<ProGearForm {...defaultProps} {...spouseProGearProps} />);
-      expect(screen.getByLabelText('My spouse')).toBeChecked();
-      expect(screen.getByLabelText('Me')).not.toBeChecked();
-    });
-    it('selects "My spouse" radio when selfProGear is false', () => {
-      render(<ProGearForm {...defaultProps} {...spouseProGearProps} />);
+      render(
+        <MockProviders initialState={testState}>
+          <ProGearForm {...defaultProps} {...spouseProGearProps} />
+        </MockProviders>,
+      );
       expect(screen.getByLabelText('My spouse')).toBeChecked();
       expect(screen.getByLabelText('Me')).not.toBeChecked();
     });
@@ -77,26 +96,58 @@ describe('ProGearForm component', () => {
     it('calls the onSubmit callback with selfProGear set', async () => {
       const expectedPayload = {
         selfProGear: 'true',
-        proGearDocument: [],
+        document: [],
         proGearWeight: '1',
         description: 'Description',
         missingWeightTicket: '',
       };
-      render(<ProGearForm {...defaultProps} {...proGearProps} />);
+      render(<ProGearForm {...defaultProps} {...proGearProps} />, { wrapper: MockProviders });
 
-      await userEvent.click(screen.getByRole('button', { name: 'Save & Continue' }));
+      userEvent.click(screen.getByRole('button', { name: 'Save & Continue' }));
 
       await waitFor(() => {
         expect(defaultProps.onSubmit).toHaveBeenCalledWith(expectedPayload, expect.anything());
       });
     });
     it('calls the onBack prop when the Return To Homepage button is clicked', async () => {
-      render(<ProGearForm {...defaultProps} />);
+      render(<ProGearForm {...defaultProps} />, { wrapper: MockProviders });
 
-      await userEvent.click(screen.getByRole('button', { name: 'Return To Homepage' }));
+      userEvent.click(screen.getByRole('button', { name: 'Return To Homepage' }));
 
       await waitFor(() => {
         expect(defaultProps.onBack).toHaveBeenCalled();
+      });
+    });
+  });
+  describe('handles entitlements', () => {
+    it("displays self's pro-gear maximum.", () => {
+      const { container } = render(<ProGearForm {...defaultProps} {...proGearProps} />, { wrapper: MockProviders });
+      expect(container).toHaveTextContent('Your maximum allowance is 1,234 lbs.');
+    });
+    it("displays spouse's pro-gear maximum.", () => {
+      const { container } = render(<ProGearForm {...defaultProps} {...proGearProps} {...spouseProGearProps} />, {
+        wrapper: MockProviders,
+      });
+      expect(container).toHaveTextContent('Your maximum allowance is 987 lbs.');
+    });
+    it('invalidates if weight exceeds the maximum.', async () => {
+      render(<ProGearForm {...defaultProps} {...proGearProps} />, { wrapper: MockProviders });
+      userEvent.type(screen.getByRole('textbox', { name: /^Shipment's pro-gear weight/ }), '2000');
+      await waitFor(() => {
+        expect(screen.getByText(/Pro gear weight must be less than or equal to 1,234 lbs./)).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: 'Save & Continue' })).toBeDisabled();
+      });
+    });
+    it('invalidates if a valid weight is entered but a lower maximum is subsequently selected', async () => {
+      render(<ProGearForm {...defaultProps} {...proGearProps} />, { wrapper: MockProviders });
+      userEvent.type(screen.getByRole('textbox', { name: /^Shipment's pro-gear weight/ }), '1000');
+      await waitFor(() => {
+        expect(screen.queryByText(/Pro gear weight must be less than or equal to 1,234 lbs./)).not.toBeInTheDocument();
+      });
+      userEvent.click(screen.getByLabelText('My spouse'));
+      await waitFor(() => {
+        expect(screen.getByText(/Pro gear weight must be less than or equal to 987 lbs./)).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: 'Save & Continue' })).toBeDisabled();
       });
     });
   });

--- a/src/components/Customer/PPM/Closeout/ProGearForm/ProGearForm.test.jsx
+++ b/src/components/Customer/PPM/Closeout/ProGearForm/ProGearForm.test.jsx
@@ -94,16 +94,6 @@ describe('ProGearForm component', () => {
       expect(screen.getByLabelText('My spouse')).not.toBeChecked();
       expect(container).toHaveTextContent("You have to separate yours and your spouse's pro-gear.");
     });
-    // TODO: Move test to WeightTicketUpload.test.jsx
-    // it('populates form when weight ticket is missing', async () => {
-    //   render(<ProGearForm {...defaultProps} {...belongsToSelfProps} />);
-    //   await waitFor(() => {
-    //     expect(screen.getByLabelText("I don't have weight tickets")).toHaveDisplayValue('missingWeightTicket');
-    //   });
-    //   expect(
-    //     screen.getByText('Download the official government spreadsheet to calculate the constructed weight.'),
-    //   ).toBeInTheDocument();
-    // });
 
     it('selects "My spouse" radio when belongsToSelf is false', () => {
       render(<ProGearForm {...defaultProps} {...spouseProGearProps} />, { wrapper: MockProviders });

--- a/src/components/Customer/PPM/Closeout/ProGearForm/ProGearForm.test.jsx
+++ b/src/components/Customer/PPM/Closeout/ProGearForm/ProGearForm.test.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { render, waitFor, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { act } from 'react-dom/test-utils';
 
 import { MockProviders } from 'testUtils';
 import ProGearForm from 'components/Customer/PPM/Closeout/ProGearForm/ProGearForm';
@@ -149,7 +150,9 @@ describe('ProGearForm component', () => {
     });
     it('invalidates if weight exceeds the maximum.', async () => {
       render(<ProGearForm {...defaultProps} {...proGearProps} />, { wrapper: MockProviders });
-      userEvent.type(screen.getByRole('textbox', { name: /^Shipment's pro-gear weight/ }), '2000');
+      act(() => {
+        userEvent.type(screen.getByRole('textbox', { name: /^Shipment's pro-gear weight/ }), '2000');
+      });
       await waitFor(() => {
         expect(screen.getByText(/Pro gear weight must be less than or equal to 1,234 lbs./)).toBeInTheDocument();
         expect(screen.getByRole('button', { name: 'Save & Continue' })).toBeDisabled();
@@ -157,11 +160,15 @@ describe('ProGearForm component', () => {
     });
     it('invalidates if a valid weight is entered but a lower maximum is subsequently selected', async () => {
       render(<ProGearForm {...defaultProps} {...proGearProps} />, { wrapper: MockProviders });
-      userEvent.type(screen.getByRole('textbox', { name: /^Shipment's pro-gear weight/ }), '1000');
+      act(() => {
+        userEvent.type(screen.getByRole('textbox', { name: /^Shipment's pro-gear weight/ }), '1000');
+      });
       await waitFor(() => {
         expect(screen.queryByText(/Pro gear weight must be less than or equal to 1,234 lbs./)).not.toBeInTheDocument();
       });
-      userEvent.click(screen.getByLabelText('My spouse'));
+      act(() => {
+        userEvent.click(screen.getByLabelText('My spouse'));
+      });
       await waitFor(() => {
         expect(screen.getByText(/Pro gear weight must be less than or equal to 987 lbs./)).toBeInTheDocument();
         expect(screen.getByRole('button', { name: 'Save & Continue' })).toBeDisabled();

--- a/src/components/Customer/PPM/Closeout/WeightTicketUpload/WeightTicketUpload.jsx
+++ b/src/components/Customer/PPM/Closeout/WeightTicketUpload/WeightTicketUpload.jsx
@@ -61,7 +61,7 @@ const WeightTicketUpload = ({
       return 'Upload empty weight ticket';
     }
 
-    if (name === 'proGearDocument') {
+    if (name === 'document') {
       return "Upload your pro-gear's weight tickets";
     }
 

--- a/src/components/Customer/PPM/Closeout/WeightTicketUpload/WeightTicketUpload.test.jsx
+++ b/src/components/Customer/PPM/Closeout/WeightTicketUpload/WeightTicketUpload.test.jsx
@@ -1,0 +1,25 @@
+import React, { createRef } from 'react';
+import { render, screen } from '@testing-library/react';
+
+import WeightTicketUpload from './WeightTicketUpload';
+
+import { MockProviders } from 'testUtils';
+
+const weightTicketUploadMissingWeightTicket = {
+  fieldName: 'document',
+  missingWeightTicket: true,
+  formikProps: { touched: {} },
+  values: { document: [] },
+  fileUploadRef: createRef(),
+  onCreateUpload: jest.fn(),
+  onUploadComplete: jest.fn(),
+  onUploadDelete: jest.fn(),
+};
+describe('WeightTicketUpload', () => {
+  it('populates form when weight ticket is missing', async () => {
+    render(<WeightTicketUpload {...weightTicketUploadMissingWeightTicket} />, { wrapper: MockProviders });
+    expect(
+      screen.getByText('Download the official government spreadsheet to calculate constructed weight.'),
+    ).toBeInTheDocument();
+  });
+});

--- a/src/pages/MyMove/PPM/Closeout/ProGear/ProGear.jsx
+++ b/src/pages/MyMove/PPM/Closeout/ProGear/ProGear.jsx
@@ -1,21 +1,147 @@
-import React from 'react';
-import { useHistory } from 'react-router-dom';
-import { Grid, GridContainer } from '@trussworks/react-uswds';
+import React, { useEffect, useState } from 'react';
+import { generatePath, useHistory, useParams } from 'react-router-dom';
+import { useDispatch, useSelector } from 'react-redux';
+import { Alert, Grid, GridContainer } from '@trussworks/react-uswds';
 
+import { selectMTOShipmentById, selectProGearWeightTicketAndIndexById } from 'store/entities/selectors';
 import ppmPageStyles from 'pages/MyMove/PPM/PPM.module.scss';
 import ShipmentTag from 'components/ShipmentTag/ShipmentTag';
 import { shipmentTypes } from 'constants/shipments';
-import { generalRoutes } from 'constants/routes';
+import { customerRoutes, generalRoutes } from 'constants/routes';
+import {
+  createUploadForPPMDocument,
+  createProGearWeightTicket,
+  deleteUpload,
+  patchProGearWeightTicket,
+} from 'services/internalApi';
+import LoadingPlaceholder from 'shared/LoadingPlaceholder';
 import closingPageStyles from 'pages/MyMove/PPM/Closeout/Closeout.module.scss';
 import ProGearForm from 'components/Customer/PPM/Closeout/ProGearForm/ProGearForm';
-
-const handleSubmit = () => {};
+import { updateMTOShipment } from 'store/entities/actions';
 
 const ProGear = () => {
+  const dispatch = useDispatch();
   const history = useHistory();
   const handleBack = () => {
     history.push(generalRoutes.HOME_PATH);
   };
+  const [errorMessage, setErrorMessage] = useState(null);
+  const { moveId, mtoShipmentId, proGearId } = useParams();
+
+  const mtoShipment = useSelector((state) => selectMTOShipmentById(state, mtoShipmentId));
+  const { proGearWeightTicket: currentProGearWeightTicket, index: currentIndex } = useSelector((state) =>
+    selectProGearWeightTicketAndIndexById(state, mtoShipmentId, proGearId),
+  );
+
+  useEffect(() => {
+    if (!proGearId) {
+      createProGearWeightTicket(mtoShipment?.ppmShipment?.id)
+        .then((resp) => {
+          if (mtoShipment?.ppmShipment?.proGearWeightTickets) {
+            mtoShipment.ppmShipment.proGearWeightTickets.push(resp);
+          } else {
+            mtoShipment.ppmShipment.proGearWeightTickets = [resp];
+          }
+          // Update the URL so the back button would work and not create a new weight ticket or on
+          // refresh either.
+          history.replace(
+            generatePath(customerRoutes.SHIPMENT_PPM_PRO_GEAR_EDIT_PATH, {
+              moveId,
+              mtoShipmentId,
+              proGearId: resp.id,
+            }),
+          );
+          dispatch(updateMTOShipment(mtoShipment));
+        })
+        .catch(() => {
+          setErrorMessage('Failed to create trip record');
+        });
+    }
+  }, [proGearId, moveId, mtoShipmentId, history, dispatch, mtoShipment]);
+
+  const handleCreateUpload = async (fieldName, file, setFieldTouched) => {
+    const documentId = currentProGearWeightTicket[`${fieldName}Id`];
+
+    createUploadForPPMDocument(mtoShipment.ppmShipment.id, documentId, file)
+      .then((upload) => {
+        mtoShipment.ppmShipment.proGearWeightTickets[currentIndex][fieldName].uploads.push(upload);
+        dispatch(updateMTOShipment(mtoShipment));
+        setFieldTouched(fieldName, true);
+        return upload;
+      })
+      .catch(() => {
+        setErrorMessage('Failed to save the file upload');
+      });
+  };
+
+  const handleUploadComplete = (err) => {
+    if (err) {
+      setErrorMessage('Encountered error when completing file upload');
+    }
+  };
+
+  const handleUploadDelete = (uploadId, fieldName, setFieldTouched, setFieldValue) => {
+    deleteUpload(uploadId)
+      .then(() => {
+        const filteredUploads = mtoShipment.ppmShipment.proGearWeightTickets[currentIndex][fieldName].uploads.filter(
+          (upload) => upload.id !== uploadId,
+        );
+        mtoShipment.ppmShipment.proGearWeightTickets[currentIndex][fieldName].uploads = filteredUploads;
+        setFieldValue(fieldName, filteredUploads, true);
+        setFieldTouched(fieldName, true, true);
+        dispatch(updateMTOShipment(mtoShipment));
+      })
+      .catch(() => {
+        setErrorMessage('Failed to delete the file upload');
+      });
+  };
+
+  const handleSubmit = async (values, { setSubmitting }) => {
+    setErrorMessage(null);
+    const hasWeightTickets = !values.missingWeightTicket;
+    const belongsToSelf = values.belongsToSelf === 'true';
+    const payload = {
+      ppmShipmentId: mtoShipment.ppmShipment.id,
+      proGearWeightTicketId: currentProGearWeightTicket.id,
+      description: values.description,
+      weight: parseInt(values.weight, 10),
+      belongsToSelf,
+      hasWeightTickets,
+    };
+
+    patchProGearWeightTicket(
+      mtoShipment?.ppmShipment?.id,
+      currentProGearWeightTicket.id,
+      payload,
+      currentProGearWeightTicket.eTag,
+    )
+      .then((resp) => {
+        setSubmitting(false);
+        mtoShipment.ppmShipment.proGearWeightTickets[currentIndex] = resp;
+        history.push(generatePath(customerRoutes.SHIPMENT_PPM_REVIEW_PATH, { moveId, mtoShipmentId }));
+        dispatch(updateMTOShipment(mtoShipment));
+      })
+      .catch(() => {
+        setSubmitting(false);
+        setErrorMessage('Failed to save updated trip record');
+      });
+  };
+
+  const renderError = () => {
+    if (!errorMessage) {
+      return null;
+    }
+
+    return (
+      <Alert slim type="error">
+        {errorMessage}
+      </Alert>
+    );
+  };
+
+  if (!mtoShipment || !currentProGearWeightTicket) {
+    return renderError() || <LoadingPlaceholder />;
+  }
   return (
     <div className={ppmPageStyles.ppmPageStyle}>
       <GridContainer>
@@ -30,11 +156,13 @@ const ProGear = () => {
               </p>
             </div>
             <ProGearForm
+              proGear={currentProGearWeightTicket}
+              setNumber={currentIndex + 1}
               onBack={handleBack}
               onSubmit={handleSubmit}
-              onCreateUpload={() => {}}
-              onUploadComplete={() => {}}
-              onUploadDelete={() => {}}
+              onCreateUpload={handleCreateUpload}
+              onUploadComplete={handleUploadComplete}
+              onUploadDelete={handleUploadDelete}
             />
           </Grid>
         </Grid>

--- a/src/pages/MyMove/PPM/Closeout/ProGear/ProGear.jsx
+++ b/src/pages/MyMove/PPM/Closeout/ProGear/ProGear.jsx
@@ -149,6 +149,7 @@ const ProGear = () => {
           <Grid col desktop={{ col: 8, offset: 2 }}>
             <ShipmentTag shipmentType={shipmentTypes.PPM} />
             <h1>Pro-gear</h1>
+            {renderError()}
             <div className={closingPageStyles['closing-section']}>
               <p>
                 If you moved pro-gear for yourself or your spouse as part of this PPM, document the total weight here.

--- a/src/pages/MyMove/PPM/Closeout/ProGear/ProGear.jsx
+++ b/src/pages/MyMove/PPM/Closeout/ProGear/ProGear.jsx
@@ -96,8 +96,9 @@ const ProGear = () => {
       });
   };
 
-  const handleSubmit = async (values, { setSubmitting }) => {
+  const handleSubmit = async (values, { setSubmitting, setErrors }) => {
     setErrorMessage(null);
+    setErrors({});
     const hasWeightTickets = !values.missingWeightTicket;
     const belongsToSelf = values.belongsToSelf === 'true';
     const payload = {

--- a/src/pages/MyMove/PPM/Closeout/ProGear/ProGear.test.jsx
+++ b/src/pages/MyMove/PPM/Closeout/ProGear/ProGear.test.jsx
@@ -290,6 +290,40 @@ describe('Pro-gear page', () => {
     });
   });
 
+  it('displays an error if delete fails', async () => {
+    useParams.mockImplementation(() => ({
+      moveId: mockMoveId,
+      mtoShipmentId: mockMTOShipmentId,
+      proGearId: mockProGearWeightTicketId,
+    }));
+
+    selectProGearWeightTicketAndIndexById.mockReturnValue({
+      proGearWeightTicket: mockProGearWeightTicketWithUploads,
+      index: 0,
+    });
+
+    selectMTOShipmentById.mockReturnValue({
+      ...mockMTOShipment,
+      ppmShipment: {
+        ...mockMTOShipment.ppmShipment,
+        proGearWeightTickets: [mockProGearWeightTicketWithUploads],
+      },
+    });
+
+    deleteUpload.mockRejectedValue('error');
+    render(<ProGear />, { wrapper: MockProviders });
+
+    let deleteButtons;
+    await waitFor(() => {
+      deleteButtons = screen.getAllByRole('button', { name: 'Delete' });
+      expect(deleteButtons).toHaveLength(2);
+    });
+    userEvent.click(deleteButtons[1]);
+    await waitFor(() => {
+      expect(screen.getByText(/Failed to delete the file upload/)).toBeInTheDocument();
+    });
+  });
+
   it('expect loadingPlaceholder when mtoShipment is falsy', async () => {
     selectMTOShipmentById.mockReturnValueOnce(null);
 

--- a/src/pages/MyMove/PPM/Closeout/ProGear/ProGear.test.jsx
+++ b/src/pages/MyMove/PPM/Closeout/ProGear/ProGear.test.jsx
@@ -1,37 +1,297 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { generatePath } from 'react-router-dom';
+import { useParams, generatePath } from 'react-router-dom';
+import { v4 } from 'uuid';
 
-import { generalRoutes } from 'constants/routes';
+import { MockProviders } from 'testUtils';
+import { customerRoutes, generalRoutes } from 'constants/routes';
 import ProGear from 'pages/MyMove/PPM/Closeout/ProGear/ProGear';
+import { createProGearWeightTicket, deleteUpload, patchProGearWeightTicket } from 'services/internalApi';
+import { SHIPMENT_OPTIONS } from 'shared/constants';
+import { selectMTOShipmentById, selectProGearWeightTicketAndIndexById } from 'store/entities/selectors';
+
+const mockMoveId = 'cc03c553-d317-46af-8b2d-3c9f899f6451';
+const mockMTOShipmentId = '6b7a5769-4393-46fb-a4c4-d3f6ac7584c7';
+const mockPPMShipmentId = v4();
+const mockProGearWeightTicketId = v4();
+const mockProGearWeightTicketETag = window.btoa(new Date());
 
 const mockPush = jest.fn();
 const mockReplace = jest.fn();
-const homePath = generatePath(generalRoutes.HOME_PATH);
 jest.mock('react-router-dom', () => ({
   ...jest.requireActual('react-router-dom'),
   useHistory: () => ({
     push: mockPush,
     replace: mockReplace,
   }),
-  useLocation: () => ({}),
+  useParams: jest.fn(() => ({
+    moveId: 'cc03c553-d317-46af-8b2d-3c9f899f6451',
+    mtoShipmentId: '6b7a5769-4393-46fb-a4c4-d3f6ac7584c7',
+  })),
 }));
 
+jest.mock('services/internalApi', () => ({
+  ...jest.requireActual('services/internalApi'),
+  createProGearWeightTicket: jest.fn(),
+  createUploadForDocument: jest.fn(),
+  deleteUpload: jest.fn(),
+  patchProGearWeightTicket: jest.fn(),
+  getResponseError: jest.fn(),
+}));
+
+const mockMTOShipment = {
+  id: mockMTOShipmentId,
+  shipmentType: SHIPMENT_OPTIONS.PPM,
+  ppmShipment: {
+    id: mockPPMShipmentId,
+    pickupPostalCode: '10001',
+    destinationPostalCode: '10002',
+    expectedDepartureDate: '2022-04-30',
+    advanceRequested: true,
+    advance: 598700,
+    estimatedWeight: 4000,
+    estimatedIncentive: 1000000,
+    sitExpected: false,
+    hasProGear: false,
+    proGearWeight: null,
+    spouseProGearWeight: null,
+  },
+  eTag: 'dGVzdGluZzIzNDQzMjQ',
+};
+
+const mockDocumentId = v4();
+
+const mockProGearWeightTicket = {
+  id: mockProGearWeightTicketId,
+  ppmShipmentId: mockPPMShipmentId,
+  weight: 123,
+  description: 'Professional items',
+  belongsToSelf: true,
+  hasWeightTickets: true,
+  eTag: mockProGearWeightTicketETag,
+};
+
+const mockProGearWeightTicketWithUploads = {
+  id: mockProGearWeightTicketId,
+  ppmShipmentId: mockPPMShipmentId,
+  belongsToSelf: false,
+  documentId: mockDocumentId,
+  document: {
+    uploads: [
+      {
+        id: '299e2fb4-432d-4261-bbed-d8280c6090af',
+        createdAt: '2022-06-22T23:25:50.490Z',
+        bytes: 819200,
+        url: 'a/fake/path',
+        filename: 'weight_ticket.jpg',
+        contentType: 'image/jpg',
+      },
+      {
+        id: 'fd4e80f8-d025-44b2-8c33-15240fac51ab',
+        createdAt: '2022-06-24T23:25:50.490Z',
+        bytes: 204800,
+        url: 'a/fake/path',
+        filename: 'weight_ticket.pdf',
+        contentType: 'application/pdf',
+      },
+    ],
+  },
+  eTag: mockProGearWeightTicketETag,
+};
+
+const mockEmptyProGearWeightTicketAndIndex = {
+  proGearWeightTicket: null,
+  index: -1,
+};
+
+const mockEntitlement = {
+  proGear: 1234,
+  proGearSpouse: 123,
+};
+
+jest.mock('store/entities/selectors', () => ({
+  ...jest.requireActual('store/entities/selectors'),
+  selectMTOShipmentById: jest.fn(() => mockMTOShipment),
+  selectProGearWeightTicketAndIndexById: jest.fn(() => mockEmptyProGearWeightTicketAndIndex),
+  selectProGearEntitlements: jest.fn(() => mockEntitlement),
+}));
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+const homePath = generatePath(generalRoutes.HOME_PATH);
+const proGearWeightTicketsEditPath = generatePath(customerRoutes.SHIPMENT_PPM_PRO_GEAR_EDIT_PATH, {
+  moveId: mockMoveId,
+  mtoShipmentId: mockMTOShipmentId,
+  proGearId: mockProGearWeightTicketId,
+});
+const reviewPath = generatePath(customerRoutes.SHIPMENT_PPM_REVIEW_PATH, {
+  moveId: mockMoveId,
+  mtoShipmentId: mockMTOShipmentId,
+});
+
 describe('Pro-gear page', () => {
-  it('displays the page', () => {
-    render(<ProGear />);
+  it('loads the selected shipment from redux', async () => {
+    createProGearWeightTicket.mockResolvedValue(mockProGearWeightTicket);
+
+    render(<ProGear />, { wrapper: MockProviders });
+
+    await waitFor(() => {
+      expect(selectMTOShipmentById).toHaveBeenCalledWith(expect.anything(), mockMTOShipmentId);
+    });
+  });
+
+  it('displays an error if the createProGearWeightTicket request fails', async () => {
+    createProGearWeightTicket.mockRejectedValue('an error occurred');
+
+    render(<ProGear />, { wrapper: MockProviders });
+
+    await waitFor(() => {
+      expect(screen.getByText('Failed to create trip record')).toBeInTheDocument();
+    });
+  });
+
+  it('does not make create pro gear weight ticket api request if id param exists', async () => {
+    useParams.mockImplementationOnce(() => ({
+      moveId: mockMoveId,
+      mtoShipmentId: mockMTOShipmentId,
+      proGearId: mockProGearWeightTicketId,
+    }));
+    selectProGearWeightTicketAndIndexById.mockReturnValue({ proGearWeightTicket: mockProGearWeightTicket, index: 0 });
+
+    render(<ProGear />, { wrapper: MockProviders });
+
+    await waitFor(() => {
+      expect(createProGearWeightTicket).not.toHaveBeenCalled();
+    });
+  });
+
+  it('displays the page', async () => {
+    createProGearWeightTicket.mockResolvedValue(mockProGearWeightTicket);
+    render(<ProGear />, { wrapper: MockProviders });
     expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent('Pro-gear');
   });
   it('displays reminder to include pro-gear weight in total', () => {
-    render(<ProGear />);
+    render(<ProGear />, { wrapper: MockProviders });
     expect(screen.getByText(/This pro-gear should be included in your total weight moved./)).toBeInTheDocument();
   });
-  it('routes back to home when return to homepage is clicked', async () => {
-    render(<ProGear />);
 
-    expect(screen.getByRole('button', { name: 'Return To Homepage' })).toBeInTheDocument();
+  it('replaces the router history with newly created pro gear weight ticket id', async () => {
+    createProGearWeightTicket.mockResolvedValue(mockProGearWeightTicket);
+    selectProGearWeightTicketAndIndexById.mockReturnValueOnce({ proGearWeightTicket: null, index: -1 });
+    selectProGearWeightTicketAndIndexById.mockReturnValue({
+      proGearWeightTicket: mockProGearWeightTicket,
+      index: 0,
+    });
+
+    render(<ProGear />, { wrapper: MockProviders });
+
+    await waitFor(() => {
+      expect(mockReplace).toHaveBeenCalledWith(proGearWeightTicketsEditPath);
+    });
+  });
+
+  it('routes back to home when return to homepage is clicked', async () => {
+    createProGearWeightTicket.mockResolvedValue(mockProGearWeightTicket);
+    selectProGearWeightTicketAndIndexById.mockReturnValue({ proGearWeightTicket: mockProGearWeightTicket, index: 0 });
+
+    render(<ProGear />, { wrapper: MockProviders });
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Return To Homepage' })).toBeInTheDocument();
+    });
     await userEvent.click(screen.getByRole('button', { name: 'Return To Homepage' }));
     expect(mockPush).toHaveBeenCalledWith(homePath);
+  });
+
+  it('calls patchProGearWeightTicket with the appropriate payload', async () => {
+    createProGearWeightTicket.mockResolvedValue(mockProGearWeightTicketWithUploads);
+    selectProGearWeightTicketAndIndexById.mockReturnValue({
+      proGearWeightTicket: mockProGearWeightTicketWithUploads,
+      index: 1,
+    });
+    patchProGearWeightTicket.mockResolvedValue({});
+
+    render(<ProGear />, { wrapper: MockProviders });
+
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { level: 2 })).toHaveTextContent('Set 2');
+    });
+    userEvent.click(screen.getByLabelText('My spouse'));
+    await waitFor(() => {
+      expect(screen.getByLabelText(/^Brief description of the pro-gear/)).toBeInTheDocument();
+      expect(screen.getByLabelText(/I don't have weight tickets/)).toBeInTheDocument();
+    });
+    userEvent.type(screen.getByLabelText(/^Brief description of the pro-gear/), 'Professional gear');
+    userEvent.type(screen.getByLabelText(/^Shipment's pro-gear weight/), '100');
+    userEvent.click(screen.getByLabelText(/I don't have weight tickets/));
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Save & Continue' })).toBeEnabled();
+    });
+
+    userEvent.click(screen.getByRole('button', { name: 'Save & Continue' }));
+
+    await waitFor(() => {
+      expect(patchProGearWeightTicket).toHaveBeenCalledWith(
+        mockPPMShipmentId,
+        mockProGearWeightTicketId,
+        {
+          ppmShipmentId: mockProGearWeightTicketWithUploads.ppmShipmentId,
+          proGearWeightTicketId: mockProGearWeightTicketId,
+          description: 'Professional gear',
+          belongsToSelf: false,
+          weight: 100,
+          hasWeightTickets: false,
+        },
+        mockProGearWeightTicketETag,
+      );
+    });
+
+    expect(mockPush).toHaveBeenCalledWith(reviewPath);
+  });
+
+  it('calls the delete handler when removing an existing upload', async () => {
+    useParams.mockImplementation(() => ({
+      moveId: mockMoveId,
+      mtoShipmentId: mockMTOShipmentId,
+      proGearId: mockProGearWeightTicketId,
+    }));
+    selectProGearWeightTicketAndIndexById.mockReturnValue({
+      proGearWeightTicket: mockProGearWeightTicketWithUploads,
+      index: 0,
+    });
+
+    selectMTOShipmentById.mockReturnValue({
+      ...mockMTOShipment,
+      ppmShipment: {
+        ...mockMTOShipment.ppmShipment,
+        proGearWeightTickets: [mockProGearWeightTicketWithUploads],
+      },
+    });
+    deleteUpload.mockResolvedValue({});
+    render(<ProGear />, { wrapper: MockProviders });
+
+    let deleteButtons;
+    await waitFor(() => {
+      deleteButtons = screen.getAllByRole('button', { name: 'Delete' });
+      expect(deleteButtons).toHaveLength(2);
+    });
+    userEvent.click(deleteButtons[0]);
+    await waitFor(() => {
+      expect(screen.queryByText('weight_ticket.jpg')).not.toBeInTheDocument();
+    });
+  });
+
+  it('expect loadingPlaceholder when mtoShipment is falsy', async () => {
+    selectMTOShipmentById.mockReturnValueOnce(null);
+
+    render(<ProGear />, { wrapper: MockProviders });
+
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { level: 2 })).toHaveTextContent('Loading, please wait...');
+    });
   });
 });

--- a/src/pages/MyMove/PPM/Closeout/ProGear/ProGear.test.jsx
+++ b/src/pages/MyMove/PPM/Closeout/ProGear/ProGear.test.jsx
@@ -72,30 +72,32 @@ const mockProGearWeightTicket = {
   eTag: mockProGearWeightTicketETag,
 };
 
+const mockUploads = [
+  {
+    id: '299e2fb4-432d-4261-bbed-d8280c6090af',
+    createdAt: '2022-06-22T23:25:50.490Z',
+    bytes: 819200,
+    url: 'a/fake/path',
+    filename: 'weight_ticket.jpg',
+    contentType: 'image/jpg',
+  },
+  {
+    id: 'fd4e80f8-d025-44b2-8c33-15240fac51ab',
+    createdAt: '2022-06-24T23:25:50.490Z',
+    bytes: 204800,
+    url: 'a/fake/path',
+    filename: 'weight_ticket.pdf',
+    contentType: 'application/pdf',
+  },
+];
+
 const mockProGearWeightTicketWithUploads = {
   id: mockProGearWeightTicketId,
   ppmShipmentId: mockPPMShipmentId,
   belongsToSelf: false,
   documentId: mockDocumentId,
   document: {
-    uploads: [
-      {
-        id: '299e2fb4-432d-4261-bbed-d8280c6090af',
-        createdAt: '2022-06-22T23:25:50.490Z',
-        bytes: 819200,
-        url: 'a/fake/path',
-        filename: 'weight_ticket.jpg',
-        contentType: 'image/jpg',
-      },
-      {
-        id: 'fd4e80f8-d025-44b2-8c33-15240fac51ab',
-        createdAt: '2022-06-24T23:25:50.490Z',
-        bytes: 204800,
-        url: 'a/fake/path',
-        filename: 'weight_ticket.pdf',
-        contentType: 'application/pdf',
-      },
-    ],
+    uploads: mockUploads,
   },
   eTag: mockProGearWeightTicketETag,
 };
@@ -291,6 +293,7 @@ describe('Pro-gear page', () => {
   });
 
   it('displays an error if delete fails', async () => {
+    mockProGearWeightTicketWithUploads.document.uploads = mockUploads;
     useParams.mockImplementation(() => ({
       moveId: mockMoveId,
       mtoShipmentId: mockMTOShipmentId,

--- a/src/pages/MyMove/PPM/Closeout/ProGear/ProGear.test.jsx
+++ b/src/pages/MyMove/PPM/Closeout/ProGear/ProGear.test.jsx
@@ -279,9 +279,14 @@ describe('Pro-gear page', () => {
       deleteButtons = screen.getAllByRole('button', { name: 'Delete' });
       expect(deleteButtons).toHaveLength(2);
     });
+    userEvent.click(deleteButtons[1]);
+    await waitFor(() => {
+      expect(screen.queryByText('weight_ticket.pdf')).not.toBeInTheDocument();
+    });
     userEvent.click(deleteButtons[0]);
     await waitFor(() => {
       expect(screen.queryByText('weight_ticket.jpg')).not.toBeInTheDocument();
+      expect(screen.getByText(/At least one upload is required/)).toBeInTheDocument();
     });
   });
 

--- a/src/pages/MyMove/PPM/Closeout/Review/Review.jsx
+++ b/src/pages/MyMove/PPM/Closeout/Review/Review.jsx
@@ -28,7 +28,7 @@ import { ModalContainer, Overlay } from 'components/MigratedModal/MigratedModal'
 import Modal, { ModalActions, ModalClose, ModalTitle } from 'components/Modal/Modal';
 import { deleteWeightTicket } from 'services/internalApi';
 import ppmStyles from 'components/Customer/PPM/PPM.module.scss';
-import { hasCompletedAllWeightTickets, hasCompletedAllExpenses } from 'utils/shipments';
+import { hasCompletedAllWeightTickets, hasCompletedAllExpenses, hasCompletedAllProGear } from 'utils/shipments';
 
 const ReviewDeleteCloseoutItemModal = ({ onClose, onSubmit, itemToDelete }) => (
   <div>
@@ -112,7 +112,8 @@ const Review = () => {
 
   const weightTicketsTotal = calculateTotalNetWeightForWeightTickets(weightTickets);
 
-  const canAdvance = hasCompletedAllWeightTickets(weightTickets) && hasCompletedAllExpenses(expenses);
+  const canAdvance =
+    hasCompletedAllWeightTickets(weightTickets) && hasCompletedAllExpenses(expenses) && hasCompletedAllProGear(proGear);
 
   const proGearContents = formatProGearItems(
     proGear,

--- a/src/pages/MyMove/PPM/Closeout/Review/Review.jsx
+++ b/src/pages/MyMove/PPM/Closeout/Review/Review.jsx
@@ -64,7 +64,7 @@ const Review = () => {
   const mtoShipment = useSelector((state) => selectMTOShipmentById(state, mtoShipmentId));
 
   const weightTickets = mtoShipment?.ppmShipment?.weightTickets;
-  const proGear = mtoShipment?.ppmShipment?.proGear;
+  const proGear = mtoShipment?.ppmShipment?.proGearWeightTickets;
   const expenses = mtoShipment?.ppmShipment?.movingExpenses;
 
   if (!mtoShipment) {

--- a/src/pages/MyMove/PPM/Closeout/Review/Review.test.jsx
+++ b/src/pages/MyMove/PPM/Closeout/Review/Review.test.jsx
@@ -117,7 +117,7 @@ const mockMTOShipmentWithProGear = {
     hasProGear: true,
     proGearWeight: 100,
     spouseProGearWeight: null,
-    proGear: [createBaseProGearWeightTicket()],
+    proGearWeightTickets: [createBaseProGearWeightTicket()],
   },
   eTag: 'dGVzdGluZzIzNDQzMjQ',
 };
@@ -276,7 +276,7 @@ describe('Review page', () => {
     const editProGearWeightTicket = generatePath(customerRoutes.SHIPMENT_PPM_PRO_GEAR_EDIT_PATH, {
       moveId: mockMoveId,
       mtoShipmentId: mockMTOShipmentId,
-      proGearId: mockMTOShipmentWithProGear.ppmShipment.proGear[0].id,
+      proGearId: mockMTOShipmentWithProGear.ppmShipment.proGearWeightTickets[0].id,
     });
 
     const { memoryHistory, mockProviderWithHistory } = setUpProvidersWithHistory();

--- a/src/services/internalApi.js
+++ b/src/services/internalApi.js
@@ -333,6 +333,37 @@ export async function deleteWeightTicket() {
   return Promise.resolve();
 }
 
+export async function createProGearWeightTicket(ppmShipmentId) {
+  return makeInternalRequest(
+    'ppm.createProGearWeightTicket',
+    {
+      ppmShipmentId,
+    },
+    {
+      normalize: false,
+    },
+  );
+}
+
+export async function patchProGearWeightTicket(ppmShipmentId, proGearWeightTicketId, payload, eTag) {
+  return makeInternalRequest(
+    'ppm.updateProGearWeightTicket',
+    {
+      ppmShipmentId,
+      proGearWeightTicketId,
+      'If-Match': eTag,
+      updateProGearWeightTicket: payload,
+    },
+    {
+      normalize: false,
+    },
+  );
+}
+
+export async function deleteProGearWeightTicket() {
+  return Promise.resolve();
+}
+
 /** PPMS */
 export async function getPPMsForMove(moveId) {
   return makeInternalRequest(

--- a/src/store/entities/selectors.js
+++ b/src/store/entities/selectors.js
@@ -268,12 +268,4 @@ export const selectWeightAllotmentsForLoggedInUser = createSelector(
 export const selectProGearEntitlements = (state) => {
   const orders = selectCurrentOrders(state);
   return orders?.entitlement || null;
-  // switch (proGearOwnerIsSelf) {
-  //   case true:
-  //     return orders.entitlement.proGear;
-  //   case false:
-  //     return orders.entitlement.spouseProGear;
-  //   default:
-  //     return null;
-  // }
 };

--- a/src/store/entities/selectors.js
+++ b/src/store/entities/selectors.js
@@ -248,3 +248,16 @@ export const selectWeightAllotmentsForLoggedInUser = createSelector(
     return weightAllotment;
   },
 );
+
+export const selectProGearEntitlements = (state) => {
+  const orders = selectCurrentOrders(state);
+  return orders?.entitlement || null;
+  // switch (proGearOwnerIsSelf) {
+  //   case true:
+  //     return orders.entitlement.proGear;
+  //   case false:
+  //     return orders.entitlement.spouseProGear;
+  //   default:
+  //     return null;
+  // }
+};

--- a/src/store/entities/selectors.js
+++ b/src/store/entities/selectors.js
@@ -204,6 +204,22 @@ export const selectPPMForMove = (state, moveId) => {
   return null;
 };
 
+export const selectProGearWeightTicketAndIndexById = (state, mtoShipmentId, proGearWeightId) => {
+  let proGearWeightTicket = null;
+  let index = -1;
+  if (proGearWeightId == null) {
+    return { proGearWeightTicket, index };
+  }
+
+  const mtoShipment = selectMTOShipmentById(state, mtoShipmentId);
+  const proGearWeightTickets = mtoShipment?.ppmShipment?.proGearWeightTickets;
+  if (Array.isArray(proGearWeightTickets)) {
+    index = proGearWeightTickets.findIndex((ele) => ele.id === proGearWeightId);
+    proGearWeightTicket = proGearWeightTickets?.[index] || null;
+  }
+  return { proGearWeightTicket, index };
+};
+
 export const selectCurrentPPM = (state) => {
   const move = selectCurrentMove(state);
   return selectPPMForMove(state, move?.id);

--- a/src/utils/ppmCloseout.jsx
+++ b/src/utils/ppmCloseout.jsx
@@ -80,8 +80,8 @@ export const formatWeightTicketItems = (weightTickets, editPath, editParams, han
 export const formatProGearItems = (proGears, editPath, editParams, handleDelete) => {
   return proGears?.map((proGear, i) => {
     const weightValues = proGear.hasWeightTickets
-      ? { id: 'weight', label: 'Weight:', value: formatWeight(proGear.fullWeight - proGear.emptyWeight) }
-      : { id: 'constructedWeight', label: 'Constructed weight:', value: formatWeight(proGear.constructedWeight) };
+      ? { id: 'weight', label: 'Weight:', value: formatWeight(proGear.weight) }
+      : { id: 'constructedWeight', label: 'Constructed weight:', value: formatWeight(proGear.weight) };
     return {
       id: proGear.id,
       subheading: <h4 className="text-bold">Set {i + 1}</h4>,
@@ -89,7 +89,7 @@ export const formatProGearItems = (proGears, editPath, editParams, handleDelete)
         {
           id: 'proGearType',
           label: 'Pro-gear Type:',
-          value: proGear.selfProGear ? 'Pro-gear' : 'Spouse pro-gear',
+          value: proGear.belongsToSelf ? 'Pro-gear' : 'Spouse pro-gear',
           hideLabel: true,
         },
         { id: 'description', label: 'Description:', value: proGear.description, hideLabel: true },
@@ -150,26 +150,9 @@ export const calculateTotalNetWeightForWeightTickets = (weightTickets = []) => {
   }, 0);
 };
 
-export const calculateNetWeightForProGearWeightTicket = (proGearWeightTicket) => {
-  if (proGearWeightTicket.constructedWeight != null && !Number.isNaN(Number(proGearWeightTicket.constructedWeight))) {
-    return proGearWeightTicket.constructedWeight;
-  }
-
-  if (
-    proGearWeightTicket.emptyWeight == null ||
-    proGearWeightTicket.fullWeight == null ||
-    Number.isNaN(Number(proGearWeightTicket.emptyWeight)) ||
-    Number.isNaN(Number(proGearWeightTicket.fullWeight))
-  ) {
-    return 0;
-  }
-
-  return proGearWeightTicket.fullWeight - proGearWeightTicket.emptyWeight;
-};
-
 export const calculateTotalNetWeightForProGearWeightTickets = (proGearWeightTickets = []) => {
   return proGearWeightTickets.reduce((prev, curr) => {
-    return prev + calculateNetWeightForProGearWeightTicket(curr);
+    return prev + curr.weight;
   }, 0);
 };
 

--- a/src/utils/ppmCloseout.jsx
+++ b/src/utils/ppmCloseout.jsx
@@ -144,6 +144,14 @@ export const calculateNetWeightForWeightTicket = (weightTicket) => {
   return weightTicket.fullWeight - weightTicket.emptyWeight;
 };
 
+export const calculateNetWeightForProGearWeightTicket = (weightTicket) => {
+  if (weightTicket.weight == null || Number.isNaN(Number(weightTicket.weight))) {
+    return 0;
+  }
+
+  return weightTicket.weight;
+};
+
 export const calculateTotalNetWeightForWeightTickets = (weightTickets = []) => {
   return weightTickets.reduce((prev, curr) => {
     return prev + calculateNetWeightForWeightTicket(curr);
@@ -152,7 +160,7 @@ export const calculateTotalNetWeightForWeightTickets = (weightTickets = []) => {
 
 export const calculateTotalNetWeightForProGearWeightTickets = (proGearWeightTickets = []) => {
   return proGearWeightTickets.reduce((prev, curr) => {
-    return prev + curr.weight;
+    return prev + calculateNetWeightForProGearWeightTicket(curr);
   }, 0);
 };
 

--- a/src/utils/ppmCloseout.test.jsx
+++ b/src/utils/ppmCloseout.test.jsx
@@ -148,27 +148,18 @@ describe('calculateTotalNetWeightForWeightTickets', () => {
 
 describe('calculateNetWeightForProGearWeightTicket', () => {
   it.each([
-    [0, 400, null, 400],
-    [15000, 17000, null, 2000],
-    [null, null, 1200, 1200],
-    [null, 1500, null, 0],
-    [0, null, null, 0],
-    [null, null, null, 0],
-    [undefined, 1500, undefined, 0],
-    [0, undefined, undefined, 0],
-    [undefined, undefined, undefined, 0],
-    ['not a number', 1500, 'not a number', 0],
-    [0, 'not a number', 'not a number', 0],
-    ['not a number', 'not a number', 'not a number', 0],
+    [0, 0],
+    [15000, 15000],
+    [null, 0],
+    [undefined, 0],
+    ['not a number', 0],
   ])(
     `calculates net weight properly | emptyWeight: %s | fullWeight: %s | constructedWeight: %s | expectedNetWeight: %s`,
-    (emptyWeight, fullWeight, constructedWeight, expectedNetWeight) => {
+    (weight, expectedNetWeight) => {
       const proGearWeightTicket = createCompleteProGearWeightTicket(
         {},
         {
-          emptyWeight,
-          fullWeight,
-          constructedWeight,
+          weight,
         },
       );
 
@@ -179,112 +170,14 @@ describe('calculateNetWeightForProGearWeightTicket', () => {
 
 describe('calculateTotalNetWeightForProGearWeightTickets', () => {
   it.each([
-    [[{ emptyWeight: 0, fullWeight: 400, constructedWeight: null }], 400],
-    [
-      [
-        { emptyWeight: 0, fullWeight: 400, constructedWeight: null },
-        { emptyWeight: 15000, fullWeight: 16000, constructedWeight: null },
-      ],
-      1400,
-    ],
-    [
-      [
-        { emptyWeight: null, fullWeight: null, constructedWeight: 250 },
-        { emptyWeight: 15000, fullWeight: 16500, constructedWeight: null },
-      ],
-      1750,
-    ],
-    [
-      [
-        { emptyWeight: null, fullWeight: null, constructedWeight: 250 },
-        { emptyWeight: null, fullWeight: null, constructedWeight: 500 },
-      ],
-      750,
-    ],
-    [
-      [
-        { emptyWeight: null, fullWeight: 400, constructedWeight: null },
-        { emptyWeight: 14000, fullWeight: 16000, constructedWeight: null },
-      ],
-      2000,
-    ],
-    [
-      [
-        { emptyWeight: 0, fullWeight: null, constructedWeight: null },
-        { emptyWeight: 14000, fullWeight: 15500, constructedWeight: null },
-      ],
-      1500,
-    ],
-    [
-      [
-        { emptyWeight: null, fullWeight: null, constructedWeight: null },
-        { emptyWeight: 14000, fullWeight: 14500, constructedWeight: null },
-      ],
-      500,
-    ],
-    [
-      [
-        { emptyWeight: null, fullWeight: null, constructedWeight: null },
-        { emptyWeight: null, fullWeight: null, constructedWeight: null },
-      ],
-      0,
-    ],
-    [
-      [
-        { emptyWeight: undefined, fullWeight: 400, constructedWeight: undefined },
-        { emptyWeight: 14000, fullWeight: 16000, constructedWeight: undefined },
-      ],
-      2000,
-    ],
-    [
-      [
-        { emptyWeight: 0, fullWeight: undefined, constructedWeight: undefined },
-        { emptyWeight: 14000, fullWeight: 15500, constructedWeight: undefined },
-      ],
-      1500,
-    ],
-    [
-      [
-        { emptyWeight: undefined, fullWeight: undefined, constructedWeight: undefined },
-        { emptyWeight: 14000, fullWeight: 14500, constructedWeight: undefined },
-      ],
-      500,
-    ],
-    [
-      [
-        { emptyWeight: undefined, fullWeight: undefined, constructedWeight: undefined },
-        { emptyWeight: undefined, fullWeight: undefined, constructedWeight: undefined },
-      ],
-      0,
-    ],
-    [
-      [
-        { emptyWeight: 'not a number', fullWeight: 400, constructedWeight: 'not a number' },
-        { emptyWeight: 14000, fullWeight: 16000, constructedWeight: 'not a number' },
-      ],
-      2000,
-    ],
-    [
-      [
-        { emptyWeight: 0, fullWeight: 'not a number', constructedWeight: 'not a number' },
-        { emptyWeight: 14000, fullWeight: 15500, constructedWeight: 'not a number' },
-      ],
-      1500,
-    ],
-    [
-      [
-        { emptyWeight: 'not a number', fullWeight: 'not a number', constructedWeight: 'not a number' },
-        { emptyWeight: 14000, fullWeight: 14500, constructedWeight: 'not a number' },
-      ],
-      500,
-    ],
-    [
-      [
-        { emptyWeight: 'not a number', fullWeight: 'not a number', constructedWeight: 'not a number' },
-        { emptyWeight: 'not a number', fullWeight: 'not a number', constructedWeight: 'not a number' },
-      ],
-      0,
-    ],
+    [[{ weight: 0 }], 0],
+    [[{ weight: 0 }, { weight: 15000 }], 15000],
+    [[{ weight: null }], 0],
+    [[{ weight: null }, { weight: 15000 }], 15000],
+    [[{ weight: undefined }], 0],
+    [[{ weight: undefined }, { weight: 15000 }], 15000],
+    [[{ weight: 'not a number' }], 0],
+    [[{ weight: 'not a number' }, { weight: 15000 }], 15000],
     [[], 0],
   ])(`calculates total net weight properly`, (proGearWeightTicketsFields, expectedNetWeight) => {
     const proGearWeightTickets = [];

--- a/src/utils/shipments.js
+++ b/src/utils/shipments.js
@@ -89,3 +89,16 @@ export function hasCompletedAllExpenses(expenses) {
 
   return !!expenses?.every(isExpenseComplete);
 }
+
+export function isProGearComplete(proGear) {
+  const hasADocumentUpload = proGear.document.uploads.length > 0;
+  const hasAnOwner = proGear.belongsToSelf !== null;
+  return !!(proGear.weight && proGear.description && hasADocumentUpload && hasAnOwner);
+}
+
+export function hasCompletedAllProGear(proGear) {
+  if (!proGear?.length) {
+    return true;
+  }
+  return !!proGear?.every(isProGearComplete);
+}

--- a/src/utils/test/factories/proGearWeightTicket.js
+++ b/src/utils/test/factories/proGearWeightTicket.js
@@ -16,7 +16,6 @@ const createBaseProGearWeightTicket = ({ serviceMemberId, creationDate = new Dat
     belongsToSelf: null,
     description: null,
     hasWeightTickets: null,
-    emptyWeight: null,
     documentId: document.id,
     document,
     weight: null,
@@ -34,8 +33,7 @@ const createCompleteProGearWeightTicket = ({ serviceMemberId, creationDate } = {
     belongsToSelf: true,
     description: 'Work equipment',
     hasWeightTickets: true,
-    emptyWeight: 14500,
-    fullWeight: 16000,
+    weight: 1500,
     ...fieldOverrides,
   };
 
@@ -63,7 +61,7 @@ const createCompleteProGearWeightTicketWithConstructedWeight = (
     belongsToSelf: true,
     description: 'Work equipment',
     hasWeightTickets: false,
-    constructedWeight: 1400,
+    weight: 1400,
     ...fieldOverrides,
   };
 

--- a/src/utils/test/factories/proGearWeightTicket.js
+++ b/src/utils/test/factories/proGearWeightTicket.js
@@ -8,9 +8,7 @@ const createBaseProGearWeightTicket = ({ serviceMemberId, creationDate = new Dat
   const createdAt = creationDate.toISOString();
 
   const smId = serviceMemberId || v4();
-  const emptyDocument = createDocumentWithoutUploads({ serviceMemberId: smId });
-  const fullDocument = createDocumentWithoutUploads({ serviceMemberId: smId });
-  const constructedWeightDocument = createDocumentWithoutUploads({ serviceMemberId: smId });
+  const document = createDocumentWithoutUploads({ serviceMemberId: smId });
 
   return {
     id: v4(),
@@ -19,14 +17,9 @@ const createBaseProGearWeightTicket = ({ serviceMemberId, creationDate = new Dat
     description: null,
     hasWeightTickets: null,
     emptyWeight: null,
-    emptyDocumentId: emptyDocument.id,
-    emptyDocument,
-    fullWeight: null,
-    fullDocumentId: fullDocument.id,
-    fullDocument,
-    constructedWeight: null,
-    constructedWeightDocumentId: constructedWeightDocument.id,
-    constructedWeightDocument,
+    documentId: document.id,
+    document,
+    weight: null,
     status: null,
     reason: null,
     createdAt,
@@ -55,12 +48,8 @@ const createCompleteProGearWeightTicket = ({ serviceMemberId, creationDate } = {
     weightTicket.eTag = window.btoa(updatedAt);
   }
 
-  if (weightTicket.emptyDocument.uploads.length === 0) {
-    weightTicket.emptyDocument.uploads.push(createUpload({ fileName: 'emptyDocument.pdf' }));
-  }
-
-  if (weightTicket.fullDocument.uploads.length === 0) {
-    weightTicket.fullDocument.uploads.push(createUpload({ fileName: 'fullDocument.pdf' }));
+  if (weightTicket.document.uploads.length === 0) {
+    weightTicket.document.uploads.push(createUpload({ fileName: 'emptyDocument.pdf' }));
   }
 
   return weightTicket;


### PR DESCRIPTION
## [Jira ticket](https://dp3.atlassian.net/browse/MB-14214) for this change

## Summary

This PR integrates the Pro Gear weight tickets form with the backend. Users should be able to:
- Create a new weight ticket from the Review page by clicking "Add Pro-Gear Weight."
- Select the pro-gear owner, add/edit a description, set a weight, and toggle whether they have tickets.
- Upload a delete weight ticket documents.
- Save these changes.

Is there anything you would like reviewers to give additional scrutiny?

Just a note that some ancillary tests were failing because of the change from using empty/full weights on pro-gear to just using weight, so this PR includes fixes for those, in addition to the primary integration tests.

## Setup to Run Your Code

<details>
<summary>💻 You will need to use three separate terminals to test this locally.</summary>

##### Terminal 1

Start the UI locally.

```sh
make client_run
```

##### Terminal 2

Start the Go server locally.

```sh
make server_run
```

</details>

### Additional steps

<!-- Fill out the next section as you see fit, these are just suggestions. -->

1. Access the Customer site
2. Login as a user who is ready to close out (I use `progearWeightTicket@ppm.approved`)
3. Navigate to the Review page
4. Add and delete uploads, and set and update all other fields
5. See errors for weights entered that exceed the allowances

## Screenshots
