### PR TITLE
Mb 14915 backfill seed moves with pp ms to include closeout office

### DIFF
--- a/cypress/integration/milmove/ppms/review.js
+++ b/cypress/integration/milmove/ppms/review.js
@@ -29,20 +29,6 @@ const fullPPMShipmentFields = [
   ['Advance requested?', 'Yes, $5,987'],
 ];
 
-const missingCloseoutPPMShipmentFields = [
-  ['Expected departure', '15 Mar 2020'],
-  ['Origin ZIP', '90210'],
-  ['Second origin ZIP', '90211'],
-  ['Destination ZIP', '30813'],
-  ['Second destination ZIP', '30814'],
-  ['Storage expected? (SIT)', 'No'],
-  ['Estimated weight', '4,000 lbs'],
-  ['Pro-gear', 'Yes, 1,987 lbs'],
-  ['Spouse pro-gear', 'Yes, 498 lbs'],
-  ['Estimated incentive', '$10,000'],
-  ['Advance requested?', 'Yes, $5,987'],
-];
-
 describe('PPM Onboarding - Review', function () {
   before(() => {
     cy.prepareCustomerApp();

--- a/pkg/testdatagen/scenario/shared.go
+++ b/pkg/testdatagen/scenario/shared.go
@@ -151,9 +151,6 @@ func createGenericPPMRelatedMove(appCtx appcontext.AppContext, moveInfo moveCrea
 			CloseoutOfficeID: moveInfo.closeoutOfficeID,
 		},
 	}
-	println("##############################################################################################################################")
-	println(moveInfo.closeoutOfficeID)
-	println("##############################################################################################################################")
 
 	testdatagen.MergeModels(&moveAssertions, assertions)
 

--- a/pkg/testdatagen/scenario/shared.go
+++ b/pkg/testdatagen/scenario/shared.go
@@ -148,13 +148,24 @@ func createGenericPPMRelatedMove(appCtx appcontext.AppContext, moveInfo moveCrea
 			ID:               moveInfo.moveID,
 			Locator:          moveInfo.moveLocator,
 			SelectedMoveType: &ppmMoveType,
-			CloseoutOfficeID: moveInfo.closeoutOfficeID,
 		},
 	}
 
 	testdatagen.MergeModels(&moveAssertions, assertions)
 
 	move := testdatagen.MakeMove(appCtx.DB(), moveAssertions)
+
+	closeoutOffice := factory.BuildTransportationOffice(appCtx.DB(), []factory.Customization{
+		{
+			Model: models.TransportationOffice{Name: "Los Angeles AFB"},
+		},
+	}, nil)
+
+	if *smWithPPM.Affiliation == models.AffiliationARMY || *smWithPPM.Affiliation == models.AffiliationAIRFORCE {
+		move.CloseoutOffice = &closeoutOffice
+		move.CloseoutOfficeID = &closeoutOffice.ID
+		testdatagen.MustSave(appCtx.DB(), &move)
+	}
 
 	return move
 }
@@ -342,6 +353,19 @@ func createMoveWithPPMAndHHG(appCtx appcontext.AppContext, userUploader *uploade
 		},
 	})
 
+	// Make a transportation office to use as the closeout office
+	closeoutOffice := factory.BuildTransportationOffice(appCtx.DB(), []factory.Customization{
+		{
+			Model: models.TransportationOffice{Name: "Los Angeles AFB"},
+		},
+	}, nil)
+
+	if *smWithCombo.Affiliation == models.AffiliationARMY || *smWithCombo.Affiliation == models.AffiliationAIRFORCE {
+		move.CloseoutOffice = &closeoutOffice
+		move.CloseoutOfficeID = &closeoutOffice.ID
+		testdatagen.MustSave(appCtx.DB(), &move)
+	}
+
 	estimatedHHGWeight := unit.Pound(1400)
 	actualHHGWeight := unit.Pound(2000)
 	testdatagen.MakeMTOShipment(db, testdatagen.Assertions{
@@ -413,7 +437,6 @@ func createGenericMoveWithPPMShipment(appCtx appcontext.AppContext, moveInfo mov
 	}
 
 	move := createGenericPPMRelatedMove(appCtx, moveInfo, assertions)
-
 	fullAssertions := testdatagen.Assertions{
 		Move: move,
 	}
@@ -464,7 +487,6 @@ func createUnSubmittedMoveWithPPMShipmentThroughEstimatedWeights(appCtx appconte
 		moveID:      testdatagen.ConvertUUIDStringToUUID("e89a7018-be76-449a-b99b-e30a09c485dc"),
 		moveLocator: "PPMEWH",
 	}
-
 	assertions := testdatagen.Assertions{
 		UserUploader: userUploader,
 		PPMShipment: models.PPMShipment{
@@ -1754,6 +1776,18 @@ func createMoveWithCloseOut(appCtx appcontext.AppContext, userUploader *uploader
 		},
 	})
 
+	closeoutOffice := factory.BuildTransportationOffice(appCtx.DB(), []factory.Customization{
+		{
+			Model: models.TransportationOffice{Name: "Los Angeles AFB"},
+		},
+	}, nil)
+
+	if branch == models.AffiliationARMY || branch == models.AffiliationAIRFORCE {
+		move.CloseoutOffice = &closeoutOffice
+		move.CloseoutOfficeID = &closeoutOffice.ID
+		testdatagen.MustSave(appCtx.DB(), &move)
+	}
+
 	mtoShipment := testdatagen.MakeMTOShipment(appCtx.DB(), testdatagen.Assertions{
 		Move: move,
 		MTOShipment: models.MTOShipment{
@@ -1817,6 +1851,18 @@ func createMoveWithCloseOutandNonCloseOut(appCtx appcontext.AppContext, userUplo
 			SubmittedAt:      &submittedAt,
 		},
 	})
+
+	closeoutOffice := factory.BuildTransportationOffice(appCtx.DB(), []factory.Customization{
+		{
+			Model: models.TransportationOffice{Name: "Los Angeles AFB"},
+		},
+	}, nil)
+
+	if branch == models.AffiliationARMY || branch == models.AffiliationAIRFORCE {
+		move.CloseoutOffice = &closeoutOffice
+		move.CloseoutOfficeID = &closeoutOffice.ID
+		testdatagen.MustSave(appCtx.DB(), &move)
+	}
 
 	mtoShipment := testdatagen.MakeMTOShipment(appCtx.DB(), testdatagen.Assertions{
 		Move: move,
@@ -1898,6 +1944,18 @@ func createMoveWith2CloseOuts(appCtx appcontext.AppContext, userUploader *upload
 		},
 	})
 
+	closeoutOffice := factory.BuildTransportationOffice(appCtx.DB(), []factory.Customization{
+		{
+			Model: models.TransportationOffice{Name: "Los Angeles AFB"},
+		},
+	}, nil)
+
+	if branch == models.AffiliationARMY || branch == models.AffiliationAIRFORCE {
+		move.CloseoutOffice = &closeoutOffice
+		move.CloseoutOfficeID = &closeoutOffice.ID
+		testdatagen.MustSave(appCtx.DB(), &move)
+	}
+
 	mtoShipment := testdatagen.MakeMTOShipment(appCtx.DB(), testdatagen.Assertions{
 		Move: move,
 		MTOShipment: models.MTOShipment{
@@ -1977,6 +2035,18 @@ func createMoveWithCloseOutandHHG(appCtx appcontext.AppContext, userUploader *up
 			SubmittedAt:      &submittedAt,
 		},
 	})
+
+	closeoutOffice := factory.BuildTransportationOffice(appCtx.DB(), []factory.Customization{
+		{
+			Model: models.TransportationOffice{Name: "Los Angeles AFB"},
+		},
+	}, nil)
+
+	if branch == models.AffiliationARMY || branch == models.AffiliationAIRFORCE {
+		move.CloseoutOffice = &closeoutOffice
+		move.CloseoutOfficeID = &closeoutOffice.ID
+		testdatagen.MustSave(appCtx.DB(), &move)
+	}
 
 	mtoShipment := testdatagen.MakeMTOShipment(appCtx.DB(), testdatagen.Assertions{
 		Move: move,
@@ -2133,7 +2203,17 @@ func createSubmittedMoveWithPPMShipmentForSC(appCtx appcontext.AppContext, userU
 			SubmittedAt:      &submittedAt,
 		},
 	})
+	closeoutOffice := factory.BuildTransportationOffice(appCtx.DB(), []factory.Customization{
+		{
+			Model: models.TransportationOffice{Name: "Los Angeles AFB"},
+		},
+	}, nil)
 
+	if *smWithPPM.Affiliation == models.AffiliationARMY || *smWithPPM.Affiliation == models.AffiliationAIRFORCE {
+		move.CloseoutOffice = &closeoutOffice
+		move.CloseoutOfficeID = &closeoutOffice.ID
+		testdatagen.MustSave(appCtx.DB(), &move)
+	}
 	mtoShipment := testdatagen.MakeMTOShipment(appCtx.DB(), testdatagen.Assertions{
 		MTOShipment: models.MTOShipment{
 			ShipmentType:    models.MTOShipmentTypePPM,
@@ -2199,6 +2279,18 @@ func createSubmittedMoveWithPPMShipmentForSCWithSIT(appCtx appcontext.AppContext
 			SubmittedAt:      &submittedAt,
 		},
 	})
+
+	closeoutOffice := factory.BuildTransportationOffice(appCtx.DB(), []factory.Customization{
+		{
+			Model: models.TransportationOffice{Name: "Los Angeles AFB"},
+		},
+	}, nil)
+
+	if *smWithPPM.Affiliation == models.AffiliationARMY || *smWithPPM.Affiliation == models.AffiliationAIRFORCE {
+		move.CloseoutOffice = &closeoutOffice
+		move.CloseoutOfficeID = &closeoutOffice.ID
+		testdatagen.MustSave(appCtx.DB(), &move)
+	}
 
 	mtoShipment := testdatagen.MakeMTOShipment(appCtx.DB(), testdatagen.Assertions{
 		MTOShipment: models.MTOShipment{
@@ -2334,6 +2426,18 @@ func createSubmittedMoveWithFullPPMShipmentComplete(appCtx appcontext.AppContext
 			Status:           models.MoveStatusSUBMITTED,
 		},
 	})
+
+	closeoutOffice := factory.BuildTransportationOffice(appCtx.DB(), []factory.Customization{
+		{
+			Model: models.TransportationOffice{Name: "Los Angeles AFB"},
+		},
+	}, nil)
+
+	if *smWithPPM.Affiliation == models.AffiliationARMY || *smWithPPM.Affiliation == models.AffiliationAIRFORCE {
+		move.CloseoutOffice = &closeoutOffice
+		move.CloseoutOfficeID = &closeoutOffice.ID
+		testdatagen.MustSave(appCtx.DB(), &move)
+	}
 
 	mtoShipment := testdatagen.MakeMTOShipment(appCtx.DB(), testdatagen.Assertions{
 		MTOShipment: models.MTOShipment{
@@ -7244,6 +7348,18 @@ func createNeedsServicesCounselingWithoutCompletedOrders(appCtx appcontext.AppCo
 		},
 		Order: orders,
 	})
+
+	closeoutOffice := factory.BuildTransportationOffice(appCtx.DB(), []factory.Customization{
+		{
+			Model: models.TransportationOffice{Name: "Los Angeles AFB"},
+		},
+	}, nil)
+
+	if *orders.ServiceMember.Affiliation == models.AffiliationARMY || *orders.ServiceMember.Affiliation == models.AffiliationAIRFORCE {
+		move.CloseoutOffice = &closeoutOffice
+		move.CloseoutOfficeID = &closeoutOffice.ID
+		testdatagen.MustSave(appCtx.DB(), &move)
+	}
 
 	requestedPickupDate := submittedAt.Add(60 * 24 * time.Hour)
 	requestedDeliveryDate := requestedPickupDate.Add(7 * 24 * time.Hour)

--- a/pkg/testdatagen/scenario/subscenarios.go
+++ b/pkg/testdatagen/scenario/subscenarios.go
@@ -8,6 +8,7 @@ import (
 	"github.com/gofrs/uuid"
 
 	"github.com/transcom/mymove/pkg/appcontext"
+	"github.com/transcom/mymove/pkg/factory"
 	"github.com/transcom/mymove/pkg/gen/internalmessages"
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/services"
@@ -236,6 +237,19 @@ func subScenarioEvaluationReport(appCtx appcontext.AppContext) func() {
 				},
 			},
 		)
+		// Make a transportation office to use as the closeout office
+		closeoutOffice := factory.BuildTransportationOffice(appCtx.DB(), []factory.Customization{
+			{
+				Model: models.TransportationOffice{Name: "Los Angeles AFB"},
+			},
+		}, nil)
+
+		if *move.Orders.ServiceMember.Affiliation == models.AffiliationARMY || *move.Orders.ServiceMember.Affiliation == models.AffiliationAIRFORCE {
+			move.CloseoutOffice = &closeoutOffice
+			move.CloseoutOfficeID = &closeoutOffice.ID
+			testdatagen.MustSave(appCtx.DB(), &move)
+		}
+
 		shipment := testdatagen.MakeMTOShipment(appCtx.DB(), testdatagen.Assertions{MTOShipment: models.MTOShipment{
 			MoveTaskOrderID:       move.ID,
 			Status:                models.MTOShipmentStatusSubmitted,


### PR DESCRIPTION
## [Jira ticket](tbd) for this change

## Summary

Is there anything you would like reviewers to give additional scrutiny?

[this article](tbd) explains more about the approach used.

## Setup to Run Your Code

<details>
<summary>💻 You will need to use three separate terminals to test this locally.</summary>

##### Terminal 1

Start the Storybook locally.

```sh
make storybook
```

##### Terminal 2

Start the UI locally.

```sh
make client_run
```

##### Terminal 3

Start the Go server locally.

```sh
make server_run
```

</details>

### Additional steps

<!-- Fill out the next section as you see fit, these are just suggestions. -->

1. Access the
2. Login as a
3.

## Verification Steps for Author

These are to be checked by the author.

- [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
- [ ] Request review from a member of a different team.
- [ ] Have the Jira acceptance criteria been met for this change?

## Verification Steps for Reviewers

These are to be checked by a reviewer.

<!-- Fill out the next sections as you see fit, these are just suggestions. -->

### Frontend

- [ ] User facing changes have been reviewed by design.
- [ ] There are no aXe warnings for UI.
- [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/main/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
- [ ] There are no new console errors in the browser devtools
- [ ] There are no new console errors in the test output
- [ ] If this PR adds a new component to Storybook, it ensures the component is fully responsive, OR if it is intentionally not, a wrapping div using the `officeApp` class or custom `min-width` styling is used to hide any states the would not be visible to the user.

### Backend

- [ ] Code follows the guidelines for [Logging](https://transcom.github.io/mymove-docs/docs/dev/contributing/backend/Backend-Programming-Guide#logging)
- [ ] The requirements listed in [Querying the Database Safely](https://transcom.github.io/mymove-docs/docs/dev/contributing/backend/Backend-Programming-Guide/#querying-the-database-safely) have been satisfied.

### Database

#### Any new migrations/schema changes:

- [ ] Follows our guidelines for [Zero-Downtime Deploys](https://transcom.github.io/mymove-docs/docs/dev/contributing/database/Database-Migrations#zero-downtime-migrations)
- [ ] Have been communicated to #g-database
- [ ] Secure migrations have been tested following the instructions in our [docs](https://transcom.github.io/mymove-docs/docs/dev/contributing/database/Database-Migrations#secure-migrations)

## Screenshots
