### PR TITLE
[ spike ] Adding some helpful messaging to check-deployed-commit CI script

### DIFF
--- a/scripts/check-deployed-commit
+++ b/scripts/check-deployed-commit
@@ -26,6 +26,8 @@ do
     fi
     if [[ "$deployed_commit" != "$target_commit" ]]; then
       echo "* On host $host, the deployed commit ($deployed_commit) DOES NOT match the given commit ($target_commit)."
+      echo "* Re-run this job from failure to try again."
+      echo "* This may happen due to multiple deployments happening at the same time."
       exit 1
     else
       echo "* On host $host, the deployed commit ($deployed_commit) matches given commit ($target_commit)."


### PR DESCRIPTION
## Summary

This is for the script that runs in CI after a successful ECS deployment
and sometimes it fails here without giving the engineer instructions on
how to fix it. This helps make that a bit easier for folks interacting
with this part of the deployment.

Take a look at the `scripts/check-deployed-commit` and notice there is some more
information for folks who encounter an error message when CI runs this script.
