### PR TITLE
[ spike ] Adding PropagateTags to the EcsParameters

### DIFF
--- a/cmd/ecs-deploy/put_target.go
+++ b/cmd/ecs-deploy/put_target.go
@@ -203,6 +203,7 @@ func putTargetFunction(cmd *cobra.Command, args []string) error {
 					NetworkConfiguration: currentTarget.EcsParameters.NetworkConfiguration,
 					TaskCount:            aws.Int64(1),
 					TaskDefinitionArn:    aws.String(taskDefARN),
+					PropagateTags:        aws.String("TASK_DEFINITION"),
 				},
 			},
 		},


### PR DESCRIPTION
## Summary

This is something that has come up on the Platform team as to why these
PropagateTags don't seem to stick when we do a `tf plan` on our infrastructure.
The drift here is caused by the Golang code modifying our infrastructure. This
helps mitigate that drift a bit in concerns with CloudWatch Events ECS
parameters.
