### PR TITLE
MB-14486 Update react-admin usage of react-router to use latest version

### DIFF
--- a/src/pages/InvalidPermissions/InvalidPermissions.jsx
+++ b/src/pages/InvalidPermissions/InvalidPermissions.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import qs from 'query-string';
 import { bool, shape, string } from 'prop-types';
 import { Button, ButtonGroup } from '@trussworks/react-uswds';
-import { useHistory } from 'react-router-dom-old';
+import { useNavigate } from 'react-router-dom';
 
 import '../../styles/office.scss';
 import styles from './InvalidPermissions.module.scss';
@@ -16,7 +16,8 @@ import Alert from 'shared/Alert';
 import { LocationShape } from 'types/index';
 
 const InvalidPermissions = ({ context, location }) => {
-  const history = useHistory();
+  const navigate = useNavigate();
+
   const { siteName } = context;
   const { traceId } = qs.parse(location.search);
   const signoutClass = siteName === 'my.move.mil' ? styles.signInButton : 'usa-button';
@@ -28,8 +29,7 @@ const InvalidPermissions = ({ context, location }) => {
       if (redirectURL) {
         window.location.href = redirectURL;
       } else {
-        history.push({
-          pathname: '/sign-in',
+        navigate('/sign-in', {
           state: { hasLoggedOut: true },
         });
       }

--- a/src/pages/SignIn/SignIn.jsx
+++ b/src/pages/SignIn/SignIn.jsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from 'react';
 import qs from 'query-string';
 import { bool, shape, string } from 'prop-types';
 import { Button, ButtonGroup } from '@trussworks/react-uswds';
-import { useHistory } from 'react-router-dom-old';
+import { useNavigate } from 'react-router-dom';
 
 import '../../styles/office.scss';
 import styles from './SignIn.module.scss';
@@ -17,15 +17,15 @@ import { isDevelopment } from 'shared/constants';
 
 const SignIn = ({ context, location, showLocalDevLogin }) => {
   const [showEula, setShowEula] = useState(false);
-  const history = useHistory();
+  const navigate = useNavigate();
 
   useEffect(() => {
     function unload() {
-      history.replace('', null);
+      navigate('', { replace: true, state: null });
     }
     window.addEventListener('beforeunload', unload);
     return () => window.removeEventListener('beforeunload', unload);
-  }, [history]);
+  }, [navigate]);
 
   const { error } = qs.parse(location.search);
   const { siteName, showLoginWarning } = context;

--- a/src/scenes/SystemAdmin/CustomRoutes.jsx
+++ b/src/scenes/SystemAdmin/CustomRoutes.jsx
@@ -1,10 +1,13 @@
 import React from 'react';
 import { Route } from 'react-router-dom-old';
 import UploadSearch from './Uploads/UploadSearch';
+import { CustomRoutes } from 'react-admin';
 
-const routes = [
-  //Custom route for search by id for uploads
-  <Route exact path="/uploads" component={UploadSearch} />,
-];
+const Routes = () => (
+  <CustomRoutes>
+    {/* Custom route for search by id for uploads */}
+    <Route exact path="/uploads" component={UploadSearch} />
+  </CustomRoutes>
+);
 
-export default routes;
+export default Routes;

--- a/src/scenes/SystemAdmin/Home.jsx
+++ b/src/scenes/SystemAdmin/Home.jsx
@@ -1,7 +1,8 @@
 import { milmoveLog, MILMOVE_LOG_LEVEL } from 'utils/milmoveLog';
 import restProvider from './shared/rest_provider';
 import { Admin, AppBar, fetchUtils, Layout, Resource } from 'react-admin';
-import { createBrowserHistory } from 'history';
+import { BrowserRouter } from 'react-router-dom';
+
 import React from 'react';
 import Menu from './shared/Menu';
 import CUIHeader from 'components/CUIHeader/CUIHeader';
@@ -31,7 +32,7 @@ import WebhookSubscriptionEdit from '../../pages/Admin/WebhookSubscriptions/Webh
 
 import styles from './Home.module.scss';
 import Cookies from 'js-cookie';
-import customRoutes from './CustomRoutes';
+import CustomRoutes from './CustomRoutes';
 import NotificationList from './Notifications/NotificationList';
 
 const httpClient = (url, options = {}) => {
@@ -57,55 +58,51 @@ const CUIWrapper = () => (
 
 const dataProvider = restProvider('/admin/v1', httpClient);
 const AdminLayout = (props) => <Layout {...props} menu={Menu} appBar={CUIWrapper} />;
-const history = createBrowserHistory({ basename: '/system' });
 
 const Home = () => (
   <div className={styles['admin-system-wrapper']}>
-    <Admin
-      dataProvider={dataProvider}
-      history={history}
-      appLayout={AdminLayout}
-      customRoutes={customRoutes}
-      disableTelemetry
-    >
-      <Resource
-        name="office_users"
-        options={{ label: 'Office Users' }}
-        list={OfficeUserList}
-        show={OfficeUserShow}
-        create={OfficeUserCreate}
-        edit={OfficeUserEdit}
-      />
-      <Resource name="offices" options={{ label: 'Offices' }} list={OfficeList} />
-      <Resource
-        name="admin_users"
-        options={{ label: 'Admin Users' }}
-        list={AdminUserList}
-        show={AdminUserShow}
-        create={AdminUserCreate}
-        edit={AdminUserEdit}
-      />
-      <Resource name="users" options={{ label: 'Users' }} list={UserList} show={UserShow} edit={UserEdit} />
-      <Resource name="moves" options={{ label: 'Moves' }} list={MoveList} show={MoveShow} edit={MoveEdit} />
-      <Resource
-        name="transportation_service_provider_performances"
-        options={{ label: 'TSPPs' }}
-        list={TSPPList}
-        show={TSPPShow}
-      />
-      <Resource name="electronic_orders" options={{ label: 'Electronic orders' }} list={ElectronicOrderList} />
-      <Resource name="uploads" options={{ label: 'Search Upload by ID' }} show={UploadShow} />
-      <Resource name="organizations" />
-      <Resource name="notifications" options={{ label: 'Notifications' }} list={NotificationList} />
-      <Resource
-        name="webhook_subscriptions"
-        options={{ label: 'Webhook Subscriptions' }}
-        show={WebhookSubscriptionShow}
-        create={WebhookSubscriptionCreate}
-        list={WebhookSubscriptionList}
-        edit={WebhookSubscriptionEdit}
-      />
-    </Admin>
+    <BrowserRouter>
+      <Admin dataProvider={dataProvider} basename="/system" appLayout={AdminLayout} disableTelemetry>
+        <CustomRoutes />
+        <Resource
+          name="office_users"
+          options={{ label: 'Office Users' }}
+          list={OfficeUserList}
+          show={OfficeUserShow}
+          create={OfficeUserCreate}
+          edit={OfficeUserEdit}
+        />
+        <Resource name="offices" options={{ label: 'Offices' }} list={OfficeList} />
+        <Resource
+          name="admin_users"
+          options={{ label: 'Admin Users' }}
+          list={AdminUserList}
+          show={AdminUserShow}
+          create={AdminUserCreate}
+          edit={AdminUserEdit}
+        />
+        <Resource name="users" options={{ label: 'Users' }} list={UserList} show={UserShow} edit={UserEdit} />
+        <Resource name="moves" options={{ label: 'Moves' }} list={MoveList} show={MoveShow} edit={MoveEdit} />
+        <Resource
+          name="transportation_service_provider_performances"
+          options={{ label: 'TSPPs' }}
+          list={TSPPList}
+          show={TSPPShow}
+        />
+        <Resource name="electronic_orders" options={{ label: 'Electronic orders' }} list={ElectronicOrderList} />
+        <Resource name="uploads" options={{ label: 'Search Upload by ID' }} show={UploadShow} />
+        <Resource name="organizations" />
+        <Resource name="notifications" options={{ label: 'Notifications' }} list={NotificationList} />
+        <Resource
+          name="webhook_subscriptions"
+          options={{ label: 'Webhook Subscriptions' }}
+          show={WebhookSubscriptionShow}
+          create={WebhookSubscriptionCreate}
+          list={WebhookSubscriptionList}
+          edit={WebhookSubscriptionEdit}
+        />
+      </Admin>
+    </BrowserRouter>
   </div>
 );
 


### PR DESCRIPTION
## [Jira ticket](https://dp3.atlassian.net/browse/MB-14486) for this change

## Summary

This PR updates the parts of react-router that interact with react-admin to use the latest (v6) version of react-router. This is one of many incremental changes required to upgrade react-admin to the latest version. The app will not compile until the rest of these changes are complete, which of course makes this basically un-testable. I would suggest just doing a code review as the review here and we will have to fully test out functionally when all updates are done and the app will build again. 

Note: This PR is merging into our feature branch that includes the react-admin upgrade and both versions of react-router. It will not work in main without the changes included in this feature branch. 

## Changes in PR
The changes in this PR align with the bullets in the ticket, no additional changes were needed. From the ticket:

- refactor <CustomRoutes> component (`src/scenes/SystemAdmin/CustomRoutes.jsx`)
- use `useNavigate` instead of `useHistory` (src/pages/InvalidPermissions and src/pages/SignIn
- use BroswerRouter component in place of createBrowserHistory (src/scenes/SystemAdmin/Home.jsx)
- update code to set base path as /admin

