### PR TITLE
MB-15198: Recreate build/downloads even if it doesn't exist already

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -172,7 +172,7 @@ build/index.html: build/downloads ## milmove serve requires this file to boot, b
 
 build/downloads: public/downloads
 	mkdir -p build
-	rm -r build/downloads
+	rm -rf build/downloads
 	cp -r public/downloads build/downloads
 
 .PHONY: client_run


### PR DESCRIPTION
## [Jira ticket](https://dp3.atlassian.net/browse/MB-15198) for this change

## Summary

Fix Makefile when the build directory doesn't exist. See also the [slack thread](https://ustcdp3.slack.com/archives/CP6F568DC/p1675967174947589)

`rm -rf build && make server_run`