### PR TITLE
[ MB-14462 ] Improve logging when health check fails by writing to server stdout

### DIFF
--- a/pkg/handlers/routing/routing_init.go
+++ b/pkg/handlers/routing/routing_init.go
@@ -2,7 +2,6 @@ package routing
 
 import (
 	"encoding/hex"
-	"io"
 	"net/http"
 	"net/http/pprof"
 	"path"
@@ -425,20 +424,6 @@ func InitHealthRouting(appCtx appcontext.AppContext, redisPool *redis.Pool, rout
 		routingConfig.GitBranch, routingConfig.GitCommit)
 	requestLoggerMiddlware := middleware.RequestLogger(appCtx.Logger())
 	site.Handle("/health", requestLoggerMiddlware(healthHandler)).Methods("GET")
-
-	// this handler will only be called if the health check fails. It
-	// is helpful to see in the logs why the health check fails
-	// because otherwise the health check failure reason is lost
-	logHandler := func(w http.ResponseWriter, r *http.Request) {
-		data, err := io.ReadAll(r.Body)
-		if err != nil {
-			appCtx.Logger().Error("logs handler error", zap.Error(err))
-		} else {
-			appCtx.Logger().Info("Health Check Log", zap.Any("logdata", string(data)))
-		}
-	}
-
-	site.Handle("/logs", requestLoggerMiddlware(http.HandlerFunc(logHandler))).Methods("POST")
 
 	return site, nil
 }

--- a/pkg/logging/log.go
+++ b/pkg/logging/log.go
@@ -47,8 +47,8 @@ func WithStacktraceLength(length int) ZapConfigOption {
 	}
 }
 
-// Config configures a Zap logger based on the environment string and debugLevel
-func Config(opts ...ZapConfigOption) (*zap.Logger, func(), error) {
+// BuildZapConfig generates the zap Config
+func BuildZapConfig(opts ...ZapConfigOption) zap.Config {
 	config := &ZapConfig{}
 
 	for _, opt := range opts {
@@ -87,12 +87,21 @@ func Config(opts ...ZapConfigOption) (*zap.Logger, func(), error) {
 		loggerConfig.Level = zap.NewAtomicLevelAt(zap.DebugLevel)
 	}
 
+	return loggerConfig
+}
+
+// Config configures a Zap logger based on the environment string and debugLevel
+func Config(opts ...ZapConfigOption) (*zap.Logger, func(), error) {
+
 	// No sync of the logger is necessary when logging to stderr as is
 	// the default. This logging package does not provide an option to
 	// override the logging destination, so this is always correct
 	//
-	// If an option is added in the future, this will need to be updated
+	// If an option is added in the future, this will need to be
+	// updated
 	noopLoggerSync := func() {}
+
+	loggerConfig := BuildZapConfig(opts...)
 
 	logger, err := loggerConfig.Build()
 	return logger, noopLoggerSync, err


### PR DESCRIPTION
Switch health checker to log to server stdout to ensure we get logs when the health check fails. Tested in experimental
