### PR TITLE
MB-13864 weight tickets overview integration

### DIFF
--- a/src/components/Office/PPM/ReviewDocumentsSidePanel/ReviewDocumentsSidePanel.jsx
+++ b/src/components/Office/PPM/ReviewDocumentsSidePanel/ReviewDocumentsSidePanel.jsx
@@ -1,8 +1,9 @@
 import React from 'react';
 import { Form } from '@trussworks/react-uswds';
+import { Formik } from 'formik';
 import classnames from 'classnames';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { number } from 'prop-types';
+import { array, func, number, object } from 'prop-types';
 
 import PPMHeaderSummary from '../PPMHeaderSummary/PPMHeaderSummary';
 
@@ -11,38 +12,56 @@ import styles from './ReviewDocumentsSidePanel.module.scss';
 import { PPMShipmentShape } from 'types/shipment';
 import formStyles from 'styles/form.module.scss';
 import DocumentViewerSidebar from 'pages/Office/DocumentViewerSidebar/DocumentViewerSidebar';
-import { ReviewDocumentsStatus } from 'constants/ppms';
+import PPMDocumentsStatus from 'constants/ppms';
 import { expenseTypes } from 'constants/ppmExpenseTypes';
 
-export default function ReviewDocumentsSidePanel({ ppmShipment, ppmNumber, expenseNumber, tripNumber }) {
+export default function ReviewDocumentsSidePanel({
+  ppmShipment,
+  ppmNumber,
+  formRef,
+  onSuccess,
+  onError,
+  expenseTickets,
+  proGearTickets,
+  weightTickets,
+}) {
   // TODO: return pro-gear tickets & expenses data will be done in later tickets. For now, we have placeholders here (proGearTickets, expenseTickets).
-
-  const proGearTickets = [
-    { status: ReviewDocumentsStatus.EXCLUDE, reason: 'Objects not applicable' },
-    { status: ReviewDocumentsStatus.ACCEPT, reason: null },
-  ];
-
-  const expenseTickets = [
-    { movingExpenseType: expenseTypes.STORAGE, status: ReviewDocumentsStatus.REJECT, reason: 'Too large' },
-    { movingExpenseType: expenseTypes.PACKING_MATERIALS, status: ReviewDocumentsStatus.ACCEPT, reason: null },
-  ];
 
   // TODO: ability to reject/approve weight tickets will be done in another ticker. For now, this is placeholder for an accepted weight ticket
 
-  const weightTickets = [{ status: ReviewDocumentsStatus.ACCEPT, reason: null }];
+  // TODO: will need something like this for form submission
+
+  // const [patchWeightTicketMutation] = useMutation(patchWeightTicket, {
+  //   onSuccess,
+  //   onError,
+  // });
+
+  // const [confirmPPMDocuments] = useMutation(confirmPPMDocuments, {
+  //   onSuccess,
+  //   onError,
+  // });
+
+  const handleSubmit = () => {
+    // TODO: use the mutation and pass in onSuccess and onError, like ReviewWeightTicket
+    if (Math.random() < 0.9999) {
+      onSuccess();
+    } else {
+      onError();
+    }
+  };
 
   let status;
   let showReason;
 
   const statusWithIcon = (ticket) => {
-    if (ticket.status === ReviewDocumentsStatus.ACCEPT) {
+    if (ticket.status === PPMDocumentsStatus.APPROVED) {
       status = (
         <div className={styles.iconRow}>
           <FontAwesomeIcon icon="check" />
           <span>Accept</span>
         </div>
       );
-    } else if (ticket.status === ReviewDocumentsStatus.EXCLUDE) {
+    } else if (ticket.status === PPMDocumentsStatus.EXCLUDED) {
       status = (
         <div className={styles.iconRow}>
           <FontAwesomeIcon icon="ban" />
@@ -64,69 +83,79 @@ export default function ReviewDocumentsSidePanel({ ppmShipment, ppmNumber, expen
 
   return (
     <div className={classnames(styles.container, 'container--accent--ppm')}>
-      <Form className={classnames(formStyles.form, styles.ReviewDocumentsSidePanel)}>
-        <PPMHeaderSummary ppmShipment={ppmShipment} ppmNumber={ppmNumber} />
-        <hr />
-        <h3 className={styles.send}>Send to customer?</h3>
-        <DocumentViewerSidebar.Content className={styles.sideBar}>
-          {weightTickets.length > 0
-            ? weightTickets.map((weight, index) => {
-                return (
-                  <div className={styles.rowContainer} key={index}>
-                    <div className={styles.row}>
-                      <h3 className={styles.tripNumber}>Trip {tripNumber}</h3>
-                      {statusWithIcon(weight)}
+      <Formik innerRef={formRef} onSubmit={handleSubmit} initialValues>
+        <Form className={classnames(formStyles.form, styles.ReviewDocumentsSidePanel)}>
+          <PPMHeaderSummary ppmShipment={ppmShipment} ppmNumber={ppmNumber} />
+          <hr />
+          <h3 className={styles.send}>Send to customer?</h3>
+          <DocumentViewerSidebar.Content className={styles.sideBar}>
+            {weightTickets?.length > 0
+              ? weightTickets.map((weight, index) => {
+                  return (
+                    <div className={styles.rowContainer} key={index}>
+                      <div className={styles.row}>
+                        <h3 className={styles.tripNumber}>Trip {index + 1}</h3>
+                        {statusWithIcon(weight)}
+                      </div>
+                      {showReason ? <p>{weight.reason}</p> : null}
                     </div>
-                    {showReason ? <p>{weight.weightTicketReason}</p> : null}
-                  </div>
-                );
-              })
-            : null}
-          {proGearTickets.length > 0
-            ? proGearTickets.map((gear, index) => {
-                return (
-                  <div className={styles.rowContainer} key={index}>
-                    <div className={styles.row}>
-                      <h3 className={styles.tripNumber}>Pro-gear {index + 1}</h3>
-                      {statusWithIcon(gear)}
+                  );
+                })
+              : null}
+            {proGearTickets.length > 0
+              ? proGearTickets.map((gear, index) => {
+                  return (
+                    <div className={styles.rowContainer} key={index}>
+                      <div className={styles.row}>
+                        <h3 className={styles.tripNumber}>Pro-gear {index + 1}</h3>
+                        {statusWithIcon(gear)}
+                      </div>
+                      {showReason ? <p>{gear.reason}</p> : null}
                     </div>
-                    {showReason ? <p>{gear.reason}</p> : null}
-                  </div>
-                );
-              })
-            : null}
-          {expenseTickets.length > 0
-            ? expenseTickets.map((exp, index) => {
-                return (
-                  <div className={styles.rowContainer} key={index}>
-                    <div className={styles.row}>
-                      <h3 className={styles.tripNumber}>
-                        {exp.movingExpenseType === expenseTypes.STORAGE ? 'Storage' : 'Receipt'}
-                        &nbsp;{expenseNumber}
-                      </h3>
-                      {statusWithIcon(exp)}
+                  );
+                })
+              : null}
+            {expenseTickets.length > 0
+              ? expenseTickets.map((exp, index) => {
+                  return (
+                    <div className={styles.rowContainer} key={index}>
+                      <div className={styles.row}>
+                        <h3 className={styles.tripNumber}>
+                          {exp.movingExpenseType === expenseTypes.STORAGE ? 'Storage' : 'Receipt'}
+                          &nbsp;{index + 1}
+                        </h3>
+                        {statusWithIcon(exp)}
+                      </div>
+                      {showReason ? <p>{exp.reason}</p> : null}
                     </div>
-                    {showReason ? <p>{exp.reason}</p> : null}
-                  </div>
-                );
-              })
-            : null}
-        </DocumentViewerSidebar.Content>
-      </Form>
+                  );
+                })
+              : null}
+          </DocumentViewerSidebar.Content>
+        </Form>
+      </Formik>
     </div>
   );
 }
 
 ReviewDocumentsSidePanel.propTypes = {
   ppmShipment: PPMShipmentShape,
-  tripNumber: number,
   ppmNumber: number,
-  expenseNumber: number,
+  formRef: object,
+  onSuccess: func,
+  onError: func,
+  expenseTickets: array,
+  proGearTickets: array,
+  weightTickets: array,
 };
 
 ReviewDocumentsSidePanel.defaultProps = {
   ppmShipment: undefined,
-  tripNumber: 1,
   ppmNumber: 1,
-  expenseNumber: 1,
+  formRef: null,
+  onSuccess: () => {},
+  onError: () => {},
+  expenseTickets: [],
+  proGearTickets: [],
+  weightTickets: [],
 };

--- a/src/components/Office/PPM/ReviewDocumentsSidePanel/ReviewDocumentsSidePanel.jsx
+++ b/src/components/Office/PPM/ReviewDocumentsSidePanel/ReviewDocumentsSidePanel.jsx
@@ -3,13 +3,13 @@ import { Form } from '@trussworks/react-uswds';
 import { Formik } from 'formik';
 import classnames from 'classnames';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { array, func, number, object } from 'prop-types';
+import { arrayOf, func, number, object } from 'prop-types';
 
 import PPMHeaderSummary from '../PPMHeaderSummary/PPMHeaderSummary';
 
 import styles from './ReviewDocumentsSidePanel.module.scss';
 
-import { PPMShipmentShape } from 'types/shipment';
+import { ExpenseShape, PPMShipmentShape, ProGearTicketShape, WeightTicketShape } from 'types/shipment';
 import formStyles from 'styles/form.module.scss';
 import DocumentViewerSidebar from 'pages/Office/DocumentViewerSidebar/DocumentViewerSidebar';
 import PPMDocumentsStatus from 'constants/ppms';
@@ -26,6 +26,8 @@ export default function ReviewDocumentsSidePanel({
 }) {
   let status;
   let showReason;
+  let storageNumber = 0;
+  let receiptNumber = 0;
 
   const handleSubmit = () => {
     // TODO: use a mutation query and then attach onSuccess and an onError handler
@@ -68,54 +70,56 @@ export default function ReviewDocumentsSidePanel({
           <hr />
           <h3 className={styles.send}>Send to customer?</h3>
           <DocumentViewerSidebar.Content className={styles.sideBar}>
-            {weightTickets.length > 0 && (
-              <ul>
-                {weightTickets.map((weight, index) => {
-                  return (
-                    <li className={styles.rowContainer} key={index}>
-                      <div className={styles.row}>
-                        <h3 className={styles.tripNumber}>Trip {index + 1}</h3>
-                        {statusWithIcon(weight)}
-                      </div>
-                      {showReason ? <p>{weight.reason}</p> : null}
-                    </li>
-                  );
-                })}
-              </ul>
-            )}
-            {proGearTickets.length > 0 && (
-              <ul>
-                {proGearTickets.map((gear, index) => {
-                  return (
-                    <li className={styles.rowContainer} key={index}>
-                      <div className={styles.row}>
-                        <h3 className={styles.tripNumber}>Pro-gear {index + 1}</h3>
-                        {statusWithIcon(gear)}
-                      </div>
-                      {showReason ? <p>{gear.reason}</p> : null}
-                    </li>
-                  );
-                })}
-              </ul>
-            )}
-            {expenseTickets.length > 0 && (
-              <ul>
-                {expenseTickets.map((exp, index) => {
-                  return (
-                    <li className={styles.rowContainer} key={index}>
-                      <div className={styles.row}>
-                        <h3 className={styles.tripNumber}>
-                          {exp.movingExpenseType === expenseTypes.STORAGE ? 'Storage' : 'Receipt'}
-                          &nbsp;{index + 1}
-                        </h3>
-                        {statusWithIcon(exp)}
-                      </div>
-                      {showReason ? <p>{exp.reason}</p> : null}
-                    </li>
-                  );
-                })}
-              </ul>
-            )}
+            <ul>
+              {weightTickets.length > 0
+                ? weightTickets.map((weight, index) => {
+                    return (
+                      <li className={styles.rowContainer} key={index}>
+                        <div className={styles.row}>
+                          <h3 className={styles.tripNumber}>Trip {index + 1}</h3>
+                          {statusWithIcon(weight)}
+                        </div>
+                        {showReason ? <p>{weight.reason}</p> : null}
+                      </li>
+                    );
+                  })
+                : null}
+              {proGearTickets.length > 0
+                ? proGearTickets.map((gear, index) => {
+                    return (
+                      <li className={styles.rowContainer} key={index}>
+                        <div className={styles.row}>
+                          <h3 className={styles.tripNumber}>Pro-gear {index + 1}</h3>
+                          {statusWithIcon(gear)}
+                        </div>
+                        {showReason ? <p>{gear.reason}</p> : null}
+                      </li>
+                    );
+                  })
+                : null}
+              {expenseTickets.length > 0
+                ? expenseTickets.map((exp, index) => {
+                    const isStorage = exp.movingExpenseType === expenseTypes.STORAGE;
+                    if (isStorage) {
+                      storageNumber += 1;
+                    } else {
+                      receiptNumber += 1;
+                    }
+                    return (
+                      <li className={styles.rowContainer} key={index}>
+                        <div className={styles.row}>
+                          <h3 className={styles.tripNumber}>
+                            {isStorage ? 'Storage' : 'Receipt'}
+                            &nbsp;{isStorage ? storageNumber : receiptNumber}
+                          </h3>
+                          {statusWithIcon(exp)}
+                        </div>
+                        {showReason ? <p>{exp.reason}</p> : null}
+                      </li>
+                    );
+                  })
+                : null}
+            </ul>
           </DocumentViewerSidebar.Content>
         </Form>
       </div>
@@ -128,9 +132,9 @@ ReviewDocumentsSidePanel.propTypes = {
   ppmNumber: number,
   formRef: object,
   onSuccess: func,
-  expenseTickets: array,
-  proGearTickets: array,
-  weightTickets: array,
+  expenseTickets: arrayOf(ExpenseShape),
+  proGearTickets: arrayOf(ProGearTicketShape),
+  weightTickets: arrayOf(WeightTicketShape),
 };
 
 ReviewDocumentsSidePanel.defaultProps = {

--- a/src/components/Office/PPM/ReviewDocumentsSidePanel/ReviewDocumentsSidePanel.jsx
+++ b/src/components/Office/PPM/ReviewDocumentsSidePanel/ReviewDocumentsSidePanel.jsx
@@ -20,38 +20,17 @@ export default function ReviewDocumentsSidePanel({
   ppmNumber,
   formRef,
   onSuccess,
-  onError,
   expenseTickets,
   proGearTickets,
   weightTickets,
 }) {
-  // TODO: return pro-gear tickets & expenses data will be done in later tickets. For now, we have placeholders here (proGearTickets, expenseTickets).
-
-  // TODO: ability to reject/approve weight tickets will be done in another ticker. For now, this is placeholder for an accepted weight ticket
-
-  // TODO: will need something like this for form submission
-
-  // const [patchWeightTicketMutation] = useMutation(patchWeightTicket, {
-  //   onSuccess,
-  //   onError,
-  // });
-
-  // const [confirmPPMDocuments] = useMutation(confirmPPMDocuments, {
-  //   onSuccess,
-  //   onError,
-  // });
-
-  const handleSubmit = () => {
-    // TODO: use the mutation and pass in onSuccess and onError, like ReviewWeightTicket
-    if (Math.random() < 0.9999) {
-      onSuccess();
-    } else {
-      onError();
-    }
-  };
-
   let status;
   let showReason;
+
+  const handleSubmit = () => {
+    // TODO: use a mutation query and then attach onSuccess and an onError handler
+    onSuccess();
+  };
 
   const statusWithIcon = (ticket) => {
     if (ticket.status === PPMDocumentsStatus.APPROVED) {
@@ -82,43 +61,48 @@ export default function ReviewDocumentsSidePanel({
   };
 
   return (
-    <div className={classnames(styles.container, 'container--accent--ppm')}>
-      <Formik innerRef={formRef} onSubmit={handleSubmit} initialValues>
+    <Formik initialValues innerRef={formRef} onSubmit={handleSubmit}>
+      <div className={classnames(styles.container, 'container--accent--ppm')}>
         <Form className={classnames(formStyles.form, styles.ReviewDocumentsSidePanel)}>
           <PPMHeaderSummary ppmShipment={ppmShipment} ppmNumber={ppmNumber} />
           <hr />
           <h3 className={styles.send}>Send to customer?</h3>
           <DocumentViewerSidebar.Content className={styles.sideBar}>
-            {weightTickets?.length > 0
-              ? weightTickets.map((weight, index) => {
+            {weightTickets.length > 0 && (
+              <ul>
+                {weightTickets.map((weight, index) => {
                   return (
-                    <div className={styles.rowContainer} key={index}>
+                    <li className={styles.rowContainer} key={index}>
                       <div className={styles.row}>
                         <h3 className={styles.tripNumber}>Trip {index + 1}</h3>
                         {statusWithIcon(weight)}
                       </div>
                       {showReason ? <p>{weight.reason}</p> : null}
-                    </div>
+                    </li>
                   );
-                })
-              : null}
-            {proGearTickets.length > 0
-              ? proGearTickets.map((gear, index) => {
+                })}
+              </ul>
+            )}
+            {proGearTickets.length > 0 && (
+              <ul>
+                {proGearTickets.map((gear, index) => {
                   return (
-                    <div className={styles.rowContainer} key={index}>
+                    <li className={styles.rowContainer} key={index}>
                       <div className={styles.row}>
                         <h3 className={styles.tripNumber}>Pro-gear {index + 1}</h3>
                         {statusWithIcon(gear)}
                       </div>
                       {showReason ? <p>{gear.reason}</p> : null}
-                    </div>
+                    </li>
                   );
-                })
-              : null}
-            {expenseTickets.length > 0
-              ? expenseTickets.map((exp, index) => {
+                })}
+              </ul>
+            )}
+            {expenseTickets.length > 0 && (
+              <ul>
+                {expenseTickets.map((exp, index) => {
                   return (
-                    <div className={styles.rowContainer} key={index}>
+                    <li className={styles.rowContainer} key={index}>
                       <div className={styles.row}>
                         <h3 className={styles.tripNumber}>
                           {exp.movingExpenseType === expenseTypes.STORAGE ? 'Storage' : 'Receipt'}
@@ -127,14 +111,15 @@ export default function ReviewDocumentsSidePanel({
                         {statusWithIcon(exp)}
                       </div>
                       {showReason ? <p>{exp.reason}</p> : null}
-                    </div>
+                    </li>
                   );
-                })
-              : null}
+                })}
+              </ul>
+            )}
           </DocumentViewerSidebar.Content>
         </Form>
-      </Formik>
-    </div>
+      </div>
+    </Formik>
   );
 }
 
@@ -143,7 +128,6 @@ ReviewDocumentsSidePanel.propTypes = {
   ppmNumber: number,
   formRef: object,
   onSuccess: func,
-  onError: func,
   expenseTickets: array,
   proGearTickets: array,
   weightTickets: array,
@@ -154,7 +138,6 @@ ReviewDocumentsSidePanel.defaultProps = {
   ppmNumber: 1,
   formRef: null,
   onSuccess: () => {},
-  onError: () => {},
   expenseTickets: [],
   proGearTickets: [],
   weightTickets: [],

--- a/src/components/Office/PPM/ReviewDocumentsSidePanel/ReviewDocumentsSidePanel.module.scss
+++ b/src/components/Office/PPM/ReviewDocumentsSidePanel/ReviewDocumentsSidePanel.module.scss
@@ -37,12 +37,17 @@
       margin: 12px 8px;
     }
   }
+  ul {
+    @include u-margin-top(0);
+    @include u-margin-bottom(0);
+  }
   .row {
     display: flex;
     flex-direction: row;
     border-top: 1px solid #dcdee0;
     padding: 12px 8px;
-    h3 {
+
+    .tripNumber {
       @include u-font-size('body', 'xs');
       @include u-margin-bottom(0);
       font-weight: normal;
@@ -88,4 +93,9 @@
 .container .ReviewDocumentsSidePanel main {
   padding-left: 0;
   padding-right: 0;
+}
+
+.sidebar {
+  @include u-margin-top(0);
+  @include u-margin-bottom(0);
 }

--- a/src/components/Office/PPM/ReviewDocumentsSidePanel/ReviewDocumentsSidePanel.module.scss
+++ b/src/components/Office/PPM/ReviewDocumentsSidePanel/ReviewDocumentsSidePanel.module.scss
@@ -38,8 +38,11 @@
     }
   }
   ul {
-    @include u-margin-top(0);
-    @include u-margin-bottom(0);
+    margin: 0;
+    padding: 0;
+    li {
+      list-style: none;
+    }
   }
   .row {
     display: flex;
@@ -91,8 +94,7 @@
 }
 
 .container .ReviewDocumentsSidePanel main {
-  padding-left: 0;
-  padding-right: 0;
+  padding: 0;
 }
 
 .sidebar {

--- a/src/components/Office/PPM/ReviewDocumentsSidePanel/ReviewDocumentsSidePanel.module.scss
+++ b/src/components/Office/PPM/ReviewDocumentsSidePanel/ReviewDocumentsSidePanel.module.scss
@@ -3,6 +3,9 @@
 @import 'shared/styles/variables';
 
 .ReviewDocumentsSidePanel {
+  main {
+    padding: 0;
+  }
 
   header {
     @include u-padding(2);
@@ -80,4 +83,9 @@
     margin-left: 17px;
     margin-right: 9px;
   }
+}
+
+.container .ReviewDocumentsSidePanel main {
+  padding-left: 0;
+  padding-right: 0;
 }

--- a/src/components/Office/PPM/ReviewDocumentsSidePanel/ReviewDocumentsSidePanel.stories.jsx
+++ b/src/components/Office/PPM/ReviewDocumentsSidePanel/ReviewDocumentsSidePanel.stories.jsx
@@ -3,6 +3,9 @@ import { Grid, GridContainer } from '@trussworks/react-uswds';
 
 import ReviewDocumentsSidePanel from './ReviewDocumentsSidePanel';
 
+import PPMDocumentsStatus from 'constants/ppms';
+import { expenseTypes } from 'constants/ppmExpenseTypes';
+
 export default {
   title: 'Office Components / PPM / Review Documents Side Panel',
   component: ReviewDocumentsSidePanel,
@@ -31,4 +34,17 @@ FilledIn.args = {
     hasReceivedAdvance: true,
     advanceAmountReceived: 60000,
   },
+  expenseTickets: [
+    { movingExpenseType: expenseTypes.STORAGE, status: PPMDocumentsStatus.REJECTED, reason: 'Too large' },
+    { movingExpenseType: expenseTypes.PACKING_MATERIALS, status: PPMDocumentsStatus.ACCEPTED, reason: null },
+  ],
+  proGearTickets: [
+    { status: PPMDocumentsStatus.EXCLUDED, reason: 'Objects not applicable' },
+    { status: PPMDocumentsStatus.ACCEPTED, reason: null },
+  ],
+  weightTickets: [
+    {
+      status: PPMDocumentsStatus.APPROVED,
+    },
+  ],
 };

--- a/src/components/Office/PPM/ReviewDocumentsSidePanel/ReviewDocumentsSidePanel.stories.jsx
+++ b/src/components/Office/PPM/ReviewDocumentsSidePanel/ReviewDocumentsSidePanel.stories.jsx
@@ -5,6 +5,9 @@ import ReviewDocumentsSidePanel from './ReviewDocumentsSidePanel';
 
 import PPMDocumentsStatus from 'constants/ppms';
 import { expenseTypes } from 'constants/ppmExpenseTypes';
+import { createCompleteMovingExpense } from 'utils/test/factories/movingExpense';
+import { createBaseProGearWeightTicket } from 'utils/test/factories/proGearWeightTicket';
+import { createCompleteWeightTicket } from 'utils/test/factories/weightTicket';
 
 export default {
   title: 'Office Components / PPM / Review Documents Side Panel',
@@ -35,16 +38,25 @@ FilledIn.args = {
     advanceAmountReceived: 60000,
   },
   expenseTickets: [
-    { movingExpenseType: expenseTypes.STORAGE, status: PPMDocumentsStatus.REJECTED, reason: 'Too large' },
-    { movingExpenseType: expenseTypes.PACKING_MATERIALS, status: PPMDocumentsStatus.ACCEPTED, reason: null },
+    createCompleteMovingExpense(
+      {},
+      { movingExpenseType: expenseTypes.STORAGE, status: PPMDocumentsStatus.REJECTED, reason: 'Too large' },
+    ),
+    createCompleteMovingExpense(
+      {},
+      { movingExpenseType: expenseTypes.PACKING_MATERIALS, status: PPMDocumentsStatus.APPROVED, reason: null },
+    ),
   ],
   proGearTickets: [
-    { status: PPMDocumentsStatus.EXCLUDED, reason: 'Objects not applicable' },
-    { status: PPMDocumentsStatus.ACCEPTED, reason: null },
+    createBaseProGearWeightTicket({}, { status: PPMDocumentsStatus.EXCLUDED, reason: 'Objects not applicable' }),
+    createBaseProGearWeightTicket({}, { status: PPMDocumentsStatus.APPROVED, reason: null }),
   ],
   weightTickets: [
-    {
-      status: PPMDocumentsStatus.APPROVED,
-    },
+    createCompleteWeightTicket(
+      {},
+      {
+        status: PPMDocumentsStatus.APPROVED,
+      },
+    ),
   ],
 };

--- a/src/components/Office/PPM/ReviewDocumentsSidePanel/ReviewDocumentsSidePanel.test.jsx
+++ b/src/components/Office/PPM/ReviewDocumentsSidePanel/ReviewDocumentsSidePanel.test.jsx
@@ -3,10 +3,33 @@ import { render, screen } from '@testing-library/react';
 
 import ReviewDocumentsSidePanel from './ReviewDocumentsSidePanel';
 
+import PPMDocumentsStatus from 'constants/ppms';
+
+const mockWeightTickets = [
+  {
+    status: PPMDocumentsStatus.APPROVED,
+  },
+  {
+    status: PPMDocumentsStatus.REJECTED,
+    reason: 'Rejection reason',
+  },
+];
+
 describe('ReviewDocumentsSidePanel', () => {
   it('renders the component', async () => {
     render(<ReviewDocumentsSidePanel />);
     const h3 = await screen.getByRole('heading', { name: 'Send to customer?', level: 3 });
     expect(h3).toBeInTheDocument();
+  });
+
+  it('shows the appropriate statuses once weight tickets are reviewed', async () => {
+    const { getAllByRole } = render(<ReviewDocumentsSidePanel weightTickets={mockWeightTickets} />);
+    const listItems = await getAllByRole('listitem');
+    expect(listItems).toHaveLength(2);
+    expect(listItems[0]).toHaveTextContent(/Trip 1/);
+    expect(listItems[0]).toHaveTextContent(/Accept/);
+    expect(listItems[1]).toHaveTextContent(/Trip 2/);
+    expect(listItems[1]).toHaveTextContent(/Reject/);
+    expect(listItems[1]).toHaveTextContent(/Rejection reason/);
   });
 });

--- a/src/components/Office/PPM/ReviewDocumentsSidePanel/ReviewDocumentsSidePanel.test.jsx
+++ b/src/components/Office/PPM/ReviewDocumentsSidePanel/ReviewDocumentsSidePanel.test.jsx
@@ -3,16 +3,23 @@ import { render, screen } from '@testing-library/react';
 
 import ReviewDocumentsSidePanel from './ReviewDocumentsSidePanel';
 
+import { createCompleteWeightTicket } from 'utils/test/factories/weightTicket';
 import PPMDocumentsStatus from 'constants/ppms';
 
 const mockWeightTickets = [
-  {
-    status: PPMDocumentsStatus.APPROVED,
-  },
-  {
-    status: PPMDocumentsStatus.REJECTED,
-    reason: 'Rejection reason',
-  },
+  createCompleteWeightTicket(
+    {},
+    {
+      status: PPMDocumentsStatus.APPROVED,
+    },
+  ),
+  createCompleteWeightTicket(
+    {},
+    {
+      status: PPMDocumentsStatus.REJECTED,
+      reason: 'Rejection reason',
+    },
+  ),
 ];
 
 describe('ReviewDocumentsSidePanel', () => {
@@ -23,8 +30,8 @@ describe('ReviewDocumentsSidePanel', () => {
   });
 
   it('shows the appropriate statuses once weight tickets are reviewed', async () => {
-    const { getAllByRole } = render(<ReviewDocumentsSidePanel weightTickets={mockWeightTickets} />);
-    const listItems = await getAllByRole('listitem');
+    render(<ReviewDocumentsSidePanel weightTickets={mockWeightTickets} />);
+    const listItems = await screen.getAllByRole('listitem');
     expect(listItems).toHaveLength(2);
     expect(listItems[0]).toHaveTextContent(/Trip 1/);
     expect(listItems[0]).toHaveTextContent(/Accept/);

--- a/src/pages/Office/PPM/ReviewDocuments/ReviewDocuments.jsx
+++ b/src/pages/Office/PPM/ReviewDocuments/ReviewDocuments.jsx
@@ -148,17 +148,17 @@ export const ReviewDocuments = ({ match }) => {
           {documentSet &&
             (showOverview ? (
               <ReviewDocumentsSidePanel
-                ppmShipment={ppmShipment}
+                ppmShipment={mtoShipment.ppmShipment}
                 weightTickets={weightTickets}
-                proGearTickets={proGearTickets}
-                expenseTickets={expenseTickets}
+                proGearTickets={proGearWeightTickets}
+                expenseTickets={movingExpenses}
                 onError={onError}
                 onSuccess={onConfirmSuccess}
                 formRef={formRef}
               />
             ) : (
               <ReviewWeightTicket
-                weightTicket={documentSet}
+                weightTicket={documentSet[0]}
                 ppmNumber={1}
                 tripNumber={documentSetIndex + 1}
                 mtoShipment={mtoShipment}

--- a/src/pages/Office/PPM/ReviewDocuments/ReviewDocuments.jsx
+++ b/src/pages/Office/PPM/ReviewDocuments/ReviewDocuments.jsx
@@ -5,6 +5,7 @@ import { generatePath, useHistory, withRouter } from 'react-router-dom';
 
 import styles from './ReviewDocuments.module.scss';
 
+import ReviewDocumentsSidePanel from 'components/Office/PPM/ReviewDocumentsSidePanel/ReviewDocumentsSidePanel';
 import { ErrorMessage } from 'components/form';
 import { servicesCounselingRoutes } from 'constants/routes';
 import LoadingPlaceholder from 'shared/LoadingPlaceholder';
@@ -85,6 +86,7 @@ export const ReviewDocuments = ({ match }) => {
   const weightTicketPanelRef = useRef();
 
   const [serverError, setServerError] = useState(null);
+  const [showOverview, setShowOverview] = useState(false);
 
   const queryClient = useQueryClient();
 
@@ -97,7 +99,9 @@ export const ReviewDocuments = ({ match }) => {
 
   const onBack = () => {
     setServerError(null);
-    if (documentSetIndex > 0) {
+    if (showOverview) {
+      setShowOverview(false);
+    } else if (documentSetIndex > 0) {
       setDocumentSetIndex(documentSetIndex - 1);
     }
   };
@@ -107,8 +111,12 @@ export const ReviewDocuments = ({ match }) => {
     if (documentSetIndex < fullDocuments.length - 1) {
       setDocumentSetIndex(documentSetIndex + 1);
     } else {
-      history.push(generatePath(servicesCounselingRoutes.MOVE_VIEW_PATH, { moveCode }));
+      setShowOverview(true);
     }
+  };
+
+  const onConfirmSuccess = () => {
+    history.push(generatePath(servicesCounselingRoutes.MOVE_VIEW_PATH, { moveCode }));
   };
 
   const onError = () => {
@@ -137,24 +145,35 @@ export const ReviewDocuments = ({ match }) => {
         <DocumentViewerSidebar.Content mainRef={weightTicketPanelRef}>
           <NotificationScrollToTop dependency={documentSetIndex || serverError} target={weightTicketPanelRef.current} />
           <ErrorMessage display={!!serverError}>{serverError}</ErrorMessage>
-          {documentSet && (
-            <ReviewWeightTicket
-              weightTicket={documentSet[0]}
-              ppmNumber={1}
-              tripNumber={documentSetIndex + 1}
-              mtoShipment={mtoShipment}
-              onError={onError}
-              onSuccess={onSuccess}
-              formRef={formRef}
-            />
-          )}
+          {documentSet &&
+            (showOverview ? (
+              <ReviewDocumentsSidePanel
+                ppmShipment={ppmShipment}
+                weightTickets={weightTickets}
+                proGearTickets={proGearTickets}
+                expenseTickets={expenseTickets}
+                onError={onError}
+                onSuccess={onConfirmSuccess}
+                formRef={formRef}
+              />
+            ) : (
+              <ReviewWeightTicket
+                weightTicket={documentSet}
+                ppmNumber={1}
+                tripNumber={documentSetIndex + 1}
+                mtoShipment={mtoShipment}
+                onError={onError}
+                onSuccess={onSuccess}
+                formRef={formRef}
+              />
+            ))}
         </DocumentViewerSidebar.Content>
         <DocumentViewerSidebar.Footer>
-          <Button onClick={onBack} disabled={documentSetIndex === 0}>
+          <Button className="usa-button--secondary" onClick={onBack} disabled={documentSetIndex === 0}>
             Back
           </Button>
           <Button type="submit" onClick={onContinue}>
-            Continue
+            {showOverview ? 'Confirm' : 'Continue'}
           </Button>
         </DocumentViewerSidebar.Footer>
       </DocumentViewerSidebar>

--- a/src/pages/Office/PPM/ReviewDocuments/ReviewDocuments.test.jsx
+++ b/src/pages/Office/PPM/ReviewDocuments/ReviewDocuments.test.jsx
@@ -230,6 +230,10 @@ describe('ReviewDocuments', () => {
       await userEvent.click(getByRole('button', { name: 'Continue' }));
       expect(queryByText('Reviewing this weight ticket is required')).not.toBeInTheDocument();
       expect(mockPatchWeightTicket).toHaveBeenCalledWith(rejectedPayload);
+      await waitFor(() => {
+        expect(getByRole('heading', { name: 'Send to customer?', level: 3 })).toBeInTheDocument();
+      });
+      await userEvent.click(getByRole('button', { name: 'Confirm' }));
       expect(mockPush).toHaveBeenCalled();
     });
     it('renders and handles the Close button', async () => {


### PR DESCRIPTION
## [Jira ticket](https://dp3.atlassian.net/browse/MB-13864) for this change

## Summary

This adds the overview component to the page. When the user clicks "Continue" after reviewing every weight ticket, the overview is displayed, and the "Continue" button becomes "Confirm." On confirmation, the reviewer is taken back to the move details pages. 

This does not include handling the confirmation or displaying pro gear tickets or expenses, which are covered in other tickets.

Note that for testing, I updated the markup on the ReviewDocumentsSidePanel component slightly to use a list instead of nested `div`s, which were tricky to query in the tests and thus tricky to identify on the accessibility tree. This change should remedy that. 

There are a few corresponding updates to the stylesheets. @rileyorr, this is causing a slight difference in Happo, too, so it would be great if I could get a review on that.

## Setup to Run Your Code

<details>
<summary>💻 You will need to use two separate terminals to test this locally.</summary>

##### Terminal 1

Start the Storybook locally.

```sh
make client_run
```

##### Terminal 2

Start the UI locally.

```sh
make server_run
```

</details>

### Additional steps

<!-- Fill out the next section as you see fit, these are just suggestions. -->

1. Access the office app
2. Login as a services_counselor_role@office.mil
3. Click "PPM Closeout," then the "WeightTickets, PPMCloseout" move, code CLOSE1
4. Click "Review Documents"
5. If necessary, approve the first weight ticket. Click "Continue"
6. If necessary, reject the second weight ticket, and provide a reason. Click "Continue"
7. Note the overview component displays the corresponding information.
8. Click "Confirm" to return to the Move Details page.

## Verification Steps for Author

These are to be checked by the author.

- [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
- [ ] Request review from a member of a different team.
- [ ] Have the Jira acceptance criteria been met for this change?

## Verification Steps for Reviewers

These are to be checked by a reviewer.

<!-- Fill out the next sections as you see fit, these are just suggestions. -->

### Frontend

- [ ] User facing changes have been reviewed by design.
- [ ] There are no aXe warnings for UI.
- [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/main/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
- [ ] There are no new console errors in the browser devtools
- [ ] There are no new console errors in the test output
- [ ] If this PR adds a new component to Storybook, it ensures the component is fully responsive, OR if it is intentionally not, a wrapping div using the `officeApp` class or custom `min-width` styling is used to hide any states the would not be visible to the user.

### Backend

- [ ] Code follows the guidelines for [Logging](https://transcom.github.io/mymove-docs/docs/dev/contributing/backend/Backend-Programming-Guide#logging)
- [ ] The requirements listed in [Querying the Database Safely](https://transcom.github.io/mymove-docs/docs/dev/contributing/backend/Backend-Programming-Guide/#querying-the-database-safely) have been satisfied.

### Database

#### Any new migrations/schema changes:

- [ ] Follows our guidelines for [Zero-Downtime Deploys](https://transcom.github.io/mymove-docs/docs/dev/contributing/database/Database-Migrations#zero-downtime-migrations)
- [ ] Have been communicated to #g-database
- [ ] Secure migrations have been tested following the instructions in our [docs](https://transcom.github.io/mymove-docs/docs/dev/contributing/database/Database-Migrations#secure-migrations)

## Screenshots
