### PR TITLE
MB-14342 Add tags to reviewed shipment cards for SC

### DIFF
--- a/src/components/Office/ShipmentDisplay/ShipmentDisplay.jsx
+++ b/src/components/Office/ShipmentDisplay/ShipmentDisplay.jsx
@@ -14,6 +14,7 @@ import { AddressShape } from 'types/address';
 import { AgentShape } from 'types/agent';
 import { OrdersLOAShape } from 'types/order';
 import { shipmentStatuses } from 'constants/shipments';
+import ppmDocumentStatus from 'constants/ppms';
 import { ShipmentStatusesOneOf } from 'types/shipment';
 import { retrieveSAC, retrieveTAC } from 'utils/shipmentDisplay';
 import Restricted from 'components/Restricted/Restricted';
@@ -84,6 +85,9 @@ const ShipmentDisplay = ({
               <Tag>cancellation requested</Tag>
             )}
             {displayInfo.usesExternalVendor && <Tag>external vendor</Tag>}
+            {displayInfo.ppmDocumentStatus === ppmDocumentStatus.REJECTED && <Tag>sent to customer</Tag>}
+            {(displayInfo.ppmDocumentStatus === ppmDocumentStatus.APPROVED ||
+              displayInfo.ppmDocumentStatus === ppmDocumentStatus.EXCLUDED) && <Tag>packet ready for download</Tag>}
           </div>
 
           <FontAwesomeIcon className={styles.icon} icon={expandableIconClasses} onClick={handleExpandClick} />

--- a/src/components/Office/ShipmentDisplay/ShipmentDisplay.jsx
+++ b/src/components/Office/ShipmentDisplay/ShipmentDisplay.jsx
@@ -85,9 +85,13 @@ const ShipmentDisplay = ({
               <Tag>cancellation requested</Tag>
             )}
             {displayInfo.usesExternalVendor && <Tag>external vendor</Tag>}
-            {displayInfo.ppmDocumentStatus === ppmDocumentStatus.REJECTED && <Tag>sent to customer</Tag>}
+            {displayInfo.ppmDocumentStatus === ppmDocumentStatus.REJECTED && (
+              <Tag className={styles.ppmStatus}>sent to customer</Tag>
+            )}
             {(displayInfo.ppmDocumentStatus === ppmDocumentStatus.APPROVED ||
-              displayInfo.ppmDocumentStatus === ppmDocumentStatus.EXCLUDED) && <Tag>packet ready for download</Tag>}
+              displayInfo.ppmDocumentStatus === ppmDocumentStatus.EXCLUDED) && (
+              <Tag className={styles.ppmStatus}>packet ready for download</Tag>
+            )}
           </div>
 
           <FontAwesomeIcon className={styles.icon} icon={expandableIconClasses} onClick={handleExpandClick} />

--- a/src/components/Office/ShipmentDisplay/ShipmentDisplay.module.scss
+++ b/src/components/Office/ShipmentDisplay/ShipmentDisplay.module.scss
@@ -32,6 +32,7 @@
       background-color: $info-light;
       &.ppmStatus {
         @include u-font-size('body', 'sm');
+        @include u-margin-left(1);
         background-color: $base-lightest;
       }
     }

--- a/src/components/Office/ShipmentDisplay/ShipmentDisplay.module.scss
+++ b/src/components/Office/ShipmentDisplay/ShipmentDisplay.module.scss
@@ -30,6 +30,10 @@
     :global(.usa-tag) {
       @include u-font-size('body', 3xs);
       background-color: $info-light;
+      &.ppmStatus {
+        @include u-font-size('body', 'sm');
+        background-color: $base-lightest;
+      }
     }
 
     :global(.usa-tag--red) {
@@ -81,7 +85,6 @@
     @include u-margin-x(3);
     @include u-margin-y(3);
   }
-
 }
 
 .storyBookWrap {

--- a/src/components/Office/ShipmentDisplay/ShipmentDisplay.stories.jsx
+++ b/src/components/Office/ShipmentDisplay/ShipmentDisplay.stories.jsx
@@ -19,6 +19,7 @@ import ShipmentDisplay from 'components/Office/ShipmentDisplay/ShipmentDisplay';
 import { SHIPMENT_OPTIONS } from 'shared/constants';
 import { MockProviders } from 'testUtils';
 import { permissionTypes } from 'constants/permissions';
+import ppmDocumentStatus from 'constants/ppms';
 
 export default {
   title: 'Office Components/Shipment Display',
@@ -539,6 +540,48 @@ export const PPMShipmentWithCounselorRemarksReadOnly = () => (
       isSubmitted
       allowApproval={false}
       warnIfMissing={['counselorRemarks']}
+    />
+  </div>
+);
+
+export const PPMShipmentServiceCounselorApproved = () => (
+  <div style={{ padding: '20px' }}>
+    <ShipmentDisplay
+      displayInfo={{ ...ppmInfo, ppmDocumentStatus: ppmDocumentStatus.APPROVED }}
+      ordersLOA={ordersLOA}
+      shipmentType={SHIPMENT_OPTIONS.PPM}
+      isSubmitted
+      allowApproval={false}
+      warnIfMissing={['counselorRemarks']}
+      reviewURL="/"
+    />
+  </div>
+);
+
+export const PPMShipmentServiceCounselorRejected = () => (
+  <div style={{ padding: '20px' }}>
+    <ShipmentDisplay
+      displayInfo={{ ...ppmInfo, ppmDocumentStatus: ppmDocumentStatus.REJECTED }}
+      ordersLOA={ordersLOA}
+      shipmentType={SHIPMENT_OPTIONS.PPM}
+      isSubmitted
+      allowApproval={false}
+      warnIfMissing={['counselorRemarks']}
+      reviewURL="/"
+    />
+  </div>
+);
+
+export const PPMShipmentServiceCounselorExcluded = () => (
+  <div style={{ padding: '20px' }}>
+    <ShipmentDisplay
+      displayInfo={{ ...ppmInfo, ppmDocumentStatus: ppmDocumentStatus.EXCLUDED }}
+      ordersLOA={ordersLOA}
+      shipmentType={SHIPMENT_OPTIONS.PPM}
+      isSubmitted
+      allowApproval={false}
+      warnIfMissing={['counselorRemarks']}
+      reviewURL="/"
     />
   </div>
 );

--- a/src/components/Office/ShipmentDisplay/ShipmentDisplay.test.jsx
+++ b/src/components/Office/ShipmentDisplay/ShipmentDisplay.test.jsx
@@ -12,11 +12,14 @@ import {
   ntsReleaseInfo,
   ntsReleaseMissingInfo,
   ordersLOA,
+  ppmInfo,
 } from './ShipmentDisplayTestData';
 import ShipmentDisplay from './ShipmentDisplay';
 
 import { MockProviders } from 'testUtils';
 import { permissionTypes } from 'constants/permissions';
+import { SHIPMENT_OPTIONS } from 'shared/constants';
+import ppmDocumentStatus from 'constants/ppms';
 
 const mockPush = jest.fn();
 jest.mock('react-router-dom', () => ({
@@ -179,6 +182,78 @@ describe('Shipment Container', () => {
         </MockProviders>,
       );
       expect(screen.getByTestId('shipment-display-checkbox')).toBeDisabled();
+    });
+  });
+
+  describe('PPM shipment', () => {
+    it('renders the container successfully', () => {
+      render(
+        <MockProviders permissions={[permissionTypes.updateShipment]}>
+          <ShipmentDisplay
+            displayInfo={ppmInfo}
+            ordersLOA={ordersLOA}
+            shipmentType={SHIPMENT_OPTIONS.PPM}
+            isSubmitted
+            allowApproval={false}
+            warnIfMissing={['counselorRemarks']}
+            reviewURL="/"
+          />
+        </MockProviders>,
+      );
+
+      expect(screen.getByTestId('shipment-display')).toBeInTheDocument();
+      expect(screen.getByText('PPM')).toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: 'Review documents' })).toBeInTheDocument();
+    });
+    describe("renders the 'packet ready for download' tag when", () => {
+      it('approved', () => {
+        render(
+          <MockProviders permissions={[permissionTypes.updateShipment]}>
+            <ShipmentDisplay
+              displayInfo={{ ...ppmInfo, ppmDocumentStatus: ppmDocumentStatus.APPROVED }}
+              ordersLOA={ordersLOA}
+              shipmentType={SHIPMENT_OPTIONS.PPM}
+              isSubmitted
+              allowApproval={false}
+              warnIfMissing={['counselorRemarks']}
+              reviewURL="/"
+            />
+          </MockProviders>,
+        );
+        expect(screen.getByTestId('tag', { name: 'packet ready for download' })).toBeInTheDocument();
+      });
+      it('excluded', () => {
+        render(
+          <MockProviders permissions={[permissionTypes.updateShipment]}>
+            <ShipmentDisplay
+              displayInfo={{ ...ppmInfo, ppmDocumentStatus: ppmDocumentStatus.EXCLUDED }}
+              ordersLOA={ordersLOA}
+              shipmentType={SHIPMENT_OPTIONS.PPM}
+              isSubmitted
+              allowApproval={false}
+              warnIfMissing={['counselorRemarks']}
+              reviewURL="/"
+            />
+          </MockProviders>,
+        );
+        expect(screen.getByTestId('tag', { name: 'packet ready for download' })).toBeInTheDocument();
+      });
+    });
+    it("renders the 'sent to customer' tag when rejected", () => {
+      render(
+        <MockProviders permissions={[permissionTypes.updateShipment]}>
+          <ShipmentDisplay
+            displayInfo={{ ...ppmInfo, ppmDocumentStatus: ppmDocumentStatus.REJECTED }}
+            ordersLOA={ordersLOA}
+            shipmentType={SHIPMENT_OPTIONS.PPM}
+            isSubmitted
+            allowApproval={false}
+            warnIfMissing={['counselorRemarks']}
+            reviewURL="/"
+          />
+        </MockProviders>,
+      );
+      expect(screen.getByTestId('tag', { name: 'sent to customer' })).toBeInTheDocument();
     });
   });
 });


### PR DESCRIPTION
## [Jira ticket](https://dp3.atlassian.net/browse/MB-14342) for this change

## Summary

This adds a "Packet Ready for Download" tag to a PPM shipment card when the SC has either approved or excluded it, and a "Sent to Customer" tag when they have rejected it.

The component is available in Storybook at `Office Components / Shipment Display / PPM Service Counselor [Approved/Rejected/Excluded]`, which can be found [at this link](https://output.circle-artifacts.com/output/job/7ee03b94-a9fe-48f7-ae67-25c9aad8ab3d/artifacts/0/storybook/index.html?path=/story/office-components-shipment-display--ppm-shipment-service-counselor-approved).

## Setup to Run Your Code

<details>
<summary>💻 You will only need Storybook to test this locally.</summary>

##### Terminal 1

Start Storybook locally.

```sh
make storybook
```

</details>

## Verification Steps for Author

These are to be checked by the author.

- [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
- [ ] Request review from a member of a different team.
- [ ] Have the Jira acceptance criteria been met for this change?

## Verification Steps for Reviewers

These are to be checked by a reviewer.

<!-- Fill out the next sections as you see fit, these are just suggestions. -->

### Frontend

- [ ] User facing changes have been reviewed by design.
- [ ] There are no aXe warnings for UI.
- [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/main/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
- [ ] There are no new console errors in the browser devtools
- [ ] There are no new console errors in the test output
- [ ] If this PR adds a new component to Storybook, it ensures the component is fully responsive, OR if it is intentionally not, a wrapping div using the `officeApp` class or custom `min-width` styling is used to hide any states the would not be visible to the user.

### Backend

- [ ] Code follows the guidelines for [Logging](https://transcom.github.io/mymove-docs/docs/dev/contributing/backend/Backend-Programming-Guide#logging)
- [ ] The requirements listed in [Querying the Database Safely](https://transcom.github.io/mymove-docs/docs/dev/contributing/backend/Backend-Programming-Guide/#querying-the-database-safely) have been satisfied.

### Database

#### Any new migrations/schema changes:

- [ ] Follows our guidelines for [Zero-Downtime Deploys](https://transcom.github.io/mymove-docs/docs/dev/contributing/database/Database-Migrations#zero-downtime-migrations)
- [ ] Have been communicated to #g-database
- [ ] Secure migrations have been tested following the instructions in our [docs](https://transcom.github.io/mymove-docs/docs/dev/contributing/database/Database-Migrations#secure-migrations)

## Screenshots
