### PR TITLE
MB-13860 Adds review component to page, allows editing weight and trailer fields.

### DIFF
--- a/pkg/services/weight_ticket/rules.go
+++ b/pkg/services/weight_ticket/rules.go
@@ -84,6 +84,18 @@ func checkRequiredFields() weightTicketValidator {
 			verrs.Add("TrailerMeetsCriteria", "Trailer Meets Criteria is required")
 		}
 
+		return verrs
+	})
+}
+
+func verifyProofOfTrailerOwnershipDocument() weightTicketValidator {
+	return weightTicketValidatorFunc(func(_ appcontext.AppContext, newWeightTicket *models.WeightTicket, originalWeightTicket *models.WeightTicket) error {
+		verrs := validate.NewErrors()
+
+		if newWeightTicket == nil || originalWeightTicket == nil {
+			return verrs
+		}
+
 		if newWeightTicket.OwnsTrailer != nil && newWeightTicket.TrailerMeetsCriteria != nil {
 			if *newWeightTicket.OwnsTrailer && *newWeightTicket.TrailerMeetsCriteria &&
 				len(originalWeightTicket.ProofOfTrailerOwnershipDocument.UserUploads) < 1 {
@@ -146,6 +158,7 @@ func basicChecksForCustomer() []weightTicketValidator {
 	return []weightTicketValidator{
 		checkID(),
 		checkRequiredFields(),
+		verifyProofOfTrailerOwnershipDocument(),
 		verifyReasonAndStatusAreConstant(),
 	}
 }

--- a/pkg/services/weight_ticket/rules_test.go
+++ b/pkg/services/weight_ticket/rules_test.go
@@ -151,7 +151,7 @@ func (suite *WeightTicketSuite) TestValidationRules() {
 			})
 
 			suite.Run("Update WeightTicket - documents required", func() {
-				err := checkRequiredFields().Validate(suite.AppContextForTest(),
+				err := verifyProofOfTrailerOwnershipDocument().Validate(suite.AppContextForTest(),
 					&models.WeightTicket{
 						ID:                       weightTicketID,
 						VehicleDescription:       models.StringPointer("1994 Mazda MX-5 Miata"),

--- a/pkg/testdatagen/scenario/shared.go
+++ b/pkg/testdatagen/scenario/shared.go
@@ -993,12 +993,12 @@ func createApprovedMoveWithPPMCloseoutComplete(appCtx appcontext.AppContext, use
 
 func createApprovedMoveWithPPMCloseoutCompleteMultipleWeightTickets(appCtx appcontext.AppContext, userUploader *uploader.UserUploader) {
 	moveInfo := moveCreatorInfo{
-		userID:      testdatagen.ConvertUUIDStringToUUID("f8af6fb0-101e-489c-9d9c-051931c52cf7"),
-		email:       "weightTicketPPM+closeout@ppm.approved",
-		smID:        testdatagen.ConvertUUIDStringToUUID("cd4d7838-d8c1-441f-b7ce-af30b6257c3a"),
+		userID:      testdatagen.ConvertUUIDStringToUUID("385bb8f6-ee86-4948-b69d-615417bf71f9"),
+		email:       "weightTicketsPPM+closeout@ppm.approved",
+		smID:        testdatagen.ConvertUUIDStringToUUID("7ad9b8d5-db20-4d00-946b-53531a24a9e1"),
 		firstName:   "PPMCloseout",
 		lastName:    "WeightTickets",
-		moveID:      testdatagen.ConvertUUIDStringToUUID("eb6f09b4-0856-466c-b5e1-854310ccf486"),
+		moveID:      testdatagen.ConvertUUIDStringToUUID("6c121a40-7037-46ba-9e94-1b63c598bcd9"),
 		moveLocator: "CLOSE1",
 	}
 
@@ -1011,11 +1011,11 @@ func createApprovedMoveWithPPMCloseoutCompleteMultipleWeightTickets(appCtx appco
 			Status: models.MoveStatusAPPROVED,
 		},
 		MTOShipment: models.MTOShipment{
-			ID:     testdatagen.ConvertUUIDStringToUUID("c0791087-9798-44e9-99df-59ae3ea9a71e"),
+			ID:     testdatagen.ConvertUUIDStringToUUID("443750dc-def6-40ae-a60a-b6a5a4742c6b"),
 			Status: models.MTOShipmentStatusApproved,
 		},
 		PPMShipment: models.PPMShipment{
-			ID:                          testdatagen.ConvertUUIDStringToUUID("defb263e-bf01-4c67-85f5-b64ab54fd4fe"),
+			ID:                          testdatagen.ConvertUUIDStringToUUID("08ab7a25-ef97-4134-bbb5-5be0e0de4734"),
 			ApprovedAt:                  &approvedAt,
 			SubmittedAt:                 models.TimePointer(approvedAt.Add(7 * time.Hour * 24)),
 			Status:                      models.PPMShipmentStatusNeedsPaymentApproval,

--- a/pkg/testdatagen/scenario/shared.go
+++ b/pkg/testdatagen/scenario/shared.go
@@ -991,6 +991,63 @@ func createApprovedMoveWithPPMCloseoutComplete(appCtx appcontext.AppContext, use
 	testdatagen.MakeWeightTicket(appCtx.DB(), weightTicketAssertions)
 }
 
+func createApprovedMoveWithPPMCloseoutCompleteMultipleWeightTickets(appCtx appcontext.AppContext, userUploader *uploader.UserUploader) {
+	moveInfo := moveCreatorInfo{
+		userID:      testdatagen.ConvertUUIDStringToUUID("f8af6fb0-101e-489c-9d9c-051931c52cf7"),
+		email:       "weightTicketPPM+closeout@ppm.approved",
+		smID:        testdatagen.ConvertUUIDStringToUUID("cd4d7838-d8c1-441f-b7ce-af30b6257c3a"),
+		firstName:   "PPMCloseout",
+		lastName:    "WeightTickets",
+		moveID:      testdatagen.ConvertUUIDStringToUUID("eb6f09b4-0856-466c-b5e1-854310ccf486"),
+		moveLocator: "CLOSE1",
+	}
+
+	approvedAt := time.Date(2022, 4, 15, 12, 30, 0, 0, time.UTC)
+	address := factory.BuildAddress(appCtx.DB(), nil, nil)
+
+	assertions := testdatagen.Assertions{
+		UserUploader: userUploader,
+		Move: models.Move{
+			Status: models.MoveStatusAPPROVED,
+		},
+		MTOShipment: models.MTOShipment{
+			ID:     testdatagen.ConvertUUIDStringToUUID("c0791087-9798-44e9-99df-59ae3ea9a71e"),
+			Status: models.MTOShipmentStatusApproved,
+		},
+		PPMShipment: models.PPMShipment{
+			ID:                          testdatagen.ConvertUUIDStringToUUID("defb263e-bf01-4c67-85f5-b64ab54fd4fe"),
+			ApprovedAt:                  &approvedAt,
+			SubmittedAt:                 models.TimePointer(approvedAt.Add(7 * time.Hour * 24)),
+			Status:                      models.PPMShipmentStatusNeedsPaymentApproval,
+			ActualMoveDate:              models.TimePointer(time.Date(testdatagen.GHCTestYear, time.March, 16, 0, 0, 0, 0, time.UTC)),
+			ActualPickupPostalCode:      models.StringPointer("42444"),
+			ActualDestinationPostalCode: models.StringPointer("30813"),
+			HasReceivedAdvance:          models.BoolPointer(true),
+			AdvanceAmountReceived:       models.CentPointer(unit.Cents(340000)),
+			W2Address:                   &address,
+		},
+	}
+
+	move, shipment := createGenericMoveWithPPMShipment(appCtx, moveInfo, false, assertions)
+
+	weightTicketAssertions := testdatagen.Assertions{
+		PPMShipment:   shipment,
+		ServiceMember: move.Orders.ServiceMember,
+	}
+
+	testdatagen.MakeWeightTicket(appCtx.DB(), weightTicketAssertions)
+
+	weightTicketAssertions = testdatagen.Assertions{
+		PPMShipment:   shipment,
+		ServiceMember: move.Orders.ServiceMember,
+		WeightTicket: models.WeightTicket{
+			MissingEmptyWeightTicket: models.BoolPointer(true),
+			MissingFullWeightTicket:  models.BoolPointer(true),
+		},
+	}
+	testdatagen.MakeWeightTicket(appCtx.DB(), weightTicketAssertions)
+}
+
 func createApprovedMoveWithPPMWithAboutFormComplete(appCtx appcontext.AppContext, userUploader *uploader.UserUploader) {
 	moveInfo := moveCreatorInfo{
 		userID:      testdatagen.ConvertUUIDStringToUUID("88007896-6ae7-4600-866a-873d3bc67fd3"),

--- a/pkg/testdatagen/scenario/subscenarios.go
+++ b/pkg/testdatagen/scenario/subscenarios.go
@@ -118,6 +118,7 @@ func subScenarioPPMCustomerFlow(appCtx appcontext.AppContext, userUploader *uplo
 		createApprovedMoveWithPPMProgearWeightTicket2(appCtx, userUploader)
 		createMoveWithPPMShipmentReadyForFinalCloseout(appCtx, userUploader)
 		createApprovedMoveWithPPMCloseoutComplete(appCtx, userUploader)
+		createApprovedMoveWithPPMCloseoutCompleteMultipleWeightTickets(appCtx, userUploader)
 	}
 }
 

--- a/src/components/DocumentViewer/DocumentViewer.test.jsx
+++ b/src/components/DocumentViewer/DocumentViewer.test.jsx
@@ -41,16 +41,16 @@ const mockFiles = [
 ];
 
 describe('DocumentViewer component', () => {
-  it('initial state is closed menu and first file selected', async () => {
-    render(<DocumentViewer files={mockFiles} />);
-    const docMenu = await screen.findByTestId('DocViewerMenu');
+  // it('initial state is closed menu and first file selected', async () => {
+  //   render(<DocumentViewer files={mockFiles} />);
+  //   const docMenu = await screen.findByTestId('DocViewerMenu');
 
-    expect(docMenu.className).toContain('collapsed');
+  //   expect(docMenu.className).toContain('collapsed');
 
-    // Files are ordered by createdAt date before being rendered.
-    const firstFile = screen.getByRole('button', { name: 'Test File 4.gif Uploaded on 16-Jun-2021' });
-    expect(firstFile.className).toContain('active');
-  });
+  //   // Files are ordered by createdAt date before being rendered.
+  //   const firstFile = screen.getByRole('button', { name: 'Test File 4.gif Uploaded on 16-Jun-2021' });
+  //   expect(firstFile.className).toContain('active');
+  // });
 
   it('renders the file creation date with the correctly sorted props', async () => {
     render(<DocumentViewer files={mockFiles} />);

--- a/src/components/DocumentViewer/DocumentViewer.test.jsx
+++ b/src/components/DocumentViewer/DocumentViewer.test.jsx
@@ -41,16 +41,16 @@ const mockFiles = [
 ];
 
 describe('DocumentViewer component', () => {
-  // it('initial state is closed menu and first file selected', async () => {
-  //   render(<DocumentViewer files={mockFiles} />);
-  //   const docMenu = await screen.findByTestId('DocViewerMenu');
+  it('initial state is closed menu and first file selected', async () => {
+    render(<DocumentViewer files={mockFiles} />);
+    const docMenu = await screen.findByTestId('DocViewerMenu');
 
-  //   expect(docMenu.className).toContain('collapsed');
+    expect(docMenu.className).toContain('collapsed');
 
-  //   // Files are ordered by createdAt date before being rendered.
-  //   const firstFile = screen.getByRole('button', { name: 'Test File 4.gif Uploaded on 16-Jun-2021' });
-  //   expect(firstFile.className).toContain('active');
-  // });
+    // Files are ordered by createdAt date before being rendered.
+    const firstFile = screen.getByRole('button', { name: 'Test File 4.gif Uploaded on 16-Jun-2021' });
+    expect(firstFile.className).toContain('active');
+  });
 
   it('renders the file creation date with the correctly sorted props', async () => {
     render(<DocumentViewer files={mockFiles} />);

--- a/src/components/DocumentViewer/Menu/Menu.jsx
+++ b/src/components/DocumentViewer/Menu/Menu.jsx
@@ -31,7 +31,7 @@ const DocViewerMenu = ({ isOpen, files, handleClose, selectedFileIndex, handleSe
         const fileDate = formatDate(moment(file.createdAt), 'DD-MMM-YYYY');
 
         return (
-          <li key={file.id + i}>
+          <li key={fileName + i}>
             <div title={fileName}>
               <Button unstyled className={itemClasses} type="button" onClick={() => handleSelectFile(i)}>
                 <p>

--- a/src/components/DocumentViewer/Menu/Menu.jsx
+++ b/src/components/DocumentViewer/Menu/Menu.jsx
@@ -31,7 +31,7 @@ const DocViewerMenu = ({ isOpen, files, handleClose, selectedFileIndex, handleSe
         const fileDate = formatDate(moment(file.createdAt), 'DD-MMM-YYYY');
 
         return (
-          <li key={file.id}>
+          <li key={file.id + i}>
             <div title={fileName}>
               <Button unstyled className={itemClasses} type="button" onClick={() => handleSelectFile(i)}>
                 <p>

--- a/src/components/NotificationScrollToTop.jsx
+++ b/src/components/NotificationScrollToTop.jsx
@@ -1,15 +1,26 @@
 import { useEffect, useRef } from 'react';
+import { object } from 'prop-types';
 
-export default function NotificationScrollToTop({ dependency }) {
+export default function NotificationScrollToTop({ dependency, target }) {
   const isMounted = useRef(false);
 
   useEffect(() => {
     if (isMounted.current) {
-      window.scrollTo(0, 0);
+      if (target) {
+        target.scrollTo(0, 0);
+      }
     } else {
       isMounted.current = true;
     }
-  }, [dependency]);
+  }, [dependency, target]);
 
   return null;
 }
+
+NotificationScrollToTop.propTypes = {
+  target: object,
+};
+
+NotificationScrollToTop.defaultProps = {
+  target: window,
+};

--- a/src/components/Office/PPM/ReviewDocumentsSidePanel/ReviewDocumentsSidePanel.jsx
+++ b/src/components/Office/PPM/ReviewDocumentsSidePanel/ReviewDocumentsSidePanel.jsx
@@ -70,9 +70,9 @@ export default function ReviewDocumentsSidePanel({ ppmShipment, ppmNumber, expen
         <h3 className={styles.send}>Send to customer?</h3>
         <DocumentViewerSidebar.Content className={styles.sideBar}>
           {weightTickets.length > 0
-            ? weightTickets.map((weight) => {
+            ? weightTickets.map((weight, index) => {
                 return (
-                  <div className={styles.rowContainer}>
+                  <div className={styles.rowContainer} key={index}>
                     <div className={styles.row}>
                       <h3 className={styles.tripNumber}>Trip {tripNumber}</h3>
                       {statusWithIcon(weight)}
@@ -85,7 +85,7 @@ export default function ReviewDocumentsSidePanel({ ppmShipment, ppmNumber, expen
           {proGearTickets.length > 0
             ? proGearTickets.map((gear, index) => {
                 return (
-                  <div className={styles.rowContainer}>
+                  <div className={styles.rowContainer} key={index}>
                     <div className={styles.row}>
                       <h3 className={styles.tripNumber}>Pro-gear {index + 1}</h3>
                       {statusWithIcon(gear)}
@@ -96,9 +96,9 @@ export default function ReviewDocumentsSidePanel({ ppmShipment, ppmNumber, expen
               })
             : null}
           {expenseTickets.length > 0
-            ? expenseTickets.map((exp) => {
+            ? expenseTickets.map((exp, index) => {
                 return (
-                  <div className={styles.rowContainer}>
+                  <div className={styles.rowContainer} key={index}>
                     <div className={styles.row}>
                       <h3 className={styles.tripNumber}>
                         {exp.movingExpenseType === expenseTypes.STORAGE ? 'Storage' : 'Receipt'}

--- a/src/components/Office/PPM/ReviewDocumentsSidePanel/ReviewDocumentsSidePanel.test.jsx
+++ b/src/components/Office/PPM/ReviewDocumentsSidePanel/ReviewDocumentsSidePanel.test.jsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+
+import ReviewDocumentsSidePanel from './ReviewDocumentsSidePanel';
+
+describe('ReviewDocumentsSidePanel', () => {
+  it('renders the component', async () => {
+    render(<ReviewDocumentsSidePanel />);
+    const h3 = await screen.getByRole('heading', { name: 'Send to customer?', level: 3 });
+    expect(h3).toBeInTheDocument();
+  });
+});

--- a/src/components/Office/PPM/ReviewWeightTicket/ReviewWeightTicket.jsx
+++ b/src/components/Office/PPM/ReviewWeightTicket/ReviewWeightTicket.jsx
@@ -96,7 +96,6 @@ export default function ReviewWeightTicket({
   const hasProofOfTrailerOwnershipDocument = proofOfTrailerOwnershipDocument?.uploads.length > 0;
 
   const initialValues = {
-    weightType: missingEmptyWeightTicket || missingFullWeightTicket ? 'constructedWeight' : 'weightTicket',
     emptyWeight: emptyWeight ? `${emptyWeight}` : '',
     fullWeight: fullWeight ? `${fullWeight}` : '',
     ownsTrailer: ownsTrailer ? 'true' : 'false',
@@ -106,8 +105,6 @@ export default function ReviewWeightTicket({
   };
 
   useEffect(() => {
-    // console.log('reviewWeightTicket rerender', initialValues);
-    // console.log('formRef.current', formRef.current);
     if (formRef?.current) {
       formRef.current.resetForm();
       formRef.current.validateForm();
@@ -126,9 +123,6 @@ export default function ReviewWeightTicket({
       >
         {(formikProps) => {
           const { handleChange, isValid, values } = formikProps;
-          // console.log('formik rerender initialValues', initialValues);
-          // console.log('formik errors', formikProps.errors);
-          // console.log('formik props', formikProps);
           const handleApprovalChange = (event) => {
             handleChange(event);
             onValid(isValid);
@@ -166,7 +160,7 @@ export default function ReviewWeightTicket({
                 label="Full weight"
                 id="fullWeight"
                 mask={Number}
-                prefix={missingFullWeightTicket ? 'Constructed weight' : 'Weight tickets'}
+                description={missingFullWeightTicket ? 'Constructed weight' : 'Weight tickets'}
                 scale={0} // digits after point, 0 for integers
                 signed={false} // disallow negative
                 thousandsSeparator=","

--- a/src/components/Office/PPM/ReviewWeightTicket/ReviewWeightTicket.jsx
+++ b/src/components/Office/PPM/ReviewWeightTicket/ReviewWeightTicket.jsx
@@ -45,6 +45,7 @@ export default function ReviewWeightTicket({
   weightTicket,
   tripNumber,
   ppmNumber,
+  onError,
   onSuccess,
   onValid,
   formRef,
@@ -53,6 +54,7 @@ export default function ReviewWeightTicket({
 
   const [patchWeightTicketMutation] = useMutation(patchWeightTicket, {
     onSuccess,
+    onError,
   });
 
   const ppmShipment = mtoShipment?.ppmShipment;
@@ -136,12 +138,10 @@ export default function ReviewWeightTicket({
           };
 
           const handleTrailerOwnedChange = (event) => {
-            if (event.target.value === 'true') {
-              setFieldValue('trailerMeetsCriteria', '');
-              setFieldTouched('trailerMeetsCriteria', false, false);
-              setFieldError('trailerMeetsCriteria', null);
-            }
             handleChange(event);
+            setFieldValue('trailerMeetsCriteria', '');
+            setFieldTouched('trailerMeetsCriteria', false, false);
+            setFieldError('trailerMeetsCriteria', null);
           };
 
           const handleTrailerClaimableChange = (event) => {
@@ -215,7 +215,7 @@ export default function ReviewWeightTicket({
                 <FormGroup>
                   <Fieldset>
                     <legend className="usa-label">{`Is the trailer's weight claimable?`}</legend>
-                    <ErrorMessage display={!!errors.trailerMeetsCriteria && touched.trailerMeetsCriteria}>
+                    <ErrorMessage display={(!!errors.trailerMeetsCriteria && touched.trailerMeetsCriteria) || false}>
                       {errors.trailerMeetsCriteria}
                     </ErrorMessage>
                     <Field
@@ -286,18 +286,18 @@ export default function ReviewWeightTicket({
 
                       {canEditRejection && (
                         <>
-                          <ErrorMessage display={!!errors.rejectionReason && touched.rejectionReason}>
+                          <ErrorMessage display={!!errors?.rejectionReason && !!touched?.rejectionReason}>
                             {errors.rejectionReason}
                           </ErrorMessage>
                           <Textarea
                             id={`rejectReason-${weightTicket?.id}`}
                             name="rejectionReason"
                             onChange={handleChange}
-                            error={errors.rejectionReason}
+                            error={touched.rejectionReason ? errors.rejectionReason : null}
                             value={values.rejectionReason}
                             placeholder="Type something"
                           />
-                          <div className={styles.hint}>500 characters</div>
+                          <div className={styles.hint}>{500 - values.rejectionReason.length} characters</div>
                         </>
                       )}
                     </FormGroup>

--- a/src/components/Office/PPM/ReviewWeightTicket/ReviewWeightTicket.jsx
+++ b/src/components/Office/PPM/ReviewWeightTicket/ReviewWeightTicket.jsx
@@ -45,7 +45,6 @@ export default function ReviewWeightTicket({
   weightTicket,
   tripNumber,
   ppmNumber,
-  onError,
   onSuccess,
   onValid,
   formRef,
@@ -54,7 +53,6 @@ export default function ReviewWeightTicket({
 
   const [patchWeightTicketMutation] = useMutation(patchWeightTicket, {
     onSuccess,
-    onError,
   });
 
   const ppmShipment = mtoShipment?.ppmShipment;

--- a/src/components/Office/PPM/ReviewWeightTicket/ReviewWeightTicket.jsx
+++ b/src/components/Office/PPM/ReviewWeightTicket/ReviewWeightTicket.jsx
@@ -3,13 +3,14 @@ import { useMutation } from 'react-query';
 import { func, number, object } from 'prop-types';
 import { Field, Formik } from 'formik';
 import classnames from 'classnames';
-import { Alert, Form, FormGroup, Label, Radio, Textarea } from '@trussworks/react-uswds';
+import { Alert, FormGroup, Label, Radio, Textarea } from '@trussworks/react-uswds';
 import * as Yup from 'yup';
 
 import PPMHeaderSummary from '../PPMHeaderSummary/PPMHeaderSummary';
 
 import styles from './ReviewWeightTicket.module.scss';
 
+import { Form } from 'components/form';
 import { patchWeightTicket } from 'services/ghcApi';
 import { ShipmentShape, WeightTicketShape } from 'types/shipment';
 import Fieldset from 'shared/Fieldset';
@@ -42,6 +43,7 @@ export default function ReviewWeightTicket({
   ppmNumber,
   onError,
   onSuccess,
+  onValid,
   formRef,
   setSubmitting,
 }) {
@@ -121,18 +123,22 @@ export default function ReviewWeightTicket({
         validateOnMount
       >
         {(formikProps) => {
-          const { handleChange, values } = formikProps;
+          const { handleChange, isValid, values } = formikProps;
           // console.log('formik rerender initialValues', initialValues);
           // console.log('formik errors', formikProps.errors);
           // console.log('formik props', formikProps);
           const handleApprovalChange = (event) => {
             handleChange(event);
+            onValid(isValid);
             setCanEditRejection(true);
           };
 
           const weightType = values.weightType === 'weightTicket' ? 'Weight tickets' : 'Constructed weight';
           return (
-            <Form className={classnames(formStyles.form, styles.ReviewWeightTicket)}>
+            <Form
+              className={classnames(formStyles.form, styles.ReviewWeightTicket)}
+              errorCallback={(errors) => onValid(errors)}
+            >
               <PPMHeaderSummary ppmShipment={ppmShipment} ppmNumber={ppmNumber} />
               <hr />
               <h3 className={styles.tripNumber}>Trip {tripNumber}</h3>
@@ -284,6 +290,7 @@ ReviewWeightTicket.propTypes = {
   tripNumber: number.isRequired,
   ppmNumber: number.isRequired,
   onSuccess: func,
+  onValid: func,
   formRef: object,
 };
 
@@ -291,5 +298,6 @@ ReviewWeightTicket.defaultProps = {
   weightTicket: null,
   mtoShipment: null,
   onSuccess: null,
+  onValid: null,
   formRef: null,
 };

--- a/src/components/Office/PPM/ReviewWeightTicket/ReviewWeightTicket.jsx
+++ b/src/components/Office/PPM/ReviewWeightTicket/ReviewWeightTicket.jsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { useMutation } from 'react-query';
 import { func, number, object } from 'prop-types';
 import { Field, Formik } from 'formik';
 import classnames from 'classnames';
@@ -41,11 +42,15 @@ export default function ReviewWeightTicket({
   ppmNumber,
   onError,
   onSuccess,
-  onValid,
   formRef,
   setSubmitting,
 }) {
   const [canEditRejection, setCanEditRejection] = useState(true);
+
+  const [patchWeightTicketMutation] = useMutation(patchWeightTicket, {
+    onSuccess,
+    onError,
+  });
 
   const ppmShipment = mtoShipment?.ppmShipment;
 
@@ -62,15 +67,13 @@ export default function ReviewWeightTicket({
       ownsTrailer,
       trailerMeetsCriteria,
     };
-
     setSubmitting(true);
-    patchWeightTicket(weightTicket.ppmShipmentId, weightTicket.id, payload, weightTicket.eTag)
-      .then(() => {
-        onSuccess();
-      })
-      .catch(() => {
-        onError();
-      });
+    await patchWeightTicketMutation({
+      ppmShipmentId: weightTicket.ppmShipmentId,
+      weightTicketId: weightTicket.id,
+      payload,
+      eTag: weightTicket.eTag,
+    });
   };
 
   const {
@@ -86,7 +89,7 @@ export default function ReviewWeightTicket({
     reason,
   } = weightTicket || {};
 
-  const hasProofOfTrailerOwnershipDocument = proofOfTrailerOwnershipDocument.uploads.length > 0;
+  const hasProofOfTrailerOwnershipDocument = proofOfTrailerOwnershipDocument?.uploads.length > 0;
 
   const initialValues = {
     weightType: missingEmptyWeightTicket || missingFullWeightTicket ? 'constructedWeight' : 'weightTicket',
@@ -105,13 +108,11 @@ export default function ReviewWeightTicket({
         innerRef={formRef}
         onSubmit={handleSubmit}
       >
-        {({ handleChange, isValid, values }) => {
+        {({ handleChange, values }) => {
           const handleApprovalChange = (event) => {
             handleChange(event);
             setCanEditRejection(true);
           };
-
-          onValid(isValid);
 
           return (
             <Form className={classnames(formStyles.form, styles.ReviewWeightTicket)}>
@@ -285,7 +286,6 @@ ReviewWeightTicket.propTypes = {
   tripNumber: number.isRequired,
   ppmNumber: number.isRequired,
   onSuccess: func,
-  onValid: func,
   formRef: object,
 };
 
@@ -293,6 +293,5 @@ ReviewWeightTicket.defaultProps = {
   weightTicket: null,
   mtoShipment: null,
   onSuccess: null,
-  onValid: null,
   formRef: null,
 };

--- a/src/components/Office/PPM/ReviewWeightTicket/ReviewWeightTicket.jsx
+++ b/src/components/Office/PPM/ReviewWeightTicket/ReviewWeightTicket.jsx
@@ -108,8 +108,10 @@ export default function ReviewWeightTicket({
   useEffect(() => {
     // console.log('reviewWeightTicket rerender', initialValues);
     // console.log('formRef.current', formRef.current);
-    formRef.current.resetForm();
-    formRef.current.validateForm();
+    if (formRef?.current) {
+      formRef.current.resetForm();
+      formRef.current.validateForm();
+    }
   }, [formRef, weightTicket]);
 
   return (
@@ -133,7 +135,6 @@ export default function ReviewWeightTicket({
             setCanEditRejection(true);
           };
 
-          const weightType = values.weightType === 'weightTicket' ? 'Weight tickets' : 'Constructed weight';
           return (
             <Form
               className={classnames(formStyles.form, styles.ReviewWeightTicket)}
@@ -144,26 +145,28 @@ export default function ReviewWeightTicket({
               <h3 className={styles.tripNumber}>Trip {tripNumber}</h3>
               <legend className={classnames('usa-label', styles.label)}>Vehicle description</legend>
               <div className={styles.displayValue}>{vehicleDescription}</div>
-              <legend className={classnames('usa-label', styles.label)}>Weight type</legend>
-              <div className={styles.displayValue}>{weightType}</div>
+
               <MaskedTextField
                 defaultValue="0"
                 name="emptyWeight"
-                label={values.weightType === 'weightTicket' ? 'Empty weight' : 'Empty constructed weight'}
+                label="Empty weight"
                 id="emptyWeight"
                 mask={Number}
+                description={missingEmptyWeightTicket ? 'Constructed weight' : 'Weight tickets'}
                 scale={0} // digits after point, 0 for integers
                 signed={false} // disallow negative
                 thousandsSeparator=","
                 lazy={false} // immediate masking evaluation
                 suffix="lbs"
               />
+
               <MaskedTextField
                 defaultValue="0"
                 name="fullWeight"
-                label={values.weightType === 'weightTicket' ? 'Full weight' : 'Full constructed weight'}
+                label="Full weight"
                 id="fullWeight"
                 mask={Number}
+                prefix={missingFullWeightTicket ? 'Constructed weight' : 'Weight tickets'}
                 scale={0} // digits after point, 0 for integers
                 signed={false} // disallow negative
                 thousandsSeparator=","
@@ -298,6 +301,6 @@ ReviewWeightTicket.defaultProps = {
   weightTicket: null,
   mtoShipment: null,
   onSuccess: null,
-  onValid: null,
+  onValid: () => {},
   formRef: null,
 };

--- a/src/components/Office/PPM/ReviewWeightTicket/ReviewWeightTicket.jsx
+++ b/src/components/Office/PPM/ReviewWeightTicket/ReviewWeightTicket.jsx
@@ -47,7 +47,6 @@ export default function ReviewWeightTicket({
   ppmNumber,
   onError,
   onSuccess,
-  onValid,
   formRef,
 }) {
   const [canEditRejection, setCanEditRejection] = useState(true);
@@ -130,10 +129,9 @@ export default function ReviewWeightTicket({
         enableReinitialize
         validateOnMount
       >
-        {({ handleChange, errors, isValid, setFieldError, setFieldTouched, setFieldValue, touched, values }) => {
+        {({ handleChange, errors, setFieldError, setFieldTouched, setFieldValue, touched, values }) => {
           const handleApprovalChange = (event) => {
             handleChange(event);
-            onValid(isValid);
             setCanEditRejection(true);
           };
 
@@ -215,7 +213,7 @@ export default function ReviewWeightTicket({
                 <FormGroup>
                   <Fieldset>
                     <legend className="usa-label">{`Is the trailer's weight claimable?`}</legend>
-                    <ErrorMessage display={(!!errors.trailerMeetsCriteria && touched.trailerMeetsCriteria) || false}>
+                    <ErrorMessage display={!!errors?.trailerMeetsCriteria && !!touched?.trailerMeetsCriteria}>
                       {errors.trailerMeetsCriteria}
                     </ErrorMessage>
                     <Field
@@ -244,7 +242,7 @@ export default function ReviewWeightTicket({
               )}
               <h3 className={styles.reviewHeader}>Review trip {tripNumber}</h3>
               <p>Add a review for this weight ticket</p>
-              <ErrorMessage display={!!errors.status && touched.status}>{errors.status}</ErrorMessage>
+              <ErrorMessage display={!!errors?.status && !!touched?.status}>{errors.status}</ErrorMessage>
               <Fieldset>
                 <div
                   className={classnames(approveRejectStyles.statusOption, {
@@ -318,7 +316,6 @@ ReviewWeightTicket.propTypes = {
   tripNumber: number.isRequired,
   ppmNumber: number.isRequired,
   onSuccess: func,
-  onValid: func,
   formRef: object,
 };
 
@@ -326,6 +323,5 @@ ReviewWeightTicket.defaultProps = {
   weightTicket: null,
   mtoShipment: null,
   onSuccess: null,
-  onValid: () => {},
   formRef: null,
 };

--- a/src/components/Office/PPM/ReviewWeightTicket/ReviewWeightTicket.module.scss
+++ b/src/components/Office/PPM/ReviewWeightTicket/ReviewWeightTicket.module.scss
@@ -3,57 +3,60 @@
 @import 'shared/styles/variables';
 
 .ReviewWeightTicket {
-    @include u-padding(2);
+  @include u-padding(2);
+  background-color: $bg-white;
+  position: relative;
 
-        hr {
-            @include u-margin-top(2);
-            @include u-margin-bottom(2);
-            position: absolute;
-            left: 0;
-            right: 0;
-        }
+  hr {
+    @include u-margin-top(2);
+    @include u-margin-bottom(2);
+    position: absolute;
+    left: 0;
+    right: 0;
+  }
 
-    h3, h2 {
-        @include u-margin-top(1);
-        @include u-margin-bottom(1);
+  h3,
+  h2 {
+    @include u-margin-top(1);
+    @include u-margin-bottom(1);
+  }
+
+  .tripNumber {
+    @include u-margin-top(4);
+  }
+
+  .label {
+    @include u-margin-bottom(1);
+  }
+
+  .displayValue {
+    @include u-margin-bottom(2);
+  }
+
+  :global(.usa-legend) {
+    @include u-margin-bottom(1);
+    @include u-margin-top(1);
+  }
+
+  .reason {
+    &:global(.usa-form-group) {
+      @include u-margin-top(0);
     }
+  }
 
-    .tripNumber {
-        @include u-margin-top(4);
-    }
+  .hint {
+    color: $base;
+    font-size: 13px;
+    line-height: 18px;
+    @include u-margin-top(1);
+    @include u-margin-bottom(0);
+  }
 
-    .label {
-        @include u-margin-bottom(1);
-    }
+  .reviewHeader {
+    @include u-margin-top(3);
+  }
 
-    .displayValue {
-        @include u-margin-bottom(2);
-    }
-
-    :global(.usa-legend) {
-        @include u-margin-bottom(1);
-        @include u-margin-top(1);
-    }
-
-    .reason{
-        &:global(.usa-form-group) {
-            @include u-margin-top(0);
-        }
-    }
-
-    .hint {
-        color: $base;
-        font-size: 13px;
-        line-height: 18px;
-        @include u-margin-top(1);
-        @include u-margin-bottom(0);
-    }
-
-    .reviewHeader {
-        @include u-margin-top(3);
-    }
-
-    div.reject {
-        @include u-margin-top(2);
-    }
+  div.reject {
+    @include u-margin-top(2);
+  }
 }

--- a/src/components/Office/PPM/ReviewWeightTicket/ReviewWeightTicket.test.jsx
+++ b/src/components/Office/PPM/ReviewWeightTicket/ReviewWeightTicket.test.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, waitFor, screen } from '@testing-library/react';
+import { render, waitFor, screen, fireEvent } from '@testing-library/react';
 
 import ReviewWeightTicket from './ReviewWeightTicket';
 
@@ -100,7 +100,19 @@ describe('ReviewWeightTicket component', () => {
         expect(screen.queryByText("Is the trailer's weight claimable?")).toBeInTheDocument();
       });
       expect(screen.queryByText('Proof of ownership is needed to accept this item.')).toBeInTheDocument();
+      expect(screen.getByLabelText('Accept')).not.toBeChecked();
       expect(screen.getByLabelText('Accept')).toHaveAttribute('disabled');
+    });
+
+    it('reenables approval after disabling it and updating weight claimable field', async () => {
+      render(<ReviewWeightTicket {...defaultProps} {...claimableTrailerProps} />);
+      await waitFor(() => {
+        expect(screen.queryByText("Is the trailer's weight claimable?")).toBeInTheDocument();
+      });
+      const claimableYesButton = screen.getAllByRole('radio', { name: 'No' })[1];
+      await fireEvent.click(claimableYesButton);
+      expect(screen.queryByText('Proof of ownership is needed to accept this item.')).not.toBeInTheDocument();
+      expect(screen.getByLabelText('Accept')).not.toHaveAttribute('disabled');
     });
   });
 });

--- a/src/components/Office/PPM/ReviewWeightTicket/ReviewWeightTicket.test.jsx
+++ b/src/components/Office/PPM/ReviewWeightTicket/ReviewWeightTicket.test.jsx
@@ -33,6 +33,7 @@ const missingWeightTicketProps = {
     ...baseWeightTicketProps,
     ownsTrailer: false,
     missingEmptyWeightTicket: true,
+    missingFullWeightTicket: true,
   },
 };
 
@@ -61,10 +62,6 @@ describe('ReviewWeightTicket component', () => {
       });
 
       expect(screen.getByText('Vehicle description')).toBeInTheDocument();
-      expect(screen.getByText('Weight type')).toBeInTheDocument();
-      expect(screen.getByLabelText('Weight tickets')).toBeInstanceOf(HTMLInputElement);
-      expect(screen.getByLabelText('Constructed weight')).toBeInstanceOf(HTMLInputElement);
-      expect(screen.getByLabelText('Empty weight')).toBeInstanceOf(HTMLInputElement);
       expect(screen.getByLabelText('Full weight')).toBeInstanceOf(HTMLInputElement);
       expect(screen.getByText('Net weight')).toBeInTheDocument();
       expect(screen.getByText('Did they use a trailer they owned?')).toBeInTheDocument();
@@ -83,8 +80,8 @@ describe('ReviewWeightTicket component', () => {
       await waitFor(() => {
         expect(screen.getByText('Kia Forte')).toBeInTheDocument();
       });
-      expect(screen.getByLabelText('Empty weight')).toHaveDisplayValue('400');
-      expect(screen.getByLabelText('Full weight')).toHaveDisplayValue('1,200');
+      expect(screen.getByLabelText('Empty weight', { description: 'Weight tickets' })).toHaveDisplayValue('400');
+      expect(screen.getByLabelText('Full weight', { description: 'Weight tickets' })).toHaveDisplayValue('1,200');
       expect(screen.getByText('800 lbs')).toBeInTheDocument();
       expect(screen.getByLabelText('No')).toBeChecked();
     });
@@ -92,10 +89,9 @@ describe('ReviewWeightTicket component', () => {
     it('populates edit form when weight ticket is missing', async () => {
       render(<ReviewWeightTicket {...defaultProps} {...missingWeightTicketProps} />);
       await waitFor(() => {
-        expect(screen.getByLabelText('Constructed weight')).toBeChecked();
+        expect(screen.getByLabelText('Empty weight', { description: 'Constructed weight' })).toBeInTheDocument();
       });
-      expect(screen.getByText('Empty constructed weight')).toBeInTheDocument();
-      expect(screen.getByText('Full constructed weight')).toBeInTheDocument();
+      expect(screen.getByLabelText('Full weight', { description: 'Constructed weight' })).toBeInTheDocument();
     });
 
     it('notifies the user when a trailer is claimable, and disables approval', async () => {

--- a/src/components/Office/PPM/ReviewWeightTicket/ReviewWeightTicket.test.jsx
+++ b/src/components/Office/PPM/ReviewWeightTicket/ReviewWeightTicket.test.jsx
@@ -65,7 +65,7 @@ describe('ReviewWeightTicket component', () => {
       expect(screen.queryByText("Is the trailer's weight claimable?")).not.toBeInTheDocument();
 
       expect(screen.getByRole('heading', { level: 3, name: 'Review trip 1' })).toBeInTheDocument();
-      expect(screen.getByLabelText('Approve')).toBeInstanceOf(HTMLInputElement);
+      expect(screen.getByLabelText('Accept')).toBeInstanceOf(HTMLInputElement);
       expect(screen.getByLabelText('Reject')).toBeInstanceOf(HTMLInputElement);
     });
 

--- a/src/components/Office/PPM/ReviewWeightTicket/ReviewWeightTicket.test.jsx
+++ b/src/components/Office/PPM/ReviewWeightTicket/ReviewWeightTicket.test.jsx
@@ -20,13 +20,17 @@ const defaultProps = {
   ppmNumber: 1,
 };
 
+const baseWeightTicketProps = {
+  id: '32ecb311-edbe-4fd4-96ee-bd693113f3f3',
+  ppmShipmentId: '343bb456-63af-4f76-89bd-7403094a5c4d',
+  vehicleDescription: 'Kia Forte',
+  emptyWeight: 400,
+  fullWeight: 1200,
+};
+
 const missingWeightTicketProps = {
   weightTicket: {
-    id: '32ecb311-edbe-4fd4-96ee-bd693113f3f3',
-    ppmShipmentId: '343bb456-63af-4f76-89bd-7403094a5c4d',
-    vehicleDescription: 'Kia Forte',
-    emptyWeight: 400,
-    fullWeight: 1200,
+    ...baseWeightTicketProps,
     ownsTrailer: false,
     missingEmptyWeightTicket: true,
   },
@@ -34,12 +38,16 @@ const missingWeightTicketProps = {
 
 const weightTicketRequiredProps = {
   weightTicket: {
-    id: '32ecb311-edbe-4fd4-96ee-bd693113f3f3',
-    ppmShipmentId: '343bb456-63af-4f76-89bd-7403094a5c4d',
-    vehicleDescription: 'Kia Forte',
-    emptyWeight: 400,
-    fullWeight: 1200,
+    ...baseWeightTicketProps,
     ownsTrailer: false,
+  },
+};
+
+const claimableTrailerProps = {
+  weightTicket: {
+    ...baseWeightTicketProps,
+    ownsTrailer: true,
+    trailerMeetsCriteria: true,
   },
 };
 
@@ -88,6 +96,15 @@ describe('ReviewWeightTicket component', () => {
       });
       expect(screen.getByText('Empty constructed weight')).toBeInTheDocument();
       expect(screen.getByText('Full constructed weight')).toBeInTheDocument();
+    });
+
+    it('notifies the user when a trailer is claimable, and disables approval', async () => {
+      render(<ReviewWeightTicket {...defaultProps} {...claimableTrailerProps} />);
+      await waitFor(() => {
+        expect(screen.queryByText("Is the trailer's weight claimable?")).toBeInTheDocument();
+      });
+      expect(screen.queryByText('Proof of ownership is needed to accept this item.')).toBeInTheDocument();
+      expect(screen.getByLabelText('Accept')).toHaveAttribute('disabled');
     });
   });
 });

--- a/src/components/form/fields/MaskedTextField/MaskedTextField.jsx
+++ b/src/components/form/fields/MaskedTextField/MaskedTextField.jsx
@@ -1,6 +1,7 @@
-import React from 'react';
+import React, { useRef } from 'react';
 import classnames from 'classnames';
 import PropTypes from 'prop-types';
+import { v4 as uuidv4 } from 'uuid';
 import { useField } from 'formik';
 import { IMaskInput } from 'react-imask';
 import { FormGroup, Label } from '@trussworks/react-uswds';
@@ -31,6 +32,7 @@ const MaskedTextField = ({
   children,
   type,
   inputTestId,
+  description,
   optional,
   errorMessage,
   error,
@@ -43,12 +45,23 @@ const MaskedTextField = ({
   const showError = (metaProps.touched && !!metaProps.error) || error;
   const showWarning = !showError && warning;
   const { value } = field;
+  const descriptionRef = useRef(uuidv4());
   return (
     <FormGroup className={classnames(!!warning && !showError && `warning`, formGroupClassName)} error={showError}>
-      <div className="labelWrapper">
+      <div
+        className={classnames({
+          labelWrapper: true,
+          [styles.hasDescription]: description,
+        })}
+      >
         <Label className={labelClassName} hint={labelHint} error={showError} htmlFor={id || name}>
           {label}
         </Label>
+        {description && (
+          <div className={styles.description} id={`description_${descriptionRef.current}`}>
+            {description}
+          </div>
+        )}
         {optional && <OptionalTag />}
       </div>
       {showError && (
@@ -86,6 +99,7 @@ const MaskedTextField = ({
             }}
             onBlur={field.onBlur}
             disabled={isDisabled}
+            aria-describedby={description && `description_${descriptionRef.current}`}
             {...props}
           />
           {suffix && <div className="suffix">{suffix}</div>}
@@ -139,6 +153,7 @@ MaskedTextField.propTypes = {
   validate: PropTypes.func,
   warning: PropTypes.string,
   inputTestId: PropTypes.string,
+  description: PropTypes.string,
   optional: PropTypes.bool,
   error: PropTypes.bool,
   errorMessage: PropTypes.string,
@@ -165,6 +180,7 @@ MaskedTextField.defaultProps = {
   validate: undefined,
   warning: '',
   inputTestId: '',
+  description: '',
   optional: false,
   error: false,
   errorMessage: '',

--- a/src/components/form/fields/MaskedTextField/MaskedTextField.module.scss
+++ b/src/components/form/fields/MaskedTextField/MaskedTextField.module.scss
@@ -1,34 +1,45 @@
 @import 'shared/styles/colors';
 
 .hasSuffix {
-    display: inline-block;
-    position: relative;
-    margin-top: 0.53rem;
+  display: inline-block;
+  position: relative;
+  margin-top: 0.53rem;
 
-    div {
-        position: absolute;
-        right: 10px;
-        bottom: 11px;
-        font-size: .8rem;
-        color: $base;
-    }
+  div {
+    position: absolute;
+    right: 10px;
+    bottom: 11px;
+    font-size: 0.8rem;
+    color: $base;
+  }
 }
 
 .hasPrefix {
-    display: inline-block;
-    position: relative;
+  display: inline-block;
+  position: relative;
 
-    div {
-        position: absolute;
-        left: 10px;
-        bottom: 9px;
-        color: $base-darkest;
-    }
-    input {
-        padding-left: 25px;
-    }
+  div {
+    position: absolute;
+    left: 10px;
+    bottom: 9px;
+    color: $base-darkest;
+  }
+  input {
+    padding-left: 25px;
+  }
 }
 
 input:disabled {
   background-color: $border-color;
+}
+
+.description {
+  font-size: 13px;
+  color: $base;
+  font-weight: normal;
+  margin-top: 0.53rem;
+}
+
+:global(.labelWrapper).hasDescription {
+  display: block;
 }

--- a/src/components/form/fields/MaskedTextField/MaskedTextField.module.scss
+++ b/src/components/form/fields/MaskedTextField/MaskedTextField.module.scss
@@ -40,6 +40,6 @@ input:disabled {
   margin-top: 0.53rem;
 }
 
-:global(.labelWrapper).hasDescription {
+:global(.usa-form-group) :global(.labelWrapper).hasDescription {
   display: block;
 }

--- a/src/pages/Office/DocumentViewerSidebar/DocumentViewerSidebar.jsx
+++ b/src/pages/Office/DocumentViewerSidebar/DocumentViewerSidebar.jsx
@@ -5,11 +5,12 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
 import styles from './DocumentViewerSidebar.module.scss';
 
-export default function DocumentViewerSidebar({ children, description, title, subtitle, onClose }) {
+export default function DocumentViewerSidebar({ children, description, title, subtitle, supertitle, onClose }) {
   return (
     <div className={styles.container}>
       <header className={styles.header}>
         <div>
+          {supertitle && <h2 className={styles.supertitle}>{supertitle}</h2>}
           <h1>{title}</h1>
           {subtitle && <h2>{subtitle}</h2>}
           {description && <h3>{description}</h3>}
@@ -27,12 +28,14 @@ DocumentViewerSidebar.propTypes = {
   children: node.isRequired,
   title: string.isRequired,
   subtitle: string,
+  supertitle: string,
   description: string,
   onClose: func.isRequired,
 };
 
 DocumentViewerSidebar.defaultProps = {
   subtitle: '',
+  supertitle: '',
   description: '',
 };
 

--- a/src/pages/Office/DocumentViewerSidebar/DocumentViewerSidebar.jsx
+++ b/src/pages/Office/DocumentViewerSidebar/DocumentViewerSidebar.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { bool, func, node, string } from 'prop-types';
+import { bool, func, object, node, string } from 'prop-types';
 import { Button } from '@trussworks/react-uswds';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import classnames from 'classnames';
@@ -55,12 +55,17 @@ DocumentViewerSidebar.defaultProps = {
   defaultH3: false,
 };
 
-DocumentViewerSidebar.Content = function Content({ children }) {
-  return <main>{children}</main>;
+DocumentViewerSidebar.Content = function Content({ children, mainRef }) {
+  return <main ref={mainRef}>{children}</main>;
 };
 
 DocumentViewerSidebar.Content.propTypes = {
   children: node.isRequired,
+  mainRef: object,
+};
+
+DocumentViewerSidebar.Content.defaultProps = {
+  mainRef: null,
 };
 
 DocumentViewerSidebar.Footer = function Footer({ children }) {

--- a/src/pages/Office/DocumentViewerSidebar/DocumentViewerSidebar.jsx
+++ b/src/pages/Office/DocumentViewerSidebar/DocumentViewerSidebar.jsx
@@ -1,13 +1,27 @@
 import React from 'react';
-import { func, node, string } from 'prop-types';
+import { bool, func, node, string } from 'prop-types';
 import { Button } from '@trussworks/react-uswds';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import classnames from 'classnames';
 
 import styles from './DocumentViewerSidebar.module.scss';
 
-export default function DocumentViewerSidebar({ children, description, title, subtitle, supertitle, onClose }) {
+export default function DocumentViewerSidebar({
+  children,
+  description,
+  title,
+  subtitle,
+  supertitle,
+  onClose,
+  defaultH3,
+}) {
   return (
-    <div className={styles.container}>
+    <div
+      className={classnames({
+        [styles.container]: true,
+        [styles.defaultH3]: defaultH3,
+      })}
+    >
       <header className={styles.header}>
         <div>
           {supertitle && <h2 className={styles.supertitle}>{supertitle}</h2>}
@@ -31,12 +45,14 @@ DocumentViewerSidebar.propTypes = {
   supertitle: string,
   description: string,
   onClose: func.isRequired,
+  defaultH3: bool,
 };
 
 DocumentViewerSidebar.defaultProps = {
   subtitle: '',
   supertitle: '',
   description: '',
+  defaultH3: false,
 };
 
 DocumentViewerSidebar.Content = function Content({ children }) {

--- a/src/pages/Office/DocumentViewerSidebar/DocumentViewerSidebar.module.scss
+++ b/src/pages/Office/DocumentViewerSidebar/DocumentViewerSidebar.module.scss
@@ -37,6 +37,14 @@
     @include u-margin-top(0.5);
   }
 
+  .supertitle {
+    font-size: 15px;
+    color: $base;
+    font-weight: normal;
+    text-transform: uppercase;
+    @include u-margin-bottom(2);
+  }
+
   .header {
     display: flex;
     justify-content: space-between;

--- a/src/pages/Office/DocumentViewerSidebar/DocumentViewerSidebar.module.scss
+++ b/src/pages/Office/DocumentViewerSidebar/DocumentViewerSidebar.module.scss
@@ -29,14 +29,6 @@
     @include u-margin-top(1.5);
   }
 
-  h3 {
-    font-size: 15px;
-    color: $base;
-    font-weight: normal;
-    text-transform: uppercase;
-    @include u-margin-top(0.5);
-  }
-
   .supertitle {
     font-size: 15px;
     color: $base;
@@ -87,4 +79,12 @@
     @include u-border-top('gray-10');
     margin-top: auto;
   }
+}
+
+.container:not(.defaultH3) h3 {
+  font-size: 15px;
+  color: $base;
+  font-weight: normal;
+  text-transform: uppercase;
+  @include u-margin-top(0.5);
 }

--- a/src/pages/Office/DocumentViewerSidebar/DocumentViewerSidebar.test.jsx
+++ b/src/pages/Office/DocumentViewerSidebar/DocumentViewerSidebar.test.jsx
@@ -8,12 +8,19 @@ describe('DocumentViewerSidebar', () => {
   it('renders header, content and footer', () => {
     const title = 'Review weights';
     const subtitle = 'Shipment weights';
+    const supertitle = 'Weight 1 of 2';
     const description = 'Shipment 1 of 2';
     const content = 'Some content';
     const buttonText = 'Review billable weights';
     const mockOnClose = jest.fn();
     render(
-      <DocumentViewerSidebar title={title} subtitle={subtitle} description={description} onClose={mockOnClose}>
+      <DocumentViewerSidebar
+        title={title}
+        subtitle={subtitle}
+        description={description}
+        onClose={mockOnClose}
+        supertitle={supertitle}
+      >
         <DocumentViewerSidebar.Content>{content}</DocumentViewerSidebar.Content>
         <DocumentViewerSidebar.Footer>
           <Button>{buttonText}</Button>
@@ -25,6 +32,7 @@ describe('DocumentViewerSidebar', () => {
     expect(mockOnClose).toHaveBeenCalledTimes(1);
     expect(screen.getByText(title)).toBeInTheDocument();
     expect(screen.getByText(subtitle)).toBeInTheDocument();
+    expect(screen.getByText(supertitle)).toBeInTheDocument();
     expect(screen.getByText(description)).toBeInTheDocument();
     expect(screen.getByText(content)).toBeInTheDocument();
     expect(screen.getByText(buttonText)).toBeInTheDocument();

--- a/src/pages/Office/PPM/ReviewDocuments/ReviewDocuments.jsx
+++ b/src/pages/Office/PPM/ReviewDocuments/ReviewDocuments.jsx
@@ -14,6 +14,7 @@ import DocumentViewer from 'components/DocumentViewer/DocumentViewer';
 import DocumentViewerSidebar from 'pages/Office/DocumentViewerSidebar/DocumentViewerSidebar';
 import { usePPMShipmentDocsQueries } from 'hooks/queries';
 import ReviewWeightTicket from 'components/Office/PPM/ReviewWeightTicket/ReviewWeightTicket';
+import { WEIGHT_TICKETS } from 'constants/queryKeys';
 
 export const ReviewDocuments = ({ match }) => {
   const { shipmentId, moveCode } = match.params;
@@ -51,7 +52,7 @@ export const ReviewDocuments = ({ match }) => {
   };
 
   const onSuccess = () => {
-    queryCache.invalidateQueries([], moveCode);
+    queryCache.invalidateQueries([WEIGHT_TICKETS, shipmentId]);
     if (documentSetIndex < weightTickets.length - 1) {
       setDocumentSetIndex(documentSetIndex + 1);
     } else {

--- a/src/pages/Office/PPM/ReviewDocuments/ReviewDocuments.jsx
+++ b/src/pages/Office/PPM/ReviewDocuments/ReviewDocuments.jsx
@@ -33,19 +33,22 @@ export const ReviewDocuments = ({ match }) => {
   const history = useHistory();
 
   const formRef = useRef();
+  // let nextEnabled = false;
+  // if (formRef.current?.isValid) {
+  //   nextEnabled = true;
+  // }
 
   useEffect(() => {
     // console.log('hi from useEffect in ReviewDocuments');
-    if (weightTickets) {
-      const sortedWeightTickets = weightTickets;
-      sortedWeightTickets.sort((a, b) => (a.createdAt < b.createdAt ? -1 : 1));
-      // setDocumentSet(sortedWeightTickets[documentSetIndex]);
-      // NB: this setter appears to work correctly, and is not affected by subsequent Formik rerenders:
-      setNextEnabled(formRef.current?.isValid);
-      // formRef.current?.resetForm();
-      // formRef.current?.validateForm();
-    }
-  }, [weightTickets, documentSetIndex]);
+
+    // const sortedWeightTickets = weightTickets;
+    // sortedWeightTickets.sort((a, b) => (a.createdAt < b.createdAt ? -1 : 1));
+    // setDocumentSet(sortedWeightTickets[documentSetIndex]);
+    // NB: this setter appears to work correctly, and is not affected by subsequent Formik rerenders:
+    setNextEnabled(formRef.current?.isValid);
+    // formRef.current?.resetForm();
+    // formRef.current?.validateForm();
+  }, [formRef, setNextEnabled]);
 
   // useEffect(() => {
   //   console.log('documentSet', documentSet);
@@ -97,6 +100,10 @@ export const ReviewDocuments = ({ match }) => {
     }
   };
 
+  const onValid = (errors) => {
+    setNextEnabled(Object.keys(errors).length === 0);
+  };
+
   return (
     <div data-testid="ReviewDocuments" className={styles.ReviewDocuments}>
       <div className={styles.embed}>
@@ -111,16 +118,19 @@ export const ReviewDocuments = ({ match }) => {
       >
         <NotificationScrollToTop dependency={documentSetIndex} />
         <DocumentViewerSidebar.Content>
-          <ReviewWeightTicket
-            weightTicket={documentSet}
-            ppmNumber={1}
-            tripNumber={documentSetIndex + 1}
-            mtoShipment={mtoShipment}
-            onError={onError}
-            onSuccess={onSuccess}
-            formRef={formRef}
-            setSubmitting={setSubmitting}
-          />
+          {documentSet && (
+            <ReviewWeightTicket
+              weightTicket={documentSet}
+              ppmNumber={1}
+              tripNumber={documentSetIndex + 1}
+              mtoShipment={mtoShipment}
+              onError={onError}
+              onSuccess={onSuccess}
+              onValid={onValid}
+              formRef={formRef}
+              setSubmitting={setSubmitting}
+            />
+          )}
         </DocumentViewerSidebar.Content>
         <DocumentViewerSidebar.Footer>
           <Button onClick={onBack} disabled={documentSetIndex === 0}>

--- a/src/pages/Office/PPM/ReviewDocuments/ReviewDocuments.jsx
+++ b/src/pages/Office/PPM/ReviewDocuments/ReviewDocuments.jsx
@@ -14,7 +14,6 @@ import DocumentViewer from 'components/DocumentViewer/DocumentViewer';
 import DocumentViewerSidebar from 'pages/Office/DocumentViewerSidebar/DocumentViewerSidebar';
 import { usePPMShipmentDocsQueries } from 'hooks/queries';
 import ReviewWeightTicket from 'components/Office/PPM/ReviewWeightTicket/ReviewWeightTicket';
-import { milmoveLog, MILMOVE_LOG_LEVEL } from 'utils/milmoveLog';
 
 export const ReviewDocuments = ({ match }) => {
   const { shipmentId, moveCode } = match.params;
@@ -49,11 +48,6 @@ export const ReviewDocuments = ({ match }) => {
     if (documentSetIndex > 0) {
       setDocumentSetIndex(documentSetIndex - 1);
     }
-  };
-
-  const onError = (error) => {
-    const errorMsg = error?.response?.body;
-    milmoveLog(MILMOVE_LOG_LEVEL.LOG, errorMsg);
   };
 
   const onSuccess = () => {
@@ -92,7 +86,6 @@ export const ReviewDocuments = ({ match }) => {
               ppmNumber={1}
               tripNumber={documentSetIndex + 1}
               mtoShipment={mtoShipment}
-              onError={onError}
               onSuccess={onSuccess}
               formRef={formRef}
             />

--- a/src/pages/Office/PPM/ReviewDocuments/ReviewDocuments.jsx
+++ b/src/pages/Office/PPM/ReviewDocuments/ReviewDocuments.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useRef, useState } from 'react';
 import { queryCache } from 'react-query';
 import { Button } from '@trussworks/react-uswds';
 import { generatePath, useHistory, withRouter } from 'react-router-dom';
@@ -27,16 +27,9 @@ export const ReviewDocuments = ({ match }) => {
     weightTickets.sort((a, b) => (a.createdAt < b.createdAt ? -1 : 1));
     documentSet = weightTickets[documentSetIndex];
   }
-  const [nextEnabled, setNextEnabled] = useState(false);
-  const [submitting, setSubmitting] = useState(false);
-
   const history = useHistory();
 
   const formRef = useRef();
-
-  useEffect(() => {
-    setNextEnabled(formRef.current?.isValid);
-  }, [formRef, setNextEnabled]);
 
   if (isLoading) return <LoadingPlaceholder />;
   if (isError) return <SomethingWentWrong />;
@@ -59,13 +52,11 @@ export const ReviewDocuments = ({ match }) => {
   };
 
   const onError = (error) => {
-    setSubmitting(false);
     const errorMsg = error?.response?.body;
     milmoveLog(MILMOVE_LOG_LEVEL.LOG, errorMsg);
   };
 
   const onSuccess = () => {
-    setSubmitting(false);
     queryCache.invalidateQueries([], moveCode);
     if (documentSetIndex < weightTickets.length - 1) {
       setDocumentSetIndex(documentSetIndex + 1);
@@ -80,10 +71,6 @@ export const ReviewDocuments = ({ match }) => {
     }
   };
 
-  const onValid = (errors) => {
-    setNextEnabled(Object.keys(errors).length === 0);
-  };
-
   return (
     <div data-testid="ReviewDocuments" className={styles.ReviewDocuments}>
       <div className={styles.embed}>
@@ -95,6 +82,7 @@ export const ReviewDocuments = ({ match }) => {
         className={styles.sidebar}
         // TODO: set this correctly based on total document sets, including pro gear and expenses
         supertitle={`${documentSetIndex + 1} of ${weightTickets.length} Document Sets`}
+        defaultH3
       >
         <NotificationScrollToTop dependency={documentSetIndex} />
         <DocumentViewerSidebar.Content>
@@ -106,9 +94,7 @@ export const ReviewDocuments = ({ match }) => {
               mtoShipment={mtoShipment}
               onError={onError}
               onSuccess={onSuccess}
-              onValid={onValid}
               formRef={formRef}
-              setSubmitting={setSubmitting}
             />
           )}
         </DocumentViewerSidebar.Content>
@@ -116,7 +102,7 @@ export const ReviewDocuments = ({ match }) => {
           <Button onClick={onBack} disabled={documentSetIndex === 0}>
             Back
           </Button>
-          <Button type="submit" onClick={onContinue} disabled={!nextEnabled || submitting}>
+          <Button type="submit" onClick={onContinue}>
             Continue
           </Button>
         </DocumentViewerSidebar.Footer>

--- a/src/pages/Office/PPM/ReviewDocuments/ReviewDocuments.jsx
+++ b/src/pages/Office/PPM/ReviewDocuments/ReviewDocuments.jsx
@@ -21,7 +21,12 @@ export const ReviewDocuments = ({ match }) => {
   const { mtoShipment, weightTickets, isLoading, isError } = usePPMShipmentDocsQueries(shipmentId);
 
   const [documentSetIndex, setDocumentSetIndex] = useState(0);
-  const [documentSet, setDocumentSet] = useState({});
+
+  let documentSet;
+  if (weightTickets) {
+    weightTickets.sort((a, b) => (a.createdAt < b.createdAt ? -1 : 1));
+    documentSet = weightTickets[documentSetIndex];
+  }
   const [nextEnabled, setNextEnabled] = useState(false);
   const [submitting, setSubmitting] = useState(false);
 
@@ -34,7 +39,7 @@ export const ReviewDocuments = ({ match }) => {
     if (weightTickets) {
       const sortedWeightTickets = weightTickets;
       sortedWeightTickets.sort((a, b) => (a.createdAt < b.createdAt ? -1 : 1));
-      setDocumentSet(sortedWeightTickets[documentSetIndex]);
+      // setDocumentSet(sortedWeightTickets[documentSetIndex]);
       // NB: this setter appears to work correctly, and is not affected by subsequent Formik rerenders:
       setNextEnabled(formRef.current?.isValid);
       // formRef.current?.resetForm();

--- a/src/pages/Office/PPM/ReviewDocuments/ReviewDocuments.jsx
+++ b/src/pages/Office/PPM/ReviewDocuments/ReviewDocuments.jsx
@@ -33,30 +33,10 @@ export const ReviewDocuments = ({ match }) => {
   const history = useHistory();
 
   const formRef = useRef();
-  // let nextEnabled = false;
-  // if (formRef.current?.isValid) {
-  //   nextEnabled = true;
-  // }
 
   useEffect(() => {
-    // console.log('hi from useEffect in ReviewDocuments');
-
-    // const sortedWeightTickets = weightTickets;
-    // sortedWeightTickets.sort((a, b) => (a.createdAt < b.createdAt ? -1 : 1));
-    // setDocumentSet(sortedWeightTickets[documentSetIndex]);
-    // NB: this setter appears to work correctly, and is not affected by subsequent Formik rerenders:
     setNextEnabled(formRef.current?.isValid);
-    // formRef.current?.resetForm();
-    // formRef.current?.validateForm();
   }, [formRef, setNextEnabled]);
-
-  // useEffect(() => {
-  //   console.log('documentSet', documentSet);
-  // }, [documentSet]);
-
-  // useEffect(() => {
-  //   console.log('formRef', formRef);
-  // }, [formRef]);
 
   if (isLoading) return <LoadingPlaceholder />;
   if (isError) return <SomethingWentWrong />;

--- a/src/pages/Office/PPM/ReviewDocuments/ReviewDocuments.jsx
+++ b/src/pages/Office/PPM/ReviewDocuments/ReviewDocuments.jsx
@@ -1,4 +1,4 @@
-import React, { useRef, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { queryCache } from 'react-query';
 import { Button } from '@trussworks/react-uswds';
 import { generatePath, useHistory, withRouter } from 'react-router-dom';
@@ -27,9 +27,12 @@ export const ReviewDocuments = ({ match }) => {
 
   const formRef = useRef();
 
-  // placeholder pro-gear tickets & expenses
-  const progearTickets = [];
-  const expenses = [];
+  useEffect(() => {
+    if (weightTickets) {
+      setNextEnabled(formRef.current.isValid);
+    }
+  }, [weightTickets, setNextEnabled]);
+
   if (isLoading) return <LoadingPlaceholder />;
   if (isError) return <SomethingWentWrong />;
 
@@ -41,7 +44,10 @@ export const ReviewDocuments = ({ match }) => {
   });
 
   // TODO: select the documentSet from among weight tickets, pro gear, and expenses
-  const documentSet = weightTickets[documentSetIndex];
+  let documentSet;
+  if (weightTickets) {
+    documentSet = weightTickets[documentSetIndex];
+  }
 
   const onClose = () => {
     history.push(generatePath(servicesCounselingRoutes.MOVE_VIEW_PATH, { moveCode }));
@@ -95,7 +101,7 @@ export const ReviewDocuments = ({ match }) => {
           <ReviewWeightTicket
             weightTicket={documentSet}
             ppmNumber={1}
-            tripNumber={1}
+            tripNumber={documentSetIndex + 1}
             mtoShipment={mtoShipment}
             onError={onError}
             onSuccess={onSuccess}

--- a/src/pages/Office/PPM/ReviewDocuments/ReviewDocuments.module.scss
+++ b/src/pages/Office/PPM/ReviewDocuments/ReviewDocuments.module.scss
@@ -1,18 +1,29 @@
+@import 'shared/styles/colors.scss';
+@import 'shared/styles/_mixins.scss';
+
 .ReviewDocuments {
-    display: flex;
-    flex-basis: 0;
-    flex-grow: 1;
-    flex-shrink: 1;
-    overflow: auto;
+  display: flex;
+  flex-basis: 0;
+  flex-grow: 1;
+  flex-shrink: 1;
+  overflow: auto;
+}
 
+.embed {
+  flex-grow: 1;
+}
 
-    .embed {
-        flex-grow: 1;
-    }
+.sidebar {
+  width: 400px;
+  display: flex;
+  flex-direction: column;
+}
 
-    .sidebar {
-        width: 400px;
-        display: flex;
-        flex-direction: column;
-    }
+.sidebarBody {
+  background-color: $base-lightest;
+  flex-basis: auto;
+}
+
+.footer {
+  justify-self: flex-end;
 }

--- a/src/pages/Office/PPM/ReviewDocuments/ReviewDocuments.test.jsx
+++ b/src/pages/Office/PPM/ReviewDocuments/ReviewDocuments.test.jsx
@@ -209,6 +209,20 @@ describe('ReviewDocuments', () => {
       await userEvent.click(getByTestId('closeSidebar'));
       expect(mockPush).toHaveBeenCalled();
     });
+    it('shows an error if submissions fails', async () => {
+      jest.spyOn(console, 'error').mockImplementation(() => {});
+      mockPatchWeightTicket.mockRejectedValueOnce('fatal error');
+      usePPMShipmentDocsQueries.mockReturnValue(usePPMShipmentDocsQueriesReturnValue);
+      const { getByRole, getByLabelText, queryByText } = render(<ReviewDocuments {...requiredProps} />);
+      await waitFor(() => {
+        expect(getByRole('button', { name: 'Continue' })).toBeInTheDocument();
+      });
+      await userEvent.type(getByRole('textbox', { name: 'Empty weight' }), '14500');
+      await userEvent.type(getByRole('textbox', { name: 'Full weight' }), '18500');
+      await userEvent.click(getByLabelText('Accept'));
+      await userEvent.click(getByRole('button', { name: 'Continue' }));
+      expect(queryByText('There was an error submitting the form. Please try again later.')).toBeInTheDocument();
+    });
   });
   describe('with multiple document sets loaded', () => {
     it('renders and handles the Accept button', async () => {

--- a/src/pages/Office/PPM/ReviewDocuments/ReviewDocuments.test.jsx
+++ b/src/pages/Office/PPM/ReviewDocuments/ReviewDocuments.test.jsx
@@ -1,10 +1,12 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
-import { act } from 'react-dom/test-utils';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 
 import { ReviewDocuments } from './ReviewDocuments';
 
 import { usePPMShipmentDocsQueries } from 'hooks/queries';
+
+Element.prototype.scrollTo = jest.fn();
 
 beforeEach(() => {
   jest.clearAllMocks();
@@ -16,6 +18,12 @@ jest.mock('react-router-dom', () => ({
   useHistory: () => ({
     push: mockPush,
   }),
+}));
+
+const mockPatchWeightTicket = jest.fn();
+jest.mock('services/ghcApi', () => ({
+  ...jest.requireActual('services/ghcApi'),
+  patchWeightTicket: (options) => mockPatchWeightTicket(options),
 }));
 
 const mockPDFUpload = {
@@ -59,12 +67,15 @@ const testShipmentId = '4321';
 const ticketDocuments = {
   emptyDocument: {
     uploads: [mockPDFUpload],
+    createdAt: '3',
   },
   fullDocument: {
     uploads: [mockXLSUpload],
+    createdAt: '2',
   },
   proofOfTrailerOwnershipDocument: {
     uploads: [mockJPGUpload],
+    createdAt: '1',
   },
 };
 
@@ -81,7 +92,39 @@ const usePPMShipmentDocsQueriesReturnValue = {
   weightTickets: [
     {
       ...ticketDocuments,
+      id: '321',
+      missingFullWeightTicket: false,
+      missingEmptyWeightTicket: false,
+      ppmShipmentId: '123',
+      vehicleDescription: '2022 Honda CR-V Hybrid',
     },
+  ],
+};
+
+const rejectedPayload = {
+  payload: {
+    ppmShipmentId: '123',
+    vehicleDescription: '2022 Honda CR-V Hybrid',
+    emptyWeight: 14500,
+    missingEmptyWeightTicket: false,
+    fullWeight: 18500,
+    missingFullWeightTicket: false,
+    ownsTrailer: false,
+    trailerMeetsCriteria: false,
+    reason: 'reason',
+    status: 'REJECTED',
+  },
+  ppmShipmentId: '123',
+  weightTicketId: '321',
+};
+
+const usePPMShipmentDocsQueriesReturnValueMultiple = {
+  ...usePPMShipmentDocsQueriesReturnValue,
+  weightTickets: [
+    {
+      ...ticketDocuments,
+    },
+    { ...ticketDocuments },
   ],
 };
 
@@ -118,10 +161,10 @@ describe('ReviewDocuments', () => {
   });
   describe('with data loaded', () => {
     it('renders the DocumentViewer', async () => {
-      await act(async () => {
-        usePPMShipmentDocsQueries.mockReturnValue(usePPMShipmentDocsQueriesReturnValue);
-        render(<ReviewDocuments {...requiredProps} />);
-        const docs = await screen.getByText(/Documents/);
+      usePPMShipmentDocsQueries.mockReturnValue(usePPMShipmentDocsQueriesReturnValue);
+      render(<ReviewDocuments {...requiredProps} />);
+      waitFor(() => {
+        const docs = screen.getByText(/Documents/);
         expect(docs).toBeInTheDocument();
       });
       expect(screen.getAllByText('test.pdf').length).toBe(2);
@@ -130,6 +173,65 @@ describe('ReviewDocuments', () => {
       expect(screen.getByRole('heading', { level: 2, name: '1 of 1 Document Sets' })).toBeInTheDocument();
       expect(screen.getByRole('button', { name: 'Continue' })).toBeInTheDocument();
       expect(screen.getByRole('button', { name: 'Back' })).toBeInTheDocument();
+      expect(screen.getByTestId('closeSidebar')).toBeInTheDocument();
+    });
+    it('renders and handles the Continue button with the appropriate payload', async () => {
+      usePPMShipmentDocsQueries.mockReturnValue(usePPMShipmentDocsQueriesReturnValue);
+      const { getByRole, getByLabelText, queryByText } = render(<ReviewDocuments {...requiredProps} />);
+      expect(getByLabelText('Accept')).toBeInTheDocument();
+      expect(getByLabelText('Reject')).toBeInTheDocument();
+      expect(getByRole('button', { name: 'Continue' })).toBeInTheDocument();
+      await userEvent.type(getByRole('textbox', { name: 'Empty weight' }), '14500');
+      await userEvent.type(getByRole('textbox', { name: 'Full weight' }), '18500');
+      expect(queryByText(/4,000 lbs/)).toBeInTheDocument();
+      await userEvent.click(getByLabelText('Reject'));
+      await waitFor(() => {
+        expect(getByLabelText('Reason')).toBeInTheDocument();
+      });
+      await userEvent.type(getByLabelText('Reason'), 'reason');
+      await userEvent.click(getByRole('button', { name: 'Continue' }));
+      expect(queryByText('Reviewing this weight ticket is required')).not.toBeInTheDocument();
+      expect(mockPatchWeightTicket).toHaveBeenCalledWith(rejectedPayload);
+      expect(mockPush).toHaveBeenCalled();
+    });
+    it('renders and handles the Close button', async () => {
+      usePPMShipmentDocsQueries.mockReturnValue(usePPMShipmentDocsQueriesReturnValue);
+      const { getByTestId } = render(<ReviewDocuments {...requiredProps} />);
+      expect(getByTestId('closeSidebar')).toBeInTheDocument();
+      await userEvent.click(getByTestId('closeSidebar'));
+      expect(mockPush).toHaveBeenCalled();
+    });
+  });
+  describe('with multiple document sets loaded', () => {
+    it('renders and handles the Accept button', async () => {
+      usePPMShipmentDocsQueries.mockReturnValue(usePPMShipmentDocsQueriesReturnValueMultiple);
+      const { getByRole, getByLabelText } = render(<ReviewDocuments {...requiredProps} />);
+      expect(getByRole('heading', { level: 2, text: '1 of 2 Document Sets' }));
+      expect(getByLabelText('Accept')).toBeInTheDocument();
+      expect(getByLabelText('Reject')).toBeInTheDocument();
+      expect(getByRole('button', { name: 'Continue' })).toBeInTheDocument();
+      expect(getByRole('button', { name: 'Back' })).toBeInTheDocument();
+      await userEvent.type(getByRole('textbox', { name: 'Empty weight' }), '14500');
+      await userEvent.type(getByRole('textbox', { name: 'Full weight' }), '18500');
+      await userEvent.click(getByLabelText('Accept'));
+      await userEvent.click(getByRole('button', { name: 'Continue' }));
+      expect(getByRole('heading', { level: 2, text: '2 of 2 Document Sets' }));
+    });
+    it('renders and handles the Back button', async () => {
+      usePPMShipmentDocsQueries.mockReturnValue(usePPMShipmentDocsQueriesReturnValueMultiple);
+      const { getByRole, getByLabelText } = render(<ReviewDocuments {...requiredProps} />);
+      expect(getByRole('heading', { level: 2, text: '1 of 2 Document Sets' }));
+      expect(getByLabelText('Accept')).toBeInTheDocument();
+      expect(getByLabelText('Reject')).toBeInTheDocument();
+      expect(getByRole('button', { name: 'Continue' })).toBeInTheDocument();
+      expect(getByRole('button', { name: 'Back' })).toBeInTheDocument();
+      await userEvent.type(getByRole('textbox', { name: 'Empty weight' }), '14500');
+      await userEvent.type(getByRole('textbox', { name: 'Full weight' }), '18500');
+      await userEvent.click(getByLabelText('Accept'));
+      await userEvent.click(getByRole('button', { name: 'Continue' }));
+      expect(getByRole('heading', { level: 2, text: '2 of 2 Document Sets' }));
+      await userEvent.click(getByRole('button', { name: 'Back' }));
+      expect(getByRole('heading', { level: 2, text: '1 of 2 Document Sets' }));
     });
   });
 });

--- a/src/pages/Office/PPM/ReviewDocuments/ReviewDocuments.test.jsx
+++ b/src/pages/Office/PPM/ReviewDocuments/ReviewDocuments.test.jsx
@@ -160,27 +160,14 @@ describe('ReviewDocuments', () => {
     });
   });
   describe('with data loaded', () => {
-    it('renders the DocumentViewer', async () => {
-      usePPMShipmentDocsQueries.mockReturnValue(usePPMShipmentDocsQueriesReturnValue);
-      render(<ReviewDocuments {...requiredProps} />);
-      waitFor(() => {
-        const docs = screen.getByText(/Documents/);
-        expect(docs).toBeInTheDocument();
-      });
-      expect(screen.getAllByText('test.pdf').length).toBe(2);
-      expect(screen.getByText('test.xls')).toBeInTheDocument();
-      expect(screen.getByText('test.jpg')).toBeInTheDocument();
-      expect(screen.getByRole('heading', { level: 2, name: '1 of 1 Document Sets' })).toBeInTheDocument();
-      expect(screen.getByRole('button', { name: 'Continue' })).toBeInTheDocument();
-      expect(screen.getByRole('button', { name: 'Back' })).toBeInTheDocument();
-      expect(screen.getByTestId('closeSidebar')).toBeInTheDocument();
-    });
     it('renders and handles the Continue button with the appropriate payload', async () => {
       usePPMShipmentDocsQueries.mockReturnValue(usePPMShipmentDocsQueriesReturnValue);
       const { getByRole, getByLabelText, queryByText } = render(<ReviewDocuments {...requiredProps} />);
-      expect(getByLabelText('Accept')).toBeInTheDocument();
-      expect(getByLabelText('Reject')).toBeInTheDocument();
-      expect(getByRole('button', { name: 'Continue' })).toBeInTheDocument();
+      await waitFor(() => {
+        expect(getByLabelText('Accept')).toBeInTheDocument();
+        expect(getByLabelText('Reject')).toBeInTheDocument();
+        expect(getByRole('button', { name: 'Continue' })).toBeInTheDocument();
+      });
       await userEvent.type(getByRole('textbox', { name: 'Empty weight' }), '14500');
       await userEvent.type(getByRole('textbox', { name: 'Full weight' }), '18500');
       expect(queryByText(/4,000 lbs/)).toBeInTheDocument();
@@ -200,6 +187,21 @@ describe('ReviewDocuments', () => {
       expect(getByTestId('closeSidebar')).toBeInTheDocument();
       await userEvent.click(getByTestId('closeSidebar'));
       expect(mockPush).toHaveBeenCalled();
+    });
+    it('renders the DocumentViewer', async () => {
+      await waitFor(() => {
+        usePPMShipmentDocsQueries.mockReturnValue(usePPMShipmentDocsQueriesReturnValue);
+        render(<ReviewDocuments {...requiredProps} />);
+      });
+      const docs = screen.getByText(/Documents/);
+      expect(docs).toBeInTheDocument();
+      expect(screen.getAllByText('test.pdf').length).toBe(2);
+      expect(screen.getByText('test.xls')).toBeInTheDocument();
+      expect(screen.getByText('test.jpg')).toBeInTheDocument();
+      expect(screen.getByRole('heading', { level: 2, name: '1 of 1 Document Sets' })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Continue' })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Back' })).toBeInTheDocument();
+      expect(screen.getByTestId('closeSidebar')).toBeInTheDocument();
     });
   });
   describe('with multiple document sets loaded', () => {

--- a/src/pages/Office/PPM/ReviewDocuments/ReviewDocuments.test.jsx
+++ b/src/pages/Office/PPM/ReviewDocuments/ReviewDocuments.test.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { render, screen, waitFor } from '@testing-library/react';
+import { useLocation } from 'react-router-dom';
 import userEvent from '@testing-library/user-event';
 
 import { ReviewDocuments } from './ReviewDocuments';
@@ -18,6 +19,7 @@ jest.mock('react-router-dom', () => ({
   useHistory: () => ({
     push: mockPush,
   }),
+  useLocation: jest.fn(),
 }));
 
 const mockPatchWeightTicket = jest.fn();
@@ -69,7 +71,8 @@ jest.mock('hooks/queries', () => ({
   usePPMShipmentDocsQueries: jest.fn(),
 }));
 
-const testShipmentId = '4321';
+const mockShipmentId = '4321';
+const mockMoveId = '1234';
 const ticketDocuments = {
   emptyDocument: {
     uploads: [mockPDFUpload],
@@ -135,7 +138,7 @@ const usePPMShipmentDocsQueriesReturnValueMultiple = {
 };
 
 const requiredProps = {
-  match: { params: { shipmentId: testShipmentId, moveCode: 'READY' } },
+  match: { params: { shipmentId: mockShipmentId, moveCode: 'READY' } },
 };
 
 const loadingReturnValue = {
@@ -167,6 +170,9 @@ describe('ReviewDocuments', () => {
   });
   describe('with data loaded', () => {
     it('renders the DocumentViewer', async () => {
+      useLocation.mockReturnValue({
+        pathname: `/counseling/moves/${mockMoveId}/shipment/${mockShipmentId}/document-review`,
+      });
       await waitFor(() => {
         usePPMShipmentDocsQueries.mockReturnValue(usePPMShipmentDocsQueriesReturnValue);
         render(<ReviewDocuments {...requiredProps} />);

--- a/src/pages/Office/PPM/ReviewDocuments/ReviewDocuments.test.jsx
+++ b/src/pages/Office/PPM/ReviewDocuments/ReviewDocuments.test.jsx
@@ -85,7 +85,6 @@ describe('ReviewDocuments', () => {
   describe('check loading and error component states', () => {
     it('renders the Loading Placeholder when the query is still loading', async () => {
       usePPMShipmentDocsQueries.mockReturnValue(loadingReturnValue);
-
       render(<ReviewDocuments {...requiredProps} />);
 
       const h2 = await screen.getByRole('heading', { name: 'Loading, please wait...', level: 2 });

--- a/src/pages/Office/PPM/ReviewDocuments/ReviewDocuments.test.jsx
+++ b/src/pages/Office/PPM/ReviewDocuments/ReviewDocuments.test.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
+import { act } from 'react-dom/test-utils';
 
 import { ReviewDocuments } from './ReviewDocuments';
 
@@ -105,63 +106,30 @@ describe('ReviewDocuments', () => {
     it('renders the Loading Placeholder when the query is still loading', async () => {
       usePPMShipmentDocsQueries.mockReturnValue(loadingReturnValue);
       render(<ReviewDocuments {...requiredProps} />);
-
       const h2 = await screen.getByRole('heading', { name: 'Loading, please wait...', level: 2 });
       expect(h2).toBeInTheDocument();
     });
-
     it('renders the Something Went Wrong component when the query errors', async () => {
       usePPMShipmentDocsQueries.mockReturnValue(errorReturnValue);
-
       render(<ReviewDocuments {...requiredProps} />);
-
       const errorMessage = await screen.getByText(/Something went wrong./);
       expect(errorMessage).toBeInTheDocument();
     });
   });
-
   describe('with data loaded', () => {
     it('renders the DocumentViewer', async () => {
-      usePPMShipmentDocsQueries.mockReturnValue(usePPMShipmentDocsQueriesReturnValue);
-      render(<ReviewDocuments {...requiredProps} />);
-
-      const docs = await screen.getByText(/Documents/);
-      expect(docs).toBeInTheDocument();
+      await act(async () => {
+        usePPMShipmentDocsQueries.mockReturnValue(usePPMShipmentDocsQueriesReturnValue);
+        render(<ReviewDocuments {...requiredProps} />);
+        const docs = await screen.getByText(/Documents/);
+        expect(docs).toBeInTheDocument();
+      });
       expect(screen.getAllByText('test.pdf').length).toBe(2);
       expect(screen.getByText('test.xls')).toBeInTheDocument();
       expect(screen.getByText('test.jpg')).toBeInTheDocument();
-
       expect(screen.getByRole('heading', { level: 2, name: '1 of 1 Document Sets' })).toBeInTheDocument();
       expect(screen.getByRole('button', { name: 'Continue' })).toBeInTheDocument();
       expect(screen.getByRole('button', { name: 'Back' })).toBeInTheDocument();
-    });
-  });
-
-  describe('returns to Review page when', () => {
-    it('Close button is clicked', async () => {
-      usePPMShipmentDocsQueries.mockReturnValue(usePPMShipmentDocsQueriesReturnValue);
-      render(<ReviewDocuments {...requiredProps} />);
-
-      const closeButton = await screen.getByTestId('closeSidebar');
-      await waitFor(() => {
-        expect(closeButton).toBeInTheDocument();
-      });
-      await fireEvent.click(closeButton);
-      expect(mockPush).toHaveBeenCalled();
-    });
-  });
-
-  describe('shows an error when review is invalid', () => {
-    it('Continue button is clicked', async () => {
-      usePPMShipmentDocsQueries.mockReturnValue(usePPMShipmentDocsQueriesReturnValue);
-      render(<ReviewDocuments {...requiredProps} />);
-
-      const continueButton = await screen.getByRole('button', { name: 'Continue' });
-      await waitFor(() => {
-        expect(continueButton).toBeInTheDocument();
-      });
-      await fireEvent.click(continueButton);
-      expect(screen.getByText('Reviewing this weight ticket is required')).toBeInTheDocument();
     });
   });
 });

--- a/src/pages/Office/ServicesCounselingMoveInfo/ServicesCounselingMoveInfo.jsx
+++ b/src/pages/Office/ServicesCounselingMoveInfo/ServicesCounselingMoveInfo.jsx
@@ -88,6 +88,10 @@ const ServicesCounselingMoveInfo = () => {
     matchPath(pathname, {
       path: servicesCounselingRoutes.CUSTOMER_INFO_EDIT_PATH,
       exact: true,
+    }) ||
+    matchPath(pathname, {
+      path: servicesCounselingRoutes.SHIPMENT_REVIEW_PATH,
+      exact: true,
     });
 
   if (isLoading) return <LoadingPlaceholder />;

--- a/src/services/ghcApi.js
+++ b/src/services/ghcApi.js
@@ -29,6 +29,21 @@ export async function getWeightTickets(key, ppmShipmentId) {
   return makeGHCRequest('ppm.getWeightTickets', { ppmShipmentId }, { normalize: false });
 }
 
+export async function patchWeightTicket(ppmShipmentId, weightTicketId, payload, eTag) {
+  return makeGHCRequest(
+    'ppm.updateWeightTicket',
+    {
+      ppmShipmentId,
+      weightTicketId,
+      'If-Match': eTag,
+      updateWeightTicketPayload: payload,
+    },
+    {
+      normalize: false,
+    },
+  );
+}
+
 export async function getMove(key, locator) {
   return makeGHCRequest('move.getMove', { locator }, { normalize: false });
 }

--- a/src/services/ghcApi.js
+++ b/src/services/ghcApi.js
@@ -29,7 +29,7 @@ export async function getWeightTickets(key, ppmShipmentId) {
   return makeGHCRequest('ppm.getWeightTickets', { ppmShipmentId }, { normalize: false });
 }
 
-export async function patchWeightTicket(ppmShipmentId, weightTicketId, payload, eTag) {
+export async function patchWeightTicket({ ppmShipmentId, weightTicketId, payload, eTag }) {
   return makeGHCRequest(
     'ppm.updateWeightTicket',
     {


### PR DESCRIPTION
## [Jira ticket](https://dp3.atlassian.net/browse/MB-13860) for this change

## Summary

This adds the documents review layout and weight tickets review panel for the office user. 

This allows the office user to edit:

- empty weight
- full  weight
- "Did they use a trailer they owned?"
  - If so, "Is the trailer's weight claimable?"
- status: accept or reject
  - If rejected, the rejection reason.

This PR adds an alert when both "Did they use a trailer they owned?" and "Is the trailer's weight claimable?" are "Yes," and only allows the PPM processor to reject the ticket. It also adds a `description` prop to the `MaskedTextField` component, which is set to either "Weight tickets" or "Constructed weight," depending on whether weight tickets are missing.

## Setup to Run Your Code

<details>
<summary>💻 You will need to use three separate terminals to test this locally.</summary>

##### Terminal 1

Start the Storybook locally.

```sh
make storybook
```

##### Terminal 2

Start the UI locally.

```sh
make client_run
```

##### Terminal 3

Start the Go server locally.

```sh
make server_run
```

</details>

### Additional steps

<!-- Fill out the next section as you see fit, these are just suggestions. -->

1. Access the office app
2. Login as a services_counselor_role@office.mil
3. Click the PPM Closeout tab
4. Select the "WeightTicket, PPMCloseout" (CLOSE0) user
5. Click "Review Documents"
6. Ensure that fields are editable, that validation syncs with the Continue button, and the the Close and Continue both lead back to the Review page.
7. Repeat the above with the "WeighTickets, PPMCloseout" (CLOSE1) user
8. Ensure that the Continue and Back buttons navigate between weight tickets, or back to the review page

## Verification Steps for Author

These are to be checked by the author.

- [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
- [ ] Request review from a member of a different team.
- [ ] Have the Jira acceptance criteria been met for this change?

## Verification Steps for Reviewers

These are to be checked by a reviewer.

<!-- Fill out the next sections as you see fit, these are just suggestions. -->

### Frontend

- [ ] User facing changes have been reviewed by design.
- [ ] There are no aXe warnings for UI.
- [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/main/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
- [ ] There are no new console errors in the browser devtools
- [ ] There are no new console errors in the test output
- [ ] If this PR adds a new component to Storybook, it ensures the component is fully responsive, OR if it is intentionally not, a wrapping div using the `officeApp` class or custom `min-width` styling is used to hide any states the would not be visible to the user.

### Backend

- [ ] Code follows the guidelines for [Logging](https://transcom.github.io/mymove-docs/docs/dev/contributing/backend/Backend-Programming-Guide#logging)
- [ ] The requirements listed in [Querying the Database Safely](https://transcom.github.io/mymove-docs/docs/dev/contributing/backend/Backend-Programming-Guide/#querying-the-database-safely) have been satisfied.

### Database

#### Any new migrations/schema changes:

- [ ] Follows our guidelines for [Zero-Downtime Deploys](https://transcom.github.io/mymove-docs/docs/dev/contributing/database/Database-Migrations#zero-downtime-migrations)
- [ ] Have been communicated to #g-database
- [ ] Secure migrations have been tested following the instructions in our [docs](https://transcom.github.io/mymove-docs/docs/dev/contributing/database/Database-Migrations#secure-migrations)

## Screenshots
