### PR TITLE
[MB-14916] Create convenience PPM closeout office users in devseed for the Navy/Coast Guard/Marine Corps GBLOCs

### DIFF
--- a/pkg/testdatagen/scenario/e2ebasic.go
+++ b/pkg/testdatagen/scenario/e2ebasic.go
@@ -448,105 +448,6 @@ func userWithPrimeSimulatorRole(appCtx appcontext.AppContext) {
 	})
 }
 
-func userWithCloseoutNavy(appCtx appcontext.AppContext, userID uuid.UUID, email string) {
-	closeoutNavyRole := roles.Role{}
-	err := appCtx.DB().Where("role_type = $1", roles.RoleTypeQaeCsr).First(&closeoutNavyRole)
-	if err != nil {
-		log.Panic(fmt.Errorf("failed to find RoleTypeQAECSR in the DB: %w", err))
-	}
-
-	loginGovID := uuid.Must(uuid.NewV4())
-
-	factory.BuildUser(appCtx.DB(), []factory.Customization{
-		{
-			Model: models.User{
-				ID:            userID,
-				LoginGovUUID:  &loginGovID,
-				LoginGovEmail: email,
-				Active:        true,
-				Roles:         []roles.Role{closeoutNavyRole},
-			},
-		},
-	}, nil)
-
-	testdatagen.MakeOfficeUser(appCtx.DB(), testdatagen.Assertions{
-		OfficeUser: models.OfficeUser{
-			Email:  email,
-			Active: true,
-			UserID: &userID,
-		},
-		TransportationOffice: models.TransportationOffice{
-			Gbloc: "NAVY",
-		},
-	})
-}
-
-func userWithCloseoutCoastGuard(appCtx appcontext.AppContext, userID uuid.UUID, email string) {
-	closeoutCoastGuardRole := roles.Role{}
-	err := appCtx.DB().Where("role_type = $1", roles.RoleTypeQaeCsr).First(&closeoutCoastGuardRole)
-	if err != nil {
-		log.Panic(fmt.Errorf("failed to find RoleTypeQAECSR in the DB: %w", err))
-	}
-
-	loginGovID := uuid.Must(uuid.NewV4())
-
-	factory.BuildUser(appCtx.DB(), []factory.Customization{
-		{
-			Model: models.User{
-				ID:            userID,
-				LoginGovUUID:  &loginGovID,
-				LoginGovEmail: email,
-				Active:        true,
-				Roles:         []roles.Role{closeoutCoastGuardRole},
-			},
-		},
-	}, nil)
-
-	testdatagen.MakeOfficeUser(appCtx.DB(), testdatagen.Assertions{
-		OfficeUser: models.OfficeUser{
-			Email:  email,
-			Active: true,
-			UserID: &userID,
-		},
-		TransportationOffice: models.TransportationOffice{
-			Gbloc: "USCG",
-		},
-	})
-}
-
-func userWithCloseoutMarineCorps(appCtx appcontext.AppContext, userID uuid.UUID, email string) {
-	closeoutMarineCorpsRole := roles.Role{}
-	err := appCtx.DB().Where("role_type = $1", roles.RoleTypeQaeCsr).First(&closeoutMarineCorpsRole)
-	if err != nil {
-		log.Panic(fmt.Errorf("failed to find RoleTypeQAECSR in the DB: %w", err))
-	}
-
-	loginGovID := uuid.Must(uuid.NewV4())
-
-	factory.BuildUser(appCtx.DB(), []factory.Customization{
-		{
-			Model: models.User{
-				ID:            userID,
-				LoginGovUUID:  &loginGovID,
-				LoginGovEmail: email,
-				Active:        true,
-				Roles:         []roles.Role{closeoutMarineCorpsRole},
-			},
-		},
-	}, nil)
-
-	testdatagen.MakeOfficeUser(appCtx.DB(), testdatagen.Assertions{
-		OfficeUser: models.OfficeUser{
-			Email:  email,
-			Active: true,
-			UserID: &userID,
-		},
-		TransportationOffice: models.TransportationOffice{
-			Gbloc: "TVCB",
-		},
-	})
-}
-
 /*
  * Moves
  */
@@ -4297,9 +4198,6 @@ func (e e2eBasicScenario) Run(appCtx appcontext.AppContext, userUploader *upload
 	userWithTOOandTIOandQAECSRRole(appCtx)
 	userWithTOOandTIOandServicesCounselorRole(appCtx)
 	userWithPrimeSimulatorRole(appCtx)
-	userWithCloseoutNavy(appCtx, uuid.Must(uuid.FromString("8bed04b0-9c64-4fb2-bc1a-65223319f109")), "ppm.processing.navy@office.mil")
-	userWithCloseoutCoastGuard(appCtx, uuid.Must(uuid.FromString("96b45e64-a501-49ce-9f8d-975bcb7b417c")), "ppm.processing.coastguard@office.mil")
-	userWithCloseoutMarineCorps(appCtx, uuid.Must(uuid.FromString("f38cb4ed-fa1f-4f92-a52d-9695ba8cc85c")), "ppm.processing.marinecorps@office.mil")
 
 	// Moves
 	serviceMemberWithUploadedOrdersAndNewPPM(appCtx, userUploader, moveRouter)

--- a/pkg/testdatagen/scenario/e2ebasic.go
+++ b/pkg/testdatagen/scenario/e2ebasic.go
@@ -448,6 +448,105 @@ func userWithPrimeSimulatorRole(appCtx appcontext.AppContext) {
 	})
 }
 
+func userWithCloseoutNavy(appCtx appcontext.AppContext, userID uuid.UUID, email string) {
+	closeoutNavyRole := roles.Role{}
+	err := appCtx.DB().Where("role_type = $1", roles.RoleTypeQaeCsr).First(&closeoutNavyRole)
+	if err != nil {
+		log.Panic(fmt.Errorf("failed to find RoleTypeQAECSR in the DB: %w", err))
+	}
+
+	loginGovID := uuid.Must(uuid.NewV4())
+
+	factory.BuildUser(appCtx.DB(), []factory.Customization{
+		{
+			Model: models.User{
+				ID:            userID,
+				LoginGovUUID:  &loginGovID,
+				LoginGovEmail: email,
+				Active:        true,
+				Roles:         []roles.Role{closeoutNavyRole},
+			},
+		},
+	}, nil)
+
+	testdatagen.MakeOfficeUser(appCtx.DB(), testdatagen.Assertions{
+		OfficeUser: models.OfficeUser{
+			Email:  email,
+			Active: true,
+			UserID: &userID,
+		},
+		TransportationOffice: models.TransportationOffice{
+			Gbloc: "NAVY",
+		},
+	})
+}
+
+func userWithCloseoutCoastGuard(appCtx appcontext.AppContext, userID uuid.UUID, email string) {
+	closeoutCoastGuardRole := roles.Role{}
+	err := appCtx.DB().Where("role_type = $1", roles.RoleTypeQaeCsr).First(&closeoutCoastGuardRole)
+	if err != nil {
+		log.Panic(fmt.Errorf("failed to find RoleTypeQAECSR in the DB: %w", err))
+	}
+
+	loginGovID := uuid.Must(uuid.NewV4())
+
+	factory.BuildUser(appCtx.DB(), []factory.Customization{
+		{
+			Model: models.User{
+				ID:            userID,
+				LoginGovUUID:  &loginGovID,
+				LoginGovEmail: email,
+				Active:        true,
+				Roles:         []roles.Role{closeoutCoastGuardRole},
+			},
+		},
+	}, nil)
+
+	testdatagen.MakeOfficeUser(appCtx.DB(), testdatagen.Assertions{
+		OfficeUser: models.OfficeUser{
+			Email:  email,
+			Active: true,
+			UserID: &userID,
+		},
+		TransportationOffice: models.TransportationOffice{
+			Gbloc: "USCG",
+		},
+	})
+}
+
+func userWithCloseoutMarineCorps(appCtx appcontext.AppContext, userID uuid.UUID, email string) {
+	closeoutMarineCorpsRole := roles.Role{}
+	err := appCtx.DB().Where("role_type = $1", roles.RoleTypeQaeCsr).First(&closeoutMarineCorpsRole)
+	if err != nil {
+		log.Panic(fmt.Errorf("failed to find RoleTypeQAECSR in the DB: %w", err))
+	}
+
+	loginGovID := uuid.Must(uuid.NewV4())
+
+	factory.BuildUser(appCtx.DB(), []factory.Customization{
+		{
+			Model: models.User{
+				ID:            userID,
+				LoginGovUUID:  &loginGovID,
+				LoginGovEmail: email,
+				Active:        true,
+				Roles:         []roles.Role{closeoutMarineCorpsRole},
+			},
+		},
+	}, nil)
+
+	testdatagen.MakeOfficeUser(appCtx.DB(), testdatagen.Assertions{
+		OfficeUser: models.OfficeUser{
+			Email:  email,
+			Active: true,
+			UserID: &userID,
+		},
+		TransportationOffice: models.TransportationOffice{
+			Gbloc: "TVCB",
+		},
+	})
+}
+
 /*
  * Moves
  */
@@ -4198,6 +4297,9 @@ func (e e2eBasicScenario) Run(appCtx appcontext.AppContext, userUploader *upload
 	userWithTOOandTIOandQAECSRRole(appCtx)
 	userWithTOOandTIOandServicesCounselorRole(appCtx)
 	userWithPrimeSimulatorRole(appCtx)
+	userWithCloseoutNavy(appCtx, uuid.Must(uuid.FromString("8bed04b0-9c64-4fb2-bc1a-65223319f109")), "ppm.processing.navy@office.mil")
+	userWithCloseoutCoastGuard(appCtx, uuid.Must(uuid.FromString("96b45e64-a501-49ce-9f8d-975bcb7b417c")), "ppm.processing.coastguard@office.mil")
+	userWithCloseoutMarineCorps(appCtx, uuid.Must(uuid.FromString("f38cb4ed-fa1f-4f92-a52d-9695ba8cc85c")), "ppm.processing.marinecorps@office.mil")
 
 	// Moves
 	serviceMemberWithUploadedOrdersAndNewPPM(appCtx, userUploader, moveRouter)

--- a/pkg/testdatagen/scenario/shared.go
+++ b/pkg/testdatagen/scenario/shared.go
@@ -6292,6 +6292,50 @@ func createTXOServicesUSMCCounselor(appCtx appcontext.AppContext) {
 	})
 }
 
+func createServicesCounselorForCloseoutWithGbloc(appCtx appcontext.AppContext, userID uuid.UUID, email string, gbloc string) {
+	db := appCtx.DB()
+	officeUser := models.OfficeUser{}
+	officeUserExists, err := db.Where("email = $1", email).Exists(&officeUser)
+	if err != nil {
+		log.Panic(fmt.Errorf("failed to query OfficeUser in the DB: %w", err))
+	}
+	// no need to create
+	if officeUserExists {
+		return
+	}
+
+	servicesCounselorRole := roles.Role{}
+	err = db.Where("role_type = $1", roles.RoleTypeServicesCounselor).First(&servicesCounselorRole)
+	if err != nil {
+		log.Panic(fmt.Errorf("failed to find RoleTypeServicesCounselor in the DB: %w", err))
+	}
+
+	loginGovID := uuid.Must(uuid.NewV4())
+
+	factory.BuildUser(appCtx.DB(), []factory.Customization{
+		{
+			Model: models.User{
+				ID:            userID,
+				LoginGovUUID:  &loginGovID,
+				LoginGovEmail: email,
+				Active:        true,
+				Roles:         []roles.Role{servicesCounselorRole},
+			},
+		},
+	}, nil)
+
+	testdatagen.MakeOfficeUser(appCtx.DB(), testdatagen.Assertions{
+		OfficeUser: models.OfficeUser{
+			Email:  email,
+			Active: true,
+			UserID: &userID,
+		},
+		TransportationOffice: models.TransportationOffice{
+			Gbloc: gbloc,
+		},
+	})
+}
+
 func createPrimeUser(appCtx appcontext.AppContext) models.User {
 	db := appCtx.DB()
 	/* A user with the prime role */

--- a/pkg/testdatagen/scenario/subscenarios.go
+++ b/pkg/testdatagen/scenario/subscenarios.go
@@ -73,6 +73,9 @@ func subScenarioHHGOnboarding(appCtx appcontext.AppContext, userUploader *upload
 func subScenarioPPMCloseOut(appCtx appcontext.AppContext, userUploader *uploader.UserUploader) func() {
 	return func() {
 		createServicesCounselor(appCtx)
+		createServicesCounselorForCloseoutWithGbloc(appCtx, uuid.Must(uuid.FromString("8bed04b0-9c64-4fb2-bc1a-65223319f109")), "ppm.processing.navy@office.mil", "NAVY")
+		createServicesCounselorForCloseoutWithGbloc(appCtx, uuid.Must(uuid.FromString("96b45e64-a501-49ce-9f8d-975bcb7b417c")), "ppm.processing.coastguard@office.mil", "USCG")
+		createServicesCounselorForCloseoutWithGbloc(appCtx, uuid.Must(uuid.FromString("f38cb4ed-fa1f-4f92-a52d-9695ba8cc85c")), "ppm.processing.marinecorps@office.mil", "TVCB")
 
 		// PPM Closeout
 		createMovesForEachBranch(appCtx, userUploader)


### PR DESCRIPTION
## [Jira ticket](https://dp3.atlassian.net/browse/MB-14916) for this change

## Summary
This PR adds three new services counselors for Navy/Coast Guard/Marine Corps GBLOCs
* `ppm.processing.navy@office.mil`, `"NAVY"`
* `ppm.processing.coastguard@office.mil`, `"USCG"`
* `ppm.processing.marinecorps@office.mil`, `"TVCB"`

## Setup to Run Your Code

<details>
<summary>💻 You will want to use three separate terminals to test this locally.</summary>

#### Terminal 1

Run `rm bin/generate-test-data` then `make bin/generate-test-data`

#### Terminal 2

Start the Go server locally.

```sh
make server_run
```

#### Terminal 3

Start the UI locally.

```sh
make client_run
```


</details>

### Additional steps

<!-- Fill out the next section as you see fit, these are just suggestions. -->

1. Access the [office client](http://officelocal:3000/sign-in)
2. Scroll down and click `ppm.processing.navy@office.mil` 
3. Confirm you are logged into a services counselor view of NAVY closeouts
4. Repeat for `ppm.processing.coastguard@office.mil` and `ppm.processing.marinecorps@office.mil`

An additional check that could be used would be to copy/paste
`@Review App Bot deploy https://github.com/transcom/mymove/pull/9935` into the Truss #ustc-milmove-bots Slack channel though I do not believe that to be necessary to review this PR

## Verification Steps for Author

These are to be checked by the author.

- [x] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
- [x] Request review from a member of a different team.
- [x] Have the Jira acceptance criteria been met for this change?

## Verification Steps for Reviewers

These are to be checked by a reviewer.

<!-- Fill out the next sections as you see fit, these are just suggestions. -->

### Frontend

- [ ] User facing changes have been reviewed by design.
- [ ] There are no aXe warnings for UI.
- [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/main/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
- [ ] There are no new console errors in the browser devtools
- [ ] There are no new console errors in the test output
- [ ] If this PR adds a new component to Storybook, it ensures the component is fully responsive, OR if it is intentionally not, a wrapping div using the `officeApp` class or custom `min-width` styling is used to hide any states the would not be visible to the user.

### Backend

- [ ] Code follows the guidelines for [Logging](https://transcom.github.io/mymove-docs/docs/dev/contributing/backend/Backend-Programming-Guide#logging)
- [ ] The requirements listed in [Querying the Database Safely](https://transcom.github.io/mymove-docs/docs/dev/contributing/backend/Backend-Programming-Guide/#querying-the-database-safely) have been satisfied.

### Database

#### Any new migrations/schema changes:

- [ ] Follows our guidelines for [Zero-Downtime Deploys](https://transcom.github.io/mymove-docs/docs/dev/contributing/database/Database-Migrations#zero-downtime-migrations)
- [ ] Have been communicated to #g-database
- [ ] Secure migrations have been tested following the instructions in our [docs](https://transcom.github.io/mymove-docs/docs/dev/contributing/database/Database-Migrations#secure-migrations)

## Screenshots
![Screenshot 2023-01-24 at 12 14 57 PM](https://user-images.githubusercontent.com/16230705/214362806-fd7042f8-8773-498b-b5bd-f39c29edb9c8.png)

<img width="1006" alt="Screenshot 2023-01-24 at 12 19 48 PM" src="https://user-images.githubusercontent.com/16230705/214362922-a921df61-e4db-4790-b21f-ce3d9777246d.png">


<img width="1007" alt="Screenshot 2023-01-24 at 12 20 14 PM" src="https://user-images.githubusercontent.com/16230705/214363033-d4fd022b-c69b-4026-844c-7ff503f28133.png">

<img width="1007" alt="Screenshot 2023-01-24 at 12 20 46 PM" src="https://user-images.githubusercontent.com/16230705/214363168-44b54c6e-f3ca-4e06-b265-86fd3e8a3c2d.png">
