### PR TITLE
[ on-call ] Updating the CircleCI badge with a new API token

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Personal Property Prototype
 
-[![CircleCI](https://circleci.com/gh/transcom/mymove/tree/main.svg?style=shield&circle-token=8782cc55afd824ba48e89fc4e49b466c5e2ce7b1)](https://circleci.com/gh/transcom/mymove/tree/main)
+[![CircleCI](https://dl.circleci.com/status-badge/img/gh/transcom/mymove/tree/main.svg?style=shield&circle-token=410fc6818d60d0bebc772f15ee347ee86ad855f1)](https://dl.circleci.com/status-badge/redirect/gh/transcom/mymove/tree/main)
 
 [![GoDoc](https://godoc.org/github.com/transcom/mymove?status.svg)](https://godoc.org/github.com/transcom/mymove)
 


### PR DESCRIPTION
## Summary

The CircleCI badge isn't displaying correctly on the default branch right now. This patch fixes things.

## Verification Steps for Author

Verify the badge shows up in the README.md file and isn't a missing image.

- [➡️ Here's a link to the current file with the broken image.](https://github.com/transcom/mymove/blob/main/README.md)
- [➡️ Here's a link to the current file to preview the fix.](https://github.com/transcom/mymove/blob/57a44f68ab352c94e83a9e65b8e8599e00e580b1/README.md)