### PR TITLE
MB-14756 Make swagger_autorebuild the default

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -215,6 +215,9 @@ require CSRF_AUTH_KEY "See 'DISABLE_AWS_VAULT_WRAPPER=1 AWS_REGION=us-gov-west-1
 # Always show Swagger UI in development
 export SERVE_SWAGGER_UI=true
 
+# Regenerate swagger files if necessary.
+export SWAGGER_AUTOREBUILD=1
+
 # HAPPO Keys
 require HAPPO_API_KEY "See 'DISABLE_AWS_VAULT_WRAPPER=1 AWS_REGION=us-gov-west-1 aws-vault exec transcom-gov-dev -- chamber read app-devlocal happo_api_key'"
 require HAPPO_API_SECRET "See 'DISABLE_AWS_VAULT_WRAPPER=1 AWS_REGION=us-gov-west-1 aws-vault exec transcom-gov-dev -- chamber read app-devlocal happo_api_secret'"

--- a/Makefile
+++ b/Makefile
@@ -310,7 +310,7 @@ SWAGGER_AUTOREBUILD=1
 endif
 SWAGGER_FILES = $(shell find swagger swagger-def -type f)
 .swagger_build.stamp: $(SWAGGER_FILES)
-ifndef SWAGGER_AUTOREBUILD
+ifeq ($(SWAGGER_AUTOREBUILD),0)
 ifneq ("$(shell find swagger -type f -name '*.yaml' -newer .swagger_build.stamp)","")
 	@echo "Unexpected changes found in swagger build files. Code may be overwritten."
 	@read -p "Continue with rebuild? [y/N] : " ANS && test "$${ANS}" == "y" || (echo "Exiting rebuild."; false)


### PR DESCRIPTION
## [Jira ticket](https://dp3.atlassian.net/browse/MB-14756) for this change



## Summary

This changes swagger_generate to skip the prompt by default. 
Devs can re-enable the prompt by setting `SWAGGER_AUTOREBUILD=0` locally.

## Setup to Run Your Code

##### Terminal 1

```sh
direnv allow 
touch swagger/prime.yaml 
make swagger_generate
## Should bundle the api files...
./scripts/openapi bundle -o swagger/ ## Bundles the API definition files into a complete specification

touch swagger/prime.yaml 
SWAGGER_AUTOREBUILD=0 make swagger_generate
## Should prompt first before bundling the api files
Unexpected changes found in swagger build files. Code may be overwritten.
Continue with rebuild? [y/N] : 
```