### PR TITLE
MB-15228: devlocal multi role and testharness 

### DIFF
--- a/pkg/factory/role_factory.go
+++ b/pkg/factory/role_factory.go
@@ -108,6 +108,17 @@ func GetTraitQaeCsrRole() []Customization {
 	}
 }
 
+func GetTraitPrimeSimulatorRole() []Customization {
+	return []Customization{
+		{
+			Model: roles.Role{
+				RoleType: roles.RoleTypePrimeSimulator,
+				RoleName: "Prime Simulator",
+			},
+		},
+	}
+}
+
 func GetTraitContractingOfficerRole() []Customization {
 	return []Customization{
 		{

--- a/pkg/handlers/authentication/devlocal.go
+++ b/pkg/handlers/authentication/devlocal.go
@@ -79,9 +79,7 @@ func (h UserListHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				http.StatusInternalServerError)
 			return
 		}
-		appCtx.Logger().Info("DREW DEBUG ir", zap.Any("roles", identities[i].Roles))
 	}
-	appCtx.Logger().Info("DREW DEBUG id", zap.Any("identities", identities))
 
 	// grab all GBLOCs
 	var gblocList []string

--- a/pkg/handlers/authentication/devlocal.go
+++ b/pkg/handlers/authentication/devlocal.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"html/template"
 	"net/http"
+	"regexp"
 	"strings"
 	"time"
 
@@ -29,9 +30,11 @@ const (
 	// ServicesCounselorOfficeUserType is the type of user for an Office User
 	ServicesCounselorOfficeUserType string = "Services Counselor office"
 	// PrimeSimulatorOfficeUserType is the type of user for an Office user
-	PrimeSimulatorOfficeUserType string = "Prime Simulator"
+	PrimeSimulatorOfficeUserType string = "Prime Simulator office"
 	// QaeCsrOfficeUserType is a type of user for an Office user
 	QaeCsrOfficeUserType string = "QAE/CSR office"
+	// MultiRoleOfficeUserType has all the Office user roles
+	MultiRoleOfficeUserType string = "Multi role office"
 	// AdminUserType is the type of user for an admin user
 	AdminUserType string = "admin"
 )
@@ -64,6 +67,22 @@ func (h UserListHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// get roles for all identities
+	for i := range identities {
+		rerr := appCtx.DB().RawQuery(`SELECT * FROM roles
+									WHERE id in (select role_id from users_roles
+										where deleted_at is null and user_id = ?)`, identities[i].ID).All(&identities[i].Roles)
+		if rerr != nil {
+			appCtx.Logger().Error("Could not load identity roles", zap.Error(rerr))
+			http.Error(w,
+				fmt.Sprintf("%s - Could not load list of users, try migrating the DB", http.StatusText(500)),
+				http.StatusInternalServerError)
+			return
+		}
+		appCtx.Logger().Info("DREW DEBUG ir", zap.Any("roles", identities[i].Roles))
+	}
+	appCtx.Logger().Info("DREW DEBUG id", zap.Any("identities", identities))
+
 	// grab all GBLOCs
 	var gblocList []string
 	err = appCtx.DB().RawQuery("select distinct gbloc from transportation_offices").All(&gblocList)
@@ -87,6 +106,7 @@ func (h UserListHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		ServicesCounselorOfficeUserType string
 		PrimeSimulatorOfficeUserType    string
 		QaeCsrOfficeUserType            string
+		MultiRoleOfficeUserType         string
 		IsAdminApp                      bool
 		AdminUserType                   string
 		CsrfToken                       string
@@ -105,6 +125,7 @@ func (h UserListHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		ServicesCounselorOfficeUserType: ServicesCounselorOfficeUserType,
 		PrimeSimulatorOfficeUserType:    PrimeSimulatorOfficeUserType,
 		QaeCsrOfficeUserType:            QaeCsrOfficeUserType,
+		MultiRoleOfficeUserType:         MultiRoleOfficeUserType,
 		IsAdminApp:                      auth.AdminApp == appCtx.Session().ApplicationName,
 		AdminUserType:                   AdminUserType,
 		// Build CSRF token instead of grabbing from middleware. Otherwise throws errors when accessed directly.
@@ -153,7 +174,7 @@ func (h UserListHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						  ({{$.AdminUserType}})
 						  <input type="hidden" name="userType" value="{{$.AdminUserType}}">
 						{{else if .OfficeUserID}}
-						  ({{$.TOOOfficeUserType}})
+
 						  <input type="hidden" name="userType" value="{{$.TOOOfficeUserType}}">
 						{{else}}
 						  ({{$.MilMoveUserType}})
@@ -229,6 +250,15 @@ func (h UserListHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 					  <input type="hidden" name="userType" value="{{.QaeCsrOfficeUserType}}">
 					  ` + gblocSelectHTML + `
 					  <button type="submit" data-hook="new-user-login-{{.QaeCsrOfficeUserType}}">Create a New {{.QaeCsrOfficeUserType}} User</button>
+					</p>
+				  </form>
+
+				<form method="post" action="/devlocal-auth/new">
+					<p>
+					  <input type="hidden" name="gorilla.csrf.Token" value="{{.CsrfToken}}">
+					  <input type="hidden" name="userType" value="{{.MultiRoleOfficeUserType}}">
+					  ` + gblocSelectHTML + `
+					  <button type="submit" data-hook="new-user-login-{{.MultiRoleOfficeUserType}}">Create a New {{.MultiRoleOfficeUserType}} User</button>
 					</p>
 				  </form>
 
@@ -382,6 +412,7 @@ func createUser(h devlocalAuthHandler, w http.ResponseWriter, r *http.Request) (
 	if telephone == "" {
 		telephone = "333-333-3333"
 	}
+	userType := r.PostFormValue("userType")
 	email := r.PostFormValue("email")
 	if email == "" {
 		// Time alone doesn't guarantee uniqueness if a system is being automated
@@ -389,7 +420,14 @@ func createUser(h devlocalAuthHandler, w http.ResponseWriter, r *http.Request) (
 		now := time.Now()
 		guid, _ := uuid.NewV4()
 		nonce := strings.Split(guid.String(), "-")[4]
-		email = fmt.Sprintf("%s-%s@example.com", now.Format("20060102150405"), nonce)
+		prefix := now.Format("20060102150405")
+		i := strings.Index(userType, " office")
+		if i > 0 {
+			// turn e.g. Prime Simulator office into "prime-simulator"
+			re := regexp.MustCompile(`[^\w]+`)
+			prefix = re.ReplaceAllString(strings.ToLower(userType[0:i]), "-") + "-" + prefix
+		}
+		email = fmt.Sprintf("%s-%s@example.com", prefix, nonce)
 	}
 	gbloc := r.PostFormValue("gbloc")
 	if gbloc == "" {
@@ -403,7 +441,6 @@ func createUser(h devlocalAuthHandler, w http.ResponseWriter, r *http.Request) (
 		Active:        true,
 	}
 
-	userType := r.PostFormValue("userType")
 	verrs, err := appCtx.DB().ValidateAndCreate(&user)
 	if err != nil {
 		appCtx.Logger().Error("could not create user", zap.Error(err))
@@ -783,6 +820,85 @@ func createUser(h devlocalAuthHandler, w http.ResponseWriter, r *http.Request) (
 		if verrs.HasAny() {
 			appCtx.Logger().Error("validation errors creating office user", zap.Stringer("errors", verrs))
 		}
+	case MultiRoleOfficeUserType:
+		// Now create the Truss JPPSO
+		address := models.Address{
+			StreetAddress1: "1333 Minna St",
+			City:           "San Francisco",
+			State:          "CA",
+			PostalCode:     "94115",
+		}
+
+		verrs, err := appCtx.DB().ValidateAndSave(&address)
+		if err != nil {
+			appCtx.Logger().Error("could not create address", zap.Error(err))
+		}
+		if verrs.HasAny() {
+			appCtx.Logger().Error("validation errors creating address", zap.Stringer("errors", verrs))
+		}
+
+		officeUserRoleTypes := []roles.RoleType{roles.RoleTypeTOO,
+			roles.RoleTypeTIO,
+			roles.RoleTypeServicesCounselor,
+			roles.RoleTypePrimeSimulator,
+		}
+		var userRoles roles.Roles
+		err = appCtx.DB().Where("role_type IN (?)", officeUserRoleTypes).All(&userRoles)
+		if err != nil {
+			appCtx.Logger().Error("could not fetch multi user roles", zap.Error(err))
+		}
+
+		for i := range userRoles {
+			usersRole := models.UsersRoles{
+				UserID: user.ID,
+				RoleID: userRoles[i].ID,
+			}
+
+			verrs, err = appCtx.DB().ValidateAndSave(&usersRole)
+			if err != nil {
+				appCtx.Logger().Error("could not create user role", zap.Error(err))
+			}
+			if verrs.HasAny() {
+				appCtx.Logger().Error("validation errors creating user role", zap.Stringer("errors", verrs))
+			}
+		}
+
+		office := models.TransportationOffice{
+			Name:      "Truss",
+			AddressID: address.ID,
+			Latitude:  37.7678355,
+			Longitude: -122.4199298,
+			Hours:     models.StringPointer("0900-1800 Mon-Sat"),
+			Gbloc:     gbloc,
+		}
+
+		verrs, err = appCtx.DB().ValidateAndSave(&office)
+		if err != nil {
+			appCtx.Logger().Error("could not create office", zap.Error(err))
+		}
+		if verrs.HasAny() {
+			appCtx.Logger().Error("validation errors creating office", zap.Stringer("errors", verrs))
+		}
+
+		officeUser := models.OfficeUser{
+			FirstName:              firstName,
+			LastName:               lastName,
+			Telephone:              telephone,
+			TransportationOfficeID: office.ID,
+			Email:                  email,
+			Active:                 true,
+		}
+		if user.ID != uuid.Nil {
+			officeUser.UserID = &user.ID
+		}
+
+		verrs, err = appCtx.DB().ValidateAndSave(&officeUser)
+		if err != nil {
+			appCtx.Logger().Error("could not create office user", zap.Error(err))
+		}
+		if verrs.HasAny() {
+			appCtx.Logger().Error("validation errors creating office user", zap.Stringer("errors", verrs))
+		}
 	case AdminUserType:
 
 		adminUser := models.AdminUser{
@@ -834,7 +950,7 @@ func createSession(h devlocalAuthHandler, user *models.User, userType string, w 
 
 	// Keep the logic for redirection separate from setting the session user ids
 	switch userType {
-	case TOOOfficeUserType, TIOOfficeUserType, ServicesCounselorOfficeUserType, PrimeSimulatorOfficeUserType, QaeCsrOfficeUserType:
+	case TOOOfficeUserType, TIOOfficeUserType, ServicesCounselorOfficeUserType, PrimeSimulatorOfficeUserType, QaeCsrOfficeUserType, MultiRoleOfficeUserType:
 		session.ApplicationName = auth.OfficeApp
 		session.Hostname = h.AppNames().OfficeServername
 		active = userIdentity.Active || (userIdentity.OfficeActive != nil && *userIdentity.OfficeActive)

--- a/pkg/handlers/routing/routing_init.go
+++ b/pkg/handlers/routing/routing_init.go
@@ -254,6 +254,8 @@ func InitRouting(appCtx appcontext.AppContext, redisPool *redis.Pool,
 			testHarnessMux.Use(addAuditUserToRequestContextMiddleware)
 			testHarnessMux.Handle("/build/{action}",
 				testharnessapi.NewDefaultBuilder(routingConfig.HandlerConfig)).Methods("POST")
+			testHarnessMux.Handle("/list",
+				testharnessapi.NewBuilderList(routingConfig.HandlerConfig)).Methods("GET")
 
 		}
 		primeServerName := routingConfig.HandlerConfig.AppNames().PrimeServername

--- a/pkg/handlers/testharnessapi/api.go
+++ b/pkg/handlers/testharnessapi/api.go
@@ -2,7 +2,9 @@ package testharnessapi
 
 import (
 	"encoding/json"
+	"html/template"
 	"net/http"
+	"strings"
 
 	"github.com/gorilla/mux"
 	"go.uber.org/zap"
@@ -38,7 +40,64 @@ func NewDefaultBuilder(handlerConfig handlers.HandlerConfig) http.Handler {
 				}
 			}
 
+			// if the accept header starts with text/html, assume this
+			// is a human using a browser and return something vaguely
+			// human readable
+			if strings.HasPrefix(r.Header.Get("Accept"), "text/html") {
+				w.Header().Set("content-type", "text/html")
+				t := template.Must(template.New("users").Parse(`
+				  <html>
+				  <head>
+					<link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css" integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T" crossorigin="anonymous">
+				  </head>
+				  <body class="py-4">
+					<div class="container">
+					  <div class="row mb-3">
+						<pre>{{.}}</pre>
+					  </div>
+					</div> <!-- container -->
+				  </body>
+				  </html>
+				`))
+				b, err := json.MarshalIndent(response, "", "\t")
+				if err != nil {
+					return err
+				}
+				return t.Execute(w, string(b))
+
+			}
+
 			w.Header().Set("content-type", "application/json")
 			return json.NewEncoder(w).Encode(response)
+		})
+}
+
+func NewBuilderList(handlerConfig handlers.HandlerConfig) http.Handler {
+	return handlerConfig.AuditableAppContextFromRequestBasicHandler(
+		func(appCtx appcontext.AppContext, w http.ResponseWriter, r *http.Request) error {
+			actions := testharness.Actions()
+			t := template.Must(template.New("actions").Parse(`
+	  <html>
+	  <head>
+		<link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css" integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T" crossorigin="anonymous">
+	  </head>
+	  <body class="py-4">
+		<div class="container">
+		  <div class="row mb-3">
+			<div class="col-md-8">
+			{{range .}}
+			<form method="post" action="/testharness/build/{{.}}">
+				<button type="submit" value="{{.}}">{{.}}</button>
+			</form>
+			{{end}}
+			</div>
+		  </div>
+		</div> <!-- container -->
+	  </body>
+	  </html>
+	`))
+			w.Header().Add("Content-type", "text/html")
+			return t.Execute(w, actions)
+
 		})
 }

--- a/pkg/handlers/testharnessapi/api_test.go
+++ b/pkg/handlers/testharnessapi/api_test.go
@@ -1,0 +1,70 @@
+package testharnessapi
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gorilla/mux"
+	"github.com/stretchr/testify/suite"
+
+	"github.com/transcom/mymove/pkg/handlers"
+	"github.com/transcom/mymove/pkg/notifications"
+	"github.com/transcom/mymove/pkg/testingsuite"
+)
+
+type TestHarnessAPISuite struct {
+	handlers.BaseHandlerTestSuite
+}
+
+// func (suite *TestHarnessAPISuite) SetupTest() {
+
+// }
+
+func TestTestHarnessAPISuite(t *testing.T) {
+	hs := &TestHarnessAPISuite{
+		BaseHandlerTestSuite: handlers.NewBaseHandlerTestSuite(notifications.NewStubNotificationSender("milmovelocal"), testingsuite.CurrentPackage(), testingsuite.WithPerTestTransaction()),
+	}
+	suite.Run(t, hs)
+	hs.PopTestSuite.TearDown()
+}
+
+// tests a post without an accept header
+func (suite *TestHarnessAPISuite) TestNewDefaultBuilderNoAcceptHeader() {
+	req := httptest.NewRequest("POST", "/build/DefaultMove", nil)
+	req = mux.SetURLVars(req, map[string]string{"action": "DefaultMove"})
+	rr := httptest.NewRecorder()
+	handler := NewDefaultBuilder(suite.HandlerConfig())
+	handler.ServeHTTP(rr, req)
+
+	suite.Equal(http.StatusOK, rr.Code)
+	suite.Equal("application/json", rr.Header().Get("Content-type"))
+}
+
+// tests a post without an accept header
+func (suite *TestHarnessAPISuite) TestNewDefaultBuilderWithAcceptHeader() {
+	req := httptest.NewRequest("POST", "/build/DefaultMove", nil)
+	req = mux.SetURLVars(req, map[string]string{"action": "DefaultMove"})
+	req.Header.Add("Accept", "text/html")
+	rr := httptest.NewRecorder()
+	handler := NewDefaultBuilder(suite.HandlerConfig())
+	handler.ServeHTTP(rr, req)
+
+	suite.Equal(http.StatusOK, rr.Code)
+	suite.Equal("text/html", rr.Header().Get("Content-type"))
+}
+
+// tests a post without an accept header
+func (suite *TestHarnessAPISuite) TestNewBuilderList() {
+	req := httptest.NewRequest("POST", "/list", nil)
+	rr := httptest.NewRecorder()
+	handler := NewBuilderList(suite.HandlerConfig())
+	handler.ServeHTTP(rr, req)
+
+	suite.Equal(http.StatusOK, rr.Code)
+	suite.Equal("text/html", rr.Header().Get("Content-type"))
+
+	// the body contains at least one form for building
+	suite.True(strings.Contains(rr.Body.String(), `form method="post" action="/testharness/build/`))
+}

--- a/pkg/handlers/testharnessapi/api_test.go
+++ b/pkg/handlers/testharnessapi/api_test.go
@@ -18,10 +18,6 @@ type TestHarnessAPISuite struct {
 	handlers.BaseHandlerTestSuite
 }
 
-// func (suite *TestHarnessAPISuite) SetupTest() {
-
-// }
-
 func TestTestHarnessAPISuite(t *testing.T) {
 	hs := &TestHarnessAPISuite{
 		BaseHandlerTestSuite: handlers.NewBaseHandlerTestSuite(notifications.NewStubNotificationSender("milmovelocal"), testingsuite.CurrentPackage(), testingsuite.WithPerTestTransaction()),

--- a/pkg/testdatagen/testharness/dispatch.go
+++ b/pkg/testdatagen/testharness/dispatch.go
@@ -2,6 +2,7 @@ package testharness
 
 import (
 	"errors"
+	"sort"
 
 	"go.uber.org/zap"
 
@@ -129,6 +130,15 @@ var actionDispatcher = map[string]actionFunc{
 	"WebhookSubscription": func(appCtx appcontext.AppContext) testHarnessResponse {
 		return testdatagen.MakeWebhookSubscription(appCtx.DB(), testdatagen.Assertions{})
 	},
+}
+
+func Actions() []string {
+	actions := make([]string, 0, len(actionDispatcher))
+	for k := range actionDispatcher {
+		actions = append(actions, k)
+	}
+	sort.Strings(actions)
+	return actions
 }
 
 func Dispatch(appCtx appcontext.AppContext, action string) (testHarnessResponse, error) {

--- a/playwright/tests/utils/officeTest.js
+++ b/playwright/tests/utils/officeTest.js
@@ -15,7 +15,7 @@ export const TOOOfficeUserType = 'TOO office';
 export const TIOOfficeUserType = 'TIO office';
 export const QAECSROfficeUserType = 'QAE/CSR office';
 export const ServicesCounselorOfficeUserType = 'Services Counselor office';
-export const PrimeSimulatorUserType = 'Prime Simulator';
+export const PrimeSimulatorUserType = 'Prime Simulator office';
 
 /**
  * office test fixture for playwright


### PR DESCRIPTION
## [Jira ticket](https://dp3.atlassian.net/browse/MB-15228) for this change

## Summary

This adds a way to create a multi role login to the office app and tries to prefix office user emails with their role for easier discovery later on.

This also exposes `/testharness/list` as a crude way to drive the testharness creation, so moves can be created on demand.

## Setup to Run Your Code

<details>
<summary>💻 You will need to use three separate terminals to test this locally.</summary>

##### Terminal 1

Start the UI locally.

```sh
make client_run
```

##### Terminal 2

Start the Go server locally.

```sh
make server_run
```

1. Visit http://officelocal:3000/devlocal-auth/login and create a multi role login
2. Visit http://officelocal:3000/testharness/list and create a move on demand
</details>

