### PR TITLE
MB-14969 factory.BuildContractor added as new version of testdatagen.MakeContractor 

### DIFF
--- a/pkg/factory/constants.go
+++ b/pkg/factory/constants.go
@@ -1,0 +1,10 @@
+package factory
+
+// DefaultContractName name used for contractor in testing
+const DefaultContractName = "Default contractor name for test"
+
+// DefaultContractType default prime type is Prime for testing
+const DefaultContractType = "Prime"
+
+// DefaultContractNumber is the default contract number for  testing
+const DefaultContractNumber = "HTC111-11-1-1111"

--- a/pkg/factory/contractor_factory.go
+++ b/pkg/factory/contractor_factory.go
@@ -1,0 +1,60 @@
+package factory
+
+import (
+	"database/sql"
+	"log"
+
+	"github.com/gobuffalo/pop/v6"
+
+	"github.com/transcom/mymove/pkg/models"
+	"github.com/transcom/mymove/pkg/testdatagen"
+)
+
+// BuildContractor creates a single Contractor
+// Params:
+// - customs is a slice that will be modified by the factory
+// - db can be set to nil to create a stubbed model that is not stored in DB.
+func BuildContractor(db *pop.Connection, customs []Customization, traits []Trait) models.Contractor {
+	customs = setupCustomizations(customs, traits)
+
+	var cContractor models.Contractor
+	if result := findValidCustomization(customs, Contractor); result != nil {
+		cContractor = result.Model.(models.Contractor)
+		if result.LinkOnly {
+			return cContractor
+		}
+	}
+
+	contractor := models.Contractor{
+		Name:           DefaultContractName,
+		ContractNumber: DefaultContractNumber,
+		Type:           DefaultContractType,
+	}
+
+	// Overwrite values with those from customizations
+	testdatagen.MergeModels(&contractor, cContractor)
+
+	// If db is false, it's a stub. No need to create in database
+	if db != nil {
+		mustCreate(db, &contractor)
+	}
+	return contractor
+}
+
+// FetchOrBuildDefaultContractor tries fetching an existing contractor, then falls back to creating one
+func FetchOrBuildDefaultContractor(db *pop.Connection, customs []Customization, traits []Trait) models.Contractor {
+	if db == nil {
+		return BuildContractor(db, customs, traits)
+	}
+
+	var contractor models.Contractor
+	err := db.Q().Where(`contract_number=$1`, DefaultContractNumber).First(&contractor)
+	if err != nil && err != sql.ErrNoRows {
+		log.Panic(err)
+	} else if err == nil {
+		return contractor
+	}
+
+	return BuildContractor(db, customs, traits)
+
+}

--- a/pkg/factory/contractor_factory_test.go
+++ b/pkg/factory/contractor_factory_test.go
@@ -1,0 +1,100 @@
+package factory
+
+import (
+	"github.com/gofrs/uuid"
+
+	"github.com/transcom/mymove/pkg/models"
+)
+
+func (suite *FactorySuite) TestBuildContractor() {
+	suite.Run("Successful creation of default contractor", func() {
+		// Under test:      BuildContractor
+		// Mocked:          None
+		// Set up:          Create a contractor with no customizations or traits
+		// Expected outcome:Contractor should be created with default values
+
+		// SETUP
+		// Create a default contractor to compare values
+		defContractor := models.Contractor{
+			Name:           DefaultContractName,
+			ContractNumber: DefaultContractNumber,
+			Type:           DefaultContractType,
+		}
+
+		// FUNCTION UNDER TEST
+		contractor := BuildContractor(suite.DB(), nil, nil)
+
+		// VALIDATE RESULTS
+		suite.Equal(defContractor.Name, contractor.Name)
+		suite.Equal(defContractor.ContractNumber, contractor.ContractNumber)
+		suite.Equal(defContractor.Type, contractor.Type)
+	})
+
+	suite.Run("Successful creation of customized contractor", func() {
+		// Under test:      BuildContractor
+		// Mocked:          None
+		// Set up:          Create a contractor with customization
+		// Expected outcome:Contractor should be created with customized values
+
+		// SETUP
+		// Create a custom contractor to compare values
+		custContractor := models.Contractor{
+			Name:           "Custom Contract Name",
+			ContractNumber: "11111-2222-3333-4444",
+			Type:           "Super Prime",
+		}
+
+		// FUNCTION UNDER TEST
+		contractor := BuildContractor(suite.DB(), []Customization{
+			{Model: custContractor},
+		}, nil)
+
+		// VALIDATE RESULTS
+		suite.Equal(custContractor.Name, contractor.Name)
+		suite.Equal(custContractor.ContractNumber, contractor.ContractNumber)
+		suite.Equal(custContractor.Type, contractor.Type)
+	})
+
+	suite.Run("Successful return of linkOnly contractor", func() {
+		// Under test:      BuildContractor
+		// Set up:          Create a contractor and pass in a linkOnly contractor
+		// Expected outcome:No new contractor should be created
+
+		// Check num contractors
+		precount, err := suite.DB().Count(&models.Contractor{})
+		suite.NoError(err)
+
+		contractor := BuildContractor(suite.DB(), []Customization{
+			{
+				Model: models.Contractor{
+					ID:   uuid.Must(uuid.NewV4()),
+					Type: "Super Prime",
+				},
+				LinkOnly: true,
+			},
+		}, nil)
+		count, err := suite.DB().Count(&models.Contractor{})
+		suite.Equal(precount, count)
+		suite.NoError(err)
+		suite.Equal("Super Prime", contractor.Type)
+	})
+
+	suite.Run("Two contractors should not be created", func() {
+		// Under test:      FetchOrBuildDefaultContractor
+		// Set up:          Create a contractor with no customized state or traits
+		// Expected outcome:Only 1 contractor should be created
+		count, potentialErr := suite.DB().Where(`contract_number=$1`, DefaultContractNumber).Count(&models.Contractor{})
+		suite.NoError(potentialErr)
+		suite.Zero(count)
+
+		firstContractor := FetchOrBuildDefaultContractor(suite.DB(), nil, nil)
+
+		secondContractor := FetchOrBuildDefaultContractor(suite.DB(), nil, nil)
+
+		suite.Equal(firstContractor.ID, secondContractor.ID)
+
+		existingContractorCount, err := suite.DB().Where(`contract_number=$1`, DefaultContractNumber).Count(&models.Contractor{})
+		suite.NoError(err)
+		suite.Equal(1, existingContractorCount)
+	})
+}

--- a/pkg/factory/shared.go
+++ b/pkg/factory/shared.go
@@ -36,11 +36,8 @@ type CustomType string
 var control CustomType = "Control"
 var Address CustomType = "Address"
 var AdminUser CustomType = "AdminUser"
-<<<<<<< HEAD
-var DutyLocation CustomType = "DutyLocation"
-=======
 var Contractor CustomType = "Contractor"
->>>>>>> 2845a92706 (add BuildContractor funcs + tests)
+var DutyLocation CustomType = "DutyLocation"
 var Entitlement CustomType = "Entitlement"
 var OfficePhoneLine CustomType = "OfficePhoneLine"
 var OfficeUser CustomType = "OfficeUser"

--- a/pkg/factory/shared.go
+++ b/pkg/factory/shared.go
@@ -36,7 +36,11 @@ type CustomType string
 var control CustomType = "Control"
 var Address CustomType = "Address"
 var AdminUser CustomType = "AdminUser"
+<<<<<<< HEAD
 var DutyLocation CustomType = "DutyLocation"
+=======
+var Contractor CustomType = "Contractor"
+>>>>>>> 2845a92706 (add BuildContractor funcs + tests)
 var Entitlement CustomType = "Entitlement"
 var OfficePhoneLine CustomType = "OfficePhoneLine"
 var OfficeUser CustomType = "OfficeUser"
@@ -53,6 +57,7 @@ var UsersRoles CustomType = "UsersRoles"
 var defaultTypesMap = map[string]CustomType{
 	"models.Address":              Address,
 	"models.AdminUser":            AdminUser,
+	"models.Contractor":           Contractor,
 	"models.DutyLocation":         DutyLocation,
 	"models.Entitlement":          Entitlement,
 	"models.OfficePhoneLine":      OfficePhoneLine,

--- a/pkg/handlers/adminapi/webhook_subscriptions_test.go
+++ b/pkg/handlers/adminapi/webhook_subscriptions_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/mock"
 
 	"github.com/transcom/mymove/pkg/etag"
+	"github.com/transcom/mymove/pkg/factory"
 	webhooksubscriptionop "github.com/transcom/mymove/pkg/gen/adminapi/adminoperations/webhook_subscriptions"
 	"github.com/transcom/mymove/pkg/gen/adminmessages"
 	"github.com/transcom/mymove/pkg/handlers"
@@ -173,7 +174,7 @@ func (suite *HandlerSuite) TestCreateWebhookSubscriptionHandler() {
 
 	// Actually test handler and creator on test database,
 	suite.Run("201 - Successful create", func() {
-		subscriber := testdatagen.MakeDefaultContractor(suite.DB())
+		subscriber := factory.FetchOrBuildDefaultContractor(suite.DB(), nil, nil)
 		params := webhooksubscriptionop.CreateWebhookSubscriptionParams{
 			HTTPRequest: suite.setupAuthenticatedRequest("POST", "/webhook_subscriptions"),
 			WebhookSubscription: &adminmessages.CreateWebhookSubscription{

--- a/pkg/handlers/internalapi/office_test.go
+++ b/pkg/handlers/internalapi/office_test.go
@@ -142,7 +142,7 @@ func (suite *HandlerSuite) TestCancelMoveHandler() {
 	// Given: a set of orders, a move, and office user
 	// Orders has service member with transportation office and phone nums
 	orders := testdatagen.MakeDefaultOrder(suite.DB())
-	testdatagen.MakeDefaultContractor(suite.DB())
+	factory.FetchOrBuildDefaultContractor(suite.DB(), nil, nil)
 	moveRouter := moverouter.NewMoveRouter()
 
 	selectedMoveType := models.SelectedMoveTypePPM

--- a/pkg/handlers/internalapi/orders_test.go
+++ b/pkg/handlers/internalapi/orders_test.go
@@ -22,7 +22,6 @@ import (
 func (suite *HandlerSuite) TestCreateOrder() {
 	sm := testdatagen.MakeExtendedServiceMember(suite.DB(), testdatagen.Assertions{})
 	dutyLocation := factory.FetchOrBuildCurrentDutyLocation(suite.DB())
-	testdatagen.MakeDefaultContractor(suite.DB())
 
 	req := httptest.NewRequest("POST", "/orders", nil)
 	req = suite.AuthenticateRequest(req, sm)

--- a/pkg/handlers/internalapi/orders_test.go
+++ b/pkg/handlers/internalapi/orders_test.go
@@ -22,6 +22,7 @@ import (
 func (suite *HandlerSuite) TestCreateOrder() {
 	sm := testdatagen.MakeExtendedServiceMember(suite.DB(), testdatagen.Assertions{})
 	dutyLocation := factory.FetchOrBuildCurrentDutyLocation(suite.DB())
+	factory.FetchOrBuildDefaultContractor(suite.DB(), nil, nil)
 
 	req := httptest.NewRequest("POST", "/orders", nil)
 	req = suite.AuthenticateRequest(req, sm)

--- a/pkg/handlers/internalapi/personally_procured_move_test.go
+++ b/pkg/handlers/internalapi/personally_procured_move_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/gofrs/uuid"
 	"github.com/stretchr/testify/mock"
 
+	"github.com/transcom/mymove/pkg/factory"
 	ppmop "github.com/transcom/mymove/pkg/gen/internalapi/internaloperations/ppm"
 	"github.com/transcom/mymove/pkg/gen/internalmessages"
 	"github.com/transcom/mymove/pkg/handlers"
@@ -154,7 +155,7 @@ func (suite *HandlerSuite) setupPersonallyProcuredMoveTest() {
 func (suite *HandlerSuite) TestCreatePPMHandler() {
 	user1 := testdatagen.MakeDefaultServiceMember(suite.DB())
 	orders := testdatagen.MakeDefaultOrder(suite.DB())
-	testdatagen.MakeDefaultContractor(suite.DB())
+	factory.FetchOrBuildDefaultContractor(suite.DB(), nil, nil)
 
 	selectedMoveType := models.SelectedMoveTypeHHGPPM
 
@@ -449,7 +450,7 @@ func (suite *HandlerSuite) TestPatchPPMHandlerWrongMoveID() {
 
 	orders := testdatagen.MakeDefaultOrder(suite.DB())
 	orders1 := testdatagen.MakeDefaultOrder(suite.DB())
-	testdatagen.MakeDefaultContractor(suite.DB())
+	factory.FetchOrBuildDefaultContractor(suite.DB(), nil, nil)
 
 	selectedMoveType := models.SelectedMoveTypeHHGPPM
 

--- a/pkg/handlers/primeapi/upload_test.go
+++ b/pkg/handlers/primeapi/upload_test.go
@@ -27,7 +27,7 @@ func (suite *HandlerSuite) TestCreateUploadHandler() {
 			paymentrequest.NewPaymentRequestUploadCreator(handlerConfig.FileStorer()),
 		}
 		paymentRequest := testdatagen.MakeDefaultPaymentRequest(suite.DB())
-		testdatagen.MakeDefaultContractor(suite.DB())
+		factory.FetchOrBuildDefaultContractor(suite.DB(), nil, nil)
 		return handler, paymentRequest
 	}
 

--- a/pkg/handlers/supportapi/move_task_order_test.go
+++ b/pkg/handlers/supportapi/move_task_order_test.go
@@ -227,7 +227,7 @@ func (suite *HandlerSuite) TestCreateMoveTaskOrderRequestHandler() {
 		destinationDutyLocation := factory.BuildDutyLocation(suite.DB(), nil, nil)
 		originDutyLocation := factory.BuildDutyLocation(suite.DB(), nil, nil)
 		customer := testdatagen.MakeDefaultServiceMember(suite.DB())
-		contractor := testdatagen.MakeDefaultContractor(suite.DB())
+		contractor := factory.FetchOrBuildDefaultContractor(suite.DB(), nil, nil)
 		document := testdatagen.MakeDefaultDocument(suite.DB())
 
 		// Create the mto payload we will be requesting to create

--- a/pkg/models/move_test.go
+++ b/pkg/models/move_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/gofrs/uuid"
 
 	"github.com/transcom/mymove/pkg/auth"
+	"github.com/transcom/mymove/pkg/factory"
 	. "github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/testdatagen"
 )
@@ -37,7 +38,7 @@ func (suite *ModelSuite) TestBasicMoveInstantiation() {
 
 func (suite *ModelSuite) TestCreateNewMoveValidLocatorString() {
 	orders := testdatagen.MakeDefaultOrder(suite.DB())
-	testdatagen.MakeDefaultContractor(suite.DB())
+	factory.FetchOrBuildDefaultContractor(suite.DB(), nil, nil)
 	selectedMoveType := SelectedMoveTypeHHG
 
 	moveOptions := MoveOptions{
@@ -73,7 +74,7 @@ func (suite *ModelSuite) TestFetchMove() {
 	setupTestData := func() (*auth.Session, Order) {
 
 		order := testdatagen.MakeDefaultOrder(suite.DB())
-		testdatagen.MakeDefaultContractor(suite.DB())
+		factory.FetchOrBuildDefaultContractor(suite.DB(), nil, nil)
 
 		session := &auth.Session{
 			UserID:          order.ServiceMember.UserID,
@@ -208,7 +209,7 @@ func (suite *ModelSuite) TestSaveMoveDependenciesFail() {
 	// Given: A move with Orders with unacceptable status
 	orders := testdatagen.MakeDefaultOrder(suite.DB())
 	orders.Status = ""
-	testdatagen.MakeDefaultContractor(suite.DB())
+	factory.FetchOrBuildDefaultContractor(suite.DB(), nil, nil)
 	selectedMoveType := SelectedMoveTypeHHGPPM
 
 	moveOptions := MoveOptions{
@@ -229,7 +230,7 @@ func (suite *ModelSuite) TestSaveMoveDependenciesSuccess() {
 	// Given: A move with Orders with acceptable status
 	orders := testdatagen.MakeDefaultOrder(suite.DB())
 	orders.Status = OrderStatusSUBMITTED
-	testdatagen.MakeDefaultContractor(suite.DB())
+	factory.FetchOrBuildDefaultContractor(suite.DB(), nil, nil)
 	selectedMoveType := SelectedMoveTypeHHGPPM
 
 	moveOptions := MoveOptions{

--- a/pkg/models/personally_procured_move_test.go
+++ b/pkg/models/personally_procured_move_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/gofrs/uuid"
 
 	"github.com/transcom/mymove/pkg/auth"
+	"github.com/transcom/mymove/pkg/factory"
 	. "github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/testdatagen"
 )
@@ -66,7 +67,7 @@ func (suite *ModelSuite) TestPPMStateMachine() {
 	orders := testdatagen.MakeDefaultOrder(suite.DB())
 	orders.Status = OrderStatusSUBMITTED // NEVER do this outside of a test.
 	suite.MustSave(&orders)
-	testdatagen.MakeDefaultContractor(suite.DB())
+	factory.FetchOrBuildDefaultContractor(suite.DB(), nil, nil)
 
 	selectedMoveType := SelectedMoveTypeHHGPPM
 

--- a/pkg/models/prime_upload_test.go
+++ b/pkg/models/prime_upload_test.go
@@ -5,6 +5,7 @@ import (
 	"github.com/jackc/pgerrcode"
 
 	"github.com/transcom/mymove/pkg/db/dberr"
+	"github.com/transcom/mymove/pkg/factory"
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/testdatagen"
 )
@@ -49,7 +50,7 @@ func (suite *ModelSuite) Test_PrimeUploadValidations() {
 
 func (suite *ModelSuite) TestFetchPrimeUploadWithNoUpload() {
 	posDoc := testdatagen.MakeDefaultProofOfServiceDoc(suite.DB())
-	contractor := testdatagen.MakeDefaultContractor(suite.DB())
+	contractor := factory.FetchOrBuildDefaultContractor(suite.DB(), nil, nil)
 
 	primeUpload := models.PrimeUpload{
 		ProofOfServiceDocID: posDoc.ID,
@@ -64,7 +65,7 @@ func (suite *ModelSuite) TestFetchPrimeUpload() {
 	t := suite.T()
 
 	posDoc := testdatagen.MakeDefaultProofOfServiceDoc(suite.DB())
-	contractor := testdatagen.MakeDefaultContractor(suite.DB())
+	contractor := factory.FetchOrBuildDefaultContractor(suite.DB(), nil, nil)
 
 	upload := models.Upload{
 		Filename:    "test.pdf",
@@ -107,7 +108,7 @@ func (suite *ModelSuite) TestFetchDeletedPrimeUpload() {
 	t := suite.T()
 
 	posDoc := testdatagen.MakeDefaultProofOfServiceDoc(suite.DB())
-	contractor := testdatagen.MakeDefaultContractor(suite.DB())
+	contractor := factory.FetchOrBuildDefaultContractor(suite.DB(), nil, nil)
 
 	upload := models.Upload{
 		Filename:    "test.pdf",

--- a/pkg/models/queue_test.go
+++ b/pkg/models/queue_test.go
@@ -4,13 +4,14 @@ import (
 	"github.com/go-openapi/swag"
 	"github.com/gofrs/uuid"
 
+	"github.com/transcom/mymove/pkg/factory"
 	. "github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/testdatagen"
 )
 
 func (suite *ModelSuite) TestCreateMoveWithPPMShow() {
 	orders := testdatagen.MakeDefaultOrder(suite.DB())
-	testdatagen.MakeDefaultContractor(suite.DB())
+	factory.FetchOrBuildDefaultContractor(suite.DB(), nil, nil)
 
 	move := testdatagen.MakeMove(suite.DB(), testdatagen.Assertions{
 		Order: orders,
@@ -35,7 +36,7 @@ func (suite *ModelSuite) TestCreateMoveWithPPMShow() {
 
 func (suite *ModelSuite) TestCreateMoveWithPPMNoShow() {
 	orders := testdatagen.MakeDefaultOrder(suite.DB())
-	testdatagen.MakeDefaultContractor(suite.DB())
+	factory.FetchOrBuildDefaultContractor(suite.DB(), nil, nil)
 
 	move := testdatagen.MakeMove(suite.DB(), testdatagen.Assertions{
 		Order: orders,
@@ -61,7 +62,7 @@ func (suite *ModelSuite) TestCreateMoveWithPPMNoShow() {
 
 func (suite *ModelSuite) TestCreateNewMoveWithNoPPMShow() {
 	orders := testdatagen.MakeDefaultOrder(suite.DB())
-	testdatagen.MakeDefaultContractor(suite.DB())
+	factory.FetchOrBuildDefaultContractor(suite.DB(), nil, nil)
 
 	moveOptions := MoveOptions{
 		Show: swag.Bool(true),

--- a/pkg/services/move_task_order/move_task_order_creator_test.go
+++ b/pkg/services/move_task_order/move_task_order_creator_test.go
@@ -3,6 +3,7 @@ package movetaskorder_test
 import (
 	"github.com/gofrs/uuid"
 
+	"github.com/transcom/mymove/pkg/factory"
 	"github.com/transcom/mymove/pkg/models"
 	. "github.com/transcom/mymove/pkg/services/move_task_order"
 	"github.com/transcom/mymove/pkg/services/query"
@@ -28,7 +29,7 @@ func (suite *MoveTaskOrderServiceSuite) TestMoveTaskOrderCreatorIntegration() {
 	mtoCreator := NewMoveTaskOrderCreator(builder)
 
 	order := testdatagen.MakeDefaultOrder(suite.DB())
-	contractor := testdatagen.MakeDefaultContractor(suite.DB())
+	contractor := factory.FetchOrBuildDefaultContractor(suite.DB(), nil, nil)
 	contractorID := contractor.ID
 	newMto := models.Move{
 		OrdersID:     order.ID,

--- a/pkg/services/payment_request/payment_request_recalculator_test.go
+++ b/pkg/services/payment_request/payment_request_recalculator_test.go
@@ -72,7 +72,7 @@ func (suite *PaymentRequestServiceSuite) TestRecalculatePaymentRequestSuccess() 
 			},
 		})
 		oldProofOfServiceDocIDs = append(oldProofOfServiceDocIDs, proofOfServiceDoc.ID.String())
-		contractor := testdatagen.MakeDefaultContractor(suite.DB())
+		contractor := factory.FetchOrBuildDefaultContractor(suite.DB(), nil, nil)
 		testdatagen.MakePrimeUpload(suite.DB(), testdatagen.Assertions{
 			PrimeUpload: models.PrimeUpload{
 				ProofOfServiceDocID: proofOfServiceDoc.ID,

--- a/pkg/services/payment_request/payment_request_shipment_recalculate_test.go
+++ b/pkg/services/payment_request/payment_request_shipment_recalculate_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/mock"
 
 	"github.com/transcom/mymove/pkg/apperror"
+	"github.com/transcom/mymove/pkg/factory"
 	"github.com/transcom/mymove/pkg/models"
 	routemocks "github.com/transcom/mymove/pkg/route/mocks"
 	"github.com/transcom/mymove/pkg/services/ghcrateengine"
@@ -43,7 +44,7 @@ func (suite *PaymentRequestServiceSuite) TestRecalculateShipmentPaymentRequestSu
 				PaymentRequestID: paymentRequest1.ID,
 			},
 		})
-		contractor := testdatagen.MakeDefaultContractor(suite.DB())
+		contractor := factory.FetchOrBuildDefaultContractor(suite.DB(), nil, nil)
 		testdatagen.MakePrimeUpload(suite.DB(), testdatagen.Assertions{
 			PrimeUpload: models.PrimeUpload{
 				ProofOfServiceDocID: proofOfServiceDoc.ID,
@@ -71,7 +72,7 @@ func (suite *PaymentRequestServiceSuite) TestRecalculateShipmentPaymentRequestSu
 				PaymentRequestID: paymentRequest2.ID,
 			},
 		})
-		contractor := testdatagen.MakeDefaultContractor(suite.DB())
+		contractor := factory.FetchOrBuildDefaultContractor(suite.DB(), nil, nil)
 		testdatagen.MakePrimeUpload(suite.DB(), testdatagen.Assertions{
 			PrimeUpload: models.PrimeUpload{
 				ProofOfServiceDocID: proofOfServiceDoc.ID,

--- a/pkg/services/payment_request/upload_creator_test.go
+++ b/pkg/services/payment_request/upload_creator_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/gofrs/uuid"
 	"go.uber.org/zap"
 
+	"github.com/transcom/mymove/pkg/factory"
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/storage/test"
 	"github.com/transcom/mymove/pkg/testdatagen"
@@ -30,7 +31,7 @@ func (suite *PaymentRequestServiceSuite) TestCreateUploadSuccess() {
 	suite.NoError(err)
 
 	setupTestData := func() {
-		contractor = testdatagen.MakeDefaultContractor(suite.DB())
+		contractor = factory.FetchOrBuildDefaultContractor(suite.DB(), nil, nil)
 
 		fakeS3 = test.NewFakeS3Storage(true)
 		paymentRequestID, err := uuid.FromString("9b873071-149f-43c2-8971-e93348ebc5e3")
@@ -83,7 +84,7 @@ func (suite *PaymentRequestServiceSuite) TestCreateUploadFailure() {
 	fakeS3 := test.NewFakeS3Storage(true)
 
 	setupTestData := func() {
-		contractor = testdatagen.MakeDefaultContractor(suite.DB())
+		contractor = factory.FetchOrBuildDefaultContractor(suite.DB(), nil, nil)
 		testdatagen.MakeDefaultPaymentRequest(suite.DB())
 	}
 

--- a/pkg/services/webhook_subscription/webhook_subscription_creator_test.go
+++ b/pkg/services/webhook_subscription/webhook_subscription_creator_test.go
@@ -3,9 +3,9 @@ package webhooksubscription
 import (
 	"github.com/gofrs/uuid"
 
+	"github.com/transcom/mymove/pkg/factory"
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/services/query"
-	"github.com/transcom/mymove/pkg/testdatagen"
 )
 
 func (suite *WebhookSubscriptionServiceSuite) TestCreateWebhookSubscription() {
@@ -14,7 +14,7 @@ func (suite *WebhookSubscriptionServiceSuite) TestCreateWebhookSubscription() {
 
 	// Happy path
 	suite.Run("If the subscription is created successfully it should be returned", func() {
-		subscriber := testdatagen.MakeContractor(suite.DB(), testdatagen.Assertions{})
+		subscriber := factory.FetchOrBuildDefaultContractor(suite.DB(), nil, nil)
 		webhookSubscriptionInfo := models.WebhookSubscription{
 			SubscriberID: subscriber.ID,
 			Status:       models.WebhookSubscriptionStatusActive,

--- a/pkg/uploader/prime_uploader_test.go
+++ b/pkg/uploader/prime_uploader_test.go
@@ -1,6 +1,7 @@
 package uploader_test
 
 import (
+	"github.com/transcom/mymove/pkg/factory"
 	"github.com/transcom/mymove/pkg/storage/test"
 	"github.com/transcom/mymove/pkg/testdatagen"
 	"github.com/transcom/mymove/pkg/uploader"
@@ -13,7 +14,7 @@ func (suite *UploaderSuite) TestPrimeUploadFromLocalFile() {
 	suite.NoError(err)
 	file := suite.fixture("test.pdf")
 
-	contractor := testdatagen.MakeDefaultContractor(suite.DB())
+	contractor := factory.FetchOrBuildDefaultContractor(suite.DB(), nil, nil)
 
 	primeUpload, verrs, err := primeUploader.CreatePrimeUploadForDocument(suite.AppContextForTest(), &document.ID, contractor.ID, uploader.File{File: file}, uploader.AllowedTypesPDF)
 	suite.Nil(err, "failed to create upload")
@@ -31,7 +32,7 @@ func (suite *UploaderSuite) TestPrimeUploadFromLocalFileZeroLength() {
 	suite.Nil(err, "failed to create upload")
 	defer cleanup()
 
-	contractor := testdatagen.MakeDefaultContractor(suite.DB())
+	contractor := factory.FetchOrBuildDefaultContractor(suite.DB(), nil, nil)
 
 	primeUpload, verrs, err := primeUploader.CreatePrimeUploadForDocument(suite.AppContextForTest(), &document.ID, contractor.ID, uploader.File{File: file}, uploader.AllowedTypesAny)
 	suite.Equal(uploader.ErrZeroLengthFile, err)
@@ -48,7 +49,7 @@ func (suite *UploaderSuite) TestPrimeUploadFromLocalFileWrongContentType() {
 	suite.Nil(err, "failed to create upload")
 	defer cleanup()
 
-	contractor := testdatagen.MakeDefaultContractor(suite.DB())
+	contractor := factory.FetchOrBuildDefaultContractor(suite.DB(), nil, nil)
 
 	upload, verrs, err := primeUploader.CreatePrimeUploadForDocument(suite.AppContextForTest(), &document.ID, contractor.ID, uploader.File{File: file}, uploader.AllowedTypesPDF)
 	suite.Error(err)
@@ -66,7 +67,7 @@ func (suite *UploaderSuite) TestTooLargePrimeUploadFromLocalFile() {
 	suite.NoError(err)
 	defer cleanup()
 
-	contractor := testdatagen.MakeDefaultContractor(suite.DB())
+	contractor := factory.FetchOrBuildDefaultContractor(suite.DB(), nil, nil)
 
 	_, verrs, err := primeUploader.CreatePrimeUploadForDocument(suite.AppContextForTest(), &document.ID, contractor.ID, uploader.File{File: f}, uploader.AllowedTypesAny)
 	suite.Error(err)
@@ -86,7 +87,7 @@ func (suite *UploaderSuite) TestPrimeUploadStorerCalledWithTags() {
 
 	tags := "metaDataTag=value"
 
-	contractor := testdatagen.MakeDefaultContractor(suite.DB())
+	contractor := factory.FetchOrBuildDefaultContractor(suite.DB(), nil, nil)
 
 	// assert tags are passed along to storer
 	_, verrs, err := primeUploader.CreatePrimeUploadForDocument(suite.AppContextForTest(), &document.ID, contractor.ID, uploader.File{File: f, Tags: &tags}, uploader.AllowedTypesAny)


### PR DESCRIPTION
## [Jira ticket](https://dp3.atlassian.net/browse/MB-14969) for this change

## Summary

This ticket adds a factory package with function BuildContractor intended to be an eventual replacement for testdatagen.MakeContractor
* Created BuildContractor/FetchOrBuildDefaultContractor and shared functions
* Created tests for all of those. 
* Replaces instances in code where `MakeContractor` exists with `BuildContracor` and `FetchOrBuildDefaultContractor`

## Setup to Run Your Code

`make server_test` should be enough. 

### Frontend

- No frontend changes

### Backend

- [x] Code follows the guidelines for [Logging](https://transcom.github.io/mymove-docs/docs/dev/contributing/backend/Backend-Programming-Guide#logging)
- [x] The requirements listed in [Querying the Database Safely](https://transcom.github.io/mymove-docs/docs/dev/contributing/backend/Backend-Programming-Guide/#querying-the-database-safely) have been satisfied.

### Database

#### Any new migrations/schema changes:

- No schema changes

