### PR TITLE
MB-14738 Create Transportation Office Search Service Object

### DIFF
--- a/migrations/app/migrations_manifest.txt
+++ b/migrations/app/migrations_manifest.txt
@@ -776,3 +776,4 @@
 20221208171026_remove_eval_report_durations.up.sql
 20221214212841_add_provides_ppm_closeout.up.sql
 20221215183130_set_closeout_offices_to_true_for_provides_ppm_closeout_column.up.sql
+20230104003529_transportation_offices_name_index.up.sql

--- a/migrations/app/schema/20230104003529_transportation_offices_name_index.up.sql
+++ b/migrations/app/schema/20230104003529_transportation_offices_name_index.up.sql
@@ -1,0 +1,1 @@
+CREATE INDEX transportation_offices_name_trgm_idx ON transportation_offices USING gin(name gin_trgm_ops);

--- a/pkg/handlers/ghcapi/tranportation_offices.go
+++ b/pkg/handlers/ghcapi/tranportation_offices.go
@@ -20,7 +20,7 @@ func (h GetTransportationOfficesHandler) Handle(params transportationofficeop.Ge
 	return h.AuditableAppContextFromRequestWithErrors(params.HTTPRequest,
 		func(appCtx appcontext.AppContext) (middleware.Responder, error) {
 
-			transportationOffices, err := h.TransportationOfficesFetcher.GetTransportationOffices(appCtx)
+			transportationOffices, err := h.TransportationOfficesFetcher.GetTransportationOffices(appCtx, params.Search)
 			if err != nil {
 				appCtx.Logger().Error("Error searching for Transportation Offices: ", zap.Error(err))
 				return transportationofficeop.NewGetTransportationOfficesInternalServerError(), err

--- a/pkg/handlers/ghcapi/transportation_offices_test.go
+++ b/pkg/handlers/ghcapi/transportation_offices_test.go
@@ -6,16 +6,23 @@ import (
 	"github.com/go-openapi/strfmt"
 
 	transportationofficeop "github.com/transcom/mymove/pkg/gen/ghcapi/ghcoperations/transportation_office"
+	"github.com/transcom/mymove/pkg/models"
 	transportationofficeservice "github.com/transcom/mymove/pkg/services/transportation_office"
+	"github.com/transcom/mymove/pkg/testdatagen"
 )
 
 func (suite *HandlerSuite) TestGetTransportationOfficesHandler() {
+	transportationOffice := testdatagen.MakeTransportationOffice(suite.DB(), testdatagen.Assertions{
+		TransportationOffice: models.TransportationOffice{
+			Name: "LRC Fort Knox",
+		},
+	})
 	fetcher := transportationofficeservice.NewTransportationOfficesFetcher()
 
 	req := httptest.NewRequest("GET", "/transportation_offices", nil)
 	params := transportationofficeop.GetTransportationOfficesParams{
 		HTTPRequest: req,
-		Search:      "test",
+		Search:      "LRC Fort Knox",
 	}
 
 	handler := GetTransportationOfficesHandler{
@@ -26,6 +33,33 @@ func (suite *HandlerSuite) TestGetTransportationOfficesHandler() {
 	suite.Assertions.IsType(&transportationofficeop.GetTransportationOfficesOK{}, response)
 	responsePayload := response.(*transportationofficeop.GetTransportationOfficesOK)
 
-	// Validate outgoing payload
 	suite.NoError(responsePayload.Payload.Validate(strfmt.Default))
+	suite.NoError(responsePayload.Payload.Validate(strfmt.Default))
+	suite.Equal(transportationOffice.Name, *responsePayload.Payload[0].Name)
+	suite.Equal(transportationOffice.Address.ID.String(), responsePayload.Payload[0].Address.ID.String())
+	suite.Equal(transportationOffice.Gbloc, responsePayload.Payload[0].Gbloc)
+
+}
+
+func (suite *HandlerSuite) TestNoTransportationOfficesHandler() {
+
+	fetcher := transportationofficeservice.NewTransportationOfficesFetcher()
+
+	req := httptest.NewRequest("GET", "/transportation_offices", nil)
+	params := transportationofficeop.GetTransportationOfficesParams{
+		HTTPRequest: req,
+		Search:      "LRC Fort Know",
+	}
+
+	handler := GetTransportationOfficesHandler{
+		HandlerConfig:                suite.HandlerConfig(),
+		TransportationOfficesFetcher: fetcher}
+
+	response := handler.Handle(params)
+	suite.Assertions.IsType(&transportationofficeop.GetTransportationOfficesOK{}, response)
+	responsePayload, ok := response.(*transportationofficeop.GetTransportationOfficesOK)
+
+	suite.True(ok)
+	suite.NotNil(responsePayload, "Response should not be nil")
+
 }

--- a/pkg/handlers/ghcapi/transportation_offices_test.go
+++ b/pkg/handlers/ghcapi/transportation_offices_test.go
@@ -49,7 +49,7 @@ func (suite *HandlerSuite) TestNoTransportationOfficesHandler() {
 	req := httptest.NewRequest("GET", "/transportation_offices", nil)
 	params := transportationofficeop.GetTransportationOfficesParams{
 		HTTPRequest: req,
-		Search:      "LRC Fort Know",
+		Search:      "LRC Fort Knox",
 	}
 
 	handler := GetTransportationOfficesHandler{

--- a/pkg/handlers/ghcapi/transportation_offices_test.go
+++ b/pkg/handlers/ghcapi/transportation_offices_test.go
@@ -14,7 +14,8 @@ import (
 func (suite *HandlerSuite) TestGetTransportationOfficesHandler() {
 	transportationOffice := testdatagen.MakeTransportationOffice(suite.DB(), testdatagen.Assertions{
 		TransportationOffice: models.TransportationOffice{
-			Name: "LRC Fort Knox",
+			Name:             "LRC Fort Knox",
+			ProvidesCloseout: true,
 		},
 	})
 	fetcher := transportationofficeservice.NewTransportationOfficesFetcher()

--- a/pkg/handlers/internalapi/transportation_offices.go
+++ b/pkg/handlers/internalapi/transportation_offices.go
@@ -51,7 +51,7 @@ func (h GetTransportationOfficesHandler) Handle(params transportationofficeop.Ge
 				return transportationofficeop.NewGetTransportationOfficesForbidden(), noServiceMemberIDErr
 			}
 
-			transportationOffices, err := h.TransportationOfficesFetcher.GetTransportationOffices(appCtx)
+			transportationOffices, err := h.TransportationOfficesFetcher.GetTransportationOffices(appCtx, params.Search)
 			if err != nil {
 				appCtx.Logger().Error("Error searching for Transportation Offices: ", zap.Error(err))
 				return transportationofficeop.NewGetTransportationOfficesInternalServerError(), err

--- a/pkg/services/mocks/TransportationOfficesFetcher.go
+++ b/pkg/services/mocks/TransportationOfficesFetcher.go
@@ -39,13 +39,13 @@ func (_m *TransportationOfficesFetcher) GetTransportationOffice(appCtx appcontex
 	return r0, r1
 }
 
-// GetTransportationOffices provides a mock function with given fields: appCtx
-func (_m *TransportationOfficesFetcher) GetTransportationOffices(appCtx appcontext.AppContext) (*models.TransportationOffices, error) {
-	ret := _m.Called(appCtx)
+// GetTransportationOffices provides a mock function with given fields: appCtx, search
+func (_m *TransportationOfficesFetcher) GetTransportationOffices(appCtx appcontext.AppContext, search string) (*models.TransportationOffices, error) {
+	ret := _m.Called(appCtx, search)
 
 	var r0 *models.TransportationOffices
-	if rf, ok := ret.Get(0).(func(appcontext.AppContext) *models.TransportationOffices); ok {
-		r0 = rf(appCtx)
+	if rf, ok := ret.Get(0).(func(appcontext.AppContext, string) *models.TransportationOffices); ok {
+		r0 = rf(appCtx, search)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*models.TransportationOffices)
@@ -53,8 +53,8 @@ func (_m *TransportationOfficesFetcher) GetTransportationOffices(appCtx appconte
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(appcontext.AppContext) error); ok {
-		r1 = rf(appCtx)
+	if rf, ok := ret.Get(1).(func(appcontext.AppContext, string) error); ok {
+		r1 = rf(appCtx, search)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/pkg/services/transportation_office.go
+++ b/pkg/services/transportation_office.go
@@ -1,14 +1,11 @@
 package services
 
 import (
-	"github.com/gofrs/uuid"
-
 	"github.com/transcom/mymove/pkg/appcontext"
 	"github.com/transcom/mymove/pkg/models"
 )
 
 //go:generate mockery --name TransportationOfficesFetcher --disable-version-string
 type TransportationOfficesFetcher interface {
-	GetTransportationOffice(appCtx appcontext.AppContext, transportationOfficeID uuid.UUID, includeOnlyPPMCloseoutOffices bool) (*models.TransportationOffice, error)
-	GetTransportationOffices(appCtx appcontext.AppContext) (*models.TransportationOffices, error)
+	GetTransportationOffices(appCtx appcontext.AppContext, search string) (*models.TransportationOffices, error)
 }

--- a/pkg/services/transportation_office.go
+++ b/pkg/services/transportation_office.go
@@ -2,6 +2,7 @@ package services
 
 import (
 	"github.com/gofrs/uuid"
+
 	"github.com/transcom/mymove/pkg/appcontext"
 	"github.com/transcom/mymove/pkg/models"
 )

--- a/pkg/services/transportation_office.go
+++ b/pkg/services/transportation_office.go
@@ -1,6 +1,7 @@
 package services
 
 import (
+	"github.com/gofrs/uuid"
 	"github.com/transcom/mymove/pkg/appcontext"
 	"github.com/transcom/mymove/pkg/models"
 )
@@ -8,4 +9,5 @@ import (
 //go:generate mockery --name TransportationOfficesFetcher --disable-version-string
 type TransportationOfficesFetcher interface {
 	GetTransportationOffices(appCtx appcontext.AppContext, search string) (*models.TransportationOffices, error)
+	GetTransportationOffice(appCtx appcontext.AppContext, transportationOfficeID uuid.UUID, includeOnlyPPMCloseoutOffices bool) (*models.TransportationOffice, error)
 }

--- a/pkg/services/transportation_office/transportation_office_fetcher.go
+++ b/pkg/services/transportation_office/transportation_office_fetcher.go
@@ -65,6 +65,7 @@ func FindTransportationOffice(appCtx appcontext.AppContext, search string) (mode
 	with names as (select office.id as transportation_office_id, office.name, similarity(office.name, $1) as sim
         from transportation_offices as office
         where name % $1 and provides_ppm_closeout is true
+		order by sim desc
         limit 5)
 select office.*
         from names n inner join transportation_offices office on n.transportation_office_id = office.id

--- a/pkg/services/transportation_office/transportation_office_fetcher.go
+++ b/pkg/services/transportation_office/transportation_office_fetcher.go
@@ -2,9 +2,9 @@ package transportationoffice
 
 import (
 	"database/sql"
-	"time"
 
 	"github.com/gofrs/uuid"
+	"github.com/pkg/errors"
 
 	"github.com/transcom/mymove/pkg/appcontext"
 	"github.com/transcom/mymove/pkg/apperror"
@@ -19,70 +19,51 @@ func NewTransportationOfficesFetcher() services.TransportationOfficesFetcher {
 	return &transportationOfficesFetcher{}
 }
 
-func (o transportationOfficesFetcher) GetTransportationOffice(appCtx appcontext.AppContext, transportationOfficeID uuid.UUID, includeOnlyPPMCloseoutOffices bool) (*models.TransportationOffice, error) {
-	var transportationOffice models.TransportationOffice
-	err := appCtx.DB().EagerPreload("Address").
-		Where("provides_ppm_closeout = ?", includeOnlyPPMCloseoutOffices).
-		Find(&transportationOffice, transportationOfficeID)
+func (o transportationOfficesFetcher) GetTransportationOffices(appCtx appcontext.AppContext, search string) (*models.TransportationOffices, error) {
+	officeList, err := FindTransportationOffice(appCtx, search)
 
 	if err != nil {
 		switch err {
 		case sql.ErrNoRows:
-			return nil, apperror.NewNotFoundError(transportationOfficeID, "while looking for TransportationOffice")
+			return &officeList, apperror.NewNotFoundError(uuid.Nil, "Search string: "+search)
 		default:
-			return nil, apperror.NewQueryError("GetTransportationOffice by transportationOfficeID", err, "")
+			return &officeList, err
 		}
 	}
 
-	return &transportationOffice, nil
+	return &officeList, nil
 }
 
-func (o transportationOfficesFetcher) GetTransportationOffices(appCtx appcontext.AppContext) (*models.TransportationOffices, error) {
+func FindTransportationOffice(appCtx appcontext.AppContext, search string) (models.TransportationOffices, error) {
+	var officeList []models.TransportationOffice
 
-	// Mock response values, to be replaced with real values in later ticket
-	mockTransportationOffices := models.TransportationOffices{
-		{
-			ID:   uuid.FromStringOrNil("a2119fd0-bd06-4055-a94a-a266385780dc"),
-			Name: "Transportation Office 1",
-			Address: models.Address{
-				ID:             uuid.FromStringOrNil("a2119fd0-bd06-4055-a94a-a266385780dc"),
-				StreetAddress1: "123 Main St",
-				City:           "Anytown",
-				State:          "CA",
-				PostalCode:     "90210",
-			},
-			PhoneLines: models.OfficePhoneLines{
-				{
-					ID:     uuid.FromStringOrNil("b3119fd0-bd06-4055-a94a-a266385780ab"),
-					Number: "555-555-5555",
-					Type:   "voice",
-				},
-			},
-			Gbloc:     "LKNQ",
-			CreatedAt: time.Now(),
-			UpdatedAt: time.Now(),
-		},
-		{
-			ID:   uuid.FromStringOrNil("21d3faf3-812c-455c-b1d4-339b43081f40"),
-			Name: "Transportation Office 2",
-			Address: models.Address{
-				ID:             uuid.FromStringOrNil("a2119fd0-bd06-4055-a94a-a266385780dc"),
-				StreetAddress1: "123 ABC St",
-				City:           "Anycity",
-				State:          "CO",
-				PostalCode:     "80487",
-			},
-			PhoneLines: models.OfficePhoneLines{
-				{
-					ID:     uuid.FromStringOrNil("b3119fd0-bd06-4055-a94a-a266385780ab"),
-					Number: "555-555-5556",
-					Type:   "voice",
-				},
-			},
-			Gbloc:     "KKFA",
-			CreatedAt: time.Now(),
-			UpdatedAt: time.Now(),
-		},
+	// The % operator filters out strings that are below this similarity threshold
+	err := appCtx.DB().Q().RawQuery("SET pg_trgm.similarity_threshold = 0.03").Exec()
+	if err != nil {
+		return officeList, err
 	}
-	return &mockTransportationOffices, nil
+
+	sqlQuery := `
+	with names as (select office.id as transportation_office_id, office.name, similarity(office.name, $1) as sim
+        from transportation_offices as office
+        where name % $1 and provides_ppm_closeout is true
+        limit 5)
+select office.*
+        from names n inner join transportation_offices office on n.transportation_office_id = office.id
+        group by office.id
+        order by max(n.sim) desc, office.name
+        limit 5`
+	query := appCtx.DB().Q().RawQuery(sqlQuery, search)
+	if err := query.All(&officeList); err != nil {
+		if errors.Cause(err).Error() != models.RecordNotFoundErrorString {
+			return officeList, err
+		}
+	}
+	for i := range officeList {
+		err := appCtx.DB().Load(&officeList[i], "Address")
+		if err != nil {
+			return officeList, err
+		}
+	}
+	return officeList, nil
 }

--- a/pkg/services/transportation_office/transportation_office_fetcher_test.go
+++ b/pkg/services/transportation_office/transportation_office_fetcher_test.go
@@ -1,0 +1,83 @@
+package transportationoffice
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+
+	"github.com/transcom/mymove/pkg/models"
+	"github.com/transcom/mymove/pkg/testdatagen"
+	"github.com/transcom/mymove/pkg/testingsuite"
+)
+
+type TransportationOfficeServiceSuite struct {
+	*testingsuite.PopTestSuite
+}
+
+func TestTransportationOfficeServiceSuite(t *testing.T) {
+
+	ts := &TransportationOfficeServiceSuite{
+		PopTestSuite: testingsuite.NewPopTestSuite(
+			testingsuite.CurrentPackage(),
+			testingsuite.WithPerTestTransaction(),
+		),
+	}
+	suite.Run(t, ts)
+	ts.PopTestSuite.TearDown()
+}
+
+func (suite *TransportationOfficeServiceSuite) Test_SearchTransportationOffice() {
+
+	transportationOffice := testdatagen.MakeTransportationOffice(suite.DB(), testdatagen.Assertions{
+		TransportationOffice: models.TransportationOffice{
+			Name:             "LRC Fort Knox",
+			ProvidesCloseout: true,
+		},
+	})
+	office, err := FindTransportationOffice(suite.AppContextForTest(), "LRC Fort Knox")
+
+	suite.NoError(err)
+	suite.Equal(transportationOffice.Name, office[0].Name)
+	suite.Equal(transportationOffice.Address.ID, office[0].Address.ID)
+	suite.Equal(transportationOffice.Gbloc, office[0].Gbloc)
+
+}
+
+func (suite *TransportationOfficeServiceSuite) Test_SearchWithNoTransportationOffices() {
+
+	office, err := FindTransportationOffice(suite.AppContextForTest(), "LRC Fort Knox")
+	suite.NoError(err)
+	suite.Len(office, 0)
+}
+
+func (suite *TransportationOfficeServiceSuite) Test_SortedTransportationOffices() {
+
+	transportationOffice1 := testdatagen.MakeTransportationOffice(suite.DB(), testdatagen.Assertions{
+		TransportationOffice: models.TransportationOffice{
+			Name:             "JPPSO",
+			ProvidesCloseout: true,
+		},
+	})
+
+	transportationOffice3 := testdatagen.MakeTransportationOffice(suite.DB(), testdatagen.Assertions{
+		TransportationOffice: models.TransportationOffice{
+			Name:             "SO",
+			ProvidesCloseout: true,
+		},
+	})
+
+	transportationOffice2 := testdatagen.MakeTransportationOffice(suite.DB(), testdatagen.Assertions{
+		TransportationOffice: models.TransportationOffice{
+			Name:             "PPSO",
+			ProvidesCloseout: true,
+		},
+	})
+
+	office, err := FindTransportationOffice(suite.AppContextForTest(), "JPPSO")
+
+	suite.NoError(err)
+	suite.Equal(transportationOffice1.Name, office[0].Name)
+	suite.Equal(transportationOffice2.Name, office[1].Name)
+	suite.Equal(transportationOffice3.Name, office[2].Name)
+
+}

--- a/pkg/services/transportation_office/transportation_office_fetcher_test.go
+++ b/pkg/services/transportation_office/transportation_office_fetcher_test.go
@@ -77,7 +77,10 @@ func (suite *TransportationOfficeServiceSuite) Test_SortedTransportationOffices(
 
 	suite.NoError(err)
 	suite.Equal(transportationOffice1.Name, office[0].Name)
+	suite.Equal(transportationOffice1.ProvidesCloseout, true)
 	suite.Equal(transportationOffice2.Name, office[1].Name)
+	suite.Equal(transportationOffice2.ProvidesCloseout, true)
 	suite.Equal(transportationOffice3.Name, office[2].Name)
+	suite.Equal(transportationOffice3.ProvidesCloseout, true)
 
 }


### PR DESCRIPTION
## [Jira ticket](https://dp3.atlassian.net/browse/MB-14738) for this change

## Summary
In order to support transportation office search, a service object was created to accept a query and return matching PPM Closeout transportation office names from the database.

In this PR, 
- A FindTransportationOffice() service object was created to accept a search string from the handlers

- Queried the database for transportation_offices that offer PPM Closeout and ordered the top 5 results by highest similarity to the transportation office name value: 
 `with names as (select office.id as transportation_office_id, office.name, similarity(office.name, $1) as sim
         from transportation_offices as office
         where name % $1
         order by sim desc
         limit 5)
select office.*
         from names n inner join transportation_offices office on n.transportation_office_id = office.id
         group by office.id
         order by max(n.sim) desc, office.name
         limit 5`

- Added a migration for an index to the transportation_offices name column.

## Setup to Run Your Code

<details>
<summary>💻 You will need to use three separate terminals to test this locally.</summary>

##### Terminal 1

Start the Storybook locally.

```sh
make storybook
```

##### Terminal 2

Start the UI locally.

```sh
make client_run
```

##### Terminal 3

Start the Go server locally.

```sh
make server_run
```

</details>

## Verification Steps for Author

These are to be checked by the author.
In /mymove/pkg/services/transportation_office, 
- [ ] Run go test --testify.m Test_SortedTransportationOffices
- [ ] Run go test --testify.m  Test_SearchWithNoTransportationOffices
- [ ] Run go test --testify.m  Test_SearchTransportationOffice

## Verification Steps for Reviewers

These are to be checked by a reviewer.
- [ ] Code Review
- [ ] Verify tests ran by author are passing 

[MB-14738]: https://dp3.atlassian.net/browse/MB-14738?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ