### PR TITLE
MB-14502 - Create new function for amended order routing

### DIFF
--- a/pkg/handlers/internalapi/moves.go
+++ b/pkg/handlers/internalapi/moves.go
@@ -353,7 +353,7 @@ func (h SubmitAmendedOrdersHandler) Handle(params moveop.SubmitAmendedOrdersPara
 
 			logger := appCtx.Logger().With(zap.String("moveLocator", move.Locator))
 
-			err = h.MoveRouter.Submit(appCtx, move, nil)
+			err = h.MoveRouter.RouteAfterAmendingOrders(appCtx, move)
 			if err != nil {
 				return handlers.ResponseForError(logger, err), err
 			}

--- a/pkg/services/mocks/MoveRouter.go
+++ b/pkg/services/mocks/MoveRouter.go
@@ -79,6 +79,20 @@ func (_m *MoveRouter) CompleteServiceCounseling(appCtx appcontext.AppContext, mo
 	return r0
 }
 
+// RouteAfterAmendingOrders provides a mock function with given fields: appCtx, move
+func (_m *MoveRouter) RouteAfterAmendingOrders(appCtx appcontext.AppContext, move *models.Move) error {
+	ret := _m.Called(appCtx, move)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(appcontext.AppContext, *models.Move) error); ok {
+		r0 = rf(appCtx, move)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
 // SendToOfficeUser provides a mock function with given fields: appCtx, move
 func (_m *MoveRouter) SendToOfficeUser(appCtx appcontext.AppContext, move *models.Move) error {
 	ret := _m.Called(appCtx, move)

--- a/pkg/services/move.go
+++ b/pkg/services/move.go
@@ -44,6 +44,7 @@ type MoveRouter interface {
 	ApproveOrRequestApproval(appCtx appcontext.AppContext, move models.Move) (*models.Move, error)
 	Cancel(appCtx appcontext.AppContext, reason string, move *models.Move) error
 	CompleteServiceCounseling(appCtx appcontext.AppContext, move *models.Move) error
+	RouteAfterAmendingOrders(appCtx appcontext.AppContext, move *models.Move) error
 	SendToOfficeUser(appCtx appcontext.AppContext, move *models.Move) error
 	Submit(appCtx appcontext.AppContext, move *models.Move, newSignedCertification *models.SignedCertification) error
 }

--- a/pkg/services/move/move_router_test.go
+++ b/pkg/services/move/move_router_test.go
@@ -99,7 +99,7 @@ func (suite *MoveServiceSuite) TestMoveSubmission() {
 	})
 
 	suite.Run("moves with amended orders are set to APPROVALSREQUESTED status", func() {
-		// Under test: MoveRouter.Submit
+		// Under test: MoveRouter.RouteAfterAmendingOrders
 		// Set up: Submit an approved move with an orders record
 		// Expected outcome: move status updated to APPROVALSREQUESTED
 		document := testdatagen.MakeDefaultDocument(suite.DB())
@@ -115,19 +115,14 @@ func (suite *MoveServiceSuite) TestMoveSubmission() {
 			},
 			Order: order,
 		})
-		newSignedCertification := testdatagen.MakeSignedCertification(suite.DB(), testdatagen.Assertions{
-			SignedCertification: models.SignedCertification{
-				MoveID: move.ID,
-			},
-			Stub: true,
-		})
-		err := moveRouter.Submit(suite.AppContextForTest(), &move, &newSignedCertification)
+
+		err := moveRouter.RouteAfterAmendingOrders(suite.AppContextForTest(), &move)
 		suite.NoError(err)
 		suite.Equal(models.MoveStatusAPPROVALSREQUESTED, move.Status)
 	})
 
 	suite.Run("moves with amended orders return an error if in CANCELLED status", func() {
-		// Under test: MoveRouter.Submit
+		// Under test: MoveRouter.RouteAfterAmendingOrders
 		// Set up: Create a CANCELLED move without an OrdersID
 		// Expected outcome: Error on ordersID
 		document := testdatagen.MakeDefaultDocument(suite.DB())
@@ -143,19 +138,14 @@ func (suite *MoveServiceSuite) TestMoveSubmission() {
 			},
 			Order: order,
 		})
-		newSignedCertification := testdatagen.MakeSignedCertification(suite.DB(), testdatagen.Assertions{
-			SignedCertification: models.SignedCertification{
-				MoveID: move.ID,
-			},
-			Stub: true,
-		})
-		err := moveRouter.Submit(suite.AppContextForTest(), &move, &newSignedCertification)
+
+		err := moveRouter.RouteAfterAmendingOrders(suite.AppContextForTest(), &move)
 		suite.Error(err)
 		suite.Contains(err.Error(), fmt.Sprintf("The status for the move with ID %s can not be sent to 'Approvals Requested' if the status is cancelled.", move.ID))
 	})
 
 	suite.Run("moves with amended orders that already had amended orders go into the 'Approvals Requested' status and have a nil value for 'AmendedOrdersAcknowledgedAt", func() {
-		// Under test: MoveRouter.Submit
+		// Under test: MoveRouter.RouteAfterAmendingOrders
 		// Set up: Create a move amended orders acknowledged, then submit with amended orders
 		// Expected outcome: Status goes to APPROVALSREQUESTED and timestamp is cleared
 		document := testdatagen.MakeDefaultDocument(suite.DB())
@@ -174,13 +164,8 @@ func (suite *MoveServiceSuite) TestMoveSubmission() {
 			Order: order,
 		})
 		suite.NotNil(move.Orders.AmendedOrdersAcknowledgedAt)
-		newSignedCertification := testdatagen.MakeSignedCertification(suite.DB(), testdatagen.Assertions{
-			SignedCertification: models.SignedCertification{
-				MoveID: move.ID,
-			},
-			Stub: true,
-		})
-		err := moveRouter.Submit(suite.AppContextForTest(), &move, &newSignedCertification)
+
+		err := moveRouter.RouteAfterAmendingOrders(suite.AppContextForTest(), &move)
 		suite.NoError(err)
 		var updatedOrders models.Order
 		err = suite.DB().Find(&updatedOrders, move.OrdersID)


### PR DESCRIPTION
## [Jira ticket](https://dp3.atlassian.net/browse/MB-14502) for this change

## Summary

The bug ticket was created for a situation in which amended orders could not be saved. Recent refactoring implemented a required validation of signed certification for every time the move router's `Submit` function is called, and there is an edge case in which it is called when submitting amended orders without a signed certification in the payload. 

The fix in this PR extracts the amended-order-submission edge case handling from the move router's `Submit` into a new function, `RouteAfterAmendingOrders`. This introduces a slight amount of code duplication, but in return the `Submit```` function now only has one responsibility, and its if/else clause is now much easier to understand.

This story should be tested for move submissions and order amendments for moves that require services counseling and moves that do not require  services counseling.

## Setup to Run Your Code

<details>
<summary>💻 You will need to use three separate terminals to test this locally.</summary>

##### Terminal 1

Start the Storybook locally.

```sh
make storybook
```

##### Terminal 2

Start the UI locally.

```sh
make client_run
```

##### Terminal 3

Start the Go server locally.

```sh
make server_run
```

</details>

### Additional steps

<!-- Fill out the next section as you see fit, these are just suggestions. -->

For moves that require services counseling:
1. Access the customer app and create a new move
3. Ensure the move will require services counseling based on the chosen duty station
4. Submit the move to the office app
5. Log into the office app as a services counselor and validate that the move is in the SC queue
6. Log into the customer app again as the first user
7. Submit amended orders
8. Validate that the "save" button for amended orders does not return an error
9. Log into the office app as a services counselor and validate that the move is in the SC queue


For moves that don't require services counseling:
1. Access the customer app and create a new move
3. Ensure the move will not require services counseling based on the chosen duty station
4. Submit the move to the office app
5. Log into the office app as a TOO and validate that the move is in the TOO queue
6. Log into the customer app again as the first user
7. Submit amended orders
8. Validate that the "save" button for amended orders does not return an error
9. Log into the office app as a TOO and validate that the move is in the TOO queue
## Verification Steps for Author

These are to be checked by the author.

- [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
- [ ] Request review from a member of a different team.
- [ ] Have the Jira acceptance criteria been met for this change?

## Verification Steps for Reviewers

These are to be checked by a reviewer.

<!-- Fill out the next sections as you see fit, these are just suggestions. -->


### Backend

- [ ] Code follows the guidelines for [Logging](https://transcom.github.io/mymove-docs/docs/dev/contributing/backend/Backend-Programming-Guide#logging)
- [ ] The requirements listed in [Querying the Database Safely](https://transcom.github.io/mymove-docs/docs/dev/contributing/backend/Backend-Programming-Guide/#querying-the-database-safely) have been satisfied.


## Screenshots
