### PR TITLE
[MB-14447] Standardized use of constants and string literals for templates and test

### DIFF
--- a/src/constants/MoveHistory/EventTemplates/CreateMTOServiceItem/createMTOServiceItem.test.jsx
+++ b/src/constants/MoveHistory/EventTemplates/CreateMTOServiceItem/createMTOServiceItem.test.jsx
@@ -1,14 +1,11 @@
 import { render, screen } from '@testing-library/react';
 
-import a from 'constants/MoveHistory/Database/Actions';
-import t from 'constants/MoveHistory/Database/Tables';
 import e from 'constants/MoveHistory/EventTemplates/CreateMTOServiceItem/createMTOServiceItem';
 import getTemplate from 'constants/MoveHistory/TemplateManager';
-import o from 'constants/MoveHistory/UIDisplay/Operations';
 
 describe('when given a Create basic service item history record', () => {
   const historyRecord = {
-    action: a.INSERT,
+    action: 'INSERT',
     changedValues: {
       reason: 'Test',
       status: 'SUBMITTED',
@@ -20,8 +17,8 @@ describe('when given a Create basic service item history record', () => {
         shipment_id_abbr: 'a1b2c',
       },
     ],
-    eventName: o.createMTOServiceItem,
-    tableName: t.mto_service_items,
+    eventName: 'createMTOServiceItem',
+    tableName: 'mto_service_items',
   };
 
   const template = getTemplate(historyRecord);

--- a/src/constants/MoveHistory/EventTemplates/CreateMTOServiceItem/createMTOServiceItemCustomerContacts.test.jsx
+++ b/src/constants/MoveHistory/EventTemplates/CreateMTOServiceItem/createMTOServiceItemCustomerContacts.test.jsx
@@ -1,21 +1,18 @@
 import { render, screen } from '@testing-library/react';
 
 import getTemplate from 'constants/MoveHistory/TemplateManager';
-import o from 'constants/MoveHistory/UIDisplay/Operations';
-import a from 'constants/MoveHistory/Database/Actions';
-import t from 'constants/MoveHistory/Database/Tables';
 import e from 'constants/MoveHistory/EventTemplates/CreateMTOServiceItem/createMTOServiceItemCustomerContacts';
 
 describe('when given a Create basic service item customer contacts history record', () => {
   const historyRecord = {
-    action: a.INSERT,
+    action: 'INSERT',
     changedValues: {
       first_available_delivery_date: '2022-06-30T00:00:00+00:00',
       time_military: '1500Z',
       type: 'SECOND',
     },
-    eventName: o.createMTOServiceItem,
-    tableName: t.mto_service_item_customer_contacts,
+    eventName: 'createMTOServiceItem',
+    tableName: 'mto_service_item_customer_contacts',
   };
   const template = getTemplate(historyRecord);
   it('correctly matches the create service item customer contacts event', () => {

--- a/src/constants/MoveHistory/EventTemplates/CreateMTOServiceItem/createMTOServiceItemDimensions.test.jsx
+++ b/src/constants/MoveHistory/EventTemplates/CreateMTOServiceItem/createMTOServiceItemDimensions.test.jsx
@@ -1,14 +1,11 @@
 import { render, screen } from '@testing-library/react';
 
 import getTemplate from 'constants/MoveHistory/TemplateManager';
-import o from 'constants/MoveHistory/UIDisplay/Operations';
-import a from 'constants/MoveHistory/Database/Actions';
-import t from 'constants/MoveHistory/Database/Tables';
 import e from 'constants/MoveHistory/EventTemplates/CreateMTOServiceItem/createMTOServiceItemDimensions';
 
 describe('when given a Create basic service item dimensions history record', () => {
   const historyRecord = {
-    action: a.INSERT,
+    action: 'INSERT',
     changedValues: {
       height_thousandth_inches: 1000,
       length_thousandth_inches: 3000,
@@ -22,8 +19,8 @@ describe('when given a Create basic service item dimensions history record', () 
         shipment_id_abbr: 'a1b2c',
       },
     ],
-    eventName: o.createMTOServiceItem,
-    tableName: t.mto_service_item_dimensions,
+    eventName: 'createMTOServiceItem',
+    tableName: 'mto_service_item_dimensions',
   };
   const template = getTemplate(historyRecord);
   it('correctly matches the create service item dimensions event', () => {

--- a/src/constants/MoveHistory/EventTemplates/CreateMTOServiceItem/createMTOServiceItemUpdateMoveStatus.test.jsx
+++ b/src/constants/MoveHistory/EventTemplates/CreateMTOServiceItem/createMTOServiceItemUpdateMoveStatus.test.jsx
@@ -7,7 +7,7 @@ import e from 'constants/MoveHistory/EventTemplates/CreateMTOServiceItem/createM
 describe('when given a move status update with create mto service item history record', () => {
   const historyRecord = {
     action: 'UPDATE',
-    eventName: o.createMTOServiceItem,
+    eventName: 'createMTOServiceItem',
     tableName: 'moves',
     oldValues: {
       status: 'Approved',

--- a/src/constants/MoveHistory/EventTemplates/CreateMTOShipment/createMTOShipment.test.jsx
+++ b/src/constants/MoveHistory/EventTemplates/CreateMTOShipment/createMTOShipment.test.jsx
@@ -1,16 +1,13 @@
 import { render, screen } from '@testing-library/react';
 
 import getTemplate from 'constants/MoveHistory/TemplateManager';
-import a from 'constants/MoveHistory/Database/Actions';
-import o from 'constants/MoveHistory/UIDisplay/Operations';
-import t from 'constants/MoveHistory/Database/Tables';
 import e from 'constants/MoveHistory/EventTemplates/CreateMTOShipment/createMTOShipment';
 
 describe('when given a Create mto shipment history record', () => {
   const historyRecord = {
-    action: a.INSERT,
-    eventName: o.createMTOShipment,
-    tableName: t.mto_shipments,
+    action: 'INSERT',
+    eventName: 'createMTOShipment',
+    tableName: 'mto_shipments',
     changedValues: {
       customer_remarks: 'Redacted',
       requested_delivery_date: '2022-12-12',

--- a/src/constants/MoveHistory/EventTemplates/CreateOrders/createEntitlements.test.jsx
+++ b/src/constants/MoveHistory/EventTemplates/CreateOrders/createEntitlements.test.jsx
@@ -1,15 +1,13 @@
 import { render, screen } from '@testing-library/react';
 
 import getTemplate from 'constants/MoveHistory/TemplateManager';
-import o from 'constants/MoveHistory/UIDisplay/Operations';
-import t from 'constants/MoveHistory/Database/Tables';
 import e from 'constants/MoveHistory/EventTemplates/CreateOrders/createEntitlements';
 
 describe('When given a created orders event for the entitlements table', () => {
   const item = {
     action: 'INSERT',
-    eventName: o.createOrders,
-    tableName: t.entitlements,
+    eventName: 'createOrders',
+    tableName: 'entitlements',
     eventNameDisplay: 'Created allowances',
     changedValues: {
       authorized_weight: 8000,

--- a/src/constants/MoveHistory/EventTemplates/CreateOrders/createMoves.test.jsx
+++ b/src/constants/MoveHistory/EventTemplates/CreateOrders/createMoves.test.jsx
@@ -1,15 +1,13 @@
 import { render, screen } from '@testing-library/react';
 
 import getTemplate from 'constants/MoveHistory/TemplateManager';
-import o from 'constants/MoveHistory/UIDisplay/Operations';
-import t from 'constants/MoveHistory/Database/Tables';
 import e from 'constants/MoveHistory/EventTemplates/CreateOrders/createMoves';
 
 describe('When given a created orders event for the moves table', () => {
   const item = {
     action: 'INSERT',
-    eventName: o.createOrders,
-    tableName: t.moves,
+    eventName: 'createOrders',
+    tableName: 'moves',
     eventNameDisplay: 'Created move',
     changedValues: {
       status: 'DRAFT',

--- a/src/constants/MoveHistory/EventTemplates/CreateOrders/createOrders.test.jsx
+++ b/src/constants/MoveHistory/EventTemplates/CreateOrders/createOrders.test.jsx
@@ -1,15 +1,13 @@
 import { render, screen } from '@testing-library/react';
 
 import getTemplate from 'constants/MoveHistory/TemplateManager';
-import o from 'constants/MoveHistory/UIDisplay/Operations';
-import t from 'constants/MoveHistory/Database/Tables';
 import e from 'constants/MoveHistory/EventTemplates/CreateOrders/createOrders';
 
 describe('When given a created orders event for the orders table', () => {
   const item = {
     action: 'INSERT',
-    eventName: o.createOrders,
-    tableName: t.orders,
+    eventName: 'createOrders',
+    tableName: 'orders',
     eventNameDisplay: 'Created orders',
     changedValues: {
       status: 'DRAFT',

--- a/src/constants/MoveHistory/EventTemplates/CreateServiceMember/createServiceMember.test.jsx
+++ b/src/constants/MoveHistory/EventTemplates/CreateServiceMember/createServiceMember.test.jsx
@@ -7,7 +7,7 @@ import createServiceMember from 'constants/MoveHistory/EventTemplates/CreateServ
 describe('When a service members creates a profile', () => {
   const item = {
     action: 'INSERT',
-    tableName: t.service_members,
+    tableName: 'service_members',
     eventNameDisplay: 'Created Profile',
   };
   it('correctly matches the create service member event template', () => {

--- a/src/constants/MoveHistory/EventTemplates/CreateServiceMember/createServiceMember.test.jsx
+++ b/src/constants/MoveHistory/EventTemplates/CreateServiceMember/createServiceMember.test.jsx
@@ -1,7 +1,6 @@
 import { render, screen } from '@testing-library/react';
 
 import getTemplate from 'constants/MoveHistory/TemplateManager';
-import t from 'constants/MoveHistory/Database/Tables';
 import createServiceMember from 'constants/MoveHistory/EventTemplates/CreateServiceMember/createServiceMember';
 
 describe('When a service members creates a profile', () => {

--- a/src/constants/MoveHistory/EventTemplates/CreateServiceMemberBackupContact/createServiceMemberBackupContact.test.jsx
+++ b/src/constants/MoveHistory/EventTemplates/CreateServiceMemberBackupContact/createServiceMemberBackupContact.test.jsx
@@ -1,8 +1,6 @@
 import { render, screen } from '@testing-library/react';
 
 import getTemplate from 'constants/MoveHistory/TemplateManager';
-import o from 'constants/MoveHistory/UIDisplay/Operations';
-import t from 'constants/MoveHistory/Database/Tables';
 import createServiceMemberBackupContact from 'constants/MoveHistory/EventTemplates/CreateServiceMemberBackupContact/createServiceMemberBackupContact';
 
 const BACKUP_CONTACT = {
@@ -14,8 +12,8 @@ const BACKUP_CONTACT = {
 describe('When a service members updates their profile', () => {
   const template = {
     action: 'INSERT',
-    eventName: o.createServiceMemberBackupContact,
-    tableName: t.backup_contacts,
+    eventName: 'createServiceMemberBackupContact',
+    tableName: 'backup_contacts',
     eventNameDisplay: 'Updated profile',
   };
   it('correctly matches the patch service member event template', () => {

--- a/src/constants/MoveHistory/EventTemplates/PatchServiceMember/patchServiceMember.test.jsx
+++ b/src/constants/MoveHistory/EventTemplates/PatchServiceMember/patchServiceMember.test.jsx
@@ -1,8 +1,6 @@
 import { render, screen } from '@testing-library/react';
 
 import getTemplate from 'constants/MoveHistory/TemplateManager';
-import o from 'constants/MoveHistory/UIDisplay/Operations';
-import t from 'constants/MoveHistory/Database/Tables';
 import patchServiceMember from 'constants/MoveHistory/EventTemplates/PatchServiceMember/patchServiceMember';
 
 const PROFILE = {
@@ -29,8 +27,8 @@ const PROFILE = {
 describe('When a service members updates their profile', () => {
   const template = {
     action: 'UPDATE',
-    eventName: o.patchServiceMember,
-    tableName: t.service_members,
+    eventName: 'patchServiceMember',
+    tableName: 'service_members',
     eventNameDisplay: 'Updated profile',
   };
   it('correctly matches the patch service member event template', () => {

--- a/src/constants/MoveHistory/EventTemplates/UpdateAllowances/updateAllowance.test.jsx
+++ b/src/constants/MoveHistory/EventTemplates/UpdateAllowances/updateAllowance.test.jsx
@@ -1,15 +1,13 @@
 import { render, screen } from '@testing-library/react';
 
 import getTemplate from 'constants/MoveHistory/TemplateManager';
-import o from 'constants/MoveHistory/UIDisplay/Operations';
-import t from 'constants/MoveHistory/Database/Tables';
 import updateAllowance from 'constants/MoveHistory/EventTemplates/UpdateAllowances/updateAllowance';
 
 describe('When a service counselor updates shipping allowances', () => {
   const item = {
     action: 'UPDATE',
-    eventName: o.updateAllowance,
-    tableName: t.entitlements,
+    eventName: 'updateAllowance',
+    tableName: 'entitlements',
     eventNameDisplay: 'Updated allowances',
     changedValues: {
       authorized_weight: '4000',

--- a/src/constants/MoveHistory/EventTemplates/UpdateAllowances/updateAllowanceByCounselor.test.jsx
+++ b/src/constants/MoveHistory/EventTemplates/UpdateAllowances/updateAllowanceByCounselor.test.jsx
@@ -1,16 +1,13 @@
 import { render, screen } from '@testing-library/react';
 
 import getTemplate from 'constants/MoveHistory/TemplateManager';
-import o from 'constants/MoveHistory/UIDisplay/Operations';
-import t from 'constants/MoveHistory/Database/Tables';
-import a from 'constants/MoveHistory/Database/Actions';
 import updateAllowanceByCounselor from 'constants/MoveHistory/EventTemplates/UpdateAllowances/updateAllowanceByCounselor';
 
 describe('When a service counselor updates shipping allowances', () => {
   const historyRecord = {
-    action: a.UPDATE,
-    eventName: o.counselingUpdateAllowance,
-    tableName: t.entitlements,
+    action: 'UPDATE',
+    eventName: 'counselingUpdateAllowance',
+    tableName: 'entitlements',
     eventNameDisplay: 'Updated allowances',
     changedValues: {
       authorized_weight: '8000',

--- a/src/constants/MoveHistory/EventTemplates/UpdateBillableWeight/updateBillableWeight.test.jsx
+++ b/src/constants/MoveHistory/EventTemplates/UpdateBillableWeight/updateBillableWeight.test.jsx
@@ -1,18 +1,15 @@
 import { render, screen } from '@testing-library/react';
 
-import o from 'constants/MoveHistory/UIDisplay/Operations';
 import getTemplate from 'constants/MoveHistory/TemplateManager';
 import e from 'constants/MoveHistory/EventTemplates/UpdateBillableWeight/updateBillableWeight';
-import a from 'constants/MoveHistory/Database/Actions';
-import t from 'constants/MoveHistory/Database/Tables';
 
 describe('when given an update billable weights', () => {
   const historyRecord = {
-    action: a.UPDATE,
+    action: 'UPDATE',
     // To-do: Change to max billable weight once available in database.
     changedValues: { authorized_weight: '5800' },
-    eventName: o.updateBillableWeight,
-    tableName: t.entitlements,
+    eventName: 'updateBillableWeight',
+    tableName: 'entitlements',
   };
   it('correctly matches the update billable weights event', () => {
     const result = getTemplate(historyRecord);

--- a/src/constants/MoveHistory/EventTemplates/UpdateBillableWeight/updateBillableWeightAsTIO.test.jsx
+++ b/src/constants/MoveHistory/EventTemplates/UpdateBillableWeight/updateBillableWeightAsTIO.test.jsx
@@ -1,18 +1,15 @@
 import { render, screen } from '@testing-library/react';
 
-import o from 'constants/MoveHistory/UIDisplay/Operations';
 import getTemplate from 'constants/MoveHistory/TemplateManager';
 import e from 'constants/MoveHistory/EventTemplates/UpdateBillableWeight/updateBillableWeightAsTIO';
-import a from 'constants/MoveHistory/Database/Actions';
-import t from 'constants/MoveHistory/Database/Tables';
 
 describe('when updating billable weight as a TIO ', () => {
   const historyRecord = {
-    action: a.UPDATE,
+    action: 'UPDATE',
     // To-do: Change to max billable weight once available in database.
     changedValues: { authorized_weight: '7999' },
-    eventName: o.updateBillableWeightAsTIO,
-    tableName: t.entitlements,
+    eventName: 'updateMaxBillableWeightAsTIO',
+    tableName: 'entitlements',
   };
   it('correctly matches the update billable weights event', () => {
     const result = getTemplate(historyRecord);

--- a/src/constants/MoveHistory/EventTemplates/UpdateBillableWeight/updateBillableWeightRemarksAsTIO.test.jsx
+++ b/src/constants/MoveHistory/EventTemplates/UpdateBillableWeight/updateBillableWeightRemarksAsTIO.test.jsx
@@ -1,18 +1,15 @@
 import { render, screen } from '@testing-library/react';
 
-import o from 'constants/MoveHistory/UIDisplay/Operations';
-import t from 'constants/MoveHistory/Database/Tables';
 import getTemplate from 'constants/MoveHistory/TemplateManager';
 import e from 'constants/MoveHistory/EventTemplates/UpdateBillableWeight/updateBillableWeightRemarksAsTIO';
-import a from 'constants/MoveHistory/Database/Actions';
 
 describe('when given an update billable weight remarks as a TIO', () => {
   const historyRecord = {
-    action: a.UPDATE,
+    action: 'UPDATE',
     // To-do: Change to max billable weight once available in database.
     changedValues: { authorized_weight: '8000' },
-    eventName: o.updateBillableWeightAsTIO,
-    tableName: t.moves,
+    eventName: 'updateMaxBillableWeightAsTIO',
+    tableName: 'moves',
   };
   it('correctly matches the update billable weights event', () => {
     const result = getTemplate(historyRecord);

--- a/src/constants/MoveHistory/EventTemplates/UpdateMTOReviewedBillableWeightAt/updateMTOReviewedBillableWeightsAt.test.jsx
+++ b/src/constants/MoveHistory/EventTemplates/UpdateMTOReviewedBillableWeightAt/updateMTOReviewedBillableWeightsAt.test.jsx
@@ -3,15 +3,12 @@ import { render, screen } from '@testing-library/react';
 import updateMTOReviewedBillableWeightsAt from './updateMTOReviewedBillableWeightsAt';
 
 import getTemplate from 'constants/MoveHistory/TemplateManager';
-import o from 'constants/MoveHistory/UIDisplay/Operations';
-import a from 'constants/MoveHistory/Database/Actions';
-import t from 'constants/MoveHistory/Database/Tables';
 
 describe('when given an MTO Reviewed Billable Weight At event', () => {
   const item = {
-    action: a.UPDATE,
-    eventName: o.updateMTOReviewedBillableWeightsAt,
-    tableName: t.moves,
+    action: 'UPDATE',
+    eventName: 'updateMTOReviewedBillableWeightsAt',
+    tableName: 'moves',
   };
   it('correctly matches the MTO Reviewed Billable Weight At event', () => {
     const result = getTemplate(item);

--- a/src/constants/MoveHistory/EventTemplates/UpdateReweigh/updatePaymentRequest.test.jsx
+++ b/src/constants/MoveHistory/EventTemplates/UpdateReweigh/updatePaymentRequest.test.jsx
@@ -1,12 +1,11 @@
 import { render, screen } from '@testing-library/react';
 
 import getTemplate from 'constants/MoveHistory/TemplateManager';
-import o from 'constants/MoveHistory/UIDisplay/Operations';
 
 describe('reweighs update', () => {
   const historyRecord = {
     action: 'UPDATE',
-    eventName: o.updateReweigh,
+    eventName: 'updateReweigh',
     tableName: 'payment_requests',
     context: [{ shipment_type: 'HHG' }],
     changedValues: { recalculation_of_payment_request_id: '1234' },

--- a/src/constants/MoveHistory/EventTemplates/UpdateServiceMember/updateServiceMemberByCounselor.test.jsx
+++ b/src/constants/MoveHistory/EventTemplates/UpdateServiceMember/updateServiceMemberByCounselor.test.jsx
@@ -1,16 +1,13 @@
 import { render, screen } from '@testing-library/react';
 
-import a from 'constants/MoveHistory/Database/Actions';
 import getTemplate from 'constants/MoveHistory/TemplateManager';
-import o from 'constants/MoveHistory/UIDisplay/Operations';
-import t from 'constants/MoveHistory/Database/Tables';
 import updateServiceMemberByCounselor from 'constants/MoveHistory/EventTemplates/UpdateServiceMember/updateServiceMemberByCounselor';
 
 describe('When a service counselor updates shipping allowances', () => {
   const historyRecord = {
-    action: a.UPDATE,
-    tableName: t.service_members,
-    eventName: o.counselingUpdateAllowance,
+    action: 'UPDATE',
+    tableName: 'service_members',
+    eventName: 'counselingUpdateAllowance',
     eventNameDisplay: 'Updated profile',
     changedValues: {
       affiliation: 'NAVY',

--- a/src/constants/MoveHistory/EventTemplates/UpdateServiceMember/updateServiceMemberByTOO.test.jsx
+++ b/src/constants/MoveHistory/EventTemplates/UpdateServiceMember/updateServiceMemberByTOO.test.jsx
@@ -1,15 +1,13 @@
 import { render, screen } from '@testing-library/react';
 
 import getTemplate from 'constants/MoveHistory/TemplateManager';
-import o from 'constants/MoveHistory/UIDisplay/Operations';
-import t from 'constants/MoveHistory/Database/Tables';
 import updateAllowanceServiceMemberByTOO from 'constants/MoveHistory/EventTemplates/UpdateServiceMember/updateServiceMemberByTOO';
 
 describe('When a TOO updates shipping allowances', () => {
   const historyRecord = {
     action: 'UPDATE',
-    eventName: o.updateAllowance,
-    tableName: t.service_members,
+    eventName: 'updateAllowance',
+    tableName: 'service_members',
     eventNameDisplay: 'Updated profile',
     changedValues: {
       affiliation: 'AIR_FORCE',

--- a/src/constants/MoveHistory/EventTemplates/UpdateServiceMemberBackupContact/updateServiceMemberBackupContact.test.jsx
+++ b/src/constants/MoveHistory/EventTemplates/UpdateServiceMemberBackupContact/updateServiceMemberBackupContact.test.jsx
@@ -1,8 +1,6 @@
 import { render, screen } from '@testing-library/react';
 
 import getTemplate from 'constants/MoveHistory/TemplateManager';
-import o from 'constants/MoveHistory/UIDisplay/Operations';
-import t from 'constants/MoveHistory/Database/Tables';
 import updateServiceMemberBackupContact from 'constants/MoveHistory/EventTemplates/UpdateServiceMemberBackupContact/updateServiceMemberBackupContact';
 
 const BACKUP_CONTACT = {
@@ -14,8 +12,8 @@ const BACKUP_CONTACT = {
 describe('When a service members updates their profile', () => {
   const template = {
     action: 'UPDATE',
-    eventName: o.updateServiceMemberBackupContact,
-    tableName: t.backup_contacts,
+    eventName: 'updateServiceMemberBackupContact',
+    tableName: 'backup_contacts',
     eventNameDisplay: 'Updated profile',
   };
   it('correctly matches the patch service member event template', () => {

--- a/src/constants/MoveHistory/UIDisplay/Operations.js
+++ b/src/constants/MoveHistory/UIDisplay/Operations.js
@@ -22,7 +22,7 @@ export default {
   updateBillableWeightAsTIO: 'updateMaxBillableWeightAsTIO',
   updateMoveTaskOrder: 'updateMoveTaskOrder', // ghc.yaml
   updateMoveTaskOrderStatus: 'updateMoveTaskOrderStatus', // ghc.yaml
-  updateMTOReviewedBillableWeightsAt: 'UpdateMTOReviewedBillableWeightsAt',
+  updateMTOReviewedBillableWeightsAt: 'updateMTOReviewedBillableWeightsAt',
   updateMTOServiceItemStatus: 'updateMTOServiceItemStatus', // ghc.yaml
   updateMTOServiceItem: 'updateMTOServiceItem', // ghc.yaml
   updateMTOShipment: 'updateMTOShipment', // ghc.yaml internal.yaml prime.yaml


### PR DESCRIPTION
## [Jira ticket](https://dp3.atlassian.net/browse/MB-14447) for this change

## Summary

For move template test, we want to use string literals for:

- action
- eventName
- tableName

## Setup to Run Your Code

<details>
<summary>💻 You will need to use three separate terminals to test this locally.</summary>

##### Terminal 1

Start the UI locally.

```sh
make client_run
```

##### Terminal 2

Start the Go server locally.

```sh
make server_run
```

</details>

### Additional steps

<!-- Fill out the next section as you see fit, these are just suggestions. -->

1. Access the Office Ap
2. Login as a TOO
3. Make sure move templates do not have any regressions.

