### PR TITLE
[MB-14483] including service item name

### DIFF
--- a/pkg/assets/sql_scripts/move_history_fetcher.sql
+++ b/pkg/assets/sql_scripts/move_history_fetcher.sql
@@ -109,6 +109,7 @@ WITH move AS (
 		SELECT
 			mto_service_item_customer_contacts.*,
 			jsonb_agg(jsonb_build_object(
+				'name', re_services.name,
 				'shipment_type', move_shipments.shipment_type,
 				'shipment_id_abbr', move_shipments.shipment_id_abbr
 				)
@@ -116,6 +117,7 @@ WITH move AS (
 		FROM
 			mto_service_item_customer_contacts
 		JOIN move_service_items on move_service_items.id = mto_service_item_customer_contacts.mto_service_item_id
+		JOIN re_services ON move_service_items.re_service_id = re_services.id
 			LEFT JOIN move_shipments ON move_service_items.mto_shipment_id = move_shipments.id
 		JOIN move ON move.id = move_service_items.move_id
 		GROUP BY mto_service_item_customer_contacts.id

--- a/src/constants/MoveHistory/EventTemplates/CreateMTOServiceItem/createMTOServiceItemCustomerContacts.test.jsx
+++ b/src/constants/MoveHistory/EventTemplates/CreateMTOServiceItem/createMTOServiceItemCustomerContacts.test.jsx
@@ -16,6 +16,7 @@ describe('when given a Create basic service item customer contacts history recor
     },
     context: [
       {
+        name: 'Domestic destination 1st day SIT',
         shipment_id_abbr: 'c3a9e',
         shipment_type: 'HHG',
       },
@@ -33,6 +34,7 @@ describe('when given a Create basic service item customer contacts history recor
     },
     context: [
       {
+        name: 'Domestic destination 1st day SIT',
         shipment_id_abbr: 'c3a9e',
         shipment_type: 'HHG',
       },
@@ -51,7 +53,7 @@ describe('when given a Create basic service item customer contacts history recor
     const template = getTemplate(firstHistoryRecord);
 
     render(template.getDetails(firstHistoryRecord));
-    expect(screen.getByText('HHG shipment #C3A9E'));
+    expect(screen.getByText('HHG shipment #C3A9E, Domestic destination 1st day SIT'));
   });
 
   describe('when given a specific set of details', () => {


### PR DESCRIPTION
## [Jira ticket](https://dp3.atlassian.net/browse/MB-14483) for this change

## Summary

A continuation of PR #9615 - after review it was found that the service item name was to be included in the shipment label as well. The changes in this PR ensure that the service item name is displayed in the shipment label and testing was added reflecting said change as well.

## Setup to Run Your Code

<details>
<summary>💻 You will need to use two separate terminals to test this locally.</summary>

##### Terminal 1

Start the UI locally.

```sh
make client_run
```

##### Terminal 2

Start the Go server locally.

```sh
make server_run
```

</details>

### Additional steps

<!-- Fill out the next section as you see fit, these are just suggestions. -->

1. Log in as prime simulator
2. Choose move you want to test (I used `RDY4PY`)
3. Request a new service item, Destination SIT
4. Switch to TOO role
5. Find move
6. Navigate to the move history tab
7.  Both shipment label and labeled fields should display properly

## Verification Steps for Author

These are to be checked by the author.

- [x] Have the Jira acceptance criteria been met for this change?

## Verification Steps for Reviewers

These are to be checked by a reviewer.

<!-- Fill out the next sections as you see fit, these are just suggestions. -->

### Frontend

- [ ] User facing changes have been reviewed by design.
- [ ] There are no aXe warnings for UI.
- [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/main/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
- [ ] There are no new console errors in the browser devtools
- [ ] There are no new console errors in the test output
- [ ] If this PR adds a new component to Storybook, it ensures the component is fully responsive, OR if it is intentionally not, a wrapping div using the `officeApp` class or custom `min-width` styling is used to hide any states the would not be visible to the user.

## Screenshots
Before:
![image](https://user-images.githubusercontent.com/111928238/203441362-9798df7f-dbf2-4d01-9ee0-a00c91b5ff2e.png)

After:
<img width="1330" alt="image" src="https://user-images.githubusercontent.com/111928238/203441407-91d2dacb-97e1-45f7-b4c1-4551d8425fed.png">
