### PR TITLE
MB-14936 Update Camp Lejeune (USMC) transportation office to no longer provide PPM Closeout

### DIFF
--- a/migrations/app/migrations_manifest.txt
+++ b/migrations/app/migrations_manifest.txt
@@ -781,3 +781,4 @@
 20230105211952_app_demo_cert_migration.up.sql
 20230106201854_app_loadtest_cert_migration.up.sql
 20230106211757_app_exp_cert_migration.up.sql
+20230120165432_update_camp_lejeune_closeout_value.up.sql

--- a/migrations/app/schema/20230120165432_update_camp_lejeune_closeout_value.up.sql
+++ b/migrations/app/schema/20230120165432_update_camp_lejeune_closeout_value.up.sql
@@ -1,0 +1,5 @@
+UPDATE transportation_offices
+    SET provides_ppm_closeout = FALSE
+    WHERE name in (
+	'Camp LeJeune (USMC)'
+);

--- a/migrations/app/schema/20230120165432_update_camp_lejeune_closeout_value.up.sql
+++ b/migrations/app/schema/20230120165432_update_camp_lejeune_closeout_value.up.sql
@@ -1,5 +1,3 @@
 UPDATE transportation_offices
     SET provides_ppm_closeout = FALSE
-    WHERE name in (
-	'Camp LeJeune (USMC)'
-);
+    WHERE name = 'Camp LeJeune (USMC)';


### PR DESCRIPTION
## [Jira ticket](https://dp3.atlassian.net/browse/MB-14936?atlOrigin=eyJpIjoiN2M3OTU2OWNiYmZhNGVhMWE0OTZlMjBhZGZkMWY4MTciLCJwIjoiaiJ9) for this change

## Summary

Update your local db and check to make sure that field is false now, instead of true. 
`SELECT provides_ppm_closeout FROM public.transportation_offices where name = 'Camp LeJeune (USMC)';`

## Setup to Run Your Code


## Verification Steps for Author

These are to be checked by the author.

- [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
- [ ] Request review from a member of a different team.
- [ ] Have the Jira acceptance criteria been met for this change?

## Verification Steps for Reviewers

These are to be checked by a reviewer.

<!-- Fill out the next sections as you see fit, these are just suggestions. -->

### Frontend

- [ ] User facing changes have been reviewed by design.
- [ ] There are no aXe warnings for UI.
- [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/main/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
- [ ] There are no new console errors in the browser devtools
- [ ] There are no new console errors in the test output
- [ ] If this PR adds a new component to Storybook, it ensures the component is fully responsive, OR if it is intentionally not, a wrapping div using the `officeApp` class or custom `min-width` styling is used to hide any states the would not be visible to the user.

### Backend

- [ ] Code follows the guidelines for [Logging](https://transcom.github.io/mymove-docs/docs/dev/contributing/backend/Backend-Programming-Guide#logging)
- [ ] The requirements listed in [Querying the Database Safely](https://transcom.github.io/mymove-docs/docs/dev/contributing/backend/Backend-Programming-Guide/#querying-the-database-safely) have been satisfied.

### Database

#### Any new migrations/schema changes:

- [ ] Follows our guidelines for [Zero-Downtime Deploys](https://transcom.github.io/mymove-docs/docs/dev/contributing/database/Database-Migrations#zero-downtime-migrations)
- [ ] Have been communicated to #g-database
- [ ] Secure migrations have been tested following the instructions in our [docs](https://transcom.github.io/mymove-docs/docs/dev/contributing/database/Database-Migrations#secure-migrations)

## Screenshots
