### PR TITLE
MB-14834 Document how to reset test coverage, ensure latest coverage is used

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1012,7 +1012,23 @@ jobs:
       - run: echo 'export PATH=${PATH}:${GOPATH}/bin:~/transcom/mymove/bin' >> $BASH_ENV
       - restore_cache:
           keys:
-            - server-tests-coverage
+          #
+          # https://circleci.com/docs/caching/#restoring-cache
+          #
+          # restore the latest version of the test coverage in the
+          # cache
+          #
+          # To manually reset test coverage (e.g. a refactor or
+          # deleting code means coverage has gone down and we are ok
+          # with it), increment the version number of the cache
+          # e.g. go from v1-server-tests-coverage- to
+          # v2-server-tests-coverage-
+          #
+          # Make sure you also update the key in the save_cache below
+          #
+          # The trailing hyphen in restore_cache seems important
+          # according to the page linked above
+            - v1-server-tests-coverage-
       - run:
           name: Save Baseline Test Coverage
           command: |
@@ -1046,8 +1062,13 @@ jobs:
           condition:
             equal: [main, << pipeline.git.branch >>]
           steps:
+            # Make sure this key prefix matches the one above in
+            # restore_cache
+            #
+            # Use the BuildNum to update the cache key so that the
+            # coverage cache is always updated
             save_cache:
-              key: server-tests-coverage
+              key: v1-server-tests-coverage-{{ .BuildNum }}
               paths:
                 - ~/transcom/mymove/tmp/test-results
       - announce_failure
@@ -1061,8 +1082,24 @@ jobs:
           keys:
             - v3-cache-yarn-v3-{{ checksum "yarn.lock" }}
       - restore_cache:
+          #
+          # https://circleci.com/docs/caching/#restoring-cache
+          #
+          # restore the latest version of the test coverage in the
+          # cache
+          #
+          # To manually reset test coverage (e.g. a refactor or
+          # deleting code means coverage has gone down and we are ok
+          # with it), increment the version number of the cache
+          # e.g. go from v1-client-tests-coverage- to
+          # v2-client-tests-coverage-
+          #
+          # Make sure you also update the key in the save_cache below
+          #
+          # The trailing hyphen in restore_cache seems important
+          # according to the page linked above
           keys:
-            - client-tests-coverage
+            - v1-client-tests-coverage-
       - run:
           name: Save Baseline Test Coverage
           command: |
@@ -1087,8 +1124,12 @@ jobs:
           condition:
             equal: [main, << pipeline.git.branch >>]
           steps:
+            # Make sure this key prefix matches the one above in restore_cache
+            #
+            # Use the BuildNum to update the cache key so that the
+            # coverage cache is always updated
             save_cache:
-              key: client-tests-coverage
+              key: v1-client-tests-coverage-{{ .BuildNum }}
               paths:
                 - ~/transcom/mymove/coverage
       - announce_failure


### PR DESCRIPTION
## [MB-14834](https://dp3.atlassian.net/browse/MB-14834) for this change

## Summary

This actually fixes a bug where the test coverage cache was not being updated. It also documents how to reset test coverage when necessary.

This PR will, in fact, reset coverage because it now versions the test coverage cache.

## Setup to Run Your Code

None, it's all in CircleCI

### Additional steps

Check out the execution in CircleCI


[MB-14834]: https://dp3.atlassian.net/browse/MB-14834?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MB-14834]: https://dp3.atlassian.net/browse/MB-14834?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ