### PR TITLE
[MB-14533] capture updates to customer information

### DIFF
--- a/src/constants/MoveHistory/EventTemplates/UpdateCustomer/updateCustomer.jsx
+++ b/src/constants/MoveHistory/EventTemplates/UpdateCustomer/updateCustomer.jsx
@@ -1,0 +1,14 @@
+import React from 'react';
+
+import a from 'constants/MoveHistory/Database/Actions';
+import o from 'constants/MoveHistory/UIDisplay/Operations';
+import t from 'constants/MoveHistory/Database/Tables';
+import LabeledDetails from 'pages/Office/MoveHistory/LabeledDetails';
+
+export default {
+  action: a.UPDATE,
+  eventName: o.updateCustomer,
+  tableName: t.service_members,
+  getEventNameDisplay: () => 'Updated profile',
+  getDetails: (historyRecord) => <LabeledDetails historyRecord={historyRecord} />,
+};

--- a/src/constants/MoveHistory/EventTemplates/UpdateCustomer/updateCustomer.test.jsx
+++ b/src/constants/MoveHistory/EventTemplates/UpdateCustomer/updateCustomer.test.jsx
@@ -1,0 +1,35 @@
+import { render, screen } from '@testing-library/react';
+
+import getTemplate from 'constants/MoveHistory/TemplateManager';
+import updateCustomer from 'constants/MoveHistory/EventTemplates/UpdateCustomer/updateCustomer';
+
+describe('When a service counselor updates a customer name', () => {
+  const historyRecord = {
+    action: 'UPDATE',
+    eventName: 'updateCustomer',
+    tableName: 'service_members',
+    eventNameDisplay: 'Updated profile',
+    changedValues: {
+      first_name: 'Chuck',
+      last_name: 'Bartowski',
+    },
+  };
+
+  it('correctly matches the updateCustomer event to the template', () => {
+    const template = getTemplate(historyRecord);
+    expect(template).toMatchObject(updateCustomer);
+  });
+
+  describe('Renders the correct details for updated customer name', () => {
+    it.each([
+      ['First name', ': Chuck'],
+      ['Last name', ': Bartowski'],
+    ])('expect label %s to have value %s', async (label, value) => {
+      const result = getTemplate(historyRecord);
+
+      render(result.getDetails(historyRecord));
+      expect(screen.getByText(label)).toBeInTheDocument();
+      expect(screen.getByText(value)).toBeInTheDocument();
+    });
+  });
+});

--- a/src/constants/MoveHistory/EventTemplates/UpdateServiceMemberBackupContact/updateServiceMemberBackupContact.jsx
+++ b/src/constants/MoveHistory/EventTemplates/UpdateServiceMemberBackupContact/updateServiceMemberBackupContact.jsx
@@ -2,7 +2,6 @@ import React from 'react';
 
 import a from 'constants/MoveHistory/Database/Actions';
 import t from 'constants/MoveHistory/Database/Tables';
-import o from 'constants/MoveHistory/UIDisplay/Operations';
 import LabeledDetails from 'pages/Office/MoveHistory/LabeledDetails';
 
 const formatChangedValues = (historyRecord) => {
@@ -25,7 +24,7 @@ const formatChangedValues = (historyRecord) => {
 };
 export default {
   action: a.UPDATE,
-  eventName: o.updateServiceMemberBackupContact,
+  eventName: '*', // Needs wild card to handle both updateServiceMemberBackupContact and updateCustomer event
   tableName: t.backup_contacts,
   getEventNameDisplay: () => 'Updated profile',
   getDetails: (historyRecord) => <LabeledDetails historyRecord={formatChangedValues(historyRecord)} />,

--- a/src/constants/MoveHistory/EventTemplates/UpdateServiceMemberBackupContact/updateServiceMemberBackupContact.test.jsx
+++ b/src/constants/MoveHistory/EventTemplates/UpdateServiceMemberBackupContact/updateServiceMemberBackupContact.test.jsx
@@ -1,8 +1,6 @@
 import { render, screen } from '@testing-library/react';
 
 import getTemplate from 'constants/MoveHistory/TemplateManager';
-import o from 'constants/MoveHistory/UIDisplay/Operations';
-import t from 'constants/MoveHistory/Database/Tables';
 import updateServiceMemberBackupContact from 'constants/MoveHistory/EventTemplates/UpdateServiceMemberBackupContact/updateServiceMemberBackupContact';
 
 const BACKUP_CONTACT = {
@@ -14,8 +12,8 @@ const BACKUP_CONTACT = {
 describe('When a service members updates their profile', () => {
   const template = {
     action: 'UPDATE',
-    eventName: o.updateServiceMemberBackupContact,
-    tableName: t.backup_contacts,
+    eventName: 'updateServiceMemberBackupContact',
+    tableName: 'backup_contacts',
     eventNameDisplay: 'Updated profile',
   };
   it('correctly matches the patch service member event template', () => {
@@ -30,6 +28,33 @@ describe('When a service members updates their profile', () => {
     ])('displays the correct details value for %s', async (label, value) => {
       const historyRecord = { changedValues: BACKUP_CONTACT };
       const result = getTemplate(template);
+      render(result.getDetails(historyRecord));
+      expect(screen.getByText(label)).toBeInTheDocument();
+      expect(screen.getByText(value)).toBeInTheDocument();
+    });
+  });
+});
+
+describe('When a service counselor updates a backup contact name', () => {
+  const historyRecord = {
+    action: 'UPDATE',
+    eventName: 'updateCustomer',
+    tableName: 'backup_contacts',
+    eventNameDisplay: 'Updated profile',
+    changedValues: {
+      name: 'Ron Swanson',
+    },
+  };
+
+  it('correctly matches the updateCustomer event to the template', () => {
+    const template = getTemplate(historyRecord);
+    expect(template).toMatchObject(updateServiceMemberBackupContact);
+  });
+
+  describe('Renders the correct details for updated customer name', () => {
+    it.each([['Backup contact name', ': Ron Swanson']])('expect label %s to have value %s', async (label, value) => {
+      const result = getTemplate(historyRecord);
+
       render(result.getDetails(historyRecord));
       expect(screen.getByText(label)).toBeInTheDocument();
       expect(screen.getByText(value)).toBeInTheDocument();

--- a/src/constants/MoveHistory/EventTemplates/index.js
+++ b/src/constants/MoveHistory/EventTemplates/index.js
@@ -55,3 +55,4 @@ export { default as createUpload } from './CreateUpload/createUpload';
 export { default as deleteUpload } from './DeleteUpload/deleteUpload';
 export { default as updateServiceMemberBackupContacts } from './UpdateServiceMemberBackupContact/updateServiceMemberBackupContact';
 export { default as createServiceMemberBackupContacts } from './CreateServiceMemberBackupContact/createServiceMemberBackupContact';
+export { default as updateCustomer } from './UpdateCustomer/updateCustomer';

--- a/src/constants/MoveHistory/UIDisplay/Operations.js
+++ b/src/constants/MoveHistory/UIDisplay/Operations.js
@@ -20,6 +20,7 @@ export default {
   updateAllowance: 'updateAllowance', // ghc.yaml
   updateBillableWeight: 'updateBillableWeight', // ghc.yaml
   updateBillableWeightAsTIO: 'updateMaxBillableWeightAsTIO',
+  updateCustomer: 'updateCustomer',
   updateMoveTaskOrder: 'updateMoveTaskOrder', // ghc.yaml
   updateMoveTaskOrderStatus: 'updateMoveTaskOrderStatus', // ghc.yaml
   updateMTOReviewedBillableWeightsAt: 'UpdateMTOReviewedBillableWeightsAt',


### PR DESCRIPTION
## [Jira ticket](https://dp3.atlassian.net/browse/MB-14533) for this change

## Summary

Two bugs are being handled in this PR. The first is surrounding customer name updates done by a service counselor not being captured. That was due to a missing template which has now been added. The second was a similar bug; but for the backup contact. Which was resolved by adding a wildcard event name to the pre-existing template `updateServiceMemberBackupContact`. I went with that approach since the only difference in the code would be the event name, so writing an entirely new template felt unnecessary.

## Setup to Run Your Code

<details>
<summary>💻 You will need to use two separate terminals to test this locally.</summary>

##### Terminal 1

Start the UI locally.

```sh
make client_run
```

##### Terminal 2

Start the Go server locally.

```sh
make server_run
```

</details>

### Additional steps

<!-- Fill out the next section as you see fit, these are just suggestions. -->

1. Login as a services counselor
2. Find a move (I used `8B63JG`)
3. In the move details page, scroll down and click "Edit customer info"
4. Update a field for the customer name
5. update a field for the backup contact
6. Click "Save"
7. Should display in the move history tab

## Verification Steps for Author

These are to be checked by the author.

- [x] Have the Jira acceptance criteria been met for this change?

## Verification Steps for Reviewers

These are to be checked by a reviewer.

<!-- Fill out the next sections as you see fit, these are just suggestions. -->

### Frontend

- [ ] User facing changes have been reviewed by design.
- [ ] There are no aXe warnings for UI.
- [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/main/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
- [ ] There are no new console errors in the browser devtools
- [ ] There are no new console errors in the test output
- [ ] If this PR adds a new component to Storybook, it ensures the component is fully responsive, OR if it is intentionally not, a wrapping div using the `officeApp` class or custom `min-width` styling is used to hide any states the would not be visible to the user.

## Screenshots
Updating Customer Name Before:
![image](https://user-images.githubusercontent.com/111928238/203168358-49174ae3-d24d-4ec9-ad42-7bb213b421f4.png)

Updating Customer Name After 🎉 :
![image](https://user-images.githubusercontent.com/111928238/203168433-fc429693-584b-4c19-8a26-c60283fe7334.png)

Updating Backup Contact Before:
![image](https://user-images.githubusercontent.com/111928238/203168625-9247e7ec-f803-4d38-9278-190a6cb30da2.png)

Updating Backup Contact After 🎉 :
![image](https://user-images.githubusercontent.com/111928238/203168693-e1e570f0-94fc-4c1b-8123-d79ce1a7f7d9.png)


