### PR TITLE
[ office-hours, MB-14876 ] Adding @rogeruiz CAC to STG and PRD

### DIFF
--- a/migrations/app/migrations_manifest.txt
+++ b/migrations/app/migrations_manifest.txt
@@ -783,3 +783,4 @@
 20230106211757_app_exp_cert_migration.up.sql
 20230117191419_rkoch_cac.up.sql
 20230120165432_update_camp_lejeune_closeout_value.up.sql
+20230201162639_rogeruiz_cac.up.sql

--- a/migrations/app/secure/20230201162639_rogeruiz_cac.up.sql
+++ b/migrations/app/secure/20230201162639_rogeruiz_cac.up.sql
@@ -1,0 +1,48 @@
+-- Local test migration.
+-- This will be run on development environments.
+-- It should mirror what you intend to apply on loadtest/demo/exp/stg/prd
+-- DO NOT include any sensitive data.
+
+-- README: Since this is something that we don't actually want to run in any environment besides STG and PRD, I'm purposefully commenting the following SQL and uploading a commented out file for the following environments:
+-- * loadtest
+-- * demo
+-- * exp
+
+-- INSERT INTO public.client_certs (
+-- 	id,
+-- 	sha256_digest,
+-- 	subject,
+-- 	allow_dps_auth_api,
+-- 	allow_orders_api,
+-- 	created_at,
+-- 	updated_at,
+-- 	allow_air_force_orders_read,
+-- 	allow_air_force_orders_write,
+-- 	allow_army_orders_read,
+-- 	allow_army_orders_write,
+-- 	allow_coast_guard_orders_read,
+-- 	allow_coast_guard_orders_write,
+-- 	allow_marine_corps_orders_read,
+-- 	allow_marine_corps_orders_write,
+-- 	allow_navy_orders_read,
+-- 	allow_navy_orders_write,
+-- 	allow_prime)
+-- VALUES (
+-- 	'<Generated ID for storing this>',
+-- 	'<SHA256 from the CAC card.',
+-- 	'<Subject from the CAC card.',
+-- 	false,
+-- 	true,
+-- 	now(),
+-- 	now(),
+-- 	true,
+-- 	true,
+-- 	true,
+-- 	true,
+-- 	true,
+-- 	true,
+-- 	true,
+-- 	true,
+-- 	true,
+-- 	true,
+-- 	true);

--- a/scripts/generate-secure-migration
+++ b/scripts/generate-secure-migration
@@ -1,7 +1,7 @@
 #! /usr/bin/env bash
 #
 # A script to help manage the creation of secure migrations
-# https://github.com/transcom/mymove#secure-migrations
+# https://transcom.github.io/mymove-docs/docs/backend/setup/database-migrations#secure-migrations
 #
 
 set -eu -o pipefail


### PR DESCRIPTION
## [Jira ticket](https://dp3.atlassian.net/browse/MB-14876) for this change

## Summary

- [x] Updating the link for Secure Migrations;
- [x] Adding my personal CAC card to the STG & PRD envs;

This patch is tied to @rogeruiz getting CAC access to help with troubleshooting
and debugging the work involved in testing authorized users for the Prime API.
Eventually this work will not be necessary once #9606 is merged in.

I used the following code shown below to upload things into all of the
S3 buckets across environments. I ran these scripts from the root of the
repository. The `tmp/` directory contains my sensitive information migration
which I won't show here. But it's similar to the SQL file found in this patch.

```bash
for nonAto in loadtest demo exp
do
  echo "Information for ${nonAto} environment"
  aws-vault exec \
    transcom-gov-milmove-${nonAto} -- \
      aws s3 cp --sse AES256 \
        migrations/app/secure/20230201162639_rogeruiz_cac.up.sql \
        s3://transcom-gov-milmove-${nonAto}-app-${AWS_SES_REGION}/secure-migrations/
done
```

```bash
for ato in stg prd
do
  echo "Information for ${ato} environment"
  aws-vault exec \
    transcom-gov-milmove-${ato} -- \
      aws s3 cp --sse AES256 \
        tmp/20230201162639_rogeruiz_cac.up.sql \
        s3://transcom-gov-milmove-${ato}-app-${AWS_SES_REGION}/secure-migrations/
done
```

