### PR TITLE
MB-15172: Use the default channel for circleci messages for one stop config

### DIFF
--- a/scripts/circleci-announce-broken-branch
+++ b/scripts/circleci-announce-broken-branch
@@ -17,10 +17,11 @@ if [[ $CIRCLE_JOB == *"deploy"* ]]; then
   color="danger"
 fi
 
+# use the default channel on the webhook so that config is handled in
+# one place
 slack_payload=$(
 cat <<EOM
 {
-    "channel": "#prac-engineering",
     "attachments": [
         {
             "fallback": "$message $CIRCLE_BUILD_URL",


### PR DESCRIPTION
## [Jira ticket](https://dp3.atlassian.net/browse/MB-15172) for this change

## Summary

Switch to the default channel for CircleCI failure messages
