### PR TITLE
MB-14785: Replace makeAddress calls with BuildAddress

### DIFF
--- a/pkg/factory/shared.go
+++ b/pkg/factory/shared.go
@@ -313,7 +313,7 @@ func mergeCustomization(customs []Customization, traits []Trait) []Customization
 }
 
 // Helper function for when you need to elevate the type of customization from say
-// ResidentialAddress to Address before you call makeAddress
+// ResidentialAddress to Address before you call BuildAddress
 // This is a little finicky because we want to be careful not to harm the existing list
 // TBD should we validate again here?
 func convertCustomizationInList(customs []Customization, from CustomType, to CustomType) []Customization {

--- a/pkg/handlers/ghcapi/mto_shipment_test.go
+++ b/pkg/handlers/ghcapi/mto_shipment_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/transcom/mymove/pkg/apperror"
 	"github.com/transcom/mymove/pkg/etag"
+	"github.com/transcom/mymove/pkg/factory"
 	mtoshipmentops "github.com/transcom/mymove/pkg/gen/ghcapi/ghcoperations/mto_shipment"
 	shipmentops "github.com/transcom/mymove/pkg/gen/ghcapi/ghcoperations/shipment"
 	"github.com/transcom/mymove/pkg/gen/ghcmessages"
@@ -72,7 +73,7 @@ func (suite *HandlerSuite) makeListMTOShipmentsSubtestData() (subtestData *listM
 	})
 
 	// third shipment with destination address and type
-	destinationAddress := testdatagen.MakeDefaultAddress(suite.DB())
+	destinationAddress := factory.BuildAddress(suite.DB(), nil, nil)
 	destinationType := models.DestinationTypeHomeOfRecord
 	thirdShipment := testdatagen.MakeMTOShipment(suite.DB(), testdatagen.Assertions{
 		Move: mto,
@@ -2383,8 +2384,8 @@ func (suite *HandlerSuite) makeCreateMTOShipmentSubtestData() (subtestData *crea
 	subtestData = &createMTOShipmentSubtestData{}
 
 	mto := testdatagen.MakeAvailableMove(suite.DB())
-	pickupAddress := testdatagen.MakeDefaultAddress(suite.DB())
-	destinationAddress := testdatagen.MakeDefaultAddress(suite.DB())
+	pickupAddress := factory.BuildAddress(suite.DB(), nil, nil)
+	destinationAddress := factory.BuildAddress(suite.DB(), nil, nil)
 	mtoShipment := testdatagen.MakeMTOShipment(suite.DB(), testdatagen.Assertions{
 		Move:        mto,
 		MTOShipment: models.MTOShipment{},
@@ -2880,9 +2881,9 @@ func (suite *HandlerSuite) getUpdateShipmentParams(originalShipment models.MTOSh
 	servicesCounselor.User.Roles = append(servicesCounselor.User.Roles, roles.Role{
 		RoleType: roles.RoleTypeServicesCounselor,
 	})
-	pickupAddress := testdatagen.MakeDefaultAddress(suite.DB())
+	pickupAddress := factory.BuildAddress(suite.DB(), nil, nil)
 	pickupAddress.StreetAddress1 = "123 Fake Test St NW"
-	destinationAddress := testdatagen.MakeDefaultAddress(suite.DB())
+	destinationAddress := factory.BuildAddress(suite.DB(), nil, nil)
 	destinationAddress.StreetAddress1 = "54321 Test Fake Rd SE"
 	customerRemarks := "help"
 	counselorRemarks := "counselor approved"

--- a/pkg/handlers/ghcapi/queues_test.go
+++ b/pkg/handlers/ghcapi/queues_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/go-openapi/swag"
 	"github.com/stretchr/testify/mock"
 
+	"github.com/transcom/mymove/pkg/factory"
 	"github.com/transcom/mymove/pkg/gen/ghcapi/ghcoperations/queues"
 	"github.com/transcom/mymove/pkg/gen/ghcmessages"
 	"github.com/transcom/mymove/pkg/models"
@@ -1204,15 +1205,17 @@ func (suite *HandlerSuite) makeServicesCounselingSubtestData() (subtestData *ser
 	})
 
 	// Create a move with an origin duty location outside of office user GBLOC
-	dutyLocationAddress := testdatagen.MakeAddress(suite.DB(), testdatagen.Assertions{
-		Address: models.Address{
-			StreetAddress1: "Fort Gordon",
-			City:           "Augusta",
-			State:          "GA",
-			PostalCode:     "30813",
-			Country:        swag.String("United States"),
+	dutyLocationAddress := factory.BuildAddress(suite.DB(), []factory.Customization{
+		{
+			Model: models.Address{
+				StreetAddress1: "Fort Gordon",
+				City:           "Augusta",
+				State:          "GA",
+				PostalCode:     "30813",
+				Country:        models.StringPointer("United States"),
+			},
 		},
-	})
+	}, nil)
 
 	originDutyLocation := testdatagen.MakeDutyLocation(suite.DB(), testdatagen.Assertions{
 		DutyLocation: models.DutyLocation{

--- a/pkg/handlers/internalapi/moves_test.go
+++ b/pkg/handlers/internalapi/moves_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/stretchr/testify/mock"
 
 	"github.com/transcom/mymove/pkg/etag"
+	"github.com/transcom/mymove/pkg/factory"
 	moveop "github.com/transcom/mymove/pkg/gen/internalapi/internaloperations/moves"
 	"github.com/transcom/mymove/pkg/gen/internalmessages"
 	"github.com/transcom/mymove/pkg/models"
@@ -419,15 +420,17 @@ func (suite *HandlerSuite) TestSubmitMoveForServiceCounselingHandler() {
 }
 
 func (suite *HandlerSuite) TestShowMoveDatesSummaryHandler() {
-	dutyLocationAddress := testdatagen.MakeAddress(suite.DB(), testdatagen.Assertions{
-		Address: models.Address{
-			StreetAddress1: "Fort Gordon",
-			City:           "Augusta",
-			State:          "GA",
-			PostalCode:     "30813",
-			Country:        swag.String("United States"),
+	dutyLocationAddress := factory.BuildAddress(suite.DB(), []factory.Customization{
+		{
+			Model: models.Address{
+				StreetAddress1: "Fort Gordon",
+				City:           "Augusta",
+				State:          "GA",
+				PostalCode:     "30813",
+				Country:        models.StringPointer("United States"),
+			},
 		},
-	})
+	}, nil)
 
 	dutyLocation := testdatagen.MakeDutyLocation(suite.DB(), testdatagen.Assertions{
 		DutyLocation: models.DutyLocation{
@@ -446,15 +449,17 @@ func (suite *HandlerSuite) TestShowMoveDatesSummaryHandler() {
 		},
 	})
 
-	newDutyLocationAddress := testdatagen.MakeAddress(suite.DB(), testdatagen.Assertions{
-		Address: models.Address{
-			StreetAddress1: "n/a",
-			City:           "San Antonio",
-			State:          "TX",
-			PostalCode:     "78234",
-			Country:        swag.String("United States"),
+	newDutyLocationAddress := factory.BuildAddress(suite.DB(), []factory.Customization{
+		{
+			Model: models.Address{
+				StreetAddress1: "n/a",
+				City:           "San Antonio",
+				State:          "TX",
+				PostalCode:     "78234",
+				Country:        models.StringPointer("United States"),
+			},
 		},
-	})
+	}, nil)
 
 	newDutyLocation := testdatagen.MakeDutyLocation(suite.DB(), testdatagen.Assertions{
 		DutyLocation: models.DutyLocation{

--- a/pkg/handlers/internalapi/mto_shipment_test.go
+++ b/pkg/handlers/internalapi/mto_shipment_test.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/go-openapi/strfmt"
-	"github.com/go-openapi/swag"
 	"github.com/gofrs/uuid"
 	"github.com/stretchr/testify/mock"
 
@@ -92,10 +91,10 @@ func (suite *HandlerSuite) TestCreateMTOShipmentHandler() {
 		})
 
 		subtestData.pickupAddress = testdatagen.MakeDefaultAddress(db)
-		secondaryPickupAddress := testdatagen.MakeAddress2(db, testdatagen.Assertions{})
+		secondaryPickupAddress := factory.BuildAddress(db, nil, []factory.Trait{factory.GetTraitAddress2})
 
-		destinationAddress := testdatagen.MakeAddress3(db, testdatagen.Assertions{})
-		secondaryDeliveryAddress := testdatagen.MakeAddress4(db, testdatagen.Assertions{})
+		destinationAddress := factory.BuildAddress(db, nil, []factory.Trait{factory.GetTraitAddress3})
+		secondaryDeliveryAddress := factory.BuildAddress(db, nil, []factory.Trait{factory.GetTraitAddress4})
 
 		subtestData.mtoShipment = testdatagen.MakeMTOShipment(db, testdatagen.Assertions{
 			Move:        mto,
@@ -1038,7 +1037,7 @@ func (suite *HandlerSuite) TestUpdateMTOShipmentHandler() {
 			},
 			"Allows updates to W2 Address": {
 				setUpOriginalPPM: func(appCtx appcontext.AppContext) models.PPMShipment {
-					address := testdatagen.MakeAddress(appCtx.DB(), testdatagen.Assertions{})
+					address := factory.BuildAddress(appCtx.DB(), nil, nil)
 					return testdatagen.MakeMinimalPPMShipment(appCtx.DB(), testdatagen.Assertions{
 						PPMShipment: models.PPMShipment{
 							W2Address:   &address,
@@ -1308,31 +1307,35 @@ func (suite *HandlerSuite) makeListSubtestData() (subtestData *mtoListSubtestDat
 
 	requestedPickupDate := time.Date(testdatagen.GHCTestYear, time.September, 15, 0, 0, 0, 0, time.UTC)
 
-	pickupAddress := testdatagen.MakeAddress3(suite.DB(), testdatagen.Assertions{})
-	secondaryPickupAddress := testdatagen.MakeAddress(suite.DB(), testdatagen.Assertions{
-		Address: models.Address{
-			StreetAddress1: "123 Nowhere",
-			StreetAddress2: swag.String("P.O. Box 5555"),
-			StreetAddress3: swag.String("c/o Some Other Person"),
-			City:           "El Paso",
-			State:          "TX",
-			PostalCode:     "79916",
-			Country:        swag.String("US"),
+	pickupAddress := factory.BuildAddress(suite.DB(), nil, []factory.Trait{factory.GetTraitAddress3})
+	secondaryPickupAddress := factory.BuildAddress(suite.DB(), []factory.Customization{
+		{
+			Model: models.Address{
+				StreetAddress1: "123 Nowhere",
+				StreetAddress2: models.StringPointer("P.O. Box 5555"),
+				StreetAddress3: models.StringPointer("c/o Some Other Person"),
+				City:           "El Paso",
+				State:          "TX",
+				PostalCode:     "79916",
+				Country:        models.StringPointer("US"),
+			},
 		},
-	})
+	}, nil)
 
-	deliveryAddress := testdatagen.MakeAddress4(suite.DB(), testdatagen.Assertions{})
-	secondaryDeliveryAddress := testdatagen.MakeAddress(suite.DB(), testdatagen.Assertions{
-		Address: models.Address{
-			StreetAddress1: "5432 Everywhere",
-			StreetAddress2: swag.String("P.O. Box 111"),
-			StreetAddress3: swag.String("c/o Some Other Person"),
-			City:           "Portsmouth",
-			State:          "NH",
-			PostalCode:     "03801",
-			Country:        swag.String("US"),
+	deliveryAddress := factory.BuildAddress(suite.DB(), nil, []factory.Trait{factory.GetTraitAddress4})
+	secondaryDeliveryAddress := factory.BuildAddress(suite.DB(), []factory.Customization{
+		{
+			Model: models.Address{
+				StreetAddress1: "5432 Everywhere",
+				StreetAddress2: models.StringPointer("P.O. Box 111"),
+				StreetAddress3: models.StringPointer("c/o Some Other Person"),
+				City:           "Portsmouth",
+				State:          "NH",
+				PostalCode:     "03801",
+				Country:        models.StringPointer("US"),
+			},
 		},
-	})
+	}, nil)
 
 	mtoShipment2 := testdatagen.MakeMTOShipment(suite.DB(), testdatagen.Assertions{
 		Move: mto,

--- a/pkg/handlers/internalapi/mto_shipment_test.go
+++ b/pkg/handlers/internalapi/mto_shipment_test.go
@@ -90,7 +90,7 @@ func (suite *HandlerSuite) TestCreateMTOShipmentHandler() {
 			ServiceMember: subtestData.serviceMember,
 		})
 
-		subtestData.pickupAddress = testdatagen.MakeDefaultAddress(db)
+		subtestData.pickupAddress = factory.BuildAddress(db, nil, nil)
 		secondaryPickupAddress := factory.BuildAddress(db, nil, []factory.Trait{factory.GetTraitAddress2})
 
 		destinationAddress := factory.BuildAddress(db, nil, []factory.Trait{factory.GetTraitAddress3})
@@ -584,16 +584,16 @@ func (suite *HandlerSuite) TestUpdateMTOShipmentHandler() {
 	getDefaultMTOShipmentAndParams := func(appCtx appcontext.AppContext, mockShipmentUpdater *mocks.ShipmentUpdater) *mtoUpdateSubtestData {
 		originalShipment := testdatagen.MakeDefaultMTOShipment(appCtx.DB())
 
-		pickupAddress := testdatagen.MakeDefaultAddress(appCtx.DB())
+		pickupAddress := factory.BuildAddress(appCtx.DB(), nil, nil)
 		pickupAddress.StreetAddress1 = "123 Fake Test St NW"
 
-		secondaryPickupAddress := testdatagen.MakeDefaultAddress(appCtx.DB())
+		secondaryPickupAddress := factory.BuildAddress(appCtx.DB(), nil, nil)
 		secondaryPickupAddress.StreetAddress1 = "89999 Other Test St NW"
 
-		destinationAddress := testdatagen.MakeDefaultAddress(appCtx.DB())
+		destinationAddress := factory.BuildAddress(appCtx.DB(), nil, nil)
 		destinationAddress.StreetAddress1 = "54321 Test Fake Rd SE"
 
-		secondaryDeliveryAddress := testdatagen.MakeDefaultAddress(appCtx.DB())
+		secondaryDeliveryAddress := factory.BuildAddress(appCtx.DB(), nil, nil)
 		secondaryDeliveryAddress.StreetAddress1 = "9999 Test Fake Rd SE"
 
 		mtoAgent := testdatagen.MakeDefaultMTOAgent(appCtx.DB())

--- a/pkg/handlers/internalapi/orders_test.go
+++ b/pkg/handlers/internalapi/orders_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/go-openapi/swag"
 	"github.com/gofrs/uuid"
 
+	"github.com/transcom/mymove/pkg/factory"
 	ordersop "github.com/transcom/mymove/pkg/gen/internalapi/internaloperations/orders"
 	"github.com/transcom/mymove/pkg/gen/internalmessages"
 	"github.com/transcom/mymove/pkg/handlers"
@@ -79,7 +80,7 @@ func (suite *HandlerSuite) TestCreateOrder() {
 func (suite *HandlerSuite) TestShowOrder() {
 	dutyLocation := testdatagen.MakeDutyLocation(suite.DB(), testdatagen.Assertions{
 		DutyLocation: models.DutyLocation{
-			Address: testdatagen.MakeAddress2(suite.DB(), testdatagen.Assertions{}),
+			Address: factory.BuildAddress(suite.DB(), nil, []factory.Trait{factory.GetTraitAddress2}),
 		},
 	})
 	order := testdatagen.MakeOrder(suite.DB(), testdatagen.Assertions{
@@ -121,7 +122,7 @@ func (suite *HandlerSuite) TestShowOrder() {
 func (suite *HandlerSuite) TestUploadAmendedOrder() {
 	dutyLocation := testdatagen.MakeDutyLocation(suite.DB(), testdatagen.Assertions{
 		DutyLocation: models.DutyLocation{
-			Address: testdatagen.MakeAddress2(suite.DB(), testdatagen.Assertions{}),
+			Address: factory.BuildAddress(suite.DB(), nil, []factory.Trait{factory.GetTraitAddress2}),
 		},
 	})
 	var moves models.Moves

--- a/pkg/handlers/primeapi/move_task_order_test.go
+++ b/pkg/handlers/primeapi/move_task_order_test.go
@@ -138,7 +138,7 @@ func (suite *HandlerSuite) TestGetMoveTaskOrder() {
 				Status:             models.MoveStatusAPPROVED,
 			},
 		})
-		destinationAddress := testdatagen.MakeDefaultAddress(suite.DB())
+		destinationAddress := factory.BuildAddress(suite.DB(), nil, nil)
 		destinationType := models.DestinationTypeHomeOfRecord
 		successShipment := testdatagen.MakeMTOShipment(suite.DB(), testdatagen.Assertions{
 			MTOShipment: models.MTOShipment{

--- a/pkg/handlers/primeapi/mto_service_item_test.go
+++ b/pkg/handlers/primeapi/mto_service_item_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/transcom/mymove/pkg/apperror"
 	"github.com/transcom/mymove/pkg/etag"
+	"github.com/transcom/mymove/pkg/factory"
 	mtoserviceitemops "github.com/transcom/mymove/pkg/gen/primeapi/primeoperations/mto_service_item"
 	"github.com/transcom/mymove/pkg/gen/primemessages"
 	"github.com/transcom/mymove/pkg/handlers"
@@ -61,7 +62,7 @@ func (suite *HandlerSuite) TestCreateMTOServiceItemHandler() {
 		// Do not create Address in the database (Assertions.Stub = true), because if the information is coming from the Prime
 		// via the Prime API, the address will not have a valid database ID. And tests need to ensure
 		// that we properly create the address coming in from the API.
-		actualPickupAddress := testdatagen.MakeAddress2(suite.DB(), testdatagen.Assertions{Stub: true})
+		actualPickupAddress := factory.BuildAddress(nil, nil, []factory.Trait{factory.GetTraitAddress2})
 
 		subtestData.mtoServiceItem = models.MTOServiceItem{
 			MoveTaskOrderID:           mto.ID,
@@ -777,10 +778,10 @@ func (suite *HandlerSuite) TestCreateMTOServiceItemOriginSITHandlerWithDOFSITWit
 
 		// Customer gets new pickup address
 
-		// Do not create the Address in the database (Assertions.Stub = true), because if the information is coming from the Prime
+		// Do not create the Address in the database (factory.BuildAddress(nil, nil, nil)), because if the information is coming from the Prime
 		// via the Prime API, the address will not have a valid database ID. And tests need to ensure
 		// that we properly create the address coming in from the API.
-		subtestData.actualPickupAddress = testdatagen.MakeAddress2(suite.DB(), testdatagen.Assertions{Stub: true})
+		subtestData.actualPickupAddress = factory.BuildAddress(nil, nil, []factory.Trait{factory.GetTraitAddress2})
 
 		subtestData.mtoServiceItem = models.MTOServiceItem{
 			MoveTaskOrderID:           mto.ID,

--- a/pkg/handlers/primeapi/mto_service_item_test.go
+++ b/pkg/handlers/primeapi/mto_service_item_test.go
@@ -1190,7 +1190,7 @@ func (suite *HandlerSuite) TestUpdateMTOServiceItemDDDSIT() {
 			},
 		})
 
-		destinationAddress := testdatagen.MakeDefaultAddress(suite.DB())
+		destinationAddress := factory.BuildAddress(suite.DB(), nil, nil)
 		addr := primemessages.Address{
 			StreetAddress1: &destinationAddress.StreetAddress1,
 			City:           &destinationAddress.City,

--- a/pkg/handlers/primeapi/mto_shipment_address_test.go
+++ b/pkg/handlers/primeapi/mto_shipment_address_test.go
@@ -180,7 +180,7 @@ func (suite *HandlerSuite) TestUpdateMTOShipmentAddressHandler() {
 			Move: availableMove,
 		})
 		// Make a random address that is not associated
-		randomAddress := testdatagen.MakeDefaultAddress(suite.DB())
+		randomAddress := factory.BuildAddress(suite.DB(), nil, nil)
 
 		payload := payloads.Address(&randomAddress)
 		req := httptest.NewRequest("PUT", fmt.Sprintf("/mto-shipments/%s/addresses/%s", shipment.ID.String(), randomAddress.ID.String()), nil)

--- a/pkg/handlers/primeapi/mto_shipment_address_test.go
+++ b/pkg/handlers/primeapi/mto_shipment_address_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/go-openapi/swag"
 
 	"github.com/transcom/mymove/pkg/etag"
+	"github.com/transcom/mymove/pkg/factory"
 	mtoshipmentops "github.com/transcom/mymove/pkg/gen/primeapi/primeoperations/mto_shipment"
 	"github.com/transcom/mymove/pkg/gen/primemessages"
 	"github.com/transcom/mymove/pkg/handlers"
@@ -140,7 +141,7 @@ func (suite *HandlerSuite) TestUpdateMTOShipmentAddressHandler() {
 		// Under Test: UpdateMTOShipmentAddress handler code and mtoShipmentAddressUpdater service object
 		handler, _ := setupTestData()
 		// Make a shipment with an unavailable MTO
-		pickupAddress := testdatagen.MakeAddress2(suite.DB(), testdatagen.Assertions{})
+		pickupAddress := factory.BuildAddress(suite.DB(), nil, []factory.Trait{factory.GetTraitAddress2})
 		shipment := testdatagen.MakeMTOShipmentMinimal(suite.DB(), testdatagen.Assertions{
 			MTOShipment: models.MTOShipment{
 				PickupAddress: &pickupAddress,

--- a/pkg/handlers/primeapi/mto_shipment_test.go
+++ b/pkg/handlers/primeapi/mto_shipment_test.go
@@ -63,7 +63,13 @@ func (suite *HandlerSuite) TestCreateMTOShipmentHandler() {
 		}
 
 		// Make stubbed addresses just to collect address data for payload
-		newAddress := testdatagen.MakeStubbedAddress(suite.DB())
+		newAddress := factory.BuildAddress(nil, []factory.Customization{
+			{
+				Model: models.Address{
+					ID: uuid.Must(uuid.NewV4()),
+				},
+			},
+		}, nil)
 		pickupAddress = primemessages.Address{
 			City:           &newAddress.City,
 			Country:        newAddress.Country,

--- a/pkg/handlers/primeapi/mto_shipment_test.go
+++ b/pkg/handlers/primeapi/mto_shipment_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/transcom/mymove/pkg/apperror"
 	"github.com/transcom/mymove/pkg/etag"
+	"github.com/transcom/mymove/pkg/factory"
 	fakedata "github.com/transcom/mymove/pkg/fakedata_approved"
 	mtoshipmentops "github.com/transcom/mymove/pkg/gen/primeapi/primeoperations/mto_shipment"
 	"github.com/transcom/mymove/pkg/gen/primemessages"
@@ -72,7 +73,7 @@ func (suite *HandlerSuite) TestCreateMTOShipmentHandler() {
 			StreetAddress2: newAddress.StreetAddress2,
 			StreetAddress3: newAddress.StreetAddress3,
 		}
-		newAddress = testdatagen.MakeAddress2(suite.DB(), testdatagen.Assertions{Stub: true})
+		newAddress = factory.BuildAddress(nil, nil, []factory.Trait{factory.GetTraitAddress2})
 		destinationAddress = primemessages.Address{
 			City:           &newAddress.City,
 			Country:        newAddress.Country,
@@ -565,8 +566,8 @@ func (suite *HandlerSuite) TestUpdateMTOShipmentHandler() {
 				Status:       models.MTOShipmentStatusApproved,
 				ApprovedDate: now,
 			},
-			SecondaryPickupAddress:   testdatagen.MakeAddress3(suite.DB(), testdatagen.Assertions{}),
-			SecondaryDeliveryAddress: testdatagen.MakeAddress4(suite.DB(), testdatagen.Assertions{}),
+			SecondaryPickupAddress:   factory.BuildAddress(suite.DB(), nil, []factory.Trait{factory.GetTraitAddress3}),
+			SecondaryDeliveryAddress: factory.BuildAddress(suite.DB(), nil, []factory.Trait{factory.GetTraitAddress4}),
 		})
 		return handler, shipment
 	}
@@ -1633,7 +1634,7 @@ func (suite *HandlerSuite) TestUpdateMTOShipmentDateLogic() {
 	suite.Run("PATCH Success 200 RequiredDeliveryDate updated on scheduledPickupDate update", func() {
 		handler, move := setupTestData()
 
-		address := testdatagen.MakeAddress(suite.DB(), testdatagen.Assertions{})
+		address := factory.BuildAddress(suite.DB(), nil, nil)
 		storageFacility := testdatagen.MakeStorageFacility(suite.DB(), testdatagen.Assertions{})
 
 		hhgShipment := testdatagen.MakeMTOShipment(suite.DB(), testdatagen.Assertions{
@@ -1745,7 +1746,7 @@ func (suite *HandlerSuite) TestUpdateMTOShipmentDateLogic() {
 
 		// Create shipment with populated estimated weight and scheduled date
 		tenDaysFromNow := now.AddDate(0, 0, 11)
-		pickupAddress := testdatagen.MakeAddress2(suite.DB(), testdatagen.Assertions{})
+		pickupAddress := factory.BuildAddress(suite.DB(), nil, []factory.Trait{factory.GetTraitAddress2})
 		oldShipment := testdatagen.MakeMTOShipmentMinimal(suite.DB(), testdatagen.Assertions{
 			Move: move,
 			MTOShipment: models.MTOShipment{

--- a/pkg/handlers/primeapi/payment_request_test.go
+++ b/pkg/handlers/primeapi/payment_request_test.go
@@ -596,22 +596,26 @@ func (suite *HandlerSuite) TestCreatePaymentRequestHandler() {
 }
 
 func (suite *HandlerSuite) setupDomesticLinehaulData() (models.Move, models.MTOServiceItems) {
-	pickupAddress := testdatagen.MakeAddress(suite.DB(), testdatagen.Assertions{
-		Address: models.Address{
-			StreetAddress1: "7 Q St",
-			City:           "Birmingham",
-			State:          "AL",
-			PostalCode:     "90210",
+	pickupAddress := factory.BuildAddress(suite.DB(), []factory.Customization{
+		{
+			Model: models.Address{
+				StreetAddress1: "7 Q St",
+				City:           "Birmingham",
+				State:          "AL",
+				PostalCode:     "90210",
+			},
 		},
-	})
-	destinationAddress := testdatagen.MakeAddress(suite.DB(), testdatagen.Assertions{
-		Address: models.Address{
-			StreetAddress1: "148 S East St",
-			City:           "Miami",
-			State:          "FL",
-			PostalCode:     "94535",
+	}, nil)
+	destinationAddress := factory.BuildAddress(suite.DB(), []factory.Customization{
+		{
+			Model: models.Address{
+				StreetAddress1: "148 S East St",
+				City:           "Miami",
+				State:          "FL",
+				PostalCode:     "94535",
+			},
 		},
-	})
+	}, nil)
 	testEstWeight := dlhTestWeight
 	testActualWeight := testEstWeight
 

--- a/pkg/models/distance_calculation_test.go
+++ b/pkg/models/distance_calculation_test.go
@@ -4,14 +4,26 @@ import (
 	"github.com/gofrs/uuid"
 	"github.com/stretchr/testify/mock"
 
+	"github.com/transcom/mymove/pkg/factory"
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/route/mocks"
-	"github.com/transcom/mymove/pkg/testdatagen"
 )
 
 func (suite *ModelSuite) Test_DistanceCalculationCreate() {
-	address1 := testdatagen.MakeStubbedAddress(suite.DB())
-	address2 := testdatagen.MakeStubbedAddress(suite.DB())
+	address1 := factory.BuildAddress(nil, []factory.Customization{
+		{
+			Model: models.Address{
+				ID: uuid.Must(uuid.NewV4()),
+			},
+		},
+	}, nil)
+	address2 := factory.BuildAddress(nil, []factory.Customization{
+		{
+			Model: models.Address{
+				ID: uuid.Must(uuid.NewV4()),
+			},
+		},
+	}, nil)
 
 	distanceCalculation := models.DistanceCalculation{
 		OriginAddress:        address1,
@@ -40,8 +52,20 @@ func (suite *ModelSuite) Test_DistanceCalculationValidations() {
 }
 
 func (suite *ModelSuite) Test_NewDistanceCalculationCallsPlanner() {
-	address1 := testdatagen.MakeStubbedAddress(suite.DB())
-	address2 := testdatagen.MakeStubbedAddress(suite.DB())
+	address1 := factory.BuildAddress(nil, []factory.Customization{
+		{
+			Model: models.Address{
+				ID: uuid.Must(uuid.NewV4()),
+			},
+		},
+	}, nil)
+	address2 := factory.BuildAddress(nil, []factory.Customization{
+		{
+			Model: models.Address{
+				ID: uuid.Must(uuid.NewV4()),
+			},
+		},
+	}, nil)
 	planner := &mocks.Planner{}
 	planner.On("Zip5TransitDistanceLineHaul",
 		mock.AnythingOfType("*appcontext.appContext"),

--- a/pkg/models/service_member_test.go
+++ b/pkg/models/service_member_test.go
@@ -42,8 +42,20 @@ func (suite *ModelSuite) TestIsProfileCompleteWithIncompleteSM() {
 	lastName := "sally"
 	telephone := "510 555-5555"
 	email := "bobsally@gmail.com"
-	fakeAddress := testdatagen.MakeStubbedAddress(suite.DB())
-	fakeBackupAddress := testdatagen.MakeStubbedAddress(suite.DB())
+	fakeAddress := factory.BuildAddress(nil, []factory.Customization{
+		{
+			Model: Address{
+				ID: uuid.Must(uuid.NewV4()),
+			},
+		},
+	}, nil)
+	fakeBackupAddress := factory.BuildAddress(nil, []factory.Customization{
+		{
+			Model: Address{
+				ID: uuid.Must(uuid.NewV4()),
+			},
+		},
+	}, nil)
 	location := testdatagen.MakeDutyLocation(suite.DB(), testdatagen.Assertions{
 		DutyLocation: DutyLocation{
 			ID: uuid.Must(uuid.NewV4()),
@@ -90,7 +102,7 @@ func (suite *ModelSuite) TestFetchServiceMemberForUser() {
 	user2 := factory.BuildDefaultUser(suite.DB())
 
 	firstName := "Oliver"
-	resAddress := testdatagen.MakeDefaultAddress(suite.DB())
+	resAddress := factory.BuildAddress(suite.DB(), nil, nil)
 	sm := ServiceMember{
 		User:                 user1,
 		UserID:               user1.ID,
@@ -132,7 +144,7 @@ func (suite *ModelSuite) TestFetchServiceMemberNotForUser() {
 	user1 := factory.BuildDefaultUser(suite.DB())
 
 	firstName := "Nino"
-	resAddress := testdatagen.MakeDefaultAddress(suite.DB())
+	resAddress := factory.BuildAddress(suite.DB(), nil, nil)
 	sm := ServiceMember{
 		User:                 user1,
 		UserID:               user1.ID,

--- a/pkg/payment_request/service_param_value_lookups/distance_zip_lookup_test.go
+++ b/pkg/payment_request/service_param_value_lookups/distance_zip_lookup_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/gofrs/uuid"
 
+	"github.com/transcom/mymove/pkg/factory"
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/route/mocks"
 	"github.com/transcom/mymove/pkg/testdatagen"
@@ -18,16 +19,20 @@ func (suite *ServiceParamValueLookupsSuite) TestDistanceLookup() {
 	suite.Run("Calculate transit zip distance", func() {
 		mtoServiceItem := testdatagen.MakeMTOServiceItem(suite.DB(), testdatagen.Assertions{
 			MTOShipment: testdatagen.MakeMTOShipment(suite.DB(), testdatagen.Assertions{
-				PickupAddress: testdatagen.MakeAddress(suite.DB(), testdatagen.Assertions{
-					Address: models.Address{
-						PostalCode: "33607",
+				PickupAddress: factory.BuildAddress(suite.DB(), []factory.Customization{
+					{
+						Model: models.Address{
+							PostalCode: "33607",
+						},
 					},
-				}),
-				DestinationAddress: testdatagen.MakeAddress(suite.DB(), testdatagen.Assertions{
-					Address: models.Address{
-						PostalCode: "90210",
+				}, nil),
+				DestinationAddress: factory.BuildAddress(suite.DB(), []factory.Customization{
+					{
+						Model: models.Address{
+							PostalCode: "90210",
+						},
 					},
-				}),
+				}, nil),
 			}),
 		})
 
@@ -143,16 +148,20 @@ func (suite *ServiceParamValueLookupsSuite) TestDistanceLookup() {
 	suite.Run("Sucessfully updates mtoShipment distance when the pickup and destination zips are the same", func() {
 		mtoServiceItem := testdatagen.MakeMTOServiceItem(suite.DB(), testdatagen.Assertions{
 			MTOShipment: testdatagen.MakeMTOShipment(suite.DB(), testdatagen.Assertions{
-				PickupAddress: testdatagen.MakeAddress(suite.DB(), testdatagen.Assertions{
-					Address: models.Address{
-						PostalCode: "90211",
+				PickupAddress: factory.BuildAddress(suite.DB(), []factory.Customization{
+					{
+						Model: models.Address{
+							PostalCode: "90211",
+						},
 					},
-				}),
-				DestinationAddress: testdatagen.MakeAddress(suite.DB(), testdatagen.Assertions{
-					Address: models.Address{
-						PostalCode: "90210",
+				}, nil),
+				DestinationAddress: factory.BuildAddress(suite.DB(), []factory.Customization{
+					{
+						Model: models.Address{
+							PostalCode: "90210",
+						},
 					},
-				}),
+				}, nil),
 			}),
 		})
 
@@ -181,16 +190,20 @@ func (suite *ServiceParamValueLookupsSuite) TestDistanceLookup() {
 	suite.Run("Calculate zip distance with param cache", func() {
 		mtoServiceItem := testdatagen.MakeMTOServiceItem(suite.DB(), testdatagen.Assertions{
 			MTOShipment: testdatagen.MakeMTOShipment(suite.DB(), testdatagen.Assertions{
-				PickupAddress: testdatagen.MakeAddress(suite.DB(), testdatagen.Assertions{
-					Address: models.Address{
-						PostalCode: "33607",
+				PickupAddress: factory.BuildAddress(suite.DB(), []factory.Customization{
+					{
+						Model: models.Address{
+							PostalCode: "33607",
+						},
 					},
-				}),
-				DestinationAddress: testdatagen.MakeAddress(suite.DB(), testdatagen.Assertions{
-					Address: models.Address{
-						PostalCode: "90210",
+				}, nil),
+				DestinationAddress: factory.BuildAddress(suite.DB(), []factory.Customization{
+					{
+						Model: models.Address{
+							PostalCode: "90210",
+						},
 					},
-				}),
+				}, nil),
 			}),
 		})
 		paymentRequest := testdatagen.MakePaymentRequest(suite.DB(),
@@ -262,16 +275,20 @@ func (suite *ServiceParamValueLookupsSuite) TestDistanceLookup() {
 	suite.Run("returns error if the pickup zipcode isn't at least 5 digits", func() {
 		mtoServiceItem := testdatagen.MakeMTOServiceItem(suite.DB(), testdatagen.Assertions{
 			MTOShipment: testdatagen.MakeMTOShipment(suite.DB(), testdatagen.Assertions{
-				PickupAddress: testdatagen.MakeAddress(suite.DB(), testdatagen.Assertions{
-					Address: models.Address{
-						PostalCode: "33",
+				PickupAddress: factory.BuildAddress(suite.DB(), []factory.Customization{
+					{
+						Model: models.Address{
+							PostalCode: "33",
+						},
 					},
-				}),
-				DestinationAddress: testdatagen.MakeAddress(suite.DB(), testdatagen.Assertions{
-					Address: models.Address{
-						PostalCode: "90103",
+				}, nil),
+				DestinationAddress: factory.BuildAddress(suite.DB(), []factory.Customization{
+					{
+						Model: models.Address{
+							PostalCode: "90103",
+						},
 					},
-				}),
+				}, nil),
 			}),
 		})
 
@@ -291,16 +308,20 @@ func (suite *ServiceParamValueLookupsSuite) TestDistanceLookup() {
 	suite.Run("returns error if the destination zipcode isn't at least 5 digits", func() {
 		mtoServiceItem := testdatagen.MakeMTOServiceItem(suite.DB(), testdatagen.Assertions{
 			MTOShipment: testdatagen.MakeMTOShipment(suite.DB(), testdatagen.Assertions{
-				PickupAddress: testdatagen.MakeAddress(suite.DB(), testdatagen.Assertions{
-					Address: models.Address{
-						PostalCode: "33607",
+				PickupAddress: factory.BuildAddress(suite.DB(), []factory.Customization{
+					{
+						Model: models.Address{
+							PostalCode: "33607",
+						},
 					},
-				}),
-				DestinationAddress: testdatagen.MakeAddress(suite.DB(), testdatagen.Assertions{
-					Address: models.Address{
-						PostalCode: "901",
+				}, nil),
+				DestinationAddress: factory.BuildAddress(suite.DB(), []factory.Customization{
+					{
+						Model: models.Address{
+							PostalCode: "901",
+						},
 					},
-				}),
+				}, nil),
 			}),
 		})
 
@@ -319,8 +340,8 @@ func (suite *ServiceParamValueLookupsSuite) TestDistanceLookup() {
 
 	suite.Run("returns a not found error if the service item shipment id doesn't exist", func() {
 		distanceZipLookup := DistanceZipLookup{
-			PickupAddress:      testdatagen.MakeAddress(suite.DB(), testdatagen.Assertions{Stub: true}),
-			DestinationAddress: testdatagen.MakeAddress2(suite.DB(), testdatagen.Assertions{Stub: true}),
+			PickupAddress:      factory.BuildAddress(nil, nil, nil),
+			DestinationAddress: factory.BuildAddress(nil, nil, []factory.Trait{factory.GetTraitAddress2}),
 		}
 
 		mtoShipmentID := uuid.Must(uuid.NewV4())

--- a/pkg/payment_request/service_param_value_lookups/distance_zip_sit_dest_lookup_test.go
+++ b/pkg/payment_request/service_param_value_lookups/distance_zip_sit_dest_lookup_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/stretchr/testify/mock"
 
+	"github.com/transcom/mymove/pkg/factory"
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/route/mocks"
 	"github.com/transcom/mymove/pkg/testdatagen"
@@ -34,26 +35,32 @@ func (suite *ServiceParamValueLookupsSuite) TestDistanceZipSITDestLookup() {
 			},
 		)
 
-		destAddress = testdatagen.MakeAddress(suite.DB(),
-			testdatagen.Assertions{
-				Address: models.Address{
-					PostalCode: destZip,
+		destAddress = factory.BuildAddress(suite.DB(),
+			[]factory.Customization{
+				{
+					Model: models.Address{
+						PostalCode: destZip,
+					},
 				},
-			})
+			}, nil)
 
-		finalDestSameZip3Address := testdatagen.MakeAddress(suite.DB(),
-			testdatagen.Assertions{
-				Address: models.Address{
-					PostalCode: finalDestZipSameZip3,
+		finalDestSameZip3Address := factory.BuildAddress(suite.DB(),
+			[]factory.Customization{
+				{
+					Model: models.Address{
+						PostalCode: finalDestZipSameZip3,
+					},
 				},
-			})
+			}, nil)
 
-		finalDestDiffZip3Address = testdatagen.MakeAddress(suite.DB(),
-			testdatagen.Assertions{
-				Address: models.Address{
-					PostalCode: finalDestZipDiffZip3,
+		finalDestDiffZip3Address = factory.BuildAddress(suite.DB(),
+			[]factory.Customization{
+				{
+					Model: models.Address{
+						PostalCode: finalDestZipDiffZip3,
+					},
 				},
-			})
+			}, nil)
 
 		move := testdatagen.MakeDefaultMove(suite.DB())
 

--- a/pkg/payment_request/service_param_value_lookups/distance_zip_sit_origin_lookup_test.go
+++ b/pkg/payment_request/service_param_value_lookups/distance_zip_sit_origin_lookup_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/stretchr/testify/mock"
 
+	"github.com/transcom/mymove/pkg/factory"
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/route/mocks"
 	"github.com/transcom/mymove/pkg/testdatagen"
@@ -35,26 +36,32 @@ func (suite *ServiceParamValueLookupsSuite) TestDistanceZipSITOriginLookup() {
 			},
 		)
 
-		originAddress = testdatagen.MakeAddress(suite.DB(),
-			testdatagen.Assertions{
-				Address: models.Address{
-					PostalCode: originZip,
+		originAddress = factory.BuildAddress(suite.DB(),
+			[]factory.Customization{
+				{
+					Model: models.Address{
+						PostalCode: originZip,
+					},
 				},
-			})
+			}, nil)
 
-		actualOriginSameZip3Address = testdatagen.MakeAddress(suite.DB(),
-			testdatagen.Assertions{
-				Address: models.Address{
-					PostalCode: actualOriginZipSameZip3,
+		actualOriginSameZip3Address = factory.BuildAddress(suite.DB(),
+			[]factory.Customization{
+				{
+					Model: models.Address{
+						PostalCode: actualOriginZipSameZip3,
+					},
 				},
-			})
+			}, nil)
 
-		actualOriginDiffZip3Address = testdatagen.MakeAddress(suite.DB(),
-			testdatagen.Assertions{
-				Address: models.Address{
-					PostalCode: actualOriginZipDiffZip3,
+		actualOriginDiffZip3Address = factory.BuildAddress(suite.DB(),
+			[]factory.Customization{
+				{
+					Model: models.Address{
+						PostalCode: actualOriginZipDiffZip3,
+					},
 				},
-			})
+			}, nil)
 
 		move := testdatagen.MakeDefaultMove(suite.DB())
 

--- a/pkg/payment_request/service_param_value_lookups/service_area_lookup_test.go
+++ b/pkg/payment_request/service_param_value_lookups/service_area_lookup_test.go
@@ -1,6 +1,7 @@
 package serviceparamvaluelookups
 
 import (
+	"github.com/transcom/mymove/pkg/factory"
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/testdatagen"
 )
@@ -16,16 +17,20 @@ func (suite *ServiceParamValueLookupsSuite) TestServiceAreaLookup() {
 
 	setupTestData := func() {
 
-		originAddress := testdatagen.MakeAddress(suite.DB(), testdatagen.Assertions{
-			Address: models.Address{
-				PostalCode: "35007",
+		originAddress := factory.BuildAddress(suite.DB(), []factory.Customization{
+			{
+				Model: models.Address{
+					PostalCode: "35007",
+				},
 			},
-		})
-		destAddress := testdatagen.MakeAddress(suite.DB(), testdatagen.Assertions{
-			Address: models.Address{
-				PostalCode: "45007",
+		}, nil)
+		destAddress := factory.BuildAddress(suite.DB(), []factory.Customization{
+			{
+				Model: models.Address{
+					PostalCode: "45007",
+				},
 			},
-		})
+		}, nil)
 
 		mtoServiceItem = testdatagen.MakeMTOServiceItem(suite.DB(), testdatagen.Assertions{
 			MTOShipment: models.MTOShipment{

--- a/pkg/payment_request/service_param_value_lookups/service_param_value_lookups_test.go
+++ b/pkg/payment_request/service_param_value_lookups/service_param_value_lookups_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	"github.com/transcom/mymove/pkg/apperror"
+	"github.com/transcom/mymove/pkg/factory"
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/route"
 	"github.com/transcom/mymove/pkg/route/mocks"
@@ -96,8 +97,8 @@ func (suite *ServiceParamValueLookupsSuite) setupTestMTOServiceItemWithAllWeight
 
 func (suite *ServiceParamValueLookupsSuite) setupTestMTOServiceItemWithEstimatedWeightForPPM(estimatedWeight *unit.Pound, originalWeight *unit.Pound, code models.ReServiceCode) (models.MTOServiceItem, models.PaymentRequest, *ServiceItemParamKeyData) {
 	move := testdatagen.MakeMove(suite.DB(), testdatagen.Assertions{})
-	pickupAddress := testdatagen.MakeAddress(suite.DB(), testdatagen.Assertions{})
-	destAddress := testdatagen.MakeAddress(suite.DB(), testdatagen.Assertions{})
+	pickupAddress := factory.BuildAddress(suite.DB(), nil, nil)
+	destAddress := factory.BuildAddress(suite.DB(), nil, nil)
 	mtoServiceItem := testdatagen.MakeMTOServiceItem(suite.DB(),
 		testdatagen.Assertions{
 			Move: move,
@@ -358,11 +359,13 @@ func (suite *ServiceParamValueLookupsSuite) TestServiceParamValueLookup() {
 
 		// NTS should have a pickup address and storage facility address.
 		pickupPostalCode := "29212"
-		pickupAddress := testdatagen.MakeAddress(suite.DB(), testdatagen.Assertions{
-			Address: models.Address{
-				PostalCode: pickupPostalCode,
+		pickupAddress := factory.BuildAddress(suite.DB(), []factory.Customization{
+			{
+				Model: models.Address{
+					PostalCode: pickupPostalCode,
+				},
 			},
-		})
+		}, nil)
 		storageFacilityPostalCode := "30907"
 		storageFacility := testdatagen.MakeStorageFacility(suite.DB(), testdatagen.Assertions{
 			Address: models.Address{
@@ -391,11 +394,13 @@ func (suite *ServiceParamValueLookupsSuite) TestServiceParamValueLookup() {
 
 		// NTS-Release should have a storage facility address and destination address.
 		destinationPostalCode := "29440"
-		destinationAddress := testdatagen.MakeAddress(suite.DB(), testdatagen.Assertions{
-			Address: models.Address{
-				PostalCode: destinationPostalCode,
+		destinationAddress := factory.BuildAddress(suite.DB(), []factory.Customization{
+			{
+				Model: models.Address{
+					PostalCode: destinationPostalCode,
+				},
 			},
-		})
+		}, nil)
 		ntsrServiceItem := testdatagen.MakeMTOServiceItem(suite.DB(), testdatagen.Assertions{
 			Move:      move,
 			ReService: reService,
@@ -418,7 +423,7 @@ func (suite *ServiceParamValueLookupsSuite) TestServiceParamValueLookup() {
 	})
 
 	suite.Run("SITDestinationAddress is looked up for destination sit", func() {
-		sitFinalDestAddress := testdatagen.MakeAddress3(suite.DB(), testdatagen.Assertions{})
+		sitFinalDestAddress := factory.BuildAddress(suite.DB(), nil, []factory.Trait{factory.GetTraitAddress3})
 		testData := []models.MTOServiceItem{
 			testdatagen.MakeMTOServiceItem(suite.DB(), testdatagen.Assertions{
 				ReService: models.ReService{

--- a/pkg/payment_request/service_param_value_lookups/services_schedule_lookup_test.go
+++ b/pkg/payment_request/service_param_value_lookups/services_schedule_lookup_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strconv"
 
+	"github.com/transcom/mymove/pkg/factory"
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/services/ghcrateengine"
 	"github.com/transcom/mymove/pkg/testdatagen"
@@ -20,16 +21,20 @@ func (suite *ServiceParamValueLookupsSuite) TestServicesScheduleOrigin() {
 
 	setupTestData := func() {
 
-		originAddress := testdatagen.MakeAddress(suite.DB(), testdatagen.Assertions{
-			Address: models.Address{
-				PostalCode: "35007",
+		originAddress := factory.BuildAddress(suite.DB(), []factory.Customization{
+			{
+				Model: models.Address{
+					PostalCode: "35007",
+				},
 			},
-		})
-		destAddress := testdatagen.MakeAddress(suite.DB(), testdatagen.Assertions{
-			Address: models.Address{
-				PostalCode: "45007",
+		}, nil)
+		destAddress := factory.BuildAddress(suite.DB(), []factory.Customization{
+			{
+				Model: models.Address{
+					PostalCode: "45007",
+				},
 			},
-		})
+		}, nil)
 
 		mtoServiceItem = testdatagen.MakeMTOServiceItem(suite.DB(), testdatagen.Assertions{
 			MTOShipment: models.MTOShipment{
@@ -104,9 +109,11 @@ func (suite *ServiceParamValueLookupsSuite) TestServicesScheduleOrigin() {
 	suite.Run("lookup origin ServicesSchedule not found", func() {
 		setupTestData()
 
-		pickupAddress := testdatagen.MakeAddress(suite.DB(), testdatagen.Assertions{
-			Address: models.Address{PostalCode: "00000"},
-		})
+		pickupAddress := factory.BuildAddress(suite.DB(), []factory.Customization{
+			{
+				Model: models.Address{PostalCode: "00000"},
+			},
+		}, nil)
 
 		mtoServiceItem := testdatagen.MakeMTOServiceItem(suite.DB(), testdatagen.Assertions{
 			MTOShipment: models.MTOShipment{
@@ -132,9 +139,11 @@ func (suite *ServiceParamValueLookupsSuite) TestServicesScheduleOrigin() {
 	suite.Run("lookup dest ServicesSchedule not found", func() {
 		setupTestData()
 
-		destinationAddress := testdatagen.MakeAddress(suite.DB(), testdatagen.Assertions{
-			Address: models.Address{PostalCode: "00100"},
-		})
+		destinationAddress := factory.BuildAddress(suite.DB(), []factory.Customization{
+			{
+				Model: models.Address{PostalCode: "00100"},
+			},
+		}, nil)
 
 		mtoServiceItem := testdatagen.MakeMTOServiceItem(suite.DB(), testdatagen.Assertions{
 			MTOShipment: models.MTOShipment{

--- a/pkg/payment_request/service_param_value_lookups/sit_schedule_lookup_test.go
+++ b/pkg/payment_request/service_param_value_lookups/sit_schedule_lookup_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strconv"
 
+	"github.com/transcom/mymove/pkg/factory"
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/services/ghcrateengine"
 	"github.com/transcom/mymove/pkg/testdatagen"
@@ -20,16 +21,20 @@ func (suite *ServiceParamValueLookupsSuite) TestSITSchedule() {
 
 	setupTestData := func() {
 
-		originAddress := testdatagen.MakeAddress(suite.DB(), testdatagen.Assertions{
-			Address: models.Address{
-				PostalCode: "35007",
+		originAddress := factory.BuildAddress(suite.DB(), []factory.Customization{
+			{
+				Model: models.Address{
+					PostalCode: "35007",
+				},
 			},
-		})
-		destAddress := testdatagen.MakeAddress(suite.DB(), testdatagen.Assertions{
-			Address: models.Address{
-				PostalCode: "45007",
+		}, nil)
+		destAddress := factory.BuildAddress(suite.DB(), []factory.Customization{
+			{
+				Model: models.Address{
+					PostalCode: "45007",
+				},
 			},
-		})
+		}, nil)
 
 		mtoServiceItem = testdatagen.MakeMTOServiceItem(suite.DB(), testdatagen.Assertions{
 			MTOShipment: models.MTOShipment{
@@ -104,9 +109,11 @@ func (suite *ServiceParamValueLookupsSuite) TestSITSchedule() {
 	suite.Run("lookup SITScheduleOrigin not found", func() {
 		setupTestData()
 
-		pickupAddress := testdatagen.MakeAddress(suite.DB(), testdatagen.Assertions{
-			Address: models.Address{PostalCode: "00000"},
-		})
+		pickupAddress := factory.BuildAddress(suite.DB(), []factory.Customization{
+			{
+				Model: models.Address{PostalCode: "00000"},
+			},
+		}, nil)
 
 		mtoServiceItem := testdatagen.MakeMTOServiceItem(suite.DB(), testdatagen.Assertions{
 			MTOShipment: models.MTOShipment{
@@ -132,9 +139,11 @@ func (suite *ServiceParamValueLookupsSuite) TestSITSchedule() {
 	suite.Run("lookup SITScheduleDest not found", func() {
 		setupTestData()
 
-		destinationAddress := testdatagen.MakeAddress(suite.DB(), testdatagen.Assertions{
-			Address: models.Address{PostalCode: "00100"},
-		})
+		destinationAddress := factory.BuildAddress(suite.DB(), []factory.Customization{
+			{
+				Model: models.Address{PostalCode: "00100"},
+			},
+		}, nil)
 
 		mtoServiceItem := testdatagen.MakeMTOServiceItem(suite.DB(), testdatagen.Assertions{
 			MTOShipment: models.MTOShipment{

--- a/pkg/payment_request/service_param_value_lookups/zip_sit_origin_hhg_actual_address_lookup_test.go
+++ b/pkg/payment_request/service_param_value_lookups/zip_sit_origin_hhg_actual_address_lookup_test.go
@@ -1,6 +1,7 @@
 package serviceparamvaluelookups
 
 import (
+	"github.com/transcom/mymove/pkg/factory"
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/testdatagen"
 )
@@ -25,19 +26,23 @@ func (suite *ServiceParamValueLookupsSuite) TestZipSITOriginHHGActualAddressLook
 			},
 		)
 
-		originAddress := testdatagen.MakeAddress(suite.DB(),
-			testdatagen.Assertions{
-				Address: models.Address{
-					PostalCode: originZip,
+		originAddress := factory.BuildAddress(suite.DB(),
+			[]factory.Customization{
+				{
+					Model: models.Address{
+						PostalCode: originZip,
+					},
 				},
-			})
+			}, nil)
 
-		actualOriginSameZip3Address := testdatagen.MakeAddress(suite.DB(),
-			testdatagen.Assertions{
-				Address: models.Address{
-					PostalCode: actualOriginZipSameZip3,
+		actualOriginSameZip3Address := factory.BuildAddress(suite.DB(),
+			[]factory.Customization{
+				{
+					Model: models.Address{
+						PostalCode: actualOriginZipSameZip3,
+					},
 				},
-			})
+			}, nil)
 
 		move := testdatagen.MakeDefaultMove(suite.DB())
 

--- a/pkg/payment_request/service_param_value_lookups/zip_sit_origin_hhg_original_address_lookup_test.go
+++ b/pkg/payment_request/service_param_value_lookups/zip_sit_origin_hhg_original_address_lookup_test.go
@@ -1,6 +1,7 @@
 package serviceparamvaluelookups
 
 import (
+	"github.com/transcom/mymove/pkg/factory"
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/testdatagen"
 )
@@ -24,19 +25,23 @@ func (suite *ServiceParamValueLookupsSuite) TestZipSITOriginHHGOriginalAddressLo
 			},
 		)
 
-		originAddress := testdatagen.MakeAddress(suite.DB(),
-			testdatagen.Assertions{
-				Address: models.Address{
-					PostalCode: originZip,
+		originAddress := factory.BuildAddress(suite.DB(),
+			[]factory.Customization{
+				{
+					Model: models.Address{
+						PostalCode: originZip,
+					},
 				},
-			})
+			}, nil)
 
-		actualOriginSameZip3Address := testdatagen.MakeAddress(suite.DB(),
-			testdatagen.Assertions{
-				Address: models.Address{
-					PostalCode: actualOriginZipSameZip3,
+		actualOriginSameZip3Address := factory.BuildAddress(suite.DB(),
+			[]factory.Customization{
+				{
+					Model: models.Address{
+						PostalCode: actualOriginZipSameZip3,
+					},
 				},
-			})
+			}, nil)
 
 		move := testdatagen.MakeDefaultMove(suite.DB())
 

--- a/pkg/route/here_planner_test.go
+++ b/pkg/route/here_planner_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/suite"
 
-	"github.com/transcom/mymove/pkg/testdatagen"
+	"github.com/transcom/mymove/pkg/factory"
 	"github.com/transcom/mymove/pkg/testingsuite"
 )
 
@@ -117,8 +117,8 @@ func (suite *HereFullSuite) SetupTest() {
 }
 
 func (suite *HereTestSuite) TestGeocodeResponses() {
-	address1 := testdatagen.MakeDefaultAddress(suite.DB())
-	address2 := testdatagen.MakeDefaultAddress(suite.DB())
+	address1 := factory.BuildAddress(suite.DB(), nil, nil)
+	address2 := factory.BuildAddress(suite.DB(), nil, nil)
 	// Given a HERE server that returns 400 geo codes
 	planner := suite.setupTestPlanner(testClient{
 		geoStatusCode: 400,

--- a/pkg/services/address/address_updater_test.go
+++ b/pkg/services/address/address_updater_test.go
@@ -6,13 +6,13 @@ import (
 
 	"github.com/transcom/mymove/pkg/apperror"
 	"github.com/transcom/mymove/pkg/etag"
+	"github.com/transcom/mymove/pkg/factory"
 	"github.com/transcom/mymove/pkg/models"
-	"github.com/transcom/mymove/pkg/testdatagen"
 )
 
 func (suite *AddressSuite) TestAddressUpdater() {
 	createOriginalAddress := func() *models.Address {
-		originalAddress := testdatagen.MakeAddress(suite.AppContextForTest().DB(), testdatagen.Assertions{})
+		originalAddress := factory.BuildAddress(suite.AppContextForTest().DB(), nil, nil)
 		return &originalAddress
 	}
 

--- a/pkg/services/event/notification_test.go
+++ b/pkg/services/event/notification_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/go-openapi/swag"
 	"github.com/gofrs/uuid"
 
+	"github.com/transcom/mymove/pkg/factory"
 	"github.com/transcom/mymove/pkg/gen/primemessages"
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/testdatagen"
@@ -207,10 +208,10 @@ func (suite *EventServiceSuite) TestAssembleOrderPayload() {
 func (suite *EventServiceSuite) TestAssembleMTOShipmentPayload() {
 	suite.Run("Non-external shipment returns payload with all associations", func() {
 		// Setup test data
-		pickupAddress := testdatagen.MakeAddress(suite.DB(), testdatagen.Assertions{})
-		secondaryPickupAddress := testdatagen.MakeAddress2(suite.DB(), testdatagen.Assertions{})
-		destinationAddress := testdatagen.MakeAddress3(suite.DB(), testdatagen.Assertions{})
-		secondaryDeliveryAddress := testdatagen.MakeAddress4(suite.DB(), testdatagen.Assertions{})
+		pickupAddress := factory.BuildAddress(suite.DB(), nil, nil)
+		secondaryPickupAddress := factory.BuildAddress(suite.DB(), nil, []factory.Trait{factory.GetTraitAddress2})
+		destinationAddress := factory.BuildAddress(suite.DB(), nil, []factory.Trait{factory.GetTraitAddress3})
+		secondaryDeliveryAddress := factory.BuildAddress(suite.DB(), nil, []factory.Trait{factory.GetTraitAddress4})
 
 		shipment := testdatagen.MakeMTOShipment(suite.DB(), testdatagen.Assertions{
 			MTOShipment: models.MTOShipment{

--- a/pkg/services/move_history/move_history_fetcher_test.go
+++ b/pkg/services/move_history/move_history_fetcher_test.go
@@ -33,7 +33,7 @@ func (suite *MoveHistoryServiceSuite) TestMoveHistoryFetcherFunctionality() {
 		approvedMove := testdatagen.MakeAvailableMove(suite.DB())
 		now := time.Now()
 		pickupDate := now.AddDate(0, 0, 10)
-		secondaryPickupAddress := testdatagen.MakeAddress(suite.DB(), testdatagen.Assertions{})
+		secondaryPickupAddress := factory.BuildAddress(suite.DB(), nil, nil)
 		approvedShipment := testdatagen.MakeMTOShipmentWithMove(suite.DB(), &approvedMove, testdatagen.Assertions{
 			MTOShipment: models.MTOShipment{
 				Status:              models.MTOShipmentStatusApproved,
@@ -915,9 +915,9 @@ func (suite *MoveHistoryServiceSuite) TestMoveHistoryFetcherScenarios() {
 		approvedMove := testdatagen.MakeAvailableMove(suite.DB())
 		now := time.Now()
 		pickupDate := now.AddDate(0, 0, 10)
-		secondaryPickupAddress := testdatagen.MakeAddress(suite.DB(), testdatagen.Assertions{})
-		destinationAddress := testdatagen.MakeAddress(suite.DB(), testdatagen.Assertions{})
-		secondaryDestinationAddress := testdatagen.MakeAddress(suite.DB(), testdatagen.Assertions{})
+		secondaryPickupAddress := factory.BuildAddress(suite.DB(), nil, nil)
+		destinationAddress := factory.BuildAddress(suite.DB(), nil, nil)
+		secondaryDestinationAddress := factory.BuildAddress(suite.DB(), nil, nil)
 		approvedShipment := testdatagen.MakeMTOShipmentWithMove(suite.DB(), &approvedMove, testdatagen.Assertions{
 			MTOShipment: models.MTOShipment{
 				Status:              models.MTOShipmentStatusApproved,
@@ -977,8 +977,8 @@ func (suite *MoveHistoryServiceSuite) TestMoveHistoryFetcherScenarios() {
 		serviceMember := move.Orders.ServiceMember
 		suite.NotNil(serviceMember)
 
-		residentialAddress := testdatagen.MakeAddress(suite.DB(), testdatagen.Assertions{})
-		backupAddress := testdatagen.MakeAddress(suite.DB(), testdatagen.Assertions{})
+		residentialAddress := factory.BuildAddress(suite.DB(), nil, nil)
+		backupAddress := factory.BuildAddress(suite.DB(), nil, nil)
 
 		serviceMember.ResidentialAddress = &residentialAddress
 		serviceMember.BackupMailingAddress = &backupAddress

--- a/pkg/services/move_task_order/move_task_order_hide_non_fake_test.go
+++ b/pkg/services/move_task_order/move_task_order_hide_non_fake_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/go-openapi/swag"
 
+	"github.com/transcom/mymove/pkg/factory"
 	"github.com/transcom/mymove/pkg/models"
 	. "github.com/transcom/mymove/pkg/services/move_task_order"
 	"github.com/transcom/mymove/pkg/testdatagen"
@@ -14,16 +15,20 @@ import (
 func (suite *MoveTaskOrderServiceSuite) TestMoveTaskOrderHider_Hide() {
 
 	setupTestData := func() models.ServiceMember {
-		validAddress1 := testdatagen.MakeAddress(suite.DB(), testdatagen.Assertions{
-			Address: models.Address{
-				StreetAddress1: "7 Q St",
+		validAddress1 := factory.BuildAddress(suite.DB(), []factory.Customization{
+			{
+				Model: models.Address{
+					StreetAddress1: "7 Q St",
+				},
 			},
-		})
-		validAddress2 := testdatagen.MakeAddress(suite.DB(), testdatagen.Assertions{
-			Address: models.Address{
-				StreetAddress1: "448 Washington Blvd NE",
+		}, nil)
+		validAddress2 := factory.BuildAddress(suite.DB(), []factory.Customization{
+			{
+				Model: models.Address{
+					StreetAddress1: "448 Washington Blvd NE",
+				},
 			},
-		})
+		}, nil)
 		serviceMember := testdatagen.MakeServiceMember(suite.DB(), testdatagen.Assertions{
 			ServiceMember: models.ServiceMember{
 				FirstName:          swag.String("Gregory"),
@@ -112,16 +117,20 @@ func (suite *MoveTaskOrderServiceSuite) TestMoveTaskOrderHider_isValidFakeServic
 		//                   Returns true/false, the reasons, and err
 		// Set up:           Create a servicemember with valid data
 		// Expected outcome: Returns true, no reasons
-		address1 := testdatagen.MakeAddress(suite.DB(), testdatagen.Assertions{
-			Address: models.Address{
-				StreetAddress1: "7 Q St",
+		address1 := factory.BuildAddress(suite.DB(), []factory.Customization{
+			{
+				Model: models.Address{
+					StreetAddress1: "7 Q St",
+				},
 			},
-		})
-		address2 := testdatagen.MakeAddress(suite.DB(), testdatagen.Assertions{
-			Address: models.Address{
-				StreetAddress1: "448 Washington Blvd NE",
+		}, nil)
+		address2 := factory.BuildAddress(suite.DB(), []factory.Customization{
+			{
+				Model: models.Address{
+					StreetAddress1: "448 Washington Blvd NE",
+				},
 			},
-		})
+		}, nil)
 		sm := testdatagen.MakeServiceMember(suite.DB(), testdatagen.Assertions{
 			ServiceMember: models.ServiceMember{
 				FirstName:            swag.String("Peyton"),
@@ -154,26 +163,34 @@ func (suite *MoveTaskOrderServiceSuite) TestMoveTaskOrderHider_isValidFakeServic
 	setupInvalidTestData := func(index int) (models.ServiceMember, []string) {
 		// Create a valid service member, then replace each field with an invalid string and
 		// ensure it is caught by the function.
-		address1 := testdatagen.MakeAddress(suite.DB(), testdatagen.Assertions{
-			Address: models.Address{
-				StreetAddress1: "7 Q St",
+		address1 := factory.BuildAddress(suite.DB(), []factory.Customization{
+			{
+				Model: models.Address{
+					StreetAddress1: "7 Q St",
+				},
 			},
-		})
-		address2 := testdatagen.MakeAddress(suite.DB(), testdatagen.Assertions{
-			Address: models.Address{
-				StreetAddress1: "448 Washington Blvd NE",
+		}, nil)
+		address2 := factory.BuildAddress(suite.DB(), []factory.Customization{
+			{
+				Model: models.Address{
+					StreetAddress1: "448 Washington Blvd NE",
+				},
 			},
-		})
-		invalidAddress1 := testdatagen.MakeAddress(suite.DB(), testdatagen.Assertions{
-			Address: models.Address{
-				StreetAddress1: "24 Main St",
+		}, nil)
+		invalidAddress1 := factory.BuildAddress(suite.DB(), []factory.Customization{
+			{
+				Model: models.Address{
+					StreetAddress1: "24 Main St",
+				},
 			},
-		})
-		invalidAddress2 := testdatagen.MakeAddress(suite.DB(), testdatagen.Assertions{
-			Address: models.Address{
-				StreetAddress1: "123 Not Real Fake Pl",
+		}, nil)
+		invalidAddress2 := factory.BuildAddress(suite.DB(), []factory.Customization{
+			{
+				Model: models.Address{
+					StreetAddress1: "123 Not Real Fake Pl",
+				},
 			},
-		})
+		}, nil)
 		validServiceMemberAssertions := testdatagen.Assertions{
 			ServiceMember: models.ServiceMember{
 				FirstName:            swag.String("Peyton"),
@@ -319,11 +336,13 @@ func (suite *MoveTaskOrderServiceSuite) TestMoveTaskOrderHider_isValidFakeModelA
 		// Set up:           Create an address with valid data
 		// Expected outcome: Returns true, no error
 
-		address := testdatagen.MakeAddress(suite.DB(), testdatagen.Assertions{
-			Address: models.Address{
-				StreetAddress1: "3373 NW Martin Luther King Jr Blvd",
+		address := factory.BuildAddress(suite.DB(), []factory.Customization{
+			{
+				Model: models.Address{
+					StreetAddress1: "3373 NW Martin Luther King Jr Blvd",
+				},
 			},
-		})
+		}, nil)
 		result, err := IsValidFakeModelAddress(&address)
 		suite.NoError(err)
 		suite.Equal(true, result)
@@ -336,11 +355,13 @@ func (suite *MoveTaskOrderServiceSuite) TestMoveTaskOrderHider_isValidFakeModelA
 	// Expected outcome: Returns false
 
 	suite.Run("invalid fake address data", func() {
-		address := testdatagen.MakeAddress(suite.DB(), testdatagen.Assertions{
-			Address: models.Address{
-				StreetAddress1: "1600 pennsylvania ave",
+		address := factory.BuildAddress(suite.DB(), []factory.Customization{
+			{
+				Model: models.Address{
+					StreetAddress1: "1600 pennsylvania ave",
+				},
 			},
-		})
+		}, nil)
 		result, err := IsValidFakeModelAddress(&address)
 		suite.NoError(err)
 		suite.Equal(false, result)
@@ -351,26 +372,34 @@ func (suite *MoveTaskOrderServiceSuite) TestMoveTaskOrderHider_isValidFakeModelM
 
 	setupTestData := func() models.MTOShipment {
 
-		validPickupAddress := testdatagen.MakeAddress(suite.DB(), testdatagen.Assertions{
-			Address: models.Address{
-				StreetAddress1: "7 Q St",
+		validPickupAddress := factory.BuildAddress(suite.DB(), []factory.Customization{
+			{
+				Model: models.Address{
+					StreetAddress1: "7 Q St",
+				},
 			},
-		})
-		validSecondaryPickupAddress := testdatagen.MakeAddress(suite.DB(), testdatagen.Assertions{
-			Address: models.Address{
-				StreetAddress1: "448 Washington Blvd NE",
+		}, nil)
+		validSecondaryPickupAddress := factory.BuildAddress(suite.DB(), []factory.Customization{
+			{
+				Model: models.Address{
+					StreetAddress1: "448 Washington Blvd NE",
+				},
 			},
-		})
-		validDestinationAddress := testdatagen.MakeAddress(suite.DB(), testdatagen.Assertions{
-			Address: models.Address{
-				StreetAddress1: "3373 NW Martin Luther King Jr Blvd",
+		}, nil)
+		validDestinationAddress := factory.BuildAddress(suite.DB(), []factory.Customization{
+			{
+				Model: models.Address{
+					StreetAddress1: "3373 NW Martin Luther King Jr Blvd",
+				},
 			},
-		})
-		validSecondaryDeliveryAddress := testdatagen.MakeAddress(suite.DB(), testdatagen.Assertions{
-			Address: models.Address{
-				StreetAddress1: "142 E Barrel Hoop Circle #4A",
+		}, nil)
+		validSecondaryDeliveryAddress := factory.BuildAddress(suite.DB(), []factory.Customization{
+			{
+				Model: models.Address{
+					StreetAddress1: "142 E Barrel Hoop Circle #4A",
+				},
 			},
-		})
+		}, nil)
 		shipment := testdatagen.MakeMTOShipment(suite.DB(), testdatagen.Assertions{
 			MTOShipment: models.MTOShipment{
 				ShipmentType: models.MTOShipmentTypeHHG,
@@ -419,41 +448,49 @@ func (suite *MoveTaskOrderServiceSuite) TestMoveTaskOrderHider_isValidFakeModelM
 		var shipment models.MTOShipment
 		invalidAssertion := validMTOShipmentAssertion
 		if index == 0 {
-			invalidPickupAddress := testdatagen.MakeAddress(suite.DB(), testdatagen.Assertions{
-				Address: models.Address{
-					StreetAddress1: "1600 pennsylvania ave",
+			invalidPickupAddress := factory.BuildAddress(suite.DB(), []factory.Customization{
+				{
+					Model: models.Address{
+						StreetAddress1: "1600 pennsylvania ave",
+					},
 				},
-			})
+			}, nil)
 			// Copy the valid assertions then overwrite the pickup address
 			invalidAssertion.PickupAddress = invalidPickupAddress
 			shipment = testdatagen.MakeMTOShipment(suite.DB(), invalidAssertion)
 
 		} else if index == 1 {
-			invalidSecondaryPickupAddress := testdatagen.MakeAddress(suite.DB(), testdatagen.Assertions{
-				Address: models.Address{
-					StreetAddress1: "20 W 34th St",
+			invalidSecondaryPickupAddress := factory.BuildAddress(suite.DB(), []factory.Customization{
+				{
+					Model: models.Address{
+						StreetAddress1: "20 W 34th St",
+					},
 				},
-			})
+			}, nil)
 			invalidAssertion.SecondaryPickupAddress = invalidSecondaryPickupAddress
 			shipment = testdatagen.MakeMTOShipment(suite.DB(), invalidAssertion)
 
 		} else if index == 2 {
 
-			invalidDestinationAddress := testdatagen.MakeAddress(suite.DB(), testdatagen.Assertions{
-				Address: models.Address{
-					StreetAddress1: "86 Pike Pl",
+			invalidDestinationAddress := factory.BuildAddress(suite.DB(), []factory.Customization{
+				{
+					Model: models.Address{
+						StreetAddress1: "86 Pike Pl",
+					},
 				},
-			})
+			}, nil)
 			invalidAssertion.DestinationAddress = invalidDestinationAddress
 			shipment = testdatagen.MakeMTOShipment(suite.DB(), invalidAssertion)
 
 		} else if index == 3 {
 
-			invalidSecondaryDeliveryAddress := testdatagen.MakeAddress(suite.DB(), testdatagen.Assertions{
-				Address: models.Address{
-					StreetAddress1: "4000 Central Florida Blvd",
+			invalidSecondaryDeliveryAddress := factory.BuildAddress(suite.DB(), []factory.Customization{
+				{
+					Model: models.Address{
+						StreetAddress1: "4000 Central Florida Blvd",
+					},
 				},
-			})
+			}, nil)
 			invalidAssertion.SecondaryDeliveryAddress = invalidSecondaryDeliveryAddress
 			shipment = testdatagen.MakeMTOShipment(suite.DB(), invalidAssertion)
 		}

--- a/pkg/services/move_task_order/move_task_order_updater_test.go
+++ b/pkg/services/move_task_order/move_task_order_updater_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/transcom/mymove/pkg/apperror"
 	"github.com/transcom/mymove/pkg/etag"
+	"github.com/transcom/mymove/pkg/factory"
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/services/mocks"
 	moverouter "github.com/transcom/mymove/pkg/services/move"
@@ -72,15 +73,17 @@ func (suite *MoveTaskOrderServiceSuite) TestMoveTaskOrderUpdater_UpdateStatusSer
 	suite.Run("MTO status is updated successfully with facility info", func() {
 		storageFacility := testdatagen.MakeStorageFacility(suite.DB(), testdatagen.Assertions{
 			StorageFacility: models.StorageFacility{
-				Address: testdatagen.MakeAddress(suite.DB(), testdatagen.Assertions{
-					Address: models.Address{
-						StreetAddress1: "1234 Over Here Street",
-						City:           "Houston",
-						State:          "TX",
-						PostalCode:     "77083",
-						Country:        swag.String("US"),
+				Address: factory.BuildAddress(suite.DB(), []factory.Customization{
+					{
+						Model: models.Address{
+							StreetAddress1: "1234 Over Here Street",
+							City:           "Houston",
+							State:          "TX",
+							PostalCode:     "77083",
+							Country:        models.StringPointer("US"),
+						},
 					},
-				}),
+				}, nil),
 				Email: swag.String("old@email.com"),
 			},
 		})

--- a/pkg/services/mto_service_item/mto_service_item_creator_test.go
+++ b/pkg/services/mto_service_item/mto_service_item_creator_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/transcom/mymove/pkg/appcontext"
 	"github.com/transcom/mymove/pkg/apperror"
+	"github.com/transcom/mymove/pkg/factory"
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/services"
 	moverouter "github.com/transcom/mymove/pkg/services/move"
@@ -622,7 +623,7 @@ func (suite *MTOServiceItemServiceSuite) TestCreateOriginSITServiceItem() {
 		shipment := setupTestData()
 
 		// Create and address where ID != uuid.Nil
-		actualPickupAddress := testdatagen.MakeAddress2(suite.DB(), testdatagen.Assertions{})
+		actualPickupAddress := factory.BuildAddress(suite.DB(), nil, []factory.Trait{factory.GetTraitAddress2})
 
 		serviceItemDOFSIT := models.MTOServiceItem{
 			MoveTaskOrder:             shipment.MoveTaskOrder,
@@ -661,7 +662,7 @@ func (suite *MTOServiceItemServiceSuite) TestCreateOriginSITServiceItem() {
 		// Do not create Address in the database (Assertions.Stub = true) because if the information is coming from the Prime
 		// via the Prime API, the address will not have a valid database ID. And tests need to ensure
 		// that we properly create the address coming in from the API.
-		actualPickupAddress := testdatagen.MakeAddress2(suite.DB(), testdatagen.Assertions{Stub: true})
+		actualPickupAddress := factory.BuildAddress(nil, nil, []factory.Trait{factory.GetTraitAddress2})
 		actualPickupAddress.ID = uuid.Nil
 
 		serviceItemDOFSIT := models.MTOServiceItem{
@@ -716,7 +717,7 @@ func (suite *MTOServiceItemServiceSuite) TestCreateOriginSITServiceItem() {
 
 	setupDOFSIT := func(shipment models.MTOShipment) services.MTOServiceItemCreator {
 		// Create DOFSIT
-		actualPickupAddress := testdatagen.MakeAddress2(suite.DB(), testdatagen.Assertions{Stub: true})
+		actualPickupAddress := factory.BuildAddress(nil, nil, []factory.Trait{factory.GetTraitAddress2})
 		actualPickupAddress.ID = uuid.Nil
 
 		serviceItemDOFSIT := models.MTOServiceItem{
@@ -799,7 +800,7 @@ func (suite *MTOServiceItemServiceSuite) TestCreateOriginSITServiceItem() {
 			Status:          models.MTOServiceItemStatusSubmitted,
 		}
 
-		actualPickupAddress2 := testdatagen.MakeAddress2(suite.DB(), testdatagen.Assertions{Stub: true})
+		actualPickupAddress2 := factory.BuildAddress(nil, nil, []factory.Trait{factory.GetTraitAddress2})
 		existingServiceItem := &serviceItemDOASIT
 		existingServiceItem.SITOriginHHGActualAddress = &actualPickupAddress2
 

--- a/pkg/services/mto_service_item/mto_service_item_updater_test.go
+++ b/pkg/services/mto_service_item/mto_service_item_updater_test.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/transcom/mymove/pkg/apperror"
 	"github.com/transcom/mymove/pkg/etag"
+	"github.com/transcom/mymove/pkg/factory"
 	"github.com/transcom/mymove/pkg/handlers"
 	"github.com/transcom/mymove/pkg/models"
 	moverouter "github.com/transcom/mymove/pkg/services/move"
@@ -89,7 +90,7 @@ func (suite *MTOServiceItemServiceSuite) TestMTOServiceItemUpdater() {
 		reason := "because we did this service"
 		sitEntryDate := time.Date(2020, time.December, 02, 0, 0, 0, 0, time.UTC)
 
-		newAddress := testdatagen.MakeAddress(suite.DB(), testdatagen.Assertions{Stub: true})
+		newAddress := factory.BuildAddress(nil, nil, nil)
 		newServiceItem := serviceItem
 		newServiceItem.Reason = &reason
 		newServiceItem.SITEntryDate = &sitEntryDate

--- a/pkg/services/mto_shipment/mto_shipment_address_updater_test.go
+++ b/pkg/services/mto_shipment/mto_shipment_address_updater_test.go
@@ -3,6 +3,7 @@ package mtoshipment
 import (
 	"github.com/transcom/mymove/pkg/apperror"
 	"github.com/transcom/mymove/pkg/etag"
+	"github.com/transcom/mymove/pkg/factory"
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/testdatagen"
 )
@@ -20,7 +21,7 @@ func (suite *MTOShipmentServiceSuite) TestUpdateMTOShipmentAddress() {
 	//             With mustBeAvailableToPrime = false, there should be no error
 	suite.Run("Using external vendor shipment", func() {
 		availableToPrimeMove := testdatagen.MakeAvailableMove(suite.DB())
-		address := testdatagen.MakeAddress(suite.DB(), testdatagen.Assertions{})
+		address := factory.BuildAddress(suite.DB(), nil, nil)
 		externalShipment := testdatagen.MakeMTOShipment(suite.DB(), testdatagen.Assertions{
 			Move: availableToPrimeMove,
 			MTOShipment: models.MTOShipment{

--- a/pkg/services/mto_shipment/mto_shipment_fetcher_test.go
+++ b/pkg/services/mto_shipment/mto_shipment_fetcher_test.go
@@ -108,7 +108,7 @@ func (suite *MTOShipmentServiceSuite) TestListMTOShipments() {
 
 		storageFacility := testdatagen.MakeStorageFacility(suite.DB(), testdatagen.Assertions{})
 
-		secondaryPickupAddress := testdatagen.MakeDefaultAddress(suite.DB())
+		secondaryPickupAddress := factory.BuildAddress(suite.DB(), nil, nil)
 		secondaryDeliveryAddress := factory.BuildAddress(suite.DB(), nil, []factory.Trait{factory.GetTraitAddress2})
 
 		shipment := testdatagen.MakeMTOShipment(suite.DB(), testdatagen.Assertions{

--- a/pkg/services/mto_shipment/mto_shipment_fetcher_test.go
+++ b/pkg/services/mto_shipment/mto_shipment_fetcher_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/gofrs/uuid"
 
 	"github.com/transcom/mymove/pkg/apperror"
+	"github.com/transcom/mymove/pkg/factory"
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/testdatagen"
 )
@@ -108,7 +109,7 @@ func (suite *MTOShipmentServiceSuite) TestListMTOShipments() {
 		storageFacility := testdatagen.MakeStorageFacility(suite.DB(), testdatagen.Assertions{})
 
 		secondaryPickupAddress := testdatagen.MakeDefaultAddress(suite.DB())
-		secondaryDeliveryAddress := testdatagen.MakeAddress2(suite.DB(), testdatagen.Assertions{})
+		secondaryDeliveryAddress := factory.BuildAddress(suite.DB(), nil, []factory.Trait{factory.GetTraitAddress2})
 
 		shipment := testdatagen.MakeMTOShipment(suite.DB(), testdatagen.Assertions{
 			MTOShipment: models.MTOShipment{

--- a/pkg/services/mto_shipment/mto_shipment_updater_test.go
+++ b/pkg/services/mto_shipment/mto_shipment_updater_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/transcom/mymove/pkg/apperror"
 	"github.com/transcom/mymove/pkg/auth"
 	"github.com/transcom/mymove/pkg/etag"
+	"github.com/transcom/mymove/pkg/factory"
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/notifications"
 	notificationMocks "github.com/transcom/mymove/pkg/notifications/mocks"
@@ -75,31 +76,35 @@ func (suite *MTOShipmentServiceSuite) TestMTOShipmentUpdater() {
 		oldMTOShipment = testdatagen.MakeDefaultMTOShipment(suite.DB())
 
 		requestedPickupDate := *oldMTOShipment.RequestedPickupDate
-		secondaryPickupAddress = testdatagen.MakeAddress3(suite.DB(), testdatagen.Assertions{})
-		secondaryDeliveryAddress = testdatagen.MakeAddress4(suite.DB(), testdatagen.Assertions{})
-		newDestinationAddress = testdatagen.MakeAddress(suite.DB(), testdatagen.Assertions{
-			Address: models.Address{
-				StreetAddress1: "987 Other Avenue",
-				StreetAddress2: swag.String("P.O. Box 1234"),
-				StreetAddress3: swag.String("c/o Another Person"),
-				City:           "Des Moines",
-				State:          "IA",
-				PostalCode:     "50309",
-				Country:        swag.String("US"),
+		secondaryPickupAddress = factory.BuildAddress(suite.DB(), nil, []factory.Trait{factory.GetTraitAddress3})
+		secondaryDeliveryAddress = factory.BuildAddress(suite.DB(), nil, []factory.Trait{factory.GetTraitAddress4})
+		newDestinationAddress = factory.BuildAddress(suite.DB(), []factory.Customization{
+			{
+				Model: models.Address{
+					StreetAddress1: "987 Other Avenue",
+					StreetAddress2: models.StringPointer("P.O. Box 1234"),
+					StreetAddress3: models.StringPointer("c/o Another Person"),
+					City:           "Des Moines",
+					State:          "IA",
+					PostalCode:     "50309",
+					Country:        models.StringPointer("US"),
+				},
 			},
-		})
+		}, nil)
 
-		newPickupAddress = testdatagen.MakeAddress4(suite.DB(), testdatagen.Assertions{
-			Address: models.Address{
-				StreetAddress1: "987 Over There Avenue",
-				StreetAddress2: swag.String("P.O. Box 1234"),
-				StreetAddress3: swag.String("c/o Another Person"),
-				City:           "Houston",
-				State:          "TX",
-				PostalCode:     "77083",
-				Country:        swag.String("US"),
+		newPickupAddress = factory.BuildAddress(suite.DB(), []factory.Customization{
+			{
+				Model: models.Address{
+					StreetAddress1: "987 Over There Avenue",
+					StreetAddress2: models.StringPointer("P.O. Box 1234"),
+					StreetAddress3: models.StringPointer("c/o Another Person"),
+					City:           "Houston",
+					State:          "TX",
+					PostalCode:     "77083",
+					Country:        models.StringPointer("US"),
+				},
 			},
-		})
+		}, []factory.Trait{factory.GetTraitAddress4})
 
 		mtoShipment = models.MTOShipment{
 			ID:                         oldMTOShipment.ID,
@@ -528,15 +533,17 @@ func (suite *MTOShipmentServiceSuite) TestMTOShipmentUpdater() {
 		// Create initial shipment data
 		storageFacility := testdatagen.MakeStorageFacility(suite.DB(), testdatagen.Assertions{
 			StorageFacility: models.StorageFacility{
-				Address: testdatagen.MakeAddress(suite.DB(), testdatagen.Assertions{
-					Address: models.Address{
-						StreetAddress1: "1234 Over Here Street",
-						City:           "Houston",
-						State:          "TX",
-						PostalCode:     "77083",
-						Country:        swag.String("US"),
+				Address: factory.BuildAddress(suite.DB(), []factory.Customization{
+					{
+						Model: models.Address{
+							StreetAddress1: "1234 Over Here Street",
+							City:           "Houston",
+							State:          "TX",
+							PostalCode:     "77083",
+							Country:        models.StringPointer("US"),
+						},
 					},
-				}),
+				}, nil),
 				Email: swag.String("old@email.com"),
 			},
 		})
@@ -954,8 +961,8 @@ func (suite *MTOShipmentServiceSuite) TestUpdateMTOShipmentStatus() {
 		// Note that MakeMTOShipment will automatically add a Required Delivery Date if the ScheduledPickupDate
 		// is present, therefore we need to use MakeMTOShipmentMinimal and add the Pickup and Destination addresses
 		estimatedWeight := unit.Pound(11000)
-		destinationAddress := testdatagen.MakeAddress2(suite.DB(), testdatagen.Assertions{})
-		pickupAddress := testdatagen.MakeAddress(suite.DB(), testdatagen.Assertions{})
+		destinationAddress := factory.BuildAddress(suite.DB(), nil, []factory.Trait{factory.GetTraitAddress2})
+		pickupAddress := factory.BuildAddress(suite.DB(), nil, nil)
 		shipmentHeavy := testdatagen.MakeMTOShipmentMinimal(suite.DB(), testdatagen.Assertions{
 			Move: mto,
 			MTOShipment: models.MTOShipment{
@@ -1015,8 +1022,8 @@ func (suite *MTOShipmentServiceSuite) TestUpdateMTOShipmentStatus() {
 		// is present, therefore we need to use MakeMTOShipmentMinimal and add the Pickup and Destination addresses
 		estimatedWeight := unit.Pound(11000)
 
-		destinationAddress := testdatagen.MakeAddress4(suite.DB(), testdatagen.Assertions{})
-		pickupAddress := testdatagen.MakeAddress3(suite.DB(), testdatagen.Assertions{})
+		destinationAddress := factory.BuildAddress(suite.DB(), nil, []factory.Trait{factory.GetTraitAddress4})
+		pickupAddress := factory.BuildAddress(suite.DB(), nil, []factory.Trait{factory.GetTraitAddress3})
 		storageFacility := testdatagen.MakeStorageFacility(suite.DB(), testdatagen.Assertions{})
 
 		hhgShipment := testdatagen.MakeMTOShipmentMinimal(suite.DB(), testdatagen.Assertions{

--- a/pkg/services/mto_shipment/shipment_approver_test.go
+++ b/pkg/services/mto_shipment/shipment_approver_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/transcom/mymove/pkg/appcontext"
 	"github.com/transcom/mymove/pkg/apperror"
 	"github.com/transcom/mymove/pkg/etag"
+	"github.com/transcom/mymove/pkg/factory"
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/route/mocks"
 	"github.com/transcom/mymove/pkg/services"
@@ -193,8 +194,8 @@ func (suite *MTOShipmentServiceSuite) TestApproveShipment() {
 		// Note that MakeMTOShipment will automatically add a Required Delivery Date if the ScheduledPickupDate
 		// is present, therefore we need to use MakeMTOShipmentMinimal and add the Pickup and Destination addresses
 		estimatedWeight := unit.Pound(11000)
-		destinationAddress := testdatagen.MakeAddress2(suite.DB(), testdatagen.Assertions{})
-		pickupAddress := testdatagen.MakeAddress(suite.DB(), testdatagen.Assertions{})
+		destinationAddress := factory.BuildAddress(suite.DB(), nil, []factory.Trait{factory.GetTraitAddress2})
+		pickupAddress := factory.BuildAddress(suite.DB(), nil, nil)
 
 		shipmentHeavy := testdatagen.MakeMTOShipmentMinimal(suite.DB(), testdatagen.Assertions{
 			Move: move,
@@ -395,8 +396,8 @@ func (suite *MTOShipmentServiceSuite) TestApproveShipment() {
 		// is present, therefore we need to use MakeMTOShipmentMinimal and add the Pickup and Destination addresses
 		estimatedWeight := unit.Pound(1400)
 
-		destinationAddress := testdatagen.MakeAddress4(suite.DB(), testdatagen.Assertions{})
-		pickupAddress := testdatagen.MakeAddress3(suite.DB(), testdatagen.Assertions{})
+		destinationAddress := factory.BuildAddress(suite.DB(), nil, []factory.Trait{factory.GetTraitAddress4})
+		pickupAddress := factory.BuildAddress(suite.DB(), nil, []factory.Trait{factory.GetTraitAddress3})
 		storageFacility := testdatagen.MakeStorageFacility(suite.DB(), testdatagen.Assertions{})
 
 		hhgShipment := testdatagen.MakeMTOShipmentMinimal(suite.DB(), testdatagen.Assertions{

--- a/pkg/services/order/order_fetcher_test.go
+++ b/pkg/services/order/order_fetcher_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/go-openapi/swag"
 	"github.com/gofrs/uuid"
 
+	"github.com/transcom/mymove/pkg/factory"
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/services"
 	"github.com/transcom/mymove/pkg/testdatagen"
@@ -1254,15 +1255,17 @@ func (suite *OrderServiceSuite) TestListOrdersNeedingServicesCounselingWithGBLOC
 
 		// Create data for a second Origin ZANY
 		testdatagen.MakePostalCodeToGBLOC(suite.DB(), "50309", officeUser.TransportationOffice.Gbloc)
-		dutyLocationAddress2 := testdatagen.MakeAddress(suite.DB(), testdatagen.Assertions{
-			Address: models.Address{
-				StreetAddress1: "Anchor 1212",
-				City:           "Augusta",
-				State:          "GA",
-				PostalCode:     "89898",
-				Country:        swag.String("United States"),
+		dutyLocationAddress2 := factory.BuildAddress(suite.DB(), []factory.Customization{
+			{
+				Model: models.Address{
+					StreetAddress1: "Anchor 1212",
+					City:           "Augusta",
+					State:          "GA",
+					PostalCode:     "89898",
+					Country:        models.StringPointer("United States"),
+				},
 			},
-		})
+		}, nil)
 		originDutyLocation2 := testdatagen.MakeDutyLocation(suite.DB(), testdatagen.Assertions{
 			DutyLocation: models.DutyLocation{
 				Name:      "Fort Sam Snap",

--- a/pkg/services/order/order_updater_test.go
+++ b/pkg/services/order/order_updater_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/transcom/mymove/pkg/apperror"
 	"github.com/transcom/mymove/pkg/etag"
+	"github.com/transcom/mymove/pkg/factory"
 	"github.com/transcom/mymove/pkg/gen/ghcmessages"
 	"github.com/transcom/mymove/pkg/handlers"
 	"github.com/transcom/mymove/pkg/models"
@@ -779,7 +780,7 @@ func (suite *OrderServiceSuite) TestUploadAmendedOrdersForCustomer() {
 		orderUpdater := NewOrderUpdater(moveRouter)
 		dutyLocation := testdatagen.MakeDutyLocation(suite.DB(), testdatagen.Assertions{
 			DutyLocation: models.DutyLocation{
-				Address: testdatagen.MakeAddress2(suite.DB(), testdatagen.Assertions{}),
+				Address: factory.BuildAddress(suite.DB(), nil, []factory.Trait{factory.GetTraitAddress2}),
 			},
 		})
 		var moves models.Moves
@@ -869,7 +870,7 @@ func (suite *OrderServiceSuite) TestUploadAmendedOrdersForCustomer() {
 		orderUpdater := NewOrderUpdater(moveRouter)
 		dutyLocation := testdatagen.MakeDutyLocation(suite.DB(), testdatagen.Assertions{
 			DutyLocation: models.DutyLocation{
-				Address: testdatagen.MakeAddress2(suite.DB(), testdatagen.Assertions{}),
+				Address: factory.BuildAddress(suite.DB(), nil, []factory.Trait{factory.GetTraitAddress2}),
 			},
 		})
 		var moves models.Moves

--- a/pkg/services/payment_request/payment_request_creator_test.go
+++ b/pkg/services/payment_request/payment_request_creator_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/mock"
 
 	"github.com/transcom/mymove/pkg/apperror"
+	"github.com/transcom/mymove/pkg/factory"
 	"github.com/transcom/mymove/pkg/models"
 	routemocks "github.com/transcom/mymove/pkg/route/mocks"
 	"github.com/transcom/mymove/pkg/services/ghcrateengine"
@@ -1081,22 +1082,26 @@ func (suite *PaymentRequestServiceSuite) TestCreatePaymentRequestCheckOnNTSRelea
 	//
 
 	// Make storage facility and destination addresses
-	storageFacilityAddress := testdatagen.MakeAddress(suite.DB(), testdatagen.Assertions{
-		Address: models.Address{
-			StreetAddress1: "235 Prospect Valley Road SE",
-			City:           "Augusta",
-			State:          "GA",
-			PostalCode:     testStorageFacilityZip,
+	storageFacilityAddress := factory.BuildAddress(suite.DB(), []factory.Customization{
+		{
+			Model: models.Address{
+				StreetAddress1: "235 Prospect Valley Road SE",
+				City:           "Augusta",
+				State:          "GA",
+				PostalCode:     testStorageFacilityZip,
+			},
 		},
-	})
-	destinationAddress := testdatagen.MakeAddress(suite.DB(), testdatagen.Assertions{
-		Address: models.Address{
-			StreetAddress1: "17 8th St",
-			City:           "San Antonio",
-			State:          "TX",
-			PostalCode:     testDestinationZip,
+	}, nil)
+	destinationAddress := factory.BuildAddress(suite.DB(), []factory.Customization{
+		{
+			Model: models.Address{
+				StreetAddress1: "17 8th St",
+				City:           "San Antonio",
+				State:          "TX",
+				PostalCode:     testDestinationZip,
+			},
 		},
-	})
+	}, nil)
 
 	// Make a storage facility
 	storageFacility := testdatagen.MakeStorageFacility(suite.DB(), testdatagen.Assertions{

--- a/pkg/services/payment_request/payment_request_recalculator_test.go
+++ b/pkg/services/payment_request/payment_request_recalculator_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/mock"
 
 	"github.com/transcom/mymove/pkg/apperror"
+	"github.com/transcom/mymove/pkg/factory"
 	"github.com/transcom/mymove/pkg/models"
 	routemocks "github.com/transcom/mymove/pkg/route/mocks"
 	"github.com/transcom/mymove/pkg/services/ghcrateengine"
@@ -370,22 +371,26 @@ func (suite *PaymentRequestServiceSuite) TestRecalculatePaymentRequestErrors() {
 
 func (suite *PaymentRequestServiceSuite) setupRecalculateData1() (models.Move, models.PaymentRequest) {
 	// Pickup/destination addresses
-	pickupAddress := testdatagen.MakeAddress(suite.DB(), testdatagen.Assertions{
-		Address: models.Address{
-			StreetAddress1: "235 Prospect Valley Road SE",
-			City:           "Augusta",
-			State:          "GA",
-			PostalCode:     recalculateTestPickupZip,
+	pickupAddress := factory.BuildAddress(suite.DB(), []factory.Customization{
+		{
+			Model: models.Address{
+				StreetAddress1: "235 Prospect Valley Road SE",
+				City:           "Augusta",
+				State:          "GA",
+				PostalCode:     recalculateTestPickupZip,
+			},
 		},
-	})
-	destinationAddress := testdatagen.MakeAddress(suite.DB(), testdatagen.Assertions{
-		Address: models.Address{
-			StreetAddress1: "17 8th St",
-			City:           "San Antonio",
-			State:          "TX",
-			PostalCode:     recalculateTestDestinationZip,
+	}, nil)
+	destinationAddress := factory.BuildAddress(suite.DB(), []factory.Customization{
+		{
+			Model: models.Address{
+				StreetAddress1: "17 8th St",
+				City:           "San Antonio",
+				State:          "TX",
+				PostalCode:     recalculateTestDestinationZip,
+			},
 		},
-	})
+	}, nil)
 
 	// Contract year, service area, rate area, zip3
 	contractYear, serviceArea, _, _ := testdatagen.SetupServiceAreaRateArea(suite.DB(), testdatagen.Assertions{

--- a/pkg/services/ppmshipment/ppm_shipment_updater_test.go
+++ b/pkg/services/ppmshipment/ppm_shipment_updater_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/transcom/mymove/pkg/apperror"
 	"github.com/transcom/mymove/pkg/auth"
+	"github.com/transcom/mymove/pkg/factory"
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/services"
 	"github.com/transcom/mymove/pkg/services/address"
@@ -902,7 +903,7 @@ func (suite *PPMShipmentSuite) TestUpdatePPMShipment() {
 
 		subtestData := setUpForTests(fakeEstimatedIncentive, nil, nil)
 
-		address := testdatagen.MakeAddress(appCtx.DB(), testdatagen.Assertions{})
+		address := factory.BuildAddress(appCtx.DB(), nil, nil)
 		originalPPM := testdatagen.MakeMinimalPPMShipment(appCtx.DB(), testdatagen.Assertions{
 			PPMShipment: models.PPMShipment{
 				W2Address:   &address,

--- a/pkg/testdatagen/scenario/e2ebasic.go
+++ b/pkg/testdatagen/scenario/e2ebasic.go
@@ -3140,7 +3140,7 @@ func createPrimeSimulatorMoveNeedsShipmentUpdate(appCtx appcontext.AppContext, u
 
 	// Uncomment to create the shipment with a destination address
 	/*
-		destinationAddress := testdatagen.MakeAddress2(appCtx.DB(), testdatagen.Assertions{})
+		destinationAddress := factory.BuildAddress(appCtx.DB(), nil, []factory.Trait{factory.GetTraitAddress2})
 		shipmentFields.DestinationAddress = &destinationAddress
 		shipmentFields.DestinationAddressID = &destinationAddress.ID
 	*/

--- a/pkg/testdatagen/scenario/e2ebasic.go
+++ b/pkg/testdatagen/scenario/e2ebasic.go
@@ -1989,13 +1989,14 @@ func createMoveWithServiceItemsandPaymentRequests01(appCtx appcontext.AppContext
 		},
 	})
 
-	addressAssertion := testdatagen.Assertions{
-		Address: models.Address{
-			// This is a postal code that maps to the default office user gbloc KKFA in the PostalCodeToGBLOC table
-			PostalCode: "85004",
-		}}
-
-	shipmentPickupAddress := testdatagen.MakeAddress(appCtx.DB(), addressAssertion)
+	shipmentPickupAddress := factory.BuildAddress(appCtx.DB(), []factory.Customization{
+		{
+			Model: models.Address{
+				// This is a postal code that maps to the default office user gbloc KKFA in the PostalCodeToGBLOC table
+				PostalCode: "85004",
+			},
+		},
+	}, nil)
 
 	mtoShipmentHHG := testdatagen.MakeMTOShipment(appCtx.DB(), testdatagen.Assertions{
 		MTOShipment: models.MTOShipment{
@@ -3126,7 +3127,7 @@ func createPrimeSimulatorMoveNeedsShipmentUpdate(appCtx appcontext.AppContext, u
 
 	requestedPickupDate := time.Now().AddDate(0, 3, 0)
 	requestedDeliveryDate := requestedPickupDate.AddDate(0, 1, 0)
-	pickupAddress := testdatagen.MakeAddress(appCtx.DB(), testdatagen.Assertions{})
+	pickupAddress := factory.BuildAddress(appCtx.DB(), nil, nil)
 
 	shipmentFields := models.MTOShipment{
 		ID:                    uuid.FromStringOrNil("5375f237-430c-406d-9ec8-5a27244d563a"),
@@ -3262,12 +3263,14 @@ func createNTSRMoveWithServiceItemsAndPaymentRequest(appCtx appcontext.AppContex
 	})
 
 	// Create Pickup Address
-	shipmentPickupAddress := testdatagen.MakeAddress(appCtx.DB(), testdatagen.Assertions{
-		Address: models.Address{
-			// KKFA GBLOC
-			PostalCode: "85004",
+	shipmentPickupAddress := factory.BuildAddress(appCtx.DB(), []factory.Customization{
+		{
+			Model: models.Address{
+				// KKFA GBLOC
+				PostalCode: "85004",
+			},
 		},
-	})
+	}, nil)
 
 	// Create Storage Facility
 	storageFacility := testdatagen.MakeStorageFacility(appCtx.DB(), testdatagen.Assertions{
@@ -3776,12 +3779,14 @@ func createNTSRMoveWithPaymentRequest(appCtx appcontext.AppContext, userUploader
 	})
 
 	// Create Pickup Address
-	shipmentPickupAddress := testdatagen.MakeAddress(appCtx.DB(), testdatagen.Assertions{
-		Address: models.Address{
-			// KKFA GBLOC
-			PostalCode: "85004",
+	shipmentPickupAddress := factory.BuildAddress(appCtx.DB(), []factory.Customization{
+		{
+			Model: models.Address{
+				// KKFA GBLOC
+				PostalCode: "85004",
+			},
 		},
-	})
+	}, nil)
 
 	// Create Storage Facility
 	storageFacility := testdatagen.MakeStorageFacility(appCtx.DB(), testdatagen.Assertions{

--- a/pkg/testdatagen/scenario/shared.go
+++ b/pkg/testdatagen/scenario/shared.go
@@ -901,7 +901,7 @@ func createApprovedMoveWithPPMWeightTicket(appCtx appcontext.AppContext, userUpl
 	}
 
 	approvedAt := time.Date(2022, 4, 15, 12, 30, 0, 0, time.UTC)
-	address := testdatagen.MakeAddress(appCtx.DB(), testdatagen.Assertions{})
+	address := factory.BuildAddress(appCtx.DB(), nil, nil)
 
 	assertions := testdatagen.Assertions{
 		UserUploader: userUploader,
@@ -947,7 +947,7 @@ func createApprovedMoveWithPPMCloseoutComplete(appCtx appcontext.AppContext, use
 	}
 
 	approvedAt := time.Date(2022, 4, 15, 12, 30, 0, 0, time.UTC)
-	address := testdatagen.MakeAddress(appCtx.DB(), testdatagen.Assertions{})
+	address := factory.BuildAddress(appCtx.DB(), nil, nil)
 
 	assertions := testdatagen.Assertions{
 		UserUploader: userUploader,
@@ -994,7 +994,7 @@ func createApprovedMoveWithPPMWithAboutFormComplete(appCtx appcontext.AppContext
 	}
 
 	approvedAt := time.Date(2022, 4, 15, 12, 30, 0, 0, time.UTC)
-	address := testdatagen.MakeAddress(appCtx.DB(), testdatagen.Assertions{})
+	address := factory.BuildAddress(appCtx.DB(), nil, nil)
 
 	assertions := testdatagen.Assertions{
 		UserUploader: userUploader,
@@ -1033,7 +1033,7 @@ func createApprovedMoveWithPPMWithAboutFormComplete2(appCtx appcontext.AppContex
 	}
 
 	approvedAt := time.Date(2022, 4, 15, 12, 30, 0, 0, time.UTC)
-	address := testdatagen.MakeAddress(appCtx.DB(), testdatagen.Assertions{})
+	address := factory.BuildAddress(appCtx.DB(), nil, nil)
 
 	assertions := testdatagen.Assertions{
 		UserUploader: userUploader,
@@ -1072,7 +1072,7 @@ func createApprovedMoveWithPPMWithAboutFormComplete3(appCtx appcontext.AppContex
 	}
 
 	approvedAt := time.Date(2022, 4, 15, 12, 30, 0, 0, time.UTC)
-	address := testdatagen.MakeAddress(appCtx.DB(), testdatagen.Assertions{})
+	address := factory.BuildAddress(appCtx.DB(), nil, nil)
 
 	assertions := testdatagen.Assertions{
 		UserUploader: userUploader,
@@ -1111,7 +1111,7 @@ func createApprovedMoveWithPPMWithAboutFormComplete4(appCtx appcontext.AppContex
 	}
 
 	approvedAt := time.Date(2022, 4, 15, 12, 30, 0, 0, time.UTC)
-	address := testdatagen.MakeAddress(appCtx.DB(), testdatagen.Assertions{})
+	address := factory.BuildAddress(appCtx.DB(), nil, nil)
 
 	assertions := testdatagen.Assertions{
 		UserUploader: userUploader,
@@ -1150,7 +1150,7 @@ func createApprovedMoveWithPPMWithAboutFormComplete5(appCtx appcontext.AppContex
 	}
 
 	approvedAt := time.Date(2022, 4, 15, 12, 30, 0, 0, time.UTC)
-	address := testdatagen.MakeAddress(appCtx.DB(), testdatagen.Assertions{})
+	address := factory.BuildAddress(appCtx.DB(), nil, nil)
 
 	assertions := testdatagen.Assertions{
 		UserUploader: userUploader,
@@ -1189,7 +1189,7 @@ func createApprovedMoveWithPPMWithAboutFormComplete6(appCtx appcontext.AppContex
 	}
 
 	approvedAt := time.Date(2022, 4, 15, 12, 30, 0, 0, time.UTC)
-	address := testdatagen.MakeAddress(appCtx.DB(), testdatagen.Assertions{})
+	address := factory.BuildAddress(appCtx.DB(), nil, nil)
 
 	assertions := testdatagen.Assertions{
 		UserUploader: userUploader,
@@ -1228,7 +1228,7 @@ func createApprovedMoveWithPPMWithAboutFormComplete7(appCtx appcontext.AppContex
 	}
 
 	approvedAt := time.Date(2022, 4, 15, 12, 30, 0, 0, time.UTC)
-	address := testdatagen.MakeAddress(appCtx.DB(), testdatagen.Assertions{})
+	address := factory.BuildAddress(appCtx.DB(), nil, nil)
 
 	assertions := testdatagen.Assertions{
 		UserUploader: userUploader,
@@ -1267,7 +1267,7 @@ func createApprovedMoveWithPPMWithAboutFormComplete8(appCtx appcontext.AppContex
 	}
 
 	approvedAt := time.Date(2022, 4, 15, 12, 30, 0, 0, time.UTC)
-	address := testdatagen.MakeAddress(appCtx.DB(), testdatagen.Assertions{})
+	address := factory.BuildAddress(appCtx.DB(), nil, nil)
 
 	assertions := testdatagen.Assertions{
 		UserUploader: userUploader,
@@ -1310,7 +1310,7 @@ func createApprovedMoveWithPPMMovingExpense(appCtx appcontext.AppContext, info *
 	}
 
 	approvedAt := time.Date(2022, 4, 15, 12, 30, 0, 0, time.UTC)
-	address := testdatagen.MakeAddress(appCtx.DB(), testdatagen.Assertions{})
+	address := factory.BuildAddress(appCtx.DB(), nil, nil)
 
 	assertions := testdatagen.Assertions{
 		UserUploader: userUploader,
@@ -1369,7 +1369,7 @@ func createApprovedMoveWithPPMProgearWeightTicket(appCtx appcontext.AppContext, 
 	}
 
 	approvedAt := time.Date(2022, 4, 15, 12, 30, 0, 0, time.UTC)
-	address := testdatagen.MakeAddress(appCtx.DB(), testdatagen.Assertions{})
+	address := factory.BuildAddress(appCtx.DB(), nil, nil)
 
 	assertions := testdatagen.Assertions{
 		UserUploader: userUploader,
@@ -1417,7 +1417,7 @@ func createApprovedMoveWithPPMProgearWeightTicket2(appCtx appcontext.AppContext,
 	}
 
 	approvedAt := time.Date(2022, 4, 15, 12, 30, 0, 0, time.UTC)
-	address := testdatagen.MakeAddress(appCtx.DB(), testdatagen.Assertions{})
+	address := factory.BuildAddress(appCtx.DB(), nil, nil)
 
 	assertions := testdatagen.Assertions{
 		UserUploader: userUploader,
@@ -1464,7 +1464,7 @@ func createMoveWithPPMShipmentReadyForFinalCloseout(appCtx appcontext.AppContext
 	}
 
 	approvedAt := time.Date(2022, 4, 15, 12, 30, 0, 0, time.UTC)
-	address := testdatagen.MakeAddress(appCtx.DB(), testdatagen.Assertions{})
+	address := factory.BuildAddress(appCtx.DB(), nil, nil)
 
 	assertions := testdatagen.Assertions{
 		UserUploader: userUploader,
@@ -1529,7 +1529,7 @@ func createMoveWithPPMShipmentReadyForFinalCloseout2(appCtx appcontext.AppContex
 	}
 
 	approvedAt := time.Date(2022, 4, 15, 12, 30, 0, 0, time.UTC)
-	address := testdatagen.MakeAddress(appCtx.DB(), testdatagen.Assertions{})
+	address := factory.BuildAddress(appCtx.DB(), nil, nil)
 
 	assertions := testdatagen.Assertions{
 		UserUploader: userUploader,
@@ -1593,7 +1593,7 @@ func createMoveWithPPMShipmentReadyForFinalCloseout3(appCtx appcontext.AppContex
 	}
 
 	approvedAt := time.Date(2022, 4, 15, 12, 30, 0, 0, time.UTC)
-	address := testdatagen.MakeAddress(appCtx.DB(), testdatagen.Assertions{})
+	address := factory.BuildAddress(appCtx.DB(), nil, nil)
 
 	assertions := testdatagen.Assertions{
 		UserUploader: userUploader,
@@ -1714,17 +1714,19 @@ func createMoveWithCloseOut(appCtx appcontext.AppContext, userUploader *uploader
 		},
 	})
 
-	address := testdatagen.MakeAddress(appCtx.DB(), testdatagen.Assertions{
-		Address: models.Address{
-			StreetAddress1: "2 Second St",
-			StreetAddress2: swag.String("Apt 2"),
-			StreetAddress3: swag.String("Suite B"),
-			City:           "Columbia",
-			State:          "SC",
-			PostalCode:     "29212",
-			Country:        swag.String("US"),
+	address := factory.BuildAddress(appCtx.DB(), []factory.Customization{
+		{
+			Model: models.Address{
+				StreetAddress1: "2 Second St",
+				StreetAddress2: models.StringPointer("Apt 2"),
+				StreetAddress3: models.StringPointer("Suite B"),
+				City:           "Columbia",
+				State:          "SC",
+				PostalCode:     "29212",
+				Country:        models.StringPointer("US"),
+			},
 		},
-	})
+	}, nil)
 
 	newDutyLocation := testdatagen.MakeDutyLocation(appCtx.DB(), testdatagen.Assertions{
 		DutyLocation: models.DutyLocation{
@@ -2519,8 +2521,8 @@ func createUnsubmittedHHGMoveMultipleDestinations(appCtx appcontext.AppContext) 
 		},
 	})
 
-	destinationAddress1 := testdatagen.MakeAddress3(db, testdatagen.Assertions{})
-	destinationAddress2 := testdatagen.MakeAddress4(db, testdatagen.Assertions{})
+	destinationAddress1 := factory.BuildAddress(db, nil, []factory.Trait{factory.GetTraitAddress3})
+	destinationAddress2 := factory.BuildAddress(db, nil, []factory.Trait{factory.GetTraitAddress4})
 
 	testdatagen.MakeMTOShipment(db, testdatagen.Assertions{
 		Move: move,
@@ -2591,31 +2593,35 @@ func createUnsubmittedHHGMoveMultiplePickup(appCtx appcontext.AppContext) {
 		},
 	})
 
-	pickupAddress1 := testdatagen.MakeAddress(db, testdatagen.Assertions{
-		Address: models.Address{
-			ID:             uuid.Must(uuid.NewV4()),
-			StreetAddress1: "1 First St",
-			StreetAddress2: swag.String("Apt 1"),
-			StreetAddress3: swag.String("Suite A"),
-			City:           "Columbia",
-			State:          "SC",
-			PostalCode:     "29212",
-			Country:        swag.String("US"),
+	pickupAddress1 := factory.BuildAddress(db, []factory.Customization{
+		{
+			Model: models.Address{
+				ID:             uuid.Must(uuid.NewV4()),
+				StreetAddress1: "1 First St",
+				StreetAddress2: models.StringPointer("Apt 1"),
+				StreetAddress3: models.StringPointer("Suite A"),
+				City:           "Columbia",
+				State:          "SC",
+				PostalCode:     "29212",
+				Country:        models.StringPointer("US"),
+			},
 		},
-	})
+	}, nil)
 
-	pickupAddress2 := testdatagen.MakeAddress(db, testdatagen.Assertions{
-		Address: models.Address{
-			ID:             uuid.Must(uuid.NewV4()),
-			StreetAddress1: "2 Second St",
-			StreetAddress2: swag.String("Apt 2"),
-			StreetAddress3: swag.String("Suite B"),
-			City:           "Columbia",
-			State:          "SC",
-			PostalCode:     "29212",
-			Country:        swag.String("US"),
+	pickupAddress2 := factory.BuildAddress(db, []factory.Customization{
+		{
+			Model: models.Address{
+				ID:             uuid.Must(uuid.NewV4()),
+				StreetAddress1: "2 Second St",
+				StreetAddress2: models.StringPointer("Apt 2"),
+				StreetAddress3: models.StringPointer("Suite B"),
+				City:           "Columbia",
+				State:          "SC",
+				PostalCode:     "29212",
+				Country:        models.StringPointer("US"),
+			},
 		},
-	})
+	}, nil)
 
 	testdatagen.MakeMTOShipment(db, testdatagen.Assertions{
 		Move: move,
@@ -2686,31 +2692,35 @@ func createSubmittedHHGMoveMultiplePickupAmendedOrders(appCtx appcontext.AppCont
 		},
 	})
 
-	pickupAddress1 := testdatagen.MakeAddress(db, testdatagen.Assertions{
-		Address: models.Address{
-			ID:             uuid.Must(uuid.NewV4()),
-			StreetAddress1: "1 First St",
-			StreetAddress2: swag.String("Apt 1"),
-			StreetAddress3: swag.String("Suite A"),
-			City:           "Columbia",
-			State:          "SC",
-			PostalCode:     "29212",
-			Country:        swag.String("US"),
+	pickupAddress1 := factory.BuildAddress(db, []factory.Customization{
+		{
+			Model: models.Address{
+				ID:             uuid.Must(uuid.NewV4()),
+				StreetAddress1: "1 First St",
+				StreetAddress2: models.StringPointer("Apt 1"),
+				StreetAddress3: models.StringPointer("Suite A"),
+				City:           "Columbia",
+				State:          "SC",
+				PostalCode:     "29212",
+				Country:        models.StringPointer("US"),
+			},
 		},
-	})
+	}, nil)
 
-	pickupAddress2 := testdatagen.MakeAddress(db, testdatagen.Assertions{
-		Address: models.Address{
-			ID:             uuid.Must(uuid.NewV4()),
-			StreetAddress1: "2 Second St",
-			StreetAddress2: swag.String("Apt 2"),
-			StreetAddress3: swag.String("Suite B"),
-			City:           "Columbia",
-			State:          "SC",
-			PostalCode:     "29212",
-			Country:        swag.String("US"),
+	pickupAddress2 := factory.BuildAddress(db, []factory.Customization{
+		{
+			Model: models.Address{
+				ID:             uuid.Must(uuid.NewV4()),
+				StreetAddress1: "2 Second St",
+				StreetAddress2: models.StringPointer("Apt 2"),
+				StreetAddress3: models.StringPointer("Suite B"),
+				City:           "Columbia",
+				State:          "SC",
+				PostalCode:     "29212",
+				Country:        models.StringPointer("US"),
+			},
 		},
-	})
+	}, nil)
 
 	testdatagen.MakeMTOShipment(db, testdatagen.Assertions{
 		Move: move,
@@ -2871,13 +2881,15 @@ func createHHGWithOriginSITServiceItems(appCtx appcontext.AppContext, primeUploa
 			IssueDate:    issueDate,
 			ReportByDate: reportByDate,
 		},
-		DestinationAddress: testdatagen.MakeAddress(db, testdatagen.Assertions{
-			Address: models.Address{
-				City:       "Harlem",
-				State:      "GA",
-				PostalCode: "30813",
+		DestinationAddress: factory.BuildAddress(db, []factory.Customization{
+			{
+				Model: models.Address{
+					City:       "Harlem",
+					State:      "GA",
+					PostalCode: "30813",
+				},
 			},
-		}),
+		}, nil),
 	})
 
 	move := shipment.MoveTaskOrder
@@ -3081,13 +3093,15 @@ func createHHGWithDestinationSITServiceItems(appCtx appcontext.AppContext, prime
 			IssueDate:    issueDate,
 			ReportByDate: reportByDate,
 		},
-		DestinationAddress: testdatagen.MakeAddress(db, testdatagen.Assertions{
-			Address: models.Address{
-				City:       "Harlem",
-				State:      "GA",
-				PostalCode: "30813",
+		DestinationAddress: factory.BuildAddress(db, []factory.Customization{
+			{
+				Model: models.Address{
+					City:       "Harlem",
+					State:      "GA",
+					PostalCode: "30813",
+				},
 			},
-		}),
+		}, nil),
 	})
 
 	move := shipment.MoveTaskOrder
@@ -3292,11 +3306,13 @@ func createHHGWithPaymentServiceItems(appCtx appcontext.AppContext, primeUploade
 
 	move := longhaulShipment.MoveTaskOrder
 
-	shorthaulDestinationAddress := testdatagen.MakeAddress(db, testdatagen.Assertions{
-		Address: models.Address{
-			PostalCode: "90211",
+	shorthaulDestinationAddress := factory.BuildAddress(db, []factory.Customization{
+		{
+			Model: models.Address{
+				PostalCode: "90211",
+			},
 		},
-	})
+	}, nil)
 	shorthaulShipment := testdatagen.MakeMTOShipment(db, testdatagen.Assertions{
 		MTOShipment: models.MTOShipment{
 			Status:               models.MTOShipmentStatusSubmitted,
@@ -3464,7 +3480,7 @@ func createHHGWithPaymentServiceItems(appCtx appcontext.AppContext, primeUploade
 	// have a departure date for the payment request param lookup to not encounter an error
 	originEntryDate := actualPickupDate
 
-	originSITAddress := testdatagen.MakeAddress2(db, testdatagen.Assertions{Stub: true})
+	originSITAddress := factory.BuildAddress(nil, nil, []factory.Trait{factory.GetTraitAddress2})
 	originSITAddress.ID = uuid.Nil
 
 	originSIT := testdatagen.MakeMTOServiceItem(db, testdatagen.Assertions{
@@ -3490,7 +3506,7 @@ func createHHGWithPaymentServiceItems(appCtx appcontext.AppContext, primeUploade
 
 	destEntryDate := actualPickupDate
 	destDepDate := actualPickupDate
-	destSITAddress := testdatagen.MakeAddress(db, testdatagen.Assertions{})
+	destSITAddress := factory.BuildAddress(db, nil, nil)
 	destSIT := testdatagen.MakeMTOServiceItem(db, testdatagen.Assertions{
 		Move:        move,
 		MTOShipment: longhaulShipment,
@@ -3877,13 +3893,14 @@ func createHHGMoveWithPaymentRequest(appCtx appcontext.AppContext, userUploader 
 		Move: move,
 	})
 
-	addressAssertion := testdatagen.Assertions{
-		Address: models.Address{
-			// This is a postal code that maps to the default office user gbloc LKNQ in the PostalCodeToGBLOC table
-			PostalCode: "85325",
-		}}
-
-	shipmentPickupAddress := testdatagen.MakeAddress(db, addressAssertion)
+	shipmentPickupAddress := factory.BuildAddress(db, []factory.Customization{
+		{
+			Model: models.Address{
+				// This is a postal code that maps to the default office user gbloc LKNQ in the PostalCodeToGBLOC table
+				PostalCode: "85325",
+			},
+		},
+	}, nil)
 
 	shipment := models.MTOShipment{
 		PrimeEstimatedWeight: &estimatedWeight,
@@ -4519,31 +4536,35 @@ func createMoveWithHHGAndNTSRPaymentRequest(appCtx appcontext.AppContext, userUp
 	})
 
 	// Create an HHG MTO Shipment
-	pickupAddress := testdatagen.MakeAddress(db, testdatagen.Assertions{
-		Address: models.Address{
-			ID:             uuid.Must(uuid.NewV4()),
-			StreetAddress1: "2 Second St",
-			StreetAddress2: swag.String("Apt 2"),
-			StreetAddress3: swag.String("Suite B"),
-			City:           "Columbia",
-			State:          "SC",
-			PostalCode:     "29212",
-			Country:        swag.String("US"),
+	pickupAddress := factory.BuildAddress(db, []factory.Customization{
+		{
+			Model: models.Address{
+				ID:             uuid.Must(uuid.NewV4()),
+				StreetAddress1: "2 Second St",
+				StreetAddress2: models.StringPointer("Apt 2"),
+				StreetAddress3: models.StringPointer("Suite B"),
+				City:           "Columbia",
+				State:          "SC",
+				PostalCode:     "29212",
+				Country:        models.StringPointer("US"),
+			},
 		},
-	})
+	}, nil)
 
-	destinationAddress := testdatagen.MakeAddress(db, testdatagen.Assertions{
-		Address: models.Address{
-			ID:             uuid.Must(uuid.NewV4()),
-			StreetAddress1: "2 Second St",
-			StreetAddress2: swag.String("Apt 2"),
-			StreetAddress3: swag.String("Suite B"),
-			City:           "Princeton",
-			State:          "NJ",
-			PostalCode:     "08540",
-			Country:        swag.String("US"),
+	destinationAddress := factory.BuildAddress(db, []factory.Customization{
+		{
+			Model: models.Address{
+				ID:             uuid.Must(uuid.NewV4()),
+				StreetAddress1: "2 Second St",
+				StreetAddress2: models.StringPointer("Apt 2"),
+				StreetAddress3: models.StringPointer("Suite B"),
+				City:           "Princeton",
+				State:          "NJ",
+				PostalCode:     "08540",
+				Country:        models.StringPointer("US"),
+			},
 		},
-	})
+	}, nil)
 
 	hhgShipment := testdatagen.MakeMTOShipment(db, testdatagen.Assertions{
 		MTOShipment: models.MTOShipment{
@@ -4563,15 +4584,17 @@ func createMoveWithHHGAndNTSRPaymentRequest(appCtx appcontext.AppContext, userUp
 
 	storageFacility := testdatagen.MakeStorageFacility(db, testdatagen.Assertions{
 		StorageFacility: models.StorageFacility{
-			Address: testdatagen.MakeAddress(db, testdatagen.Assertions{
-				Address: models.Address{
-					StreetAddress1: "1234 Over Here Street",
-					City:           "Houston",
-					State:          "TX",
-					PostalCode:     "77083",
-					Country:        swag.String("US"),
+			Address: factory.BuildAddress(db, []factory.Customization{
+				{
+					Model: models.Address{
+						StreetAddress1: "1234 Over Here Street",
+						City:           "Houston",
+						State:          "TX",
+						PostalCode:     "77083",
+						Country:        models.StringPointer("US"),
+					},
 				},
-			}),
+			}, nil),
 			Email:        swag.String("old@email.com"),
 			FacilityName: "Storage R Us",
 			LotNumber:    &lotNumber,
@@ -5129,7 +5152,7 @@ func createApprovedMoveWithMinimalShipment(appCtx appcontext.AppContext, userUpl
 
 	// requestedPickupDate := time.Now().AddDate(0, 3, 0)
 	// requestedDeliveryDate := requestedPickupDate.AddDate(0, 1, 0)
-	pickupAddress := testdatagen.MakeAddress(db, testdatagen.Assertions{})
+	pickupAddress := factory.BuildAddress(db, nil, nil)
 
 	shipmentFields := models.MTOShipment{
 		Status: models.MTOShipmentStatusApproved,
@@ -5141,7 +5164,7 @@ func createApprovedMoveWithMinimalShipment(appCtx appcontext.AppContext, userUpl
 
 	// Uncomment to create the shipment with a destination address
 	/*
-		destinationAddress := testdatagen.MakeAddress2(db, testdatagen.Assertions{})
+		destinationAddress := factory.BuildAddress(db, nil, []factory.Trait{factory.GetTraitAddress2})
 		shipmentFields.DestinationAddress = &destinationAddress
 		shipmentFields.DestinationAddressID = &destinationAddress.ID
 	*/
@@ -5251,31 +5274,35 @@ func createMoveWith2ShipmentsAndPaymentRequest(appCtx appcontext.AppContext, use
 	})
 
 	// Create an HHG MTO Shipment
-	pickupAddress := testdatagen.MakeAddress(db, testdatagen.Assertions{
-		Address: models.Address{
-			ID:             uuid.Must(uuid.NewV4()),
-			StreetAddress1: "2 Second St",
-			StreetAddress2: swag.String("Apt 2"),
-			StreetAddress3: swag.String("Suite B"),
-			City:           "Columbia",
-			State:          "SC",
-			PostalCode:     "29212",
-			Country:        swag.String("US"),
+	pickupAddress := factory.BuildAddress(db, []factory.Customization{
+		{
+			Model: models.Address{
+				ID:             uuid.Must(uuid.NewV4()),
+				StreetAddress1: "2 Second St",
+				StreetAddress2: models.StringPointer("Apt 2"),
+				StreetAddress3: models.StringPointer("Suite B"),
+				City:           "Columbia",
+				State:          "SC",
+				PostalCode:     "29212",
+				Country:        models.StringPointer("US"),
+			},
 		},
-	})
+	}, nil)
 
-	destinationAddress := testdatagen.MakeAddress(db, testdatagen.Assertions{
-		Address: models.Address{
-			ID:             uuid.Must(uuid.NewV4()),
-			StreetAddress1: "2 Second St",
-			StreetAddress2: swag.String("Apt 2"),
-			StreetAddress3: swag.String("Suite B"),
-			City:           "Princeton",
-			State:          "NJ",
-			PostalCode:     "08540",
-			Country:        swag.String("US"),
+	destinationAddress := factory.BuildAddress(db, []factory.Customization{
+		{
+			Model: models.Address{
+				ID:             uuid.Must(uuid.NewV4()),
+				StreetAddress1: "2 Second St",
+				StreetAddress2: models.StringPointer("Apt 2"),
+				StreetAddress3: models.StringPointer("Suite B"),
+				City:           "Princeton",
+				State:          "NJ",
+				PostalCode:     "08540",
+				Country:        models.StringPointer("US"),
+			},
 		},
-	})
+	}, nil)
 
 	hhgShipment := testdatagen.MakeMTOShipment(db, testdatagen.Assertions{
 		MTOShipment: models.MTOShipment{
@@ -7079,17 +7106,19 @@ func createMoveWithBasicServiceItems(appCtx appcontext.AppContext, userUploader 
 
 func createMoveWithUniqueDestinationAddress(appCtx appcontext.AppContext) {
 	db := appCtx.DB()
-	address := testdatagen.MakeAddress(db, testdatagen.Assertions{
-		Address: models.Address{
-			StreetAddress1: "2 Second St",
-			StreetAddress2: swag.String("Apt 2"),
-			StreetAddress3: swag.String("Suite B"),
-			City:           "Columbia",
-			State:          "SC",
-			PostalCode:     "29212",
-			Country:        swag.String("US"),
+	address := factory.BuildAddress(db, []factory.Customization{
+		{
+			Model: models.Address{
+				StreetAddress1: "2 Second St",
+				StreetAddress2: models.StringPointer("Apt 2"),
+				StreetAddress3: models.StringPointer("Suite B"),
+				City:           "Columbia",
+				State:          "SC",
+				PostalCode:     "29212",
+				Country:        models.StringPointer("US"),
+			},
 		},
-	})
+	}, nil)
 
 	newDutyLocation := testdatagen.MakeDutyLocation(db, testdatagen.Assertions{
 		DutyLocation: models.DutyLocation{

--- a/pkg/testdatagen/scenario/shared.go
+++ b/pkg/testdatagen/scenario/shared.go
@@ -3833,7 +3833,7 @@ func createMoveWithOptions(appCtx appcontext.AppContext, assertions testdatagen.
 
 	requestedPickupDate := submittedAt.Add(60 * 24 * time.Hour)
 	requestedDeliveryDate := requestedPickupDate.Add(7 * 24 * time.Hour)
-	destinationAddress := testdatagen.MakeDefaultAddress(db)
+	destinationAddress := factory.BuildAddress(db, nil, nil)
 	testdatagen.MakeMTOShipment(db, testdatagen.Assertions{
 		Move: move,
 		MTOShipment: models.MTOShipment{
@@ -7179,7 +7179,7 @@ func createNeedsServicesCounseling(appCtx appcontext.AppContext, ordersType inte
 
 	requestedPickupDate := submittedAt.Add(60 * 24 * time.Hour)
 	requestedDeliveryDate := requestedPickupDate.Add(7 * 24 * time.Hour)
-	destinationAddress := testdatagen.MakeDefaultAddress(db)
+	destinationAddress := factory.BuildAddress(db, nil, nil)
 	testdatagen.MakeMTOShipment(db, testdatagen.Assertions{
 		Move: move,
 		MTOShipment: models.MTOShipment{
@@ -7238,7 +7238,7 @@ func createNeedsServicesCounselingWithoutCompletedOrders(appCtx appcontext.AppCo
 
 	requestedPickupDate := submittedAt.Add(60 * 24 * time.Hour)
 	requestedDeliveryDate := requestedPickupDate.Add(7 * 24 * time.Hour)
-	destinationAddress := testdatagen.MakeDefaultAddress(db)
+	destinationAddress := factory.BuildAddress(db, nil, nil)
 	testdatagen.MakeMTOShipment(db, testdatagen.Assertions{
 		Move: move,
 		MTOShipment: models.MTOShipment{
@@ -7290,7 +7290,7 @@ func createUserWithLocatorAndDODID(appCtx appcontext.AppContext, locator string,
 	// Makes a basic HHG shipment to reflect likely real scenario
 	requestedPickupDate := submittedAt.Add(60 * 24 * time.Hour)
 	requestedDeliveryDate := requestedPickupDate.Add(7 * 24 * time.Hour)
-	destinationAddress := testdatagen.MakeDefaultAddress(db)
+	destinationAddress := factory.BuildAddress(db, nil, nil)
 	testdatagen.MakeMTOShipment(db, testdatagen.Assertions{
 		Move: move,
 		MTOShipment: models.MTOShipment{
@@ -7329,7 +7329,7 @@ func createNeedsServicesCounselingSingleHHG(appCtx appcontext.AppContext, orders
 	// Makes a basic HHG shipment to reflect likely real scenario
 	requestedPickupDate := submittedAt.Add(60 * 24 * time.Hour)
 	requestedDeliveryDate := requestedPickupDate.Add(7 * 24 * time.Hour)
-	destinationAddress := testdatagen.MakeDefaultAddress(db)
+	destinationAddress := factory.BuildAddress(db, nil, nil)
 	testdatagen.MakeMTOShipment(db, testdatagen.Assertions{
 		Move: move,
 		MTOShipment: models.MTOShipment{
@@ -7367,7 +7367,7 @@ func createNeedsServicesCounselingMinimalNTSR(appCtx appcontext.AppContext, orde
 
 	// Makes a basic NTS-R shipment with minimal info.
 	requestedDeliveryDate := time.Now().AddDate(0, 0, 14)
-	destinationAddress := testdatagen.MakeDefaultAddress(db)
+	destinationAddress := factory.BuildAddress(db, nil, nil)
 	testdatagen.MakeMTOShipmentMinimal(db, testdatagen.Assertions{
 		Move: move,
 		MTOShipment: models.MTOShipment{
@@ -8093,7 +8093,7 @@ func createMoveWithHHGAndNTSShipments(appCtx appcontext.AppContext, locator stri
 	// Makes a basic HHG shipment to reflect likely real scenario
 	requestedPickupDate := submittedAt.Add(60 * 24 * time.Hour)
 	requestedDeliveryDate := requestedPickupDate.Add(7 * 24 * time.Hour)
-	destinationAddress := testdatagen.MakeDefaultAddress(db)
+	destinationAddress := factory.BuildAddress(db, nil, nil)
 	testdatagen.MakeMTOShipment(db, testdatagen.Assertions{
 		Move: move,
 		MTOShipment: models.MTOShipment{
@@ -8139,7 +8139,7 @@ func createMoveWithHHGAndNTSRShipments(appCtx appcontext.AppContext, locator str
 	// Makes a basic HHG shipment to reflect likely real scenario
 	requestedPickupDate := submittedAt.Add(60 * 24 * time.Hour)
 	requestedDeliveryDate := requestedPickupDate.Add(7 * 24 * time.Hour)
-	destinationAddress := testdatagen.MakeDefaultAddress(db)
+	destinationAddress := factory.BuildAddress(db, nil, nil)
 	testdatagen.MakeMTOShipment(db, testdatagen.Assertions{
 		Move: move,
 		MTOShipment: models.MTOShipment{

--- a/pkg/testingsuite/pop_suite_test.go
+++ b/pkg/testingsuite/pop_suite_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/gofrs/uuid"
 	"github.com/stretchr/testify/suite"
 
+	"github.com/transcom/mymove/pkg/factory"
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/testdatagen"
 )
@@ -31,7 +32,7 @@ func TestSimplePopSuite(t *testing.T) {
 func (suite *SimplePopSuite) TestRunWithPreloadData() {
 	var address models.Address
 	suite.PreloadData(func() {
-		address = testdatagen.MakeAddress(suite.DB(), testdatagen.Assertions{})
+		address = factory.BuildAddress(suite.DB(), nil, nil)
 	})
 
 	suite.Run("PreloadData test records available in subtest", func() {
@@ -45,7 +46,7 @@ func (suite *SimplePopSuite) TestRunWithPreloadData() {
 	var address2 models.Address
 	suite.Run("Subtest record creation", func() {
 		// Create address to search for in the next test
-		address2 = testdatagen.MakeAddress2(suite.DB(), testdatagen.Assertions{})
+		address2 = factory.BuildAddress(suite.DB(), nil, []factory.Trait{factory.GetTraitAddress2})
 	})
 
 	suite.Run("Subtest record not found", func() {
@@ -66,7 +67,7 @@ func (suite *SimplePopSuite) TestRunWithPreloadData() {
 }
 
 func (suite *SimplePopSuite) TestMultipleDBPanic() {
-	address := testdatagen.MakeAddress(suite.DB(), testdatagen.Assertions{})
+	address := factory.BuildAddress(suite.DB(), nil, nil)
 
 	suite.Run("Trying to use db in main and subtest panics", func() {
 		panicFunc := func() {
@@ -82,7 +83,7 @@ func (suite *SimplePopSuite) TestRun() {
 	var address2 models.Address
 	suite.Run("Subtest record creation", func() {
 		// Create address to search for in the next test
-		address2 = testdatagen.MakeAddress2(suite.DB(), testdatagen.Assertions{})
+		address2 = factory.BuildAddress(suite.DB(), nil, []factory.Trait{factory.GetTraitAddress2})
 	})
 
 	suite.Run("Subtest record not found", func() {


### PR DESCRIPTION
## [Jira ticket](https://dp3.atlassian.net/browse/MB-14785) for this change

## Summary

This ticket replaces uses of `testdatagen.MakeAddress` with the new `factory.BuildAddress` in all parts of the code base where `makeAddress` function calls are found

## Setup to Run Your Code

1. Run `make server_test` and make sure tests pass
2. Run `make e2e_test` and make sure tests pass

## Verification Steps for Author

These are to be checked by the author.

- [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
- [ ] Request review from a member of a different team.
- [ ] Have the Jira acceptance criteria been met for this change?

## Verification Steps for Reviewers

These are to be checked by a reviewer.

### Backend

- [ ] Code follows the guidelines for [Logging](https://transcom.github.io/mymove-docs/docs/dev/contributing/backend/Backend-Programming-Guide#logging)
- [ ] The requirements listed in [Querying the Database Safely](https://transcom.github.io/mymove-docs/docs/dev/contributing/backend/Backend-Programming-Guide/#querying-the-database-safely) have been satisfied.
