### PR TITLE
MB-14184 - Add advance request status field

### DIFF
--- a/src/components/Office/DefinitionLists/NTSRShipmentInfoList.jsx
+++ b/src/components/Office/DefinitionLists/NTSRShipmentInfoList.jsx
@@ -9,7 +9,13 @@ import { formatDate } from 'shared/dates';
 import { ShipmentShape } from 'types/shipment';
 import { formatAddress, formatAgent, formatAccountingCode } from 'utils/shipmentDisplay';
 import { formatWeight } from 'utils/formatters';
-import { setFlagStyles, setDisplayFlags, getDisplayFlags, getMissingOrDash } from 'utils/displayFlags';
+import {
+  setFlagStyles,
+  setDisplayFlags,
+  getDisplayFlags,
+  getMissingOrDash,
+  fieldValidationShape,
+} from 'utils/displayFlags';
 
 const NTSRShipmentInfoList = ({
   className,
@@ -311,8 +317,8 @@ NTSRShipmentInfoList.propTypes = {
   className: PropTypes.string,
   shipment: ShipmentShape.isRequired,
   isExpanded: PropTypes.bool,
-  warnIfMissing: PropTypes.arrayOf(PropTypes.string),
-  errorIfMissing: PropTypes.arrayOf(PropTypes.string),
+  warnIfMissing: PropTypes.arrayOf(fieldValidationShape),
+  errorIfMissing: PropTypes.arrayOf(fieldValidationShape),
   showWhenCollapsed: PropTypes.arrayOf(PropTypes.string),
   isForEvaluationReport: PropTypes.bool,
 };

--- a/src/components/Office/DefinitionLists/NTSRShipmentInfoList.stories.jsx
+++ b/src/components/Office/DefinitionLists/NTSRShipmentInfoList.stories.jsx
@@ -78,7 +78,7 @@ export const NTSRMissingInfo = () => (
       ntsRecordedWeight: info.ntsRecordedWeight,
       serviceOrderNumber: info.serviceOrderNumber,
     }}
-    errorIfMissing={['storageFacility']}
+    errorIfMissing={[{ fieldName: 'storageFacility' }]}
   />
 );
 

--- a/src/components/Office/DefinitionLists/NTSRShipmentInfoList.test.jsx
+++ b/src/components/Office/DefinitionLists/NTSRShipmentInfoList.test.jsx
@@ -5,8 +5,14 @@ import { object, text } from '@storybook/addon-knobs';
 import NTSRShipmentInfoList from './NTSRShipmentInfoList';
 
 const showWhenCollapsed = ['counselorRemarks'];
-const warnIfMissing = ['ntsRecordedWeight', 'serviceOrderNumber', 'counselorRemarks', 'tacType', 'sacType'];
-const errorIfMissing = ['storageFacility'];
+const warnIfMissing = [
+  { fieldName: 'ntsRecordedWeight' },
+  { fieldName: 'serviceOrderNumber' },
+  { fieldName: 'counselorRemarks' },
+  { fieldName: 'tacType' },
+  { fieldName: 'sacType' },
+];
+const errorIfMissing = [{ fieldName: 'storageFacility' }];
 
 const shipment = {
   ntsRecordedWeight: 2000,

--- a/src/components/Office/DefinitionLists/NTSShipmentInfoList.jsx
+++ b/src/components/Office/DefinitionLists/NTSShipmentInfoList.jsx
@@ -8,7 +8,13 @@ import styles from 'styles/descriptionList.module.scss';
 import { formatDate } from 'shared/dates';
 import { ShipmentShape } from 'types/shipment';
 import { formatAddress, formatAgent, formatAccountingCode } from 'utils/shipmentDisplay';
-import { setFlagStyles, setDisplayFlags, getDisplayFlags, getMissingOrDash } from 'utils/displayFlags';
+import {
+  setFlagStyles,
+  setDisplayFlags,
+  getDisplayFlags,
+  getMissingOrDash,
+  fieldValidationShape,
+} from 'utils/displayFlags';
 
 const NTSShipmentInfoList = ({
   className,
@@ -303,8 +309,8 @@ NTSShipmentInfoList.propTypes = {
   className: PropTypes.string,
   shipment: ShipmentShape.isRequired,
   isExpanded: PropTypes.bool,
-  warnIfMissing: PropTypes.arrayOf(PropTypes.string),
-  errorIfMissing: PropTypes.arrayOf(PropTypes.string),
+  warnIfMissing: PropTypes.arrayOf(fieldValidationShape),
+  errorIfMissing: PropTypes.arrayOf(fieldValidationShape),
   showWhenCollapsed: PropTypes.arrayOf(PropTypes.string),
   neverShow: PropTypes.arrayOf(PropTypes.string),
   isForEvaluationReport: PropTypes.bool,

--- a/src/components/Office/DefinitionLists/NTSShipmentInfoList.stories.jsx
+++ b/src/components/Office/DefinitionLists/NTSShipmentInfoList.stories.jsx
@@ -90,7 +90,7 @@ export const NTSMissingInfo = () => (
       pickupAddress: info.pickupAddress,
       sacType: info.sacType,
     }}
-    errorIfMissing={['storageFacility', 'serviceOrderNumber', 'tacType']}
+    errorIfMissing={[{ fieldName: 'storageFacility' }, { fieldName: 'serviceOrderNumber' }, { fieldName: 'tacType' }]}
   />
 );
 
@@ -102,7 +102,7 @@ export const NTSWarning = () => (
       pickupAddress: info.pickupAddress,
       sacType: info.sacType,
     }}
-    warnIfMissing={['storageFacility', 'serviceOrderNumber', 'tacType']}
+    warnIfMissing={[{ fieldName: 'storageFacility' }, { fieldName: 'serviceOrderNumber' }, { fieldName: 'tacType' }]}
   />
 );
 

--- a/src/components/Office/DefinitionLists/NTSShipmentInfoList.test.jsx
+++ b/src/components/Office/DefinitionLists/NTSShipmentInfoList.test.jsx
@@ -118,7 +118,7 @@ describe.each([
   it(`renders ${testId} as missing and always shows when collapsed`, () => {
     render(
       <NTSShipmentInfoList
-        errorIfMissing={[shipmentField]}
+        errorIfMissing={[{ fieldName: shipmentField }]}
         shipment={{
           pickupAddress: {
             streetAddress1: '441 SW Rio de la Plata Drive',
@@ -137,7 +137,7 @@ describe.each([
   it(`renders ${testId} with a warning and always shows when collapsed`, () => {
     render(
       <NTSShipmentInfoList
-        warnIfMissing={[shipmentField]}
+        warnIfMissing={[{ fieldName: shipmentField }]}
         shipment={{
           pickupAddress: {
             streetAddress1: '441 SW Rio de la Plata Drive',

--- a/src/components/Office/DefinitionLists/PPMShipmentInfoList.jsx
+++ b/src/components/Office/DefinitionLists/PPMShipmentInfoList.jsx
@@ -38,6 +38,7 @@ const PPMShipmentInfoList = ({
   } = shipment.ppmShipment || {};
 
   const { closeoutOffice, agency } = shipment;
+  const ppmShipmentInfo = { ...shipment.ppmShipment, ...shipment };
   let closeoutDisplay;
 
   switch (agency) {
@@ -57,8 +58,9 @@ const PPMShipmentInfoList = ({
   setFlagStyles({
     row: styles.row,
     warning: shipmentDefinitionListsStyles.warning,
+    missingInfoError: shipmentDefinitionListsStyles.missingInfoError,
   });
-  setDisplayFlags(errorIfMissing, warnIfMissing, showWhenCollapsed, null, shipment);
+  setDisplayFlags(errorIfMissing, warnIfMissing, showWhenCollapsed, null, ppmShipmentInfo);
 
   const showElement = (elementFlags) => {
     return (isExpanded || elementFlags.alwaysShow) && !elementFlags.hideRow;

--- a/src/components/Office/DefinitionLists/PPMShipmentInfoList.jsx
+++ b/src/components/Office/DefinitionLists/PPMShipmentInfoList.jsx
@@ -177,7 +177,7 @@ const PPMShipmentInfoList = ({
     <div className={advanceStatusElementFlags.classes}>
       <dt>Advance request status</dt>
       <dd data-testid="advanceRequestStatus">
-        {ADVANCE_STATUSES[advanceStatus] ? ADVANCE_STATUSES[advanceStatus] : `Review required`}
+        {ADVANCE_STATUSES[advanceStatus] ? ADVANCE_STATUSES[advanceStatus].displayValue : `Review required`}
       </dd>
     </div>
   );

--- a/src/components/Office/DefinitionLists/PPMShipmentInfoList.jsx
+++ b/src/components/Office/DefinitionLists/PPMShipmentInfoList.jsx
@@ -9,6 +9,7 @@ import { formatDate } from 'shared/dates';
 import { ShipmentShape } from 'types/shipment';
 import { formatCentsTruncateWhole, formatWeight } from 'utils/formatters';
 import { setFlagStyles, setDisplayFlags, getDisplayFlags, fieldValidationShape } from 'utils/displayFlags';
+import { ADVANCE_STATUSES } from 'constants/ppms';
 import affiliation from 'content/serviceMemberAgencies';
 import { permissionTypes } from 'constants/permissions';
 import Restricted from 'components/Restricted/Restricted';
@@ -25,6 +26,7 @@ const PPMShipmentInfoList = ({
   const {
     hasRequestedAdvance,
     advanceAmountRequested,
+    advanceStatus,
     destinationPostalCode,
     estimatedIncentive,
     estimatedWeight,
@@ -170,6 +172,14 @@ const PPMShipmentInfoList = ({
     </div>
   );
 
+  const advanceStatusElementFlags = getDisplayFlags('advanceStatus');
+  const advanceStatusElement = (
+    <div className={advanceStatusElementFlags.classes}>
+      <dt>Advance request status</dt>
+      <dd data-testid="advanceRequestStatus">{ADVANCE_STATUSES[advanceStatus]}</dd>
+    </div>
+  );
+
   const counselorRemarksElementFlags = getDisplayFlags('counselorRemarks');
   const counselorRemarksElement = (
     <div className={counselorRemarksElementFlags.classes}>
@@ -201,6 +211,7 @@ const PPMShipmentInfoList = ({
       {showElement(spouseProGearElementFlags) && spouseProGearElement}
       {showElement(estimatedIncentiveElementFlags) && estimatedIncentiveElement}
       {hasRequestedAdvanceElement}
+      {hasRequestedAdvance === true && advanceStatusElement}
       {counselorRemarksElement}
     </dl>
   );

--- a/src/components/Office/DefinitionLists/PPMShipmentInfoList.jsx
+++ b/src/components/Office/DefinitionLists/PPMShipmentInfoList.jsx
@@ -8,7 +8,7 @@ import styles from 'styles/descriptionList.module.scss';
 import { formatDate } from 'shared/dates';
 import { ShipmentShape } from 'types/shipment';
 import { formatCentsTruncateWhole, formatWeight } from 'utils/formatters';
-import { setFlagStyles, setDisplayFlags, getDisplayFlags } from 'utils/displayFlags';
+import { setFlagStyles, setDisplayFlags, getDisplayFlags, fieldValidationShape } from 'utils/displayFlags';
 import affiliation from 'content/serviceMemberAgencies';
 import { permissionTypes } from 'constants/permissions';
 import Restricted from 'components/Restricted/Restricted';
@@ -243,8 +243,8 @@ const PPMShipmentInfoList = ({
 PPMShipmentInfoList.propTypes = {
   className: PropTypes.string,
   shipment: ShipmentShape.isRequired,
-  warnIfMissing: PropTypes.arrayOf(PropTypes.string),
-  errorIfMissing: PropTypes.arrayOf(PropTypes.string),
+  warnIfMissing: PropTypes.arrayOf(fieldValidationShape),
+  errorIfMissing: PropTypes.arrayOf(fieldValidationShape),
   showWhenCollapsed: PropTypes.arrayOf(PropTypes.string),
   isExpanded: PropTypes.bool,
   isForEvaluationReport: PropTypes.bool,

--- a/src/components/Office/DefinitionLists/PPMShipmentInfoList.jsx
+++ b/src/components/Office/DefinitionLists/PPMShipmentInfoList.jsx
@@ -176,7 +176,9 @@ const PPMShipmentInfoList = ({
   const advanceStatusElement = (
     <div className={advanceStatusElementFlags.classes}>
       <dt>Advance request status</dt>
-      <dd data-testid="advanceRequestStatus">{ADVANCE_STATUSES[advanceStatus]}</dd>
+      <dd data-testid="advanceRequestStatus">
+        {ADVANCE_STATUSES[advanceStatus] ? ADVANCE_STATUSES[advanceStatus] : `Review required`}
+      </dd>
     </div>
   );
 

--- a/src/components/Office/DefinitionLists/PPMShipmentInfoList.stories.jsx
+++ b/src/components/Office/DefinitionLists/PPMShipmentInfoList.stories.jsx
@@ -41,17 +41,33 @@ export const Basic = () => (
       ...ppmInfo,
       counselorRemarks: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam vulputate commodo erat. ',
     }}
-    warnIfMissing={['counselorRemarks']}
+    warnIfMissing={[{ fieldName: 'counselorRemarks' }]}
     isExpanded
   />
 );
+
 export const DefaultView = () => (
   <PPMShipmentInfoList
     shipment={{
       ...ppmInfo,
       counselorRemarks: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam vulputate commodo erat. ',
     }}
-    warnIfMissing={['counselorRemarks']}
+    warnIfMissing={[{ fieldName: 'counselorRemarks' }]}
   />
 );
-export const MissingInfo = () => <PPMShipmentInfoList shipment={ppmInfo} warnIfMissing={['counselorRemarks']} />;
+
+export const Warning = () => (
+  <PPMShipmentInfoList shipment={ppmInfo} warnIfMissing={[{ fieldName: 'counselorRemarks' }]} />
+);
+
+export const MissingInfo = () => (
+  <PPMShipmentInfoList
+    shipment={ppmInfo}
+    errorIfMissing={[
+      {
+        fieldName: 'advanceStatus',
+        condition: (shipment) => shipment?.ppmShipment?.hasRequestedAdvance === true,
+      },
+    ]}
+  />
+);

--- a/src/components/Office/DefinitionLists/ShipmentInfoList.jsx
+++ b/src/components/Office/DefinitionLists/ShipmentInfoList.jsx
@@ -8,7 +8,13 @@ import styles from 'styles/descriptionList.module.scss';
 import { formatDate } from 'shared/dates';
 import { ShipmentShape } from 'types/shipment';
 import { formatAddress, formatAgent } from 'utils/shipmentDisplay';
-import { setFlagStyles, setDisplayFlags, getDisplayFlags, getMissingOrDash } from 'utils/displayFlags';
+import {
+  setFlagStyles,
+  setDisplayFlags,
+  getDisplayFlags,
+  getMissingOrDash,
+  fieldValidationShape,
+} from 'utils/displayFlags';
 
 const ShipmentInfoList = ({
   className,
@@ -284,8 +290,8 @@ const ShipmentInfoList = ({
 ShipmentInfoList.propTypes = {
   className: PropTypes.string,
   shipment: ShipmentShape.isRequired,
-  warnIfMissing: PropTypes.arrayOf(PropTypes.string),
-  errorIfMissing: PropTypes.arrayOf(PropTypes.string),
+  warnIfMissing: PropTypes.arrayOf(fieldValidationShape),
+  errorIfMissing: PropTypes.arrayOf(fieldValidationShape),
   showWhenCollapsed: PropTypes.arrayOf(PropTypes.string),
   isExpanded: PropTypes.bool,
 };

--- a/src/components/Office/DefinitionLists/ShipmentInfoListSelector.jsx
+++ b/src/components/Office/DefinitionLists/ShipmentInfoListSelector.jsx
@@ -7,6 +7,7 @@ import PPMShipmentInfoList from 'components/Office/DefinitionLists/PPMShipmentIn
 import NTSRShipmentInfoList from 'components/Office/DefinitionLists/NTSRShipmentInfoList';
 import NTSShipmentInfoList from 'components/Office/DefinitionLists/NTSShipmentInfoList';
 import { SHIPMENT_OPTIONS } from 'shared/constants';
+import { fieldValidationShape } from 'utils/displayFlags';
 
 const ShipmentInfoListSelector = ({
   className,
@@ -92,8 +93,8 @@ ShipmentInfoListSelector.propTypes = {
   className: PropTypes.string,
   shipment: ShipmentShape.isRequired,
   isExpanded: PropTypes.bool,
-  warnIfMissing: PropTypes.arrayOf(PropTypes.string),
-  errorIfMissing: PropTypes.arrayOf(PropTypes.string),
+  warnIfMissing: PropTypes.arrayOf(fieldValidationShape),
+  errorIfMissing: PropTypes.arrayOf(fieldValidationShape),
   showWhenCollapsed: PropTypes.arrayOf(PropTypes.string),
   neverShow: PropTypes.arrayOf(PropTypes.string),
   shipmentType: PropTypes.oneOf([

--- a/src/components/Office/EvaluationReportShipmentDisplay/EvaluationReportShipmentDisplay.jsx
+++ b/src/components/Office/EvaluationReportShipmentDisplay/EvaluationReportShipmentDisplay.jsx
@@ -16,6 +16,7 @@ import { shipmentStatuses } from 'constants/shipments';
 import { ShipmentStatusesOneOf } from 'types/shipment';
 import { formatAddress, retrieveSAC, retrieveTAC } from 'utils/shipmentDisplay';
 import { formatShortIDWithPound } from 'utils/formatters';
+import { fieldValidationShape } from 'utils/displayFlags';
 
 const EvaluationReportShipmentDisplay = ({
   shipmentType,
@@ -172,8 +173,8 @@ EvaluationReportShipmentDisplay.propTypes = {
   ]).isRequired,
   allowApproval: PropTypes.bool,
   ordersLOA: OrdersLOAShape,
-  warnIfMissing: PropTypes.arrayOf(PropTypes.string),
-  errorIfMissing: PropTypes.arrayOf(PropTypes.string),
+  warnIfMissing: PropTypes.arrayOf(fieldValidationShape),
+  errorIfMissing: PropTypes.arrayOf(fieldValidationShape),
   showWhenCollapsed: PropTypes.arrayOf(PropTypes.string),
   neverShow: PropTypes.arrayOf(PropTypes.string),
 };

--- a/src/components/Office/RequestedShipments/SubmittedRequestedShipments.jsx
+++ b/src/components/Office/RequestedShipments/SubmittedRequestedShipments.jsx
@@ -19,6 +19,7 @@ import { shipmentTypeLabels } from 'content/shipments';
 import shipmentCardsStyles from 'styles/shipmentCards.module.scss';
 import { MoveTaskOrderShape, MTOServiceItemShape, OrdersInfoShape } from 'types/order';
 import { ShipmentShape } from 'types/shipment';
+import { fieldValidationShape } from 'utils/displayFlags';
 
 // nts defaults show preferred pickup date and pickup address, flagged items when collapsed
 // ntsr defaults shows preferred delivery date, storage facility address, destination address, flagged items when collapsed
@@ -290,7 +291,7 @@ SubmittedRequestedShipments.propTypes = {
   missingRequiredOrdersInfo: PropTypes.bool,
   moveCode: PropTypes.string.isRequired,
   handleAfterSuccess: PropTypes.func,
-  errorIfMissing: PropTypes.shape({}),
+  errorIfMissing: PropTypes.objectOf(PropTypes.arrayOf(fieldValidationShape)),
   displayDestinationType: PropTypes.bool,
   mtoServiceItems: PropTypes.arrayOf(MTOServiceItemShape),
 };

--- a/src/components/Office/ShipmentDisplay/ShipmentDisplay.jsx
+++ b/src/components/Office/ShipmentDisplay/ShipmentDisplay.jsx
@@ -20,6 +20,7 @@ import { retrieveSAC, retrieveTAC } from 'utils/shipmentDisplay';
 import Restricted from 'components/Restricted/Restricted';
 import { permissionTypes } from 'constants/permissions';
 import affiliation from 'content/serviceMemberAgencies';
+import { fieldValidationShape } from 'utils/displayFlags';
 
 const ShipmentDisplay = ({
   shipmentType,
@@ -202,8 +203,8 @@ ShipmentDisplay.propTypes = {
   editURL: PropTypes.string,
   reviewURL: PropTypes.string,
   ordersLOA: OrdersLOAShape,
-  warnIfMissing: PropTypes.arrayOf(PropTypes.string),
-  errorIfMissing: PropTypes.arrayOf(PropTypes.string),
+  warnIfMissing: PropTypes.arrayOf(fieldValidationShape),
+  errorIfMissing: PropTypes.arrayOf(fieldValidationShape),
   showWhenCollapsed: PropTypes.arrayOf(PropTypes.string),
   neverShow: PropTypes.arrayOf(PropTypes.string),
 };

--- a/src/components/Office/ShipmentDisplay/ShipmentDisplay.jsx
+++ b/src/components/Office/ShipmentDisplay/ShipmentDisplay.jsx
@@ -20,7 +20,7 @@ import { retrieveSAC, retrieveTAC } from 'utils/shipmentDisplay';
 import Restricted from 'components/Restricted/Restricted';
 import { permissionTypes } from 'constants/permissions';
 import affiliation from 'content/serviceMemberAgencies';
-import { fieldValidationShape } from 'utils/displayFlags';
+import { fieldValidationShape, objectIsMissingFieldWithCondition } from 'utils/displayFlags';
 
 const ShipmentDisplay = ({
   shipmentType,
@@ -43,7 +43,9 @@ const ShipmentDisplay = ({
   const tac = retrieveTAC(displayInfo.tacType, ordersLOA);
   const sac = retrieveSAC(displayInfo.sacType, ordersLOA);
 
-  const disableApproval = errorIfMissing.some((requiredInfo) => !displayInfo[requiredInfo]);
+  const disableApproval = errorIfMissing.some((requiredInfo) =>
+    objectIsMissingFieldWithCondition(displayInfo, requiredInfo),
+  );
 
   const handleExpandClick = () => {
     setIsExpanded((prev) => !prev);

--- a/src/components/Office/ShipmentDisplay/ShipmentDisplay.stories.jsx
+++ b/src/components/Office/ShipmentDisplay/ShipmentDisplay.stories.jsx
@@ -103,7 +103,7 @@ export const NTSShipmentMissingInfoAsTOO = () => (
       ordersLOA={ordersLOA}
       isSubmitted
       warnIfMissing={[]}
-      errorIfMissing={['storageFacility', 'serviceOrderNumber', 'tacType']}
+      errorIfMissing={[{ fieldName: 'storageFacility' }, { fieldName: 'serviceOrderNumber' }, { fieldName: 'tacType' }]}
       showWhenCollapsed={['tacType']}
       editURL="/"
     />
@@ -118,7 +118,7 @@ export const NTSShipmentMissingInfoAsSC = () => (
       shipmentId={ntsMissingInfo.shipmentId}
       ordersLOA={ordersLOA}
       isSubmitted
-      warnIfMissing={['counselorRemarks', 'tacType', 'sacType']}
+      warnIfMissing={[{ fieldName: 'counselorRemarks' }, { fieldName: 'tacType' }, { fieldName: 'sacType' }]}
       errorIfMissing={[]}
       showWhenCollapsed={['counselorRemarks']}
       editURL="/"
@@ -175,7 +175,12 @@ export const NTSReleaseShipmentMissingInfoAsTOO = () => (
       ordersLOA={ordersLOA}
       isSubmitted
       warnIfMissing={[]}
-      errorIfMissing={['storageFacility', 'ntsRecordedWeight', 'serviceOrderNumber', 'tacType']}
+      errorIfMissing={[
+        { fieldName: 'storageFacility' },
+        { fieldName: 'ntsRecordedWeight' },
+        { fieldName: 'serviceOrderNumber' },
+        { fieldName: 'tacType' },
+      ]}
       showWhenCollapsed={['tacType', 'ntsRecordedWeight', 'serviceOrderNumber']}
       editURL="/"
     />
@@ -190,8 +195,14 @@ export const NTSReleaseShipmentMissingInfoAsSC = () => (
       shipmentId={ntsReleaseMissingInfo.shipmentId}
       ordersLOA={ordersLOA}
       isSubmitted
-      warnIfMissing={['ntsRecordedWeight', 'serviceOrderNumber', 'counselorRemarks', 'tacType', 'sacType']}
-      errorIfMissing={['storageFacility']}
+      warnIfMissing={[
+        { fieldName: 'ntsRecordedWeight' },
+        { fieldName: 'serviceOrderNumber' },
+        { fieldName: 'counselorRemarks' },
+        { fieldName: 'tacType' },
+        { fieldName: 'sacType' },
+      ]}
+      errorIfMissing={[{ fieldName: 'storageFacility' }]}
       showWhenCollapsed={['counselorRemarks']}
       editURL="/"
     />
@@ -254,7 +265,7 @@ export const PPMShipmentServiceCounselor = () => (
       shipmentType={SHIPMENT_OPTIONS.PPM}
       isSubmitted
       allowApproval={false}
-      warnIfMissing={['counselorRemarks']}
+      warnIfMissing={[{ fieldName: 'counselorRemarks' }]}
     />
   </div>
 );
@@ -267,7 +278,7 @@ export const PPMShipmentWithCounselorRemarks = () => (
       ordersLOA={ordersLOA}
       isSubmitted
       allowApproval={false}
-      warnIfMissing={['counselorRemarks']}
+      warnIfMissing={[{ fieldName: 'counselorRemarks' }]}
     />
   </div>
 );
@@ -280,7 +291,7 @@ export const PPMShipmentServiceCounselorWithReviewButton = () => (
       shipmentType={SHIPMENT_OPTIONS.PPM}
       isSubmitted
       allowApproval={false}
-      warnIfMissing={['counselorRemarks']}
+      warnIfMissing={[{ fieldName: 'counselorRemarks' }]}
       reviewURL="/"
     />
   </div>
@@ -295,7 +306,7 @@ export const MultiplePPMShipmentsServiceCounselorWithReviewButton = () => (
         shipmentType={SHIPMENT_OPTIONS.PPM}
         isSubmitted
         allowApproval={false}
-        warnIfMissing={['counselorRemarks']}
+        warnIfMissing={[{ fieldName: 'counselorRemarks' }]}
         reviewURL="/"
       />
     </div>
@@ -306,7 +317,7 @@ export const MultiplePPMShipmentsServiceCounselorWithReviewButton = () => (
         shipmentType={SHIPMENT_OPTIONS.PPM}
         isSubmitted
         allowApproval={false}
-        warnIfMissing={['counselorRemarks']}
+        warnIfMissing={[{ fieldName: 'counselorRemarks' }]}
         reviewURL="/"
       />
     </div>
@@ -375,7 +386,7 @@ export const NTSShipmentMissingInfoAsTOOReadOnly = () => (
       ordersLOA={ordersLOA}
       isSubmitted
       warnIfMissing={[]}
-      errorIfMissing={['storageFacility', 'serviceOrderNumber', 'tacType']}
+      errorIfMissing={[{ fieldName: 'storageFacility' }, { fieldName: 'serviceOrderNumber' }, { fieldName: 'tacType' }]}
       showWhenCollapsed={['tacType']}
       editURL="/"
     />
@@ -390,7 +401,7 @@ export const NTSShipmentMissingInfoAsSCReadOnly = () => (
       shipmentId={ntsMissingInfo.shipmentId}
       ordersLOA={ordersLOA}
       isSubmitted
-      warnIfMissing={['counselorRemarks', 'tacType', 'sacType']}
+      warnIfMissing={[{ fieldName: 'counselorRemarks' }, { fieldName: 'tacType' }, { fieldName: 'sacType' }]}
       errorIfMissing={[]}
       showWhenCollapsed={['counselorRemarks']}
       editURL="/"
@@ -447,7 +458,12 @@ export const NTSReleaseShipmentMissingInfoAsTOOReadOnly = () => (
       ordersLOA={ordersLOA}
       isSubmitted
       warnIfMissing={[]}
-      errorIfMissing={['storageFacility', 'ntsRecordedWeight', 'serviceOrderNumber', 'tacType']}
+      errorIfMissing={[
+        { fieldName: 'storageFacility' },
+        { fieldName: 'ntsRecordedWeight' },
+        { fieldName: 'serviceOrderNumber' },
+        { fieldName: 'tacType' },
+      ]}
       showWhenCollapsed={['tacType', 'ntsRecordedWeight', 'serviceOrderNumber']}
       editURL="/"
     />
@@ -462,8 +478,14 @@ export const NTSReleaseShipmentMissingInfoAsSCReadOnly = () => (
       shipmentId={ntsReleaseMissingInfo.shipmentId}
       ordersLOA={ordersLOA}
       isSubmitted
-      warnIfMissing={['ntsRecordedWeight', 'serviceOrderNumber', 'counselorRemarks', 'tacType', 'sacType']}
-      errorIfMissing={['storageFacility']}
+      warnIfMissing={[
+        { fieldName: 'ntsRecordedWeight' },
+        { fieldName: 'serviceOrderNumber' },
+        { fieldName: 'counselorRemarks' },
+        { fieldName: 'tacType' },
+        { fieldName: 'sacType' },
+      ]}
+      errorIfMissing={[{ fieldName: 'storageFacility' }]}
       showWhenCollapsed={['counselorRemarks']}
       editURL="/"
     />
@@ -526,7 +548,7 @@ export const PPMShipmentServiceCounselorReadOnly = () => (
       shipmentType={SHIPMENT_OPTIONS.PPM}
       isSubmitted
       allowApproval={false}
-      warnIfMissing={['counselorRemarks']}
+      warnIfMissing={[{ fieldName: 'counselorRemarks' }]}
     />
   </div>
 );
@@ -539,7 +561,7 @@ export const PPMShipmentWithCounselorRemarksReadOnly = () => (
       ordersLOA={ordersLOA}
       isSubmitted
       allowApproval={false}
-      warnIfMissing={['counselorRemarks']}
+      warnIfMissing={[{ fieldName: 'counselorRemarks' }]}
     />
   </div>
 );
@@ -552,7 +574,7 @@ export const PPMShipmentServiceCounselorApproved = () => (
       shipmentType={SHIPMENT_OPTIONS.PPM}
       isSubmitted
       allowApproval={false}
-      warnIfMissing={['counselorRemarks']}
+      warnIfMissing={[{ fieldName: 'counselorRemarks' }]}
       reviewURL="/"
     />
   </div>
@@ -566,7 +588,7 @@ export const PPMShipmentServiceCounselorRejected = () => (
       shipmentType={SHIPMENT_OPTIONS.PPM}
       isSubmitted
       allowApproval={false}
-      warnIfMissing={['counselorRemarks']}
+      warnIfMissing={[{ fieldName: 'counselorRemarks' }]}
       reviewURL="/"
     />
   </div>
@@ -580,7 +602,7 @@ export const PPMShipmentServiceCounselorExcluded = () => (
       shipmentType={SHIPMENT_OPTIONS.PPM}
       isSubmitted
       allowApproval={false}
-      warnIfMissing={['counselorRemarks']}
+      warnIfMissing={[{ fieldName: 'counselorRemarks' }]}
       reviewURL="/"
     />
   </div>

--- a/src/components/Office/ShipmentForm/ppmShipmentSchema.js
+++ b/src/components/Office/ShipmentForm/ppmShipmentSchema.js
@@ -2,6 +2,7 @@ import * as Yup from 'yup';
 
 import { getFormattedMaxAdvancePercentage } from 'utils/incentives';
 import { InvalidZIPTypeError, ZIP5_CODE_REGEX } from 'utils/validation';
+import { ADVANCE_STATUSES } from 'constants/ppms';
 
 function closeoutOfficeSchema(showCloseoutOffice, isAdvancePage) {
   if (showCloseoutOffice && !isAdvancePage) {
@@ -93,7 +94,7 @@ const ppmShipmentSchema = ({
       is: (advance, advanceRequested, advanceStatus) =>
         (isAdvancePage &&
           (Number(advance) !== advanceAmountRequested / 100 || advanceRequested !== hasRequestedAdvance)) ||
-        (isAdvancePage && advanceStatus === 'REJECTED'),
+        (isAdvancePage && ADVANCE_STATUSES[advanceStatus] === ADVANCE_STATUSES.REJECTED),
       then: (schema) => schema.required('Required'),
     }),
   });

--- a/src/components/Office/ShipmentIncentiveAdvance/ShipmentIncentiveAdvance.jsx
+++ b/src/components/Office/ShipmentIncentiveAdvance/ShipmentIncentiveAdvance.jsx
@@ -8,14 +8,14 @@ import styles from 'components/Office/ShipmentForm/ShipmentForm.module.scss';
 import SectionWrapper from 'components/Customer/SectionWrapper';
 import MaskedTextField from 'components/form/fields/MaskedTextField/MaskedTextField';
 import { calculateMaxAdvanceAndFormatAdvanceAndIncentive } from 'utils/incentives';
-import ppmAdvanceStatus from 'constants/ppms';
+import { ADVANCE_STATUSES } from 'constants/ppms';
 
 const ShipmentIncentiveAdvance = ({ estimatedIncentive }) => {
   const [advanceInput, , advanceHelper] = useField('advanceRequested');
   const [statusInput, , statusHelper] = useField('advanceStatus');
 
   const advanceRequested = String(advanceInput.value) === 'true';
-  const advanceRequestStatus = statusInput.value === ppmAdvanceStatus.APPROVED;
+  const advanceRequestStatus = statusInput.value === ADVANCE_STATUSES.APPROVED.apiValue;
 
   const { formattedMaxAdvance, formattedIncentive } =
     calculateMaxAdvanceAndFormatAdvanceAndIncentive(estimatedIncentive);
@@ -88,7 +88,7 @@ const ShipmentIncentiveAdvance = ({ estimatedIncentive }) => {
                     id="approveAdvanceRequest"
                     label="Approve"
                     name="advanceStatus"
-                    value={ppmAdvanceStatus.APPROVED}
+                    value={ADVANCE_STATUSES.APPROVED.apiValue}
                     title="Approve"
                     checked={!!statusInput.value && advanceRequestStatus} // defaults to false if advanceStatus has a null value
                     onChange={handleAdvanceRequestStatusChange}
@@ -97,7 +97,7 @@ const ShipmentIncentiveAdvance = ({ estimatedIncentive }) => {
                     id="rejectAdvanceRequest"
                     label="Reject"
                     name="advanceStatus"
-                    value={ppmAdvanceStatus.REJECTED}
+                    value={ADVANCE_STATUSES.REJECTED.apiValue}
                     title="Reject"
                     checked={!!statusInput.value && !advanceRequestStatus} // defaults to false if advanceStatus has a null value
                     onChange={handleAdvanceRequestStatusChange}

--- a/src/constants/ppms.js
+++ b/src/constants/ppms.js
@@ -12,7 +12,7 @@ export const ReviewDocumentsStatus = {
 };
 
 export const ADVANCE_STATUSES = {
-  APPROVED: 'Approved',
-  REJECTED: 'Rejected',
-  EDITED: 'Approved with adjustment',
+  APPROVED: { apiValue: 'APPROVED', displayValue: 'Approved' },
+  REJECTED: { apiValue: 'REJECTED', displayValue: 'Rejected' },
+  EDITED: { apiValue: 'EDITED', displayValue: 'Approved with adjustment' },
 };

--- a/src/constants/ppms.js
+++ b/src/constants/ppms.js
@@ -10,3 +10,9 @@ export const ReviewDocumentsStatus = {
   REJECT: 'Reject',
   EXCLUDE: 'Exclude',
 };
+
+export const ADVANCE_STATUSES = {
+  APPROVED: 'Approved',
+  REJECTED: 'Rejected',
+  EDITED: 'Approved with adjustment',
+};

--- a/src/pages/Office/MoveDetails/MoveDetails.jsx
+++ b/src/pages/Office/MoveDetails/MoveDetails.jsx
@@ -30,6 +30,7 @@ import SomethingWentWrong from 'shared/SomethingWentWrong';
 import { SIT_EXTENSION_STATUS } from 'constants/sitExtensions';
 import { ORDERS_TYPE } from 'constants/orders';
 import { permissionTypes } from 'constants/permissions';
+import { objectIsMissingFieldWithCondition } from 'utils/displayFlags';
 
 const errorIfMissing = {
   HHG_INTO_NTS_DOMESTIC: [
@@ -200,10 +201,8 @@ const MoveDetails = ({
 
     mtoShipments?.forEach((mtoShipment) => {
       const fieldsToCheckForShipment = errorIfMissing[mtoShipment.shipmentType];
-      const existsMissingFieldsOnShipment = fieldsToCheckForShipment?.some(
-        (field) =>
-          !mtoShipment[field.fieldName] ||
-          (mtoShipment[field.fieldName] === '' && (!field.condition || field.condition(mtoShipment))),
+      const existsMissingFieldsOnShipment = fieldsToCheckForShipment?.some((field) =>
+        objectIsMissingFieldWithCondition(mtoShipment, field),
       );
 
       // If there were no fields to check, then nothing was required.

--- a/src/pages/Office/MoveDetails/MoveDetails.jsx
+++ b/src/pages/Office/MoveDetails/MoveDetails.jsx
@@ -32,8 +32,17 @@ import { ORDERS_TYPE } from 'constants/orders';
 import { permissionTypes } from 'constants/permissions';
 
 const errorIfMissing = {
-  HHG_INTO_NTS_DOMESTIC: ['storageFacility', 'serviceOrderNumber', 'tacType'],
-  HHG_OUTOF_NTS_DOMESTIC: ['storageFacility', 'ntsRecordedWeight', 'serviceOrderNumber', 'tacType'],
+  HHG_INTO_NTS_DOMESTIC: [
+    { fieldName: 'storageFacility' },
+    { fieldName: 'serviceOrderNumber' },
+    { fieldName: 'tacType' },
+  ],
+  HHG_OUTOF_NTS_DOMESTIC: [
+    { fieldName: 'storageFacility' },
+    { fieldName: 'ntsRecordedWeight' },
+    { fieldName: 'serviceOrderNumber' },
+    { fieldName: 'tacType' },
+  ],
 };
 
 const MoveDetails = ({
@@ -59,10 +68,10 @@ const MoveDetails = ({
 
   if (isRetirementOrSeparation) {
     // destination type must be set for for HHG, NTSR shipments only
-    errorIfMissing.HHG = ['destinationType'];
-    errorIfMissing.HHG_OUTOF_NTS_DOMESTIC.push('destinationType');
-    errorIfMissing.HHG_SHORTHAUL_DOMESTIC = ['destinationType'];
-    errorIfMissing.HHG_LONGHAUL_DOMESTIC = ['destinationType'];
+    errorIfMissing.HHG = [{ fieldName: 'destinationType' }];
+    errorIfMissing.HHG_OUTOF_NTS_DOMESTIC.push({ fieldName: 'destinationType' });
+    errorIfMissing.HHG_SHORTHAUL_DOMESTIC = [{ fieldName: 'destinationType' }];
+    errorIfMissing.HHG_LONGHAUL_DOMESTIC = [{ fieldName: 'destinationType' }];
   }
 
   let sections = useMemo(() => {
@@ -192,7 +201,9 @@ const MoveDetails = ({
     mtoShipments?.forEach((mtoShipment) => {
       const fieldsToCheckForShipment = errorIfMissing[mtoShipment.shipmentType];
       const existsMissingFieldsOnShipment = fieldsToCheckForShipment?.some(
-        (field) => !mtoShipment[field] || mtoShipment[field] === '',
+        (field) =>
+          !mtoShipment[field.fieldName] ||
+          (mtoShipment[field.fieldName] === '' && (!field.condition || field.condition(mtoShipment))),
       );
 
       // If there were no fields to check, then nothing was required.

--- a/src/pages/Office/ServicesCounselingMoveDetails/ServicesCounselingMoveDetails.jsx
+++ b/src/pages/Office/ServicesCounselingMoveDetails/ServicesCounselingMoveDetails.jsx
@@ -202,6 +202,7 @@ const ServicesCounselingMoveDetails = ({ infoSavedAlert, setUnapprovedShipmentCo
         destinationAddress: shipment.destinationAddress || {
           postalCode: order.destinationDutyLocation.address.postalCode,
         },
+        ...shipment.ppmShipment,
         ...shipment,
         displayDestinationType: isRetirementOrSeparation,
       };

--- a/src/pages/Office/ServicesCounselingMoveDetails/ServicesCounselingMoveDetails.jsx
+++ b/src/pages/Office/ServicesCounselingMoveDetails/ServicesCounselingMoveDetails.jsx
@@ -38,6 +38,7 @@ import ButtonDropdown from 'components/ButtonDropdown/ButtonDropdown';
 import Restricted from 'components/Restricted/Restricted';
 import { permissionTypes } from 'constants/permissions';
 import NotificationScrollToTop from 'components/NotificationScrollToTop';
+import { objectIsMissingFieldWithCondition } from 'utils/displayFlags';
 
 const ServicesCounselingMoveDetails = ({ infoSavedAlert, setUnapprovedShipmentCount }) => {
   const { moveCode } = useParams();
@@ -66,12 +67,20 @@ const ServicesCounselingMoveDetails = ({ infoSavedAlert, setUnapprovedShipmentCo
   }; // add any additional fields that we also want to always show
   const neverShow = { HHG_INTO_NTS_DOMESTIC: ['usesExternalVendor', 'serviceOrderNumber', 'storageFacility'] };
   const warnIfMissing = {
-    HHG: ['counselorRemarks'],
-    HHG_INTO_NTS_DOMESTIC: ['counselorRemarks', 'tacType', 'sacType'],
-    HHG_OUTOF_NTS_DOMESTIC: ['ntsRecordedWeight', 'serviceOrderNumber', 'counselorRemarks', 'tacType', 'sacType'],
-    PPM: ['counselorRemarks'],
+    HHG: [{ fieldName: 'counselorRemarks' }],
+    HHG_INTO_NTS_DOMESTIC: [{ fieldName: 'counselorRemarks' }, { fieldName: 'tacType' }, { fieldName: 'sacType' }],
+    HHG_OUTOF_NTS_DOMESTIC: [
+      { fieldName: 'ntsRecordedWeight' },
+      { fieldName: 'serviceOrderNumber' },
+      { fieldName: 'counselorRemarks' },
+      { fieldName: 'tacType' },
+      { fieldName: 'sacType' },
+    ],
+    PPM: [{ fieldName: 'counselorRemarks' }],
   };
-  const errorIfMissing = { HHG_OUTOF_NTS_DOMESTIC: ['storageFacility'] };
+  const errorIfMissing = {
+    HHG_OUTOF_NTS_DOMESTIC: [{ fieldName: 'storageFacility' }],
+  };
 
   let shipmentsInfo = [];
   let ppmShipmentsInfoNeedsApproval = [];
@@ -87,10 +96,10 @@ const ServicesCounselingMoveDetails = ({ infoSavedAlert, setUnapprovedShipmentCo
 
   if (isRetirementOrSeparation) {
     // destination type must be set for for HHG, NTSR shipments only
-    errorIfMissing.HHG = ['destinationType'];
-    errorIfMissing.HHG_OUTOF_NTS_DOMESTIC.push('destinationType');
-    errorIfMissing.HHG_SHORTHAUL_DOMESTIC = ['destinationType'];
-    errorIfMissing.HHG_LONGHAUL_DOMESTIC = ['destinationType'];
+    errorIfMissing.HHG = [{ fieldName: 'destinationType' }];
+    errorIfMissing.HHG_OUTOF_NTS_DOMESTIC.push({ fieldName: 'destinationType' });
+    errorIfMissing.HHG_SHORTHAUL_DOMESTIC = [{ fieldName: 'destinationType' }];
+    errorIfMissing.HHG_LONGHAUL_DOMESTIC = [{ fieldName: 'destinationType' }];
   }
 
   if (!order.department_indicator || !order.order_number || !order.order_type_detail || !order.tac)
@@ -131,11 +140,11 @@ const ServicesCounselingMoveDetails = ({ infoSavedAlert, setUnapprovedShipmentCo
       const errorIfMissingList = errorIfMissing[shipment.shipmentType];
       if (errorIfMissingList) {
         errorIfMissingList.forEach((fieldToCheck) => {
-          if (!displayInfo[fieldToCheck]) {
+          if (objectIsMissingFieldWithCondition(displayInfo, fieldToCheck)) {
             numberOfErrorIfMissingForAllShipments += 1;
             // Since storage facility gets split into two fields - the name and the address
             // it needs to be counted twice.
-            if (fieldToCheck === 'storageFacility') {
+            if (fieldToCheck.fieldName === 'storageFacility') {
               numberOfErrorIfMissingForAllShipments += 1;
             }
           }
@@ -145,12 +154,12 @@ const ServicesCounselingMoveDetails = ({ infoSavedAlert, setUnapprovedShipmentCo
       const warnIfMissingList = warnIfMissing[shipment.shipmentType];
       if (warnIfMissingList) {
         warnIfMissingList.forEach((fieldToCheck) => {
-          if (!displayInfo[fieldToCheck]) {
+          if (objectIsMissingFieldWithCondition(displayInfo, fieldToCheck)) {
             numberOfWarnIfMissingForAllShipments += 1;
           }
           // Since storage facility gets split into two fields - the name and the address
           // it needs to be counted twice.
-          if (fieldToCheck === 'storageFacility') {
+          if (fieldToCheck.fieldName === 'storageFacility') {
             numberOfErrorIfMissingForAllShipments += 1;
           }
         });
@@ -198,11 +207,11 @@ const ServicesCounselingMoveDetails = ({ infoSavedAlert, setUnapprovedShipmentCo
 
       if (errorIfMissingList) {
         errorIfMissingList.forEach((fieldToCheck) => {
-          if (!displayInfo[fieldToCheck]) {
+          if (objectIsMissingFieldWithCondition(displayInfo, fieldToCheck)) {
             numberOfErrorIfMissingForAllShipments += 1;
             // Since storage facility gets split into two fields - the name and the address
             // it needs to be counted twice.
-            if (fieldToCheck === 'storageFacility') {
+            if (fieldToCheck.fieldName === 'storageFacility') {
               numberOfErrorIfMissingForAllShipments += 1;
             }
           }
@@ -212,12 +221,12 @@ const ServicesCounselingMoveDetails = ({ infoSavedAlert, setUnapprovedShipmentCo
       const warnIfMissingList = warnIfMissing[shipment.shipmentType];
       if (warnIfMissingList) {
         warnIfMissingList.forEach((fieldToCheck) => {
-          if (!displayInfo[fieldToCheck]) {
+          if (objectIsMissingFieldWithCondition(displayInfo, fieldToCheck)) {
             numberOfWarnIfMissingForAllShipments += 1;
           }
           // Since storage facility gets split into two fields - the name and the address
           // it needs to be counted twice.
-          if (fieldToCheck === 'storageFacility') {
+          if (fieldToCheck.fieldName === 'storageFacility') {
             numberOfErrorIfMissingForAllShipments += 1;
           }
         });

--- a/src/pages/Office/ServicesCounselingMoveDetails/ServicesCounselingMoveDetails.jsx
+++ b/src/pages/Office/ServicesCounselingMoveDetails/ServicesCounselingMoveDetails.jsx
@@ -80,6 +80,12 @@ const ServicesCounselingMoveDetails = ({ infoSavedAlert, setUnapprovedShipmentCo
   };
   const errorIfMissing = {
     HHG_OUTOF_NTS_DOMESTIC: [{ fieldName: 'storageFacility' }],
+    PPM: [
+      {
+        fieldName: 'advanceStatus',
+        condition: (shipment) => shipment?.ppmShipment?.hasRequestedAdvance === true,
+      },
+    ],
   };
 
   let shipmentsInfo = [];

--- a/src/pages/Office/ServicesCounselingMoveDetails/ServicesCounselingMoveDetails.jsx
+++ b/src/pages/Office/ServicesCounselingMoveDetails/ServicesCounselingMoveDetails.jsx
@@ -234,7 +234,7 @@ const ServicesCounselingMoveDetails = ({ infoSavedAlert, setUnapprovedShipmentCo
           // Since storage facility gets split into two fields - the name and the address
           // it needs to be counted twice.
           if (fieldToCheck.fieldName === 'storageFacility') {
-            numberOfErrorIfMissingForAllShipments += 1;
+            numberOfWarnIfMissingForAllShipments += 1;
           }
         });
       }

--- a/src/pages/Office/ServicesCounselingMoveDetails/ServicesCounselingMoveDetails.jsx
+++ b/src/pages/Office/ServicesCounselingMoveDetails/ServicesCounselingMoveDetails.jsx
@@ -133,6 +133,7 @@ const ServicesCounselingMoveDetails = ({ infoSavedAlert, setUnapprovedShipmentCo
         },
         agency: customerData.agency,
         closeoutOffice,
+        ...shipment.ppmShipment,
         ...shipment,
         displayDestinationType: isRetirementOrSeparation,
       };

--- a/src/pages/Office/ServicesCounselingMoveDetails/ServicesCounselingMoveDetails.test.jsx
+++ b/src/pages/Office/ServicesCounselingMoveDetails/ServicesCounselingMoveDetails.test.jsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { generatePath } from 'react-router';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { debug } from 'jest-preview';
 
 import ServicesCounselingMoveDetails from './ServicesCounselingMoveDetails';
 
@@ -307,7 +308,7 @@ const ppmShipmentQuery = {
     {
       customerRemarks: 'Please treat gently',
       eTag: 'MjAyMi0xMS0wOFQyMzo0NDo1OC4yMTc4MVo=',
-      id: '167985a7-6d47-4412-b620-d4b7f98a09ed',
+      id: 'e33a1a7b-530f-4df4-b947-d3d719786385',
       moveTaskOrderID: 'ddf94b4f-db77-4916-83ff-0d6bc68c8b42',
       ppmShipment: {
         actualDestinationPostalCode: null,
@@ -335,7 +336,7 @@ const ppmShipmentQuery = {
         reviewedAt: null,
         secondaryDestinationPostalCode: '30814',
         secondaryPickupPostalCode: '90211',
-        shipmentId: '167985a7-6d47-4412-b620-d4b7f98a09ed',
+        shipmentId: 'e33a1a7b-530f-4df4-b947-d3d719786385',
         sitEstimatedCost: null,
         sitEstimatedDepartureDate: null,
         sitEstimatedEntryDate: null,
@@ -561,6 +562,15 @@ describe('MoveDetails page', () => {
       useMoveDetailsQueries.mockReturnValue(ppmShipmentQuery);
       render(mockedComponent);
       expect(screen.getAllByRole('button', { name: 'Review documents' }).length).toBe(2);
+    });
+
+    it('shows an error if there is an advance requested and no advance status for a PPM shipment', async () => {
+      useMoveDetailsQueries.mockReturnValue(ppmShipmentQuery);
+      render(mockedComponent);
+
+      debug();
+      const advanceStatusElement = screen.getAllByTestId('advanceRequestStatus')[0];
+      expect(advanceStatusElement.parentElement).toHaveClass('missingInfoError');
     });
 
     it('renders shipments info even if destination address is missing', async () => {

--- a/src/utils/displayFlags.js
+++ b/src/utils/displayFlags.js
@@ -1,4 +1,6 @@
+/* eslint-disable no-console */
 import classNames from 'classnames';
+import PropTypes from 'prop-types';
 
 let errorIfMissing = [];
 let warnIfMissing = [];
@@ -6,6 +8,10 @@ let showWhenCollapsed = [];
 let neverShow = [];
 let flaggedItem = null;
 let flagStyles = null;
+
+export function objectIsMissingFieldWithCondition(object, { fieldName, condition }) {
+  return !object[fieldName] && (!condition || condition(flaggedItem));
+}
 
 /*
   Set CSS styles for the flags
@@ -59,7 +65,8 @@ export function getDisplayFlags(fieldname) {
   // Hide row will override any always show that is set.
   let hideRow = false;
 
-  if (errorIfMissing.includes(fieldname) && !flaggedItem[fieldname]) {
+  const fieldErrorIfMissing = errorIfMissing.find((entry) => entry.fieldName === fieldname);
+  if (fieldErrorIfMissing && objectIsMissingFieldWithCondition(flaggedItem, fieldErrorIfMissing)) {
     alwaysShow = true;
     classes = classNames(flagStyles.row, flagStyles.missingInfoError);
     return {
@@ -67,7 +74,8 @@ export function getDisplayFlags(fieldname) {
       classes,
     };
   }
-  if (warnIfMissing.includes(fieldname) && !flaggedItem[fieldname]) {
+  const fieldWarnIfMissing = warnIfMissing.find((entry) => entry.fieldName === fieldname);
+  if (fieldWarnIfMissing && objectIsMissingFieldWithCondition(flaggedItem, fieldWarnIfMissing)) {
     alwaysShow = true;
     classes = classNames(flagStyles.row, flagStyles.warning);
     return {
@@ -91,5 +99,10 @@ export function getDisplayFlags(fieldname) {
 }
 
 export function getMissingOrDash(fieldName) {
-  return errorIfMissing.includes(fieldName) ? 'Missing' : '—';
+  return errorIfMissing.map((entry) => entry.fieldName).includes(fieldName) ? 'Missing' : '—';
 }
+
+export const fieldValidationShape = PropTypes.shape({
+  fieldName: PropTypes.string.isRequired,
+  condition: PropTypes.func,
+});

--- a/src/utils/displayFlags.js
+++ b/src/utils/displayFlags.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-console */
 import classNames from 'classnames';
 import PropTypes from 'prop-types';
 
@@ -10,7 +9,7 @@ let flaggedItem = null;
 let flagStyles = null;
 
 export function objectIsMissingFieldWithCondition(object, { fieldName, condition }) {
-  return !object[fieldName] && (!condition || condition(flaggedItem));
+  return !object[fieldName] && (!condition || condition(object));
 }
 
 /*

--- a/src/utils/displayFlags.test.js
+++ b/src/utils/displayFlags.test.js
@@ -2,8 +2,8 @@ import { setFlagStyles, setDisplayFlags, getDisplayFlags, getMissingOrDash } fro
 
 describe('setAndRetrieveFlags', () => {
   // example fields and data to use for testing, not reflective of reality
-  const errorIfMissing = ['firstName'];
-  const warnIfMissing = ['counselorRemarks'];
+  const errorIfMissing = [{ fieldName: 'firstName' }];
+  const warnIfMissing = [{ fieldName: 'counselorRemarks' }];
   const showWhenCollapsed = ['shipmentAddress'];
   const neverShow = ['postalCode'];
   const shipment = {

--- a/src/utils/displayFlags.test.js
+++ b/src/utils/displayFlags.test.js
@@ -3,6 +3,10 @@ import { setFlagStyles, setDisplayFlags, getDisplayFlags, getMissingOrDash } fro
 describe('setAndRetrieveFlags', () => {
   // example fields and data to use for testing, not reflective of reality
   const errorIfMissing = [{ fieldName: 'firstName' }];
+  const errorIfMissingWithConditions = [
+    { fieldName: 'fieldWithTrueCondition', condition: (shipment) => shipment.lastName },
+    { fieldName: 'fieldWithFalseCondition', condition: (shipment) => shipment.customerRemarks },
+  ];
   const warnIfMissing = [{ fieldName: 'counselorRemarks' }];
   const showWhenCollapsed = ['shipmentAddress'];
   const neverShow = ['postalCode'];
@@ -25,6 +29,18 @@ describe('setAndRetrieveFlags', () => {
 
     expect(result.alwaysShow).toEqual(true);
     expect(result.classes).toEqual('row error');
+  });
+
+  it('can set and retrieve error flags with conditions', () => {
+    setDisplayFlags(errorIfMissingWithConditions, null, null, null, shipment);
+
+    setFlagStyles(styles);
+
+    const fieldWithTrueConditionFlags = getDisplayFlags('fieldWithTrueCondition');
+    expect(fieldWithTrueConditionFlags.classes).toEqual('row error');
+
+    const fieldWithFalseConditionFlags = getDisplayFlags('fieldWithFalseCondition');
+    expect(fieldWithFalseConditionFlags.classes).toEqual('row');
   });
 
   it('can set and retrieve warning flags', () => {


### PR DESCRIPTION
## [Jira ticket](https://dp3.atlassian.net/browse/MB-14184) for this change

## Summary

This PR should add a new "advance request status" field to the PPM shipment card in move details for the services counselor.

## Setup to Run Your Code

<details>
<summary>💻 You will need to use three separate terminals to test this locally.</summary>

##### Terminal 1

Start the Storybook locally.

```sh
make storybook
```

##### Terminal 2

Start the UI locally.

```sh
make client_run
```

##### Terminal 3

Start the Go server locally.

```sh
make server_run
```

</details>

### Additional steps

<!-- Fill out the next section as you see fit, these are just suggestions. -->

Part 1
1. Access the customer app and create a new move with a PPM shipment and no advance request
2. Access the office app as a services counselor and navigate to the new move
3. Validate that on the shipment card in move details, there is no "advance status" field and no corresponding errors.

Part 2
1. Access the customer app and update the previously-created PPM shipment
2. Request an advance
3. Access the office app as a services counselor and navigate to the new move
4. Validate that on the shipment card in move details, there is now an "advance status" field and an error since the shipment has a requested advance.
5. Update the shipment and approve or deny the advance request
6. Validate that on the shipment card in move details, there is an "advance status" field that reflects the recent change and no corresponding errors.

## Verification Steps for Author

These are to be checked by the author.

- [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
- [ ] Request review from a member of a different team.
- [ ] Have the Jira acceptance criteria been met for this change?

## Verification Steps for Reviewers

These are to be checked by a reviewer.

<!-- Fill out the next sections as you see fit, these are just suggestions. -->

### Frontend

- [ ] User facing changes have been reviewed by design.
- [ ] There are no aXe warnings for UI.
- [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/main/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
- [ ] There are no new console errors in the browser devtools
- [ ] There are no new console errors in the test output
- [ ] If this PR adds a new component to Storybook, it ensures the component is fully responsive, OR if it is intentionally not, a wrapping div using the `officeApp` class or custom `min-width` styling is used to hide any states the would not be visible to the user.


## Screenshots
<img width="771" alt="image" src="https://user-images.githubusercontent.com/97245917/217594335-0d662817-f5e4-4fd0-a5a5-3b3189c012dc.png">
