### PR TITLE
Update script to work locally

### DIFF
--- a/scripts/run-e2e-test-docker
+++ b/scripts/run-e2e-test-docker
@@ -37,7 +37,7 @@ docker run \
        -e GOPATH \
        -e CIRCLECI=1 \
        ${circleci_build_image} \
-       server_build \
+       make server_build \
        bin/generate-test-data \
        bin/prime-api-client \
        bin/rds-ca-2019-root.pem \


### PR DESCRIPTION
## [Jira ticket](https://dp3.atlassian.net/browse/MB-14636) for this change

## Summary

The word `make` went missing from an accidental edit, adding it back. It doesn't make the tests all pass, but is better than the script failing due to the missing command. 

## Setup to Run Your Code

This should compile and run, even if the tests don't pass. 
```
make e2e_test_docker
```

