### PR TITLE
[MB-14368] Fix typo to allow client to call endpoint

### DIFF
--- a/src/services/ghcApi.js
+++ b/src/services/ghcApi.js
@@ -26,7 +26,7 @@ export async function getPaymentRequest(key, paymentRequestID) {
 }
 
 export async function getWeightTickets(key, ppmShipmentId) {
-  return makeGHCRequest('ppmgetWeightTickets', { ppmShipmentId }, { normalize: false });
+  return makeGHCRequest('ppm.getWeightTickets', { ppmShipmentId }, { normalize: false });
 }
 
 export async function getMove(key, locator) {


### PR DESCRIPTION
## [Jira ticket](https://dp3.atlassian.net/browse/MB-14368) for this change

## Summary

In one of the last commits in the previous PR for this work, introduced a typo in the code that finds the correct swagger definition for getting weight tickets 

## Setup to Run Your Code

<details>
<summary>💻 You will need to use three separate terminals to test this locally.</summary>

##### Terminal 1

Start the Storybook locally.

```sh
make storybook
```

##### Terminal 2

Start the UI locally.

```sh
make client_run
```

##### Terminal 3

Start the Go server locally.

```sh
make server_run
```

</details>

### Verification Steps for Reviewers
- Clicking into the Review Documents page should not show a console error 

NOTE if you are not using S3 for storage the files will not load and that's expected. If you want to see the files loaded, follow the [S3 instructions](https://dp3.atlassian.net/wiki/spaces/MT/pages/1470955567/How+to+test+storing+data+in+S3+locally)

