### PR TITLE
[ on-call ] Adding @mmayo-truss to STG Prime API

### DIFF
--- a/migrations/app/migrations_manifest.txt
+++ b/migrations/app/migrations_manifest.txt
@@ -785,3 +785,4 @@
 20230120165432_update_camp_lejeune_closeout_value.up.sql
 20230201162639_rogeruiz_cac.up.sql
 20230202193449_add_daycos_and_movehq_certs.up.sql
+20230214161337_add_mmayo-truss_certs.up.sql

--- a/migrations/app/secure/20230214161337_add_mmayo-truss_certs.up.sql
+++ b/migrations/app/secure/20230214161337_add_mmayo-truss_certs.up.sql
@@ -1,0 +1,52 @@
+-- Local test migration.
+-- This will be run on development environments.
+-- It should mirror what you intend to apply on loadtest/demo/exp/stg/prd
+-- DO NOT include any sensitive data.
+
+-- README: Since this is something that we don't actually want to run in any
+-- environment besides STG and PRD, I'm purposefully commenting the following
+-- SQL and uploading a commented out file for the following environments:
+-- * loadtest
+-- * demo
+-- * exp
+-- * prd
+
+-- INSERT INTO public.client_certs (
+-- 	id,
+-- 	sha256_digest,
+-- 	subject,
+-- 	allow_dps_auth_api,
+-- 	allow_orders_api,
+-- 	created_at,
+-- 	updated_at,
+-- 	allow_air_force_orders_read,
+-- 	allow_air_force_orders_write,
+-- 	allow_army_orders_read,
+-- 	allow_army_orders_write,
+-- 	allow_coast_guard_orders_read,
+-- 	allow_coast_guard_orders_write,
+-- 	allow_marine_corps_orders_read,
+-- 	allow_marine_corps_orders_write,
+-- 	allow_navy_orders_read,
+-- 	allow_navy_orders_write,
+-- 	allow_prime)
+-- VALUES (
+-- 	'<Generated ID for storing this>',
+-- 	'<SHA256 from the CAC card.',
+-- 	'<Subject from the CAC card.',
+-- 	false,
+-- 	true,
+-- 	now(),
+-- 	now(),
+-- 	true,
+-- 	true,
+-- 	true,
+-- 	true,
+-- 	true,
+-- 	true,
+-- 	true,
+-- 	true,
+-- 	true,
+-- 	true,
+-- 	true
+-- 	'<USERID from Users table>');


### PR DESCRIPTION
## Summary

This migration adds @mmayo-truss to the STG Prime API while doing nothing for
the other environments including `devlocal`.

### Verifying the contents of the migration in STG

```
aws-vault exec transcom-gov-milmove-stg -- \
    aws s3 ls \
        $(aws-vault exec transcom-gov-milmove-stg -- chamber read -q app-stg aws_s3_bucket_name)/secure-migrations/ | tail
```

Use the command above to check for the migrations in the STG environment to see
the last ten files that were uploaded. The file with the name
`20230214161337_add_mmayo-truss_certs.up.sql` must be listed there. Download the
contents from S3 and verify the SQL locally for more scrutiny. 

