### PR TITLE
MB-15226: Fix CircleCI playwright runner to respect path

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -709,7 +709,8 @@ commands:
             --reporter=html,junit \
             --trace=on \
             --workers << parameters.workers >> \
-            --shard="${SHARD}/${CIRCLE_NODE_TOTAL}"
+            --shard="${SHARD}/${CIRCLE_NODE_TOTAL}" \
+            << parameters.path >>
       - store_artifacts:
           path: playwright-report
       - run:


### PR DESCRIPTION
## [Jira ticket](https://dp3.atlassian.net/browse/MB-15226) for this change

## Summary

In circleci, we split up the playwright tests by admin, office, and my using a path parameter, but I made a thinko and left it off the command invocation so all runs in CI run all tests.

This fix only applies to CircleCI
