### PR TITLE
[ MB-15214 ] Fix duplicate entries issue in db_dev_e2e_populate

### DIFF
--- a/pkg/testdatagen/scenario/shared.go
+++ b/pkg/testdatagen/scenario/shared.go
@@ -1503,7 +1503,9 @@ func createMoveWithPPMShipmentReadyForFinalCloseout(appCtx appcontext.AppContext
 
 	approvedAt := time.Date(2022, 4, 15, 12, 30, 0, 0, time.UTC)
 	address := factory.BuildAddress(appCtx.DB(), nil, nil)
-	closeoutOfficeID := testdatagen.ConvertUUIDStringToUUID("59131551-efc8-4e63-bb06-9cc88bd8f8a0")
+	// Since we don't truncate the transportation_office table in our dev data generation workflow,
+	// we need to generate an ID here instead of using a string to prevent duplicate entries.
+	closeoutOfficeID := uuid.Must(uuid.NewV4())
 
 	assertions := testdatagen.Assertions{
 		UserUploader: userUploader,


### PR DESCRIPTION


## [Jira ticket](https://dp3.atlassian.net/browse/MB-15214) for this change

## Summary

The transportation_office table is not truncated in the db_dev_truncate [command](https://github.com/transcom/mymove/blob/3d88a5a1655e3e96172257fdd63bfbcf51fd5b21/Makefile#L543) since many of the transportation offices are populated in migrations. 

db_dev_e2e_populate [calls the truncation command](https://github.com/transcom/mymove/blob/3d88a5a1655e3e96172257fdd63bfbcf51fd5b21/Makefile#L548) instead of building a fresh db every time which is faster. 

However, since a string is used to create a transportation office entry in [this scenario](https://github.com/transcom/mymove/blob/e57dc73ed06cdfe27535418c063ba4fb3932a608/pkg/testdatagen/scenario/shared.go#L1506), we are now seeing a duplicate entry error.

## Setup to Run Your Code

Run `make db_dev_fresh` to get a new db
Run `make db_dev_e2e_populate` and make sure that it successfully runs.

### Additional steps

<!-- Fill out the next section as you see fit, these are just suggestions. -->

1. Access the
2. Login as a
3.

## Verification Steps for Author

These are to be checked by the author.

- [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
- [ ] Request review from a member of a different team.
- [ ] Have the Jira acceptance criteria been met for this change?

## Verification Steps for Reviewers

These are to be checked by a reviewer.

<!-- Fill out the next sections as you see fit, these are just suggestions. -->

### Frontend

- [ ] User facing changes have been reviewed by design.
- [ ] There are no aXe warnings for UI.
- [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/main/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
- [ ] There are no new console errors in the browser devtools
- [ ] There are no new console errors in the test output
- [ ] If this PR adds a new component to Storybook, it ensures the component is fully responsive, OR if it is intentionally not, a wrapping div using the `officeApp` class or custom `min-width` styling is used to hide any states the would not be visible to the user.

### Backend

- [ ] Code follows the guidelines for [Logging](https://transcom.github.io/mymove-docs/docs/dev/contributing/backend/Backend-Programming-Guide#logging)
- [ ] The requirements listed in [Querying the Database Safely](https://transcom.github.io/mymove-docs/docs/dev/contributing/backend/Backend-Programming-Guide/#querying-the-database-safely) have been satisfied.

### Database

#### Any new migrations/schema changes:

- [ ] Follows our guidelines for [Zero-Downtime Deploys](https://transcom.github.io/mymove-docs/docs/dev/contributing/database/Database-Migrations#zero-downtime-migrations)
- [ ] Have been communicated to #g-database
- [ ] Secure migrations have been tested following the instructions in our [docs](https://transcom.github.io/mymove-docs/docs/dev/contributing/database/Database-Migrations#secure-migrations)

## Screenshots
