### PR TITLE
Disables Happo for the FileUpload component

### DIFF
--- a/src/components/FileUpload/FileUpload.stories.jsx
+++ b/src/components/FileUpload/FileUpload.stories.jsx
@@ -5,6 +5,10 @@ import FileUpload from './FileUpload';
 export default {
   title: 'Components/FileUpload',
   component: FileUpload,
+  // Stories for this component keep getting repeatedly and incorrectly flagged by Happo
+  parameters: {
+    happo: false,
+  },
 };
 
 const mockCreateUploadSuccess = () => {


### PR DESCRIPTION
## Summary

This pull request introduces a parameter to the configuration for the `FileUpload` component's stories that disables Happo tests for it. 

Stories for this component have been perpetually been triggering false positives in Happo during runs; beyond being annoying to resolve, this can cause issues when trying to use automatic merging tools.