### PR TITLE
Change the spa_handler to return both the error and an file

### DIFF
--- a/pkg/handlers/spa_handler.go
+++ b/pkg/handlers/spa_handler.go
@@ -66,7 +66,15 @@ func (cfs CustomFileSystem) Open(path string) (http.File, error) {
 			}
 
 			logger.Error("Unable to open index.html in the directory", zap.Error(indexOpenErr))
-			return nil, indexOpenErr
+
+			indexPath := filepath.Join(path, "index.html")
+			indexFile, buildRootIndexOpenErr := cfs.fs.Open(filepath.Clean(indexPath))
+
+			if buildRootIndexOpenErr != nil {
+				return nil, buildRootIndexOpenErr
+			}
+
+			return indexFile, indexOpenErr
 		}
 	}
 

--- a/pkg/handlers/spa_handler.go
+++ b/pkg/handlers/spa_handler.go
@@ -67,8 +67,7 @@ func (cfs CustomFileSystem) Open(path string) (http.File, error) {
 
 			logger.Error("Unable to open index.html in the directory", zap.Error(indexOpenErr))
 
-			indexPath := filepath.Join(path, "index.html")
-			indexFile, buildRootIndexOpenErr := cfs.fs.Open(filepath.Clean(indexPath))
+			indexFile, buildRootIndexOpenErr := cfs.fs.Open(cfs.indexPath)
 
 			if buildRootIndexOpenErr != nil {
 				return nil, buildRootIndexOpenErr


### PR DESCRIPTION
- return the index.html of the base path and the error when attempting to open a directory that does not have an index.html

## [Jira ticket](tbd) for this change

## Summary

Is there anything you would like reviewers to give additional scrutiny?

[this article](tbd) explains more about the approach used.

## Setup to Run Your Code

<details>
<summary>💻 You will need to use two separate terminals to test this locally.</summary>

##### Terminal 1

Start the UI locally.

```sh
make client_run
```

##### Terminal 2

Start the Go server locally.

```sh
make server_run
```

</details>

### Additional steps

<!-- Fill out the next section as you see fit, these are just suggestions. -->

1. Access the
2. Login as a
3.

## Verification Steps for Author

These are to be checked by the author.

- [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
- [ ] Request review from a member of a different team.
- [ ] Have the Jira acceptance criteria been met for this change?

## Verification Steps for Reviewers

These are to be checked by a reviewer.

<!-- Fill out the next sections as you see fit, these are just suggestions. -->

### Backend

- [ ] Code follows the guidelines for [Logging](https://transcom.github.io/mymove-docs/docs/dev/contributing/backend/Backend-Programming-Guide#logging)
- [ ] The requirements listed in [Querying the Database Safely](https://transcom.github.io/mymove-docs/docs/dev/contributing/backend/Backend-Programming-Guide/#querying-the-database-safely) have been satisfied.
