### PR TITLE
MB-14433-Removed prop injection from page components and deleted the base path prop.

### DIFF
--- a/src/pages/Admin/AdminUsers/AdminUserCreate.jsx
+++ b/src/pages/Admin/AdminUsers/AdminUserCreate.jsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import { Create, SimpleForm, TextInput, ReferenceInput, AutocompleteInput, required } from 'react-admin';
 
-const AdminUserCreate = (props) => (
-  <Create {...props}>
+const AdminUserCreate = () => (
+  <Create>
     <SimpleForm>
       <TextInput source="email" validate={required()} />
       <TextInput source="firstName" validate={required()} />

--- a/src/pages/Admin/AdminUsers/AdminUserEdit.jsx
+++ b/src/pages/Admin/AdminUsers/AdminUserEdit.jsx
@@ -7,8 +7,8 @@ const AdminUserEditToolbar = (props) => (
   </Toolbar>
 );
 
-const AdminUserEdit = (props) => (
-  <Edit {...props}>
+const AdminUserEdit = () => (
+  <Edit>
     <SimpleForm toolbar={<AdminUserEditToolbar />}>
       <TextInput source="id" disabled />
       <TextInput source="userId" label="User Id" disabled />

--- a/src/pages/Admin/AdminUsers/AdminUserList.jsx
+++ b/src/pages/Admin/AdminUsers/AdminUserList.jsx
@@ -5,8 +5,8 @@ import AdminPagination from 'scenes/SystemAdmin/shared/AdminPagination';
 
 const defaultSort = { field: 'last_name', order: 'ASC' };
 
-const AdminUserList = (props) => (
-  <List {...props} pagination={<AdminPagination />} perPage={25} sort={defaultSort} bulkActionButtons={false}>
+const AdminUserList = () => (
+  <List pagination={<AdminPagination />} perPage={25} sort={defaultSort} bulkActionButtons={false}>
     <Datagrid rowClick="show">
       <TextField source="id" />
       <TextField source="email" />

--- a/src/pages/Admin/AdminUsers/AdminUserShow.jsx
+++ b/src/pages/Admin/AdminUsers/AdminUserShow.jsx
@@ -20,9 +20,9 @@ AdminUserShowTitle.defaultProps = {
   },
 };
 
-const AdminUserShow = (props) => {
+const AdminUserShow = () => {
   return (
-    <Show {...props} title={<AdminUserShowTitle />}>
+    <Show title={<AdminUserShowTitle />}>
       <SimpleShowLayout>
         <TextField source="id" />
         <TextField source="userId" label="User Id" />

--- a/src/pages/Admin/Moves/MoveEdit.jsx
+++ b/src/pages/Admin/Moves/MoveEdit.jsx
@@ -8,8 +8,8 @@ const MoveEditToolbar = (props) => (
   </Toolbar>
 );
 
-const MoveEdit = (props) => (
-  <Edit {...props}>
+const MoveEdit = () => (
+  <Edit>
     <SimpleForm toolbar={<MoveEditToolbar />}>
       <TextInput source="id" disabled />
       <TextInput source="locator" disabled />

--- a/src/pages/Admin/Moves/MoveList.jsx
+++ b/src/pages/Admin/Moves/MoveList.jsx
@@ -12,9 +12,8 @@ const MoveFilter = (props) => (
   </Filter>
 );
 
-const MoveList = (props) => (
+const MoveList = () => (
   <List
-    {...props}
     pagination={<AdminPagination />}
     perPage={25}
     filters={<MoveFilter />}

--- a/src/pages/Admin/Moves/MoveShow.jsx
+++ b/src/pages/Admin/Moves/MoveShow.jsx
@@ -18,10 +18,10 @@ MoveShowTitle.defaultProps = {
   },
 };
 
-const MoveShow = (props) => {
+const MoveShow = () => {
   return (
     /* eslint-disable-next-line react/jsx-props-no-spreading */
-    <Show {...props} title={<MoveShowTitle />}>
+    <Show title={<MoveShowTitle />}>
       <SimpleShowLayout>
         <TextField source="id" />
         <TextField source="locator" />

--- a/src/pages/Admin/OfficeUsers/OfficeUserCreate.jsx
+++ b/src/pages/Admin/OfficeUsers/OfficeUserCreate.jsx
@@ -4,8 +4,8 @@ import { Create, SimpleForm, TextInput, ReferenceInput, AutocompleteInput, requi
 import { RolesCheckboxInput } from 'scenes/SystemAdmin/shared/RolesCheckboxes';
 import { phoneValidators } from 'scenes/SystemAdmin/shared/form_validators';
 
-const OfficeUserCreate = (props) => (
-  <Create {...props}>
+const OfficeUserCreate = () => (
+  <Create>
     <SimpleForm>
       <TextInput source="firstName" validate={required()} />
       <TextInput source="middleInitials" />

--- a/src/pages/Admin/OfficeUsers/OfficeUserEdit.jsx
+++ b/src/pages/Admin/OfficeUsers/OfficeUserEdit.jsx
@@ -20,8 +20,8 @@ const OfficeUserEditToolbar = (props) => (
   </Toolbar>
 );
 
-const OfficeUserEdit = (props) => (
-  <Edit {...props}>
+const OfficeUserEdit = () => (
+  <Edit>
     <SimpleForm toolbar={<OfficeUserEditToolbar />}>
       <TextInput source="id" disabled />
       <TextInput source="userId" label="User Id" disabled />

--- a/src/pages/Admin/OfficeUsers/OfficeUserList.jsx
+++ b/src/pages/Admin/OfficeUsers/OfficeUserList.jsx
@@ -18,10 +18,10 @@ import AdminPagination from 'scenes/SystemAdmin/shared/AdminPagination';
 
 // Overriding the default toolbar to add import button
 const ListActions = (props) => {
-  const { basePath, total, resource, currentSort, filterValues, exporter } = props;
+  const { total, resource, currentSort, filterValues, exporter } = props;
   return (
     <TopToolbar>
-      <CreateButton basePath={basePath} />
+      <CreateButton />
       <ImportOfficeUserButton resource={resource} {...props} />
       <ExportButton
         disabled={total === 0}
@@ -42,9 +42,8 @@ const OfficeUserListFilter = (props) => (
 
 const defaultSort = { field: 'last_name', order: 'ASC' };
 
-const OfficeUserList = (props) => (
+const OfficeUserList = () => (
   <List
-    {...props}
     pagination={<AdminPagination />}
     perPage={25}
     bulkActionButtons={false}

--- a/src/pages/Admin/OfficeUsers/OfficeUserShow.jsx
+++ b/src/pages/Admin/OfficeUsers/OfficeUserShow.jsx
@@ -29,9 +29,9 @@ OfficeUserShowTitle.defaultProps = {
   },
 };
 
-const OfficeUserShow = (props) => {
+const OfficeUserShow = () => {
   return (
-    <Show {...props} title={<OfficeUserShowTitle />}>
+    <Show title={<OfficeUserShowTitle />}>
       <SimpleShowLayout>
         <TextField source="id" />
         <TextField source="userId" label="User Id" />

--- a/src/pages/Admin/Offices/OfficeList.jsx
+++ b/src/pages/Admin/Offices/OfficeList.jsx
@@ -11,9 +11,8 @@ const OfficeFilter = (props) => (
   </Filter>
 );
 
-const OfficeList = (props) => (
+const OfficeList = () => (
   <List
-    {...props}
     filters={<OfficeFilter />}
     pagination={<AdminPagination />}
     perPage={25}

--- a/src/pages/Admin/Users/UserEdit.jsx
+++ b/src/pages/Admin/Users/UserEdit.jsx
@@ -7,8 +7,8 @@ const UserEditToolbar = (props) => (
   </Toolbar>
 );
 
-const UserEdit = (props) => (
-  <Edit {...props}>
+const UserEdit = () => (
+  <Edit>
     <SimpleForm toolbar={<UserEditToolbar />}>
       <TextInput source="id" disabled />
       <TextInput source="loginGovEmail" disabled />

--- a/src/pages/Admin/Users/UserList.jsx
+++ b/src/pages/Admin/Users/UserList.jsx
@@ -12,10 +12,9 @@ const UserFilter = (props) => (
 
 const defaultSort = { field: 'loginGovEmail', order: 'ASC' };
 
-const UserList = (props) => (
+const UserList = () => (
   <List
     /* eslint-disable-next-line react/jsx-props-no-spreading */
-    {...props}
     filters={<UserFilter />}
     pagination={<AdminPagination />}
     perPage={25}

--- a/src/pages/Admin/Users/UserShow.jsx
+++ b/src/pages/Admin/Users/UserShow.jsx
@@ -18,10 +18,10 @@ UserShowTitle.defaultProps = {
   },
 };
 
-const UserShow = (props) => {
+const UserShow = () => {
   return (
     // eslint-disable-next-line react/jsx-props-no-spreading
-    <Show {...props} title={<UserShowTitle />} data-testid="user-show-detail">
+    <Show title={<UserShowTitle />} data-testid="user-show-detail">
       <SimpleShowLayout>
         <TextField source="id" label="User ID" />
         <TextField source="loginGovEmail" label="User email" />

--- a/src/pages/Admin/WebhookSubscriptions/WebhookSubscriptionCreate.jsx
+++ b/src/pages/Admin/WebhookSubscriptions/WebhookSubscriptionCreate.jsx
@@ -3,9 +3,9 @@ import { Create, SimpleForm, TextInput, SelectInput, required } from 'react-admi
 
 import { WEBHOOK_SUBSCRIPTION_STATUS } from 'shared/constants';
 
-const WebhookSubscriptionCreate = (props) => (
+const WebhookSubscriptionCreate = () => (
   /* eslint-disable-next-line react/jsx-props-no-spreading */
-  <Create {...props}>
+  <Create>
     <SimpleForm>
       <TextInput label="Subscriber Id" source="subscriberId" validate={required()} />
       <TextInput source="eventKey" validate={required()} />

--- a/src/pages/Admin/WebhookSubscriptions/WebhookSubscriptionEdit.jsx
+++ b/src/pages/Admin/WebhookSubscriptions/WebhookSubscriptionEdit.jsx
@@ -9,9 +9,9 @@ const WebhookSubscriptionEditToolbar = (props) => (
   </Toolbar>
 );
 
-const WebhookSubscriptionEdit = (props) => (
+const WebhookSubscriptionEdit = () => (
   /* eslint-disable-next-line react/jsx-props-no-spreading */
-  <Edit {...props}>
+  <Edit>
     <SimpleForm toolbar={<WebhookSubscriptionEditToolbar />}>
       <TextInput source="id" disabled />
       <TextInput label="Subscriber Id" source="subscriberId" validate={required()} />

--- a/src/pages/Admin/WebhookSubscriptions/WebhookSubscriptionShow.jsx
+++ b/src/pages/Admin/WebhookSubscriptions/WebhookSubscriptionShow.jsx
@@ -18,10 +18,10 @@ WebhookSubscriptionShowTitle.defaultProps = {
   },
 };
 
-const WebhookSubscriptionShow = (props) => {
+const WebhookSubscriptionShow = () => {
   return (
     /* eslint-disable-next-line react/jsx-props-no-spreading */
-    <Show {...props} title={<WebhookSubscriptionShowTitle />}>
+    <Show title={<WebhookSubscriptionShowTitle />}>
       <SimpleShowLayout>
         <TextField source="id" />
         <TextField label="Subscriber Id" source="subscriberId" />

--- a/src/pages/Admin/WebhookSubscriptions/WebhookSubscriptionsList.jsx
+++ b/src/pages/Admin/WebhookSubscriptions/WebhookSubscriptionsList.jsx
@@ -6,8 +6,8 @@ import AdminPagination from 'scenes/SystemAdmin/shared/AdminPagination';
 
 const defaultSort = { field: 'status', order: 'ASC' };
 
-const WebhookSubscriptionList = (props) => (
-  <List {...props} pagination={<AdminPagination />} perPage={25} sort={defaultSort} bulkActionButtons={false}>
+const WebhookSubscriptionList = () => (
+  <List pagination={<AdminPagination />} perPage={25} sort={defaultSort} bulkActionButtons={false}>
     <Datagrid rowClick="show">
       <TextField source="id" />
       <TextField source="eventKey" />


### PR DESCRIPTION
## [Jira ticket](https://dp3.atlassian.net/browse/MB-14487) for this change

## Summary

This pull request is an incremental change apart of the React Admin upgrade. Prop injection was removed from all React Admin Page components (i.e List, Create, Edit) and the basePath prop was removed from the OfficeUserList component. 

The app will not compile until the rest of the upgrade changes are complete. This pull request cannot be tested at this time. For now, all is needed is a **code review.**

Current State of Admin App without Prop Injection due to upgrade being incomplete.
<img width="995" alt="Screen Shot 2022-11-29 at 10 34 25 AM" src="https://user-images.githubusercontent.com/111006369/204572981-637df876-e901-41aa-b8a6-4a735b277498.png">

