### PR TITLE
Fixed casing on structs/functions that are now public

### DIFF
--- a/pkg/testdatagen/scenario/shared.go
+++ b/pkg/testdatagen/scenario/shared.go
@@ -964,14 +964,14 @@ func createApprovedMoveWithPPMCloseoutComplete(appCtx appcontext.AppContext, use
 }
 
 func createApprovedMoveWithPPMCloseoutCompleteMultipleWeightTickets(appCtx appcontext.AppContext, userUploader *uploader.UserUploader) {
-	moveInfo := moveCreatorInfo{
-		userID:      testdatagen.ConvertUUIDStringToUUID("385bb8f6-ee86-4948-b69d-615417bf71f9"),
-		email:       "weightTicketsPPM+closeout@ppm.approved",
-		smID:        testdatagen.ConvertUUIDStringToUUID("7ad9b8d5-db20-4d00-946b-53531a24a9e1"),
-		firstName:   "PPMCloseout",
-		lastName:    "WeightTickets",
-		moveID:      testdatagen.ConvertUUIDStringToUUID("6c121a40-7037-46ba-9e94-1b63c598bcd9"),
-		moveLocator: "CLOSE1",
+	moveInfo := MoveCreatorInfo{
+		UserID:      testdatagen.ConvertUUIDStringToUUID("385bb8f6-ee86-4948-b69d-615417bf71f9"),
+		Email:       "weightTicketsPPM+closeout@ppm.approved",
+		SmID:        testdatagen.ConvertUUIDStringToUUID("7ad9b8d5-db20-4d00-946b-53531a24a9e1"),
+		FirstName:   "PPMCloseout",
+		LastName:    "WeightTickets",
+		MoveID:      testdatagen.ConvertUUIDStringToUUID("6c121a40-7037-46ba-9e94-1b63c598bcd9"),
+		MoveLocator: "CLOSE1",
 	}
 
 	approvedAt := time.Date(2022, 4, 15, 12, 30, 0, 0, time.UTC)
@@ -1000,7 +1000,7 @@ func createApprovedMoveWithPPMCloseoutCompleteMultipleWeightTickets(appCtx appco
 		},
 	}
 
-	move, shipment := createGenericMoveWithPPMShipment(appCtx, moveInfo, false, assertions)
+	move, shipment := CreateGenericMoveWithPPMShipment(appCtx, moveInfo, false, assertions)
 
 	weightTicketAssertions := testdatagen.Assertions{
 		PPMShipment:   shipment,


### PR DESCRIPTION
## Summary

It looks like we recently changed the visibility on a couple structs/functions (made public by upper-casing the names) but a recent PR was still using the old private names, breaking `main`.  This PR hopefully gets us all green again.

## Setup to Run Your Code

<details>
<summary>💻 You will need to use three separate terminals to test this locally.</summary>

##### Terminal 1

Start the Storybook locally.

```sh
make storybook
```

##### Terminal 2

Start the UI locally.

```sh
make client_run
```

##### Terminal 3

Start the Go server locally.

```sh
make server_run
```

</details>

## Verification Steps for Author

These are to be checked by the author.

- [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
- [ ] Request review from a member of a different team.
- [ ] Have the Jira acceptance criteria been met for this change?

## Verification Steps for Reviewers

These are to be checked by a reviewer.

<!-- Fill out the next sections as you see fit, these are just suggestions. -->

### Frontend

- [ ] User facing changes have been reviewed by design.
- [ ] There are no aXe warnings for UI.
- [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/main/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
- [ ] There are no new console errors in the browser devtools
- [ ] There are no new console errors in the test output
- [ ] If this PR adds a new component to Storybook, it ensures the component is fully responsive, OR if it is intentionally not, a wrapping div using the `officeApp` class or custom `min-width` styling is used to hide any states the would not be visible to the user.

### Backend

- [ ] Code follows the guidelines for [Logging](https://transcom.github.io/mymove-docs/docs/dev/contributing/backend/Backend-Programming-Guide#logging)
- [ ] The requirements listed in [Querying the Database Safely](https://transcom.github.io/mymove-docs/docs/dev/contributing/backend/Backend-Programming-Guide/#querying-the-database-safely) have been satisfied.

### Database

#### Any new migrations/schema changes:

- [ ] Follows our guidelines for [Zero-Downtime Deploys](https://transcom.github.io/mymove-docs/docs/dev/contributing/database/Database-Migrations#zero-downtime-migrations)
- [ ] Have been communicated to #g-database
- [ ] Secure migrations have been tested following the instructions in our [docs](https://transcom.github.io/mymove-docs/docs/dev/contributing/database/Database-Migrations#secure-migrations)

## Screenshots
