### PR TITLE
MB-14781 Add additional triggers for tables for DMS

### DIFF
--- a/migrations/app/migrations_manifest.txt
+++ b/migrations/app/migrations_manifest.txt
@@ -776,3 +776,4 @@
 20221208171026_remove_eval_report_durations.up.sql
 20221214212841_add_provides_ppm_closeout.up.sql
 20221215183130_set_closeout_offices_to_true_for_provides_ppm_closeout_column.up.sql
+20221221204441_add_additional_triggers_for_dms.up.sql

--- a/migrations/app/schema/20221221204441_add_additional_triggers_for_dms.up.sql
+++ b/migrations/app/schema/20221221204441_add_additional_triggers_for_dms.up.sql
@@ -1,0 +1,702 @@
+
+SELECT add_audit_history_table(
+    target_table := 'backup_contacts',
+    audit_rows := BOOLEAN 't',
+    audit_query_text := BOOLEAN 't',
+    ignored_cols := ARRAY[
+        'created_at',
+        'updated_at'
+    ]
+);
+
+
+SELECT add_audit_history_table(
+    target_table := 'customer_support_remarks',
+    audit_rows := BOOLEAN 't',
+    audit_query_text := BOOLEAN 't',
+    ignored_cols := ARRAY[
+        'created_at',
+        'updated_at'
+    ]
+);
+
+SELECT add_audit_history_table(
+    target_table := 'distance_calculations',
+    audit_rows := BOOLEAN 't',
+    audit_query_text := BOOLEAN 't',
+    ignored_cols := ARRAY[
+        'created_at',
+        'updated_at'
+    ]
+);
+
+SELECT add_audit_history_table(
+    target_table := 'documents',
+    audit_rows := BOOLEAN 't',
+    audit_query_text := BOOLEAN 't',
+    ignored_cols := ARRAY[
+        'created_at',
+        'updated_at'
+    ]
+);
+
+SELECT add_audit_history_table(
+    target_table := 'duty_location_names',
+    audit_rows := BOOLEAN 't',
+    audit_query_text := BOOLEAN 't',
+    ignored_cols := ARRAY[
+        'created_at',
+        'updated_at'
+    ]
+);
+
+SELECT add_audit_history_table(
+    target_table := 'duty_locations',
+    audit_rows := BOOLEAN 't',
+    audit_query_text := BOOLEAN 't',
+    ignored_cols := ARRAY[
+        'created_at',
+        'updated_at'
+    ]
+);
+
+SELECT add_audit_history_table(
+    target_table := 'edi_errors',
+    audit_rows := BOOLEAN 't',
+    audit_query_text := BOOLEAN 't',
+    ignored_cols := ARRAY[
+        'created_at',
+        'updated_at'
+    ]
+);
+
+SELECT add_audit_history_table(
+    target_table := 'edi_processings',
+    audit_rows := BOOLEAN 't',
+    audit_query_text := BOOLEAN 't',
+    ignored_cols := ARRAY[
+        'created_at',
+        'updated_at'
+    ]
+);
+
+SELECT add_audit_history_table(
+    target_table := 'edi_processings',
+    audit_rows := BOOLEAN 't',
+    audit_query_text := BOOLEAN 't',
+    ignored_cols := ARRAY[
+        'created_at',
+        'updated_at'
+    ]
+);
+
+SELECT add_audit_history_table(
+    target_table := 'electronic_orders',
+    audit_rows := BOOLEAN 't',
+    audit_query_text := BOOLEAN 't',
+    ignored_cols := ARRAY[
+        'created_at',
+        'updated_at'
+    ]
+);
+
+SELECT add_audit_history_table(
+    target_table := 'electronic_orders_revisions',
+    audit_rows := BOOLEAN 't',
+    audit_query_text := BOOLEAN 't',
+    ignored_cols := ARRAY[
+        'created_at',
+        'updated_at'
+    ]
+);
+
+SELECT add_audit_history_table(
+    target_table := 'entitlements',
+    audit_rows := BOOLEAN 't',
+    audit_query_text := BOOLEAN 't',
+    ignored_cols := ARRAY[
+        'created_at',
+        'updated_at'
+    ]
+);
+
+SELECT add_audit_history_table(
+    target_table := 'evaluation_reports',
+    audit_rows := BOOLEAN 't',
+    audit_query_text := BOOLEAN 't',
+    ignored_cols := ARRAY[
+        'created_at',
+        'updated_at'
+    ]
+);
+
+SELECT add_audit_history_table(
+    target_table := 'fuel_eia_diesel_prices',
+    audit_rows := BOOLEAN 't',
+    audit_query_text := BOOLEAN 't',
+    ignored_cols := ARRAY[
+        'created_at',
+        'updated_at'
+    ]
+);
+
+SELECT add_audit_history_table(
+    target_table := 'ghc_diesel_fuel_prices',
+    audit_rows := BOOLEAN 't',
+    audit_query_text := BOOLEAN 't',
+    ignored_cols := ARRAY[
+        'created_at',
+        'updated_at'
+    ]
+);
+
+SELECT add_audit_history_table(
+    target_table := 'ghc_domestic_transit_times',
+    audit_rows := BOOLEAN 't',
+    audit_query_text := BOOLEAN 't',
+    ignored_cols := ARRAY[
+        'created_at',
+        'updated_at'
+    ]
+);
+
+SELECT add_audit_history_table(
+    target_table := 'invoice_number_trackers',
+    audit_rows := BOOLEAN 't',
+    audit_query_text := BOOLEAN 't',
+    ignored_cols := ARRAY[
+        'created_at',
+        'updated_at'
+    ]
+);
+
+SELECT add_audit_history_table(
+    target_table := 'invoices',
+    audit_rows := BOOLEAN 't',
+    audit_query_text := BOOLEAN 't',
+    ignored_cols := ARRAY[
+        'created_at',
+        'updated_at'
+    ]
+);
+
+SELECT add_audit_history_table(
+    target_table := 'jppso_region_state_assignments',
+    audit_rows := BOOLEAN 't',
+    audit_query_text := BOOLEAN 't',
+    ignored_cols := ARRAY[
+        'created_at',
+        'updated_at'
+    ]
+);
+
+SELECT add_audit_history_table(
+    target_table := 'jppso_regions',
+    audit_rows := BOOLEAN 't',
+    audit_query_text := BOOLEAN 't',
+    ignored_cols := ARRAY[
+        'created_at',
+        'updated_at'
+    ]
+);
+
+SELECT add_audit_history_table(
+    target_table := 'moving_expenses',
+    audit_rows := BOOLEAN 't',
+    audit_query_text := BOOLEAN 't',
+    ignored_cols := ARRAY[
+        'created_at',
+        'updated_at'
+    ]
+);
+
+
+SELECT add_audit_history_table(
+    target_table := 'mto_service_item_dimensions',
+    audit_rows := BOOLEAN 't',
+    audit_query_text := BOOLEAN 't',
+    ignored_cols := ARRAY[
+        'created_at',
+        'updated_at'
+    ]
+);
+
+SELECT add_audit_history_table(
+    target_table := 'mto_service_item_dimensions',
+    audit_rows := BOOLEAN 't',
+    audit_query_text := BOOLEAN 't',
+    ignored_cols := ARRAY[
+        'created_at',
+        'updated_at'
+    ]
+);
+
+SELECT add_audit_history_table(
+    target_table := 'notifications',
+    audit_rows := BOOLEAN 't',
+    audit_query_text := BOOLEAN 't',
+    ignored_cols := ARRAY[
+        'created_at',
+        'updated_at'
+    ]
+);
+
+SELECT add_audit_history_table(
+    target_table := 'office_emails',
+    audit_rows := BOOLEAN 't',
+    audit_query_text := BOOLEAN 't',
+    ignored_cols := ARRAY[
+        'created_at',
+        'updated_at'
+    ]
+);
+
+SELECT add_audit_history_table(
+    target_table := 'office_emails',
+    audit_rows := BOOLEAN 't',
+    audit_query_text := BOOLEAN 't',
+    ignored_cols := ARRAY[
+        'created_at',
+        'updated_at'
+    ]
+);
+
+SELECT add_audit_history_table(
+    target_table := 'office_phone_lines',
+    audit_rows := BOOLEAN 't',
+    audit_query_text := BOOLEAN 't',
+    ignored_cols := ARRAY[
+        'created_at',
+        'updated_at'
+    ]
+);
+
+SELECT add_audit_history_table(
+    target_table := 'office_users',
+    audit_rows := BOOLEAN 't',
+    audit_query_text := BOOLEAN 't',
+    ignored_cols := ARRAY[
+        'created_at',
+        'updated_at'
+    ]
+);
+
+SELECT add_audit_history_table(
+    target_table := 'organizations',
+    audit_rows := BOOLEAN 't',
+    audit_query_text := BOOLEAN 't',
+    ignored_cols := ARRAY[
+        'created_at',
+        'updated_at'
+    ]
+);
+
+SELECT add_audit_history_table(
+    target_table := 'payment_request_to_interchange_control_numbers',
+    audit_rows := BOOLEAN 't',
+    audit_query_text := BOOLEAN 't',
+    ignored_cols := ARRAY[
+        'created_at',
+        'updated_at'
+    ]
+);
+
+SELECT add_audit_history_table(
+    target_table := 'payment_service_item_params',
+    audit_rows := BOOLEAN 't',
+    audit_query_text := BOOLEAN 't',
+    ignored_cols := ARRAY[
+        'created_at',
+        'updated_at'
+    ]
+);
+
+SELECT add_audit_history_table(
+    target_table := 'payment_service_items',
+    audit_rows := BOOLEAN 't',
+    audit_query_text := BOOLEAN 't',
+    ignored_cols := ARRAY[
+        'created_at',
+        'updated_at'
+    ]
+);
+
+SELECT add_audit_history_table(
+    target_table := 'personally_procured_moves',
+    audit_rows := BOOLEAN 't',
+    audit_query_text := BOOLEAN 't',
+    ignored_cols := ARRAY[
+        'created_at',
+        'updated_at'
+    ]
+);
+
+SELECT add_audit_history_table(
+    target_table := 'postal_code_to_gblocs',
+    audit_rows := BOOLEAN 't',
+    audit_query_text := BOOLEAN 't',
+    ignored_cols := ARRAY[
+        'created_at',
+        'updated_at'
+    ]
+);
+
+SELECT add_audit_history_table(
+    target_table := 'ppm_shipments',
+    audit_rows := BOOLEAN 't',
+    audit_query_text := BOOLEAN 't',
+    ignored_cols := ARRAY[
+        'created_at',
+        'updated_at'
+    ]
+);
+
+SELECT add_audit_history_table(
+    target_table := 'prime_uploads',
+    audit_rows := BOOLEAN 't',
+    audit_query_text := BOOLEAN 't',
+    ignored_cols := ARRAY[
+        'created_at',
+        'updated_at'
+    ]
+);
+
+SELECT add_audit_history_table(
+    target_table := 'progear_weight_tickets',
+    audit_rows := BOOLEAN 't',
+    audit_query_text := BOOLEAN 't',
+    ignored_cols := ARRAY[
+        'created_at',
+        'updated_at'
+    ]
+);
+
+SELECT add_audit_history_table(
+    target_table := 'proof_of_service_docs',
+    audit_rows := BOOLEAN 't',
+    audit_query_text := BOOLEAN 't',
+    ignored_cols := ARRAY[
+        'created_at',
+        'updated_at'
+    ]
+);
+
+SELECT add_audit_history_table(
+    target_table := 'pws_violations',
+    audit_rows := BOOLEAN 't',
+    audit_query_text := BOOLEAN 't',
+    ignored_cols := ARRAY[
+        'created_at',
+        'updated_at'
+    ]
+);
+
+SELECT add_audit_history_table(
+    target_table := 're_contract_years',
+    audit_rows := BOOLEAN 't',
+    audit_query_text := BOOLEAN 't',
+    ignored_cols := ARRAY[
+        'created_at',
+        'updated_at'
+    ]
+);
+
+SELECT add_audit_history_table(
+    target_table := 're_contracts',
+    audit_rows := BOOLEAN 't',
+    audit_query_text := BOOLEAN 't',
+    ignored_cols := ARRAY[
+        'created_at',
+        'updated_at'
+    ]
+);
+
+SELECT add_audit_history_table(
+    target_table := 're_domestic_accessorial_prices',
+    audit_rows := BOOLEAN 't',
+    audit_query_text := BOOLEAN 't',
+    ignored_cols := ARRAY[
+        'created_at',
+        'updated_at'
+    ]
+);
+
+SELECT add_audit_history_table(
+    target_table := 're_domestic_linehaul_prices',
+    audit_rows := BOOLEAN 't',
+    audit_query_text := BOOLEAN 't',
+    ignored_cols := ARRAY[
+        'created_at',
+        'updated_at'
+    ]
+);
+
+SELECT add_audit_history_table(
+    target_table := 're_domestic_other_prices',
+    audit_rows := BOOLEAN 't',
+    audit_query_text := BOOLEAN 't',
+    ignored_cols := ARRAY[
+        'created_at',
+        'updated_at'
+    ]
+);
+
+SELECT add_audit_history_table(
+    target_table := 're_domestic_service_area_prices',
+    audit_rows := BOOLEAN 't',
+    audit_query_text := BOOLEAN 't',
+    ignored_cols := ARRAY[
+        'created_at',
+        'updated_at'
+    ]
+);
+
+SELECT add_audit_history_table(
+    target_table := 're_domestic_service_areas',
+    audit_rows := BOOLEAN 't',
+    audit_query_text := BOOLEAN 't',
+    ignored_cols := ARRAY[
+        'created_at',
+        'updated_at'
+    ]
+);
+
+SELECT add_audit_history_table(
+    target_table := 're_intl_accessorial_prices',
+    audit_rows := BOOLEAN 't',
+    audit_query_text := BOOLEAN 't',
+    ignored_cols := ARRAY[
+        'created_at',
+        'updated_at'
+    ]
+);
+
+SELECT add_audit_history_table(
+    target_table := 're_intl_accessorial_prices',
+    audit_rows := BOOLEAN 't',
+    audit_query_text := BOOLEAN 't',
+    ignored_cols := ARRAY[
+        'created_at',
+        'updated_at'
+    ]
+);
+
+SELECT add_audit_history_table(
+    target_table := 're_intl_prices',
+    audit_rows := BOOLEAN 't',
+    audit_query_text := BOOLEAN 't',
+    ignored_cols := ARRAY[
+        'created_at',
+        'updated_at'
+    ]
+);
+
+SELECT add_audit_history_table(
+    target_table := 're_rate_areas',
+    audit_rows := BOOLEAN 't',
+    audit_query_text := BOOLEAN 't',
+    ignored_cols := ARRAY[
+        'created_at',
+        'updated_at'
+    ]
+);
+
+SELECT add_audit_history_table(
+    target_table := 're_services',
+    audit_rows := BOOLEAN 't',
+    audit_query_text := BOOLEAN 't',
+    ignored_cols := ARRAY[
+        'created_at',
+        'updated_at'
+    ]
+);
+
+SELECT add_audit_history_table(
+    target_table := 're_shipment_type_prices',
+    audit_rows := BOOLEAN 't',
+    audit_query_text := BOOLEAN 't',
+    ignored_cols := ARRAY[
+        'created_at',
+        'updated_at'
+    ]
+);
+
+SELECT add_audit_history_table(
+    target_table := 're_task_order_fees',
+    audit_rows := BOOLEAN 't',
+    audit_query_text := BOOLEAN 't',
+    ignored_cols := ARRAY[
+        'created_at',
+        'updated_at'
+    ]
+);
+
+SELECT add_audit_history_table(
+    target_table := 're_zip3s',
+    audit_rows := BOOLEAN 't',
+    audit_query_text := BOOLEAN 't',
+    ignored_cols := ARRAY[
+        'created_at',
+        'updated_at'
+    ]
+);
+
+SELECT add_audit_history_table(
+    target_table := 're_zip5_rate_areas',
+    audit_rows := BOOLEAN 't',
+    audit_query_text := BOOLEAN 't',
+    ignored_cols := ARRAY[
+        'created_at',
+        'updated_at'
+    ]
+);
+
+SELECT add_audit_history_table(
+    target_table := 'report_violations',
+    audit_rows := BOOLEAN 't',
+    audit_query_text := BOOLEAN 't',
+    ignored_cols := ARRAY[
+        'created_at',
+        'updated_at'
+    ]
+);
+
+SELECT add_audit_history_table(
+    target_table := 'roles',
+    audit_rows := BOOLEAN 't',
+    audit_query_text := BOOLEAN 't',
+    ignored_cols := ARRAY[
+        'created_at',
+        'updated_at'
+    ]
+);
+
+SELECT add_audit_history_table(
+    target_table := 'service_item_param_keys',
+    audit_rows := BOOLEAN 't',
+    audit_query_text := BOOLEAN 't',
+    ignored_cols := ARRAY[
+        'created_at',
+        'updated_at'
+    ]
+);
+
+SELECT add_audit_history_table(
+    target_table := 'service_params',
+    audit_rows := BOOLEAN 't',
+    audit_query_text := BOOLEAN 't',
+    ignored_cols := ARRAY[
+        'created_at',
+        'updated_at'
+    ]
+);
+
+SELECT add_audit_history_table(
+    target_table := 'sit_extensions',
+    audit_rows := BOOLEAN 't',
+    audit_query_text := BOOLEAN 't',
+    ignored_cols := ARRAY[
+        'created_at',
+        'updated_at'
+    ]
+);
+
+SELECT add_audit_history_table(
+    target_table := 'storage_facilities',
+    audit_rows := BOOLEAN 't',
+    audit_query_text := BOOLEAN 't',
+    ignored_cols := ARRAY[
+        'created_at',
+        'updated_at'
+    ]
+);
+
+SELECT add_audit_history_table(
+    target_table := 'transportation_accounting_codes',
+    audit_rows := BOOLEAN 't',
+    audit_query_text := BOOLEAN 't',
+    ignored_cols := ARRAY[
+        'created_at',
+        'updated_at'
+    ]
+);
+
+SELECT add_audit_history_table(
+    target_table := 'transportation_offices',
+    audit_rows := BOOLEAN 't',
+    audit_query_text := BOOLEAN 't',
+    ignored_cols := ARRAY[
+        'created_at',
+        'updated_at'
+    ]
+);
+
+SELECT add_audit_history_table(
+    target_table := 'transportation_service_provider_performances',
+    audit_rows := BOOLEAN 't',
+    audit_query_text := BOOLEAN 't',
+    ignored_cols := ARRAY[
+        'created_at',
+        'updated_at'
+    ]
+);
+
+SELECT add_audit_history_table(
+    target_table := 'transportation_service_providers',
+    audit_rows := BOOLEAN 't',
+    audit_query_text := BOOLEAN 't',
+    ignored_cols := ARRAY[
+        'created_at',
+        'updated_at'
+    ]
+);
+
+SELECT add_audit_history_table(
+    target_table := 'uploads',
+    audit_rows := BOOLEAN 't',
+    audit_query_text := BOOLEAN 't',
+    ignored_cols := ARRAY[
+        'created_at',
+        'updated_at'
+    ]
+);
+
+SELECT add_audit_history_table(
+    target_table := 'users',
+    audit_rows := BOOLEAN 't',
+    audit_query_text := BOOLEAN 't',
+    ignored_cols := ARRAY[
+        'created_at',
+        'updated_at'
+    ]
+);
+
+SELECT add_audit_history_table(
+    target_table := 'users_roles',
+    audit_rows := BOOLEAN 't',
+    audit_query_text := BOOLEAN 't',
+    ignored_cols := ARRAY[
+        'created_at',
+        'updated_at'
+    ]
+);
+
+SELECT add_audit_history_table(
+    target_table := 'weight_tickets',
+    audit_rows := BOOLEAN 't',
+    audit_query_text := BOOLEAN 't',
+    ignored_cols := ARRAY[
+        'created_at',
+        'updated_at'
+    ]
+);
+
+SELECT add_audit_history_table(
+    target_table := 'zip3_distances',
+    audit_rows := BOOLEAN 't',
+    audit_query_text := BOOLEAN 't',
+    ignored_cols := ARRAY[
+        'created_at',
+        'updated_at'
+    ]
+);

--- a/migrations/app/schema/20221221204441_add_additional_triggers_for_dms.up.sql
+++ b/migrations/app/schema/20221221204441_add_additional_triggers_for_dms.up.sql
@@ -1,15 +1,3 @@
-
-SELECT add_audit_history_table(
-    target_table := 'backup_contacts',
-    audit_rows := BOOLEAN 't',
-    audit_query_text := BOOLEAN 't',
-    ignored_cols := ARRAY[
-        'created_at',
-        'updated_at'
-    ]
-);
-
-
 SELECT add_audit_history_table(
     target_table := 'customer_support_remarks',
     audit_rows := BOOLEAN 't',
@@ -210,27 +198,6 @@ SELECT add_audit_history_table(
     ]
 );
 
-
-SELECT add_audit_history_table(
-    target_table := 'mto_service_item_dimensions',
-    audit_rows := BOOLEAN 't',
-    audit_query_text := BOOLEAN 't',
-    ignored_cols := ARRAY[
-        'created_at',
-        'updated_at'
-    ]
-);
-
-SELECT add_audit_history_table(
-    target_table := 'mto_service_item_dimensions',
-    audit_rows := BOOLEAN 't',
-    audit_query_text := BOOLEAN 't',
-    ignored_cols := ARRAY[
-        'created_at',
-        'updated_at'
-    ]
-);
-
 SELECT add_audit_history_table(
     target_table := 'notifications',
     audit_rows := BOOLEAN 't',
@@ -363,16 +330,6 @@ SELECT add_audit_history_table(
 
 SELECT add_audit_history_table(
     target_table := 'progear_weight_tickets',
-    audit_rows := BOOLEAN 't',
-    audit_query_text := BOOLEAN 't',
-    ignored_cols := ARRAY[
-        'created_at',
-        'updated_at'
-    ]
-);
-
-SELECT add_audit_history_table(
-    target_table := 'proof_of_service_docs',
     audit_rows := BOOLEAN 't',
     audit_query_text := BOOLEAN 't',
     ignored_cols := ARRAY[
@@ -593,16 +550,6 @@ SELECT add_audit_history_table(
 
 SELECT add_audit_history_table(
     target_table := 'sit_extensions',
-    audit_rows := BOOLEAN 't',
-    audit_query_text := BOOLEAN 't',
-    ignored_cols := ARRAY[
-        'created_at',
-        'updated_at'
-    ]
-);
-
-SELECT add_audit_history_table(
-    target_table := 'storage_facilities',
     audit_rows := BOOLEAN 't',
     audit_query_text := BOOLEAN 't',
     ignored_cols := ARRAY[


### PR DESCRIPTION
## [Jira ticket](https://dp3.atlassian.net/browse/MB-14781) for this change

## Summary

Add additional triggers for tables so that DMS can be better supported.
Triggers for tables were initially only added for move history support, this adds an additional set of triggers for other tables. 

All data that is considered "operational" needs to have triggers added to them so that they can be recorded by the `audit_history` table.

### Tables that have triggers already prior to this PR
- `moves`
- `mto_agents`
- `mto_service_item_customer_contacts`
- `mto_service_item_dimensions`
- `mto_service_items`
- `mto_shipments`
- `orders`
- `payment_requests`
- `proof_of_service_docs`
- `reweighs`
- `service_members`
- `storage_facilities`
- `backup_contacts`
- `user_uploads`

### Tables for which triggers have **NOT** been added
These seemed fairly clear to me that they should not have triggers on them.

- `audit_history`
- `schema_migration`

### Specific review request questions

What are the implications of adding triggers to all these tables from the perspective of the UI?

Do I need to add triggers for the following tables? 
- `archived_access_codes`
- `archived_move_documents`
- `archived_moving_expense_documents`
- `archived_personally_procured_moves`
- `archived_reimbursements`
- `archived_signed_certifications`
- `archived_weight_ticket_set_documents`
- `client_certs`
- `contractors`
- `signed_certifications`
- `tariff400ng_full_pack_rates`
- `tariff400ng_full_unpack_rates`
- `tariff400ng_item_rates`
- `tariff400ng_items`
- `tariff400ng_linehaul_rates`
- `tariff400ng_service_areas`
- `tariff400ng_shorthaul_rates`
- `tariff400ng_zip3s`
- `tariff400ng_zip5_rate_areas`
- `traffic_distribution_lists`
- `webhook_notifications`
- `webhook_subscriptions`

## Setup to Run Your Code

<details>
<summary>💻 You will need to use two separate terminals to test this locally.</summary>

##### Terminal 1


Start the UI locally.

```sh
make client_run
```

##### Terminal 2

Start the Go server locally.

```sh
make server_run
```

</details>

### Additional steps

<!-- Fill out the next section as you see fit, these are just suggestions. -->

1. Perform some actions on various different things. 
2. In whatever database viewer you are using, you should see new entries in the audit history table.

## Verification Steps for Author

These are to be checked by the author.

- [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
- [ ] Request review from a member of a different team.
- [ ] Have the Jira acceptance criteria been met for this change?

## Verification Steps for Reviewers

These are to be checked by a reviewer.

<!-- Fill out the next sections as you see fit, these are just suggestions. -->

### Database

#### Any new migrations/schema changes:

- [ ] Follows our guidelines for [Zero-Downtime Deploys](https://transcom.github.io/mymove-docs/docs/dev/contributing/database/Database-Migrations#zero-downtime-migrations)
- [ ] Have been communicated to #g-database
- [ ] Secure migrations have been tested following the instructions in our [docs](https://transcom.github.io/mymove-docs/docs/dev/contributing/database/Database-Migrations#secure-migrations)
