### PR TITLE
[MB-15098] Fix documentation for prime certs migration, troubleshooting migration

### DIFF
--- a/migrations/app/secure/20230202193449_add_daycos_and_movehq_certs.up.sql
+++ b/migrations/app/secure/20230202193449_add_daycos_and_movehq_certs.up.sql
@@ -8,6 +8,22 @@
 -- across all the environments. Values here have been redacted. Please pull
 -- down the S3 migration file of the same name in the STG migration folder.
 
+-- DO $$
+-- NOTE: Variables for UserID, ClientCert SHA256, client_certs.id for
+-- both Daycos and MoveHQ must be declared.
+-- DECLARE
+-- 	daycos_user_id UUID;
+-- 	daycos_sha256 VARCHAR;
+-- 	daycos_client_cert_id UUID;
+-- 	daycos_users_roles_id UUID;
+--
+-- 	movehq_user_id UUID;
+-- 	movehq_sha256 VARCHAR;
+-- 	movehq_client_cert_id UUID;
+-- 	movehq_users_roles_id UUID;
+--
+-- 	prime_role_id UUID;
+--
 -- BEGIN
 --
 -- 	NOTE: Variables for UserID, ClientCert SHA256, client_certs.id for
@@ -23,11 +39,11 @@
 -- 	daycos_sha256 := '<SHA256>';
 -- 	daycos_client_cert_id := '<UUID>';
 -- 	daycos_users_roles_id := '<UUID>';
+--
 -- 	movehq_user_id := '<UUID>';
 -- 	movehq_sha256 := '<SHA256>';
 -- 	movehq_client_cert_id := '<UUID>';
 -- 	movehq_users_roles_id := '<UUID>';
---
 --
 -- 	prime_role_id := (SELECT id FROM roles WHERE role_type = 'prime');
 --

--- a/migrations/app/secure/20230202193449_add_daycos_and_movehq_certs.up.sql
+++ b/migrations/app/secure/20230202193449_add_daycos_and_movehq_certs.up.sql
@@ -18,7 +18,7 @@
 -- 	  -in <CERT_FILE>.crt \
 -- 	  -outform DER \
 -- 	  -out <CERT_FILE>.crt.der && \
--- 	openssl dgst -sha256 <CERT_FILE>.crt.der && \
+-- 	openssl dgst -sha256 <CERT_FILE>.crt.der
 -- 	daycos_user_id := '<UUID>';
 -- 	daycos_sha256 := '<SHA256>';
 -- 	daycos_client_cert_id := '<UUID>';


### PR DESCRIPTION
- Removed an unnecessary `&& /` in a comment to avoid confusion in the future
- The script needed to be modified to include variable declarations