### PR TITLE
[MB-15113] Creates a script to automatically create p7b files

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -205,10 +205,11 @@ These scripts are primarily used for working with a CAC and the Orders API
 
 These scripts are primarily for working with Mutual TLS certificates
 
-| Script Name                      | Description                                                        |
-| -------------------------------- | ------------------------------------------------------------------ |
-| `mutual-tls-extract-fingerprint` | Get SHA 256 fingerprint of the public certificate from a cert file |
-| `mutual-tls-extract-subject`     | Get a sha256 hash of the certificate from a cert file              |
+| Script Name                      | Description                                                          |
+| -------------------------------- | -------------------------------------------------------------------- |
+| `generate-p7b-file`              | Creates a concatenated p7b file from several certificate file formats|
+| `mutual-tls-extract-fingerprint` | Get SHA 256 fingerprint of the public certificate from a cert file   |
+| `mutual-tls-extract-subject`     | Get a sha256 hash of the certificate from a cert file                |
 
 ### Amazon Console Scripts
 

--- a/scripts/generate-p7b-file
+++ b/scripts/generate-p7b-file
@@ -1,5 +1,9 @@
 #! /usr/bin/env bash
+# The purpose of this function is to create a p7b file from a collection of certificate files that get passed in
+## Usage:
+## ./scripts/generate-p7b-file <YOUR/DESIRED/OUTPUT/PATH/FILENAME>.p7b cert1.pem cert2.pem cert3.p7b cert4.der.p7b cert5.cer cert6.crt
 
+set -e -o pipefail
 # Function to convert DER-encoded p7b files to PEM format
 function convert_der_p7b_to_pem() {
   local input_file="$1"
@@ -43,7 +47,7 @@ if [ $# -lt 1 ]; then
   exit 1
 fi
 
-# Create a temporary directory for generated files
+# Create a temporary directory for generated files. I called it tmp_certs to avoid collision with tmp
 mkdir -p tmp_certs
 
 # Extract the output file and remove it from the argument list
@@ -64,8 +68,10 @@ for file in "$@"; do
   fi
 done
 
+# concatenate all the files into one merged pem
 cat tmp_certs/*.pem > tmp_certs/merged.pem
-# Package all of the files into one p7b file
+
+# convert to p7b
 openssl crl2pkcs7 -nocrl -certfile tmp_certs/merged.pem -outform DER -out "$output_file"
 
 # Clean up any temporary files

--- a/scripts/generate-p7b-file
+++ b/scripts/generate-p7b-file
@@ -1,0 +1,73 @@
+#! /usr/bin/env bash
+
+# Function to convert DER-encoded p7b files to PEM format
+function convert_der_p7b_to_pem() {
+  local input_file="$1"
+  local output_file="tmp/$(basename "${input_file%.p7b}.pem")"
+
+  # Check if the input file is DER-encoded
+  if ! openssl pkcs7 -inform DER -in "$input_file" -print_certs > /dev/null 2>&1; then
+    echo "Error: $input_file is not a DER-encoded p7b file"
+    return 1
+  fi
+
+  # Convert the file to PEM format
+  openssl pkcs7 -inform DER -in "$input_file" -print_certs -out "$output_file"
+  echo "Converted $input_file to $output_file"
+}
+
+# Function to verify and convert any cer or crt files to PEM format
+function verify_and_convert_cer_crt_to_pem() {
+  local input_file="$1"
+  local output_file="tmp/$(basename "${input_file%.cer}.pem")"
+  output_file="${output_file%.crt}.pem"
+
+  # Check if the input file is in PEM format
+  if openssl x509 -in "$input_file" -noout > /dev/null 2>&1; then
+    cp "$input_file" "$output_file"
+    echo "Copied $input_file to $output_file"
+  # Otherwise, check if the input file is in DER format
+  elif openssl x509 -in "$input_file" -inform DER -noout > /dev/null 2>&1; then
+    openssl x509 -in "$input_file" -inform DER -out "$output_file"
+    echo "Converted $input_file to $output_file"
+  # Otherwise, throw an error
+  else
+    echo "Error: $input_file is not a valid PEM or DER-encoded certificate file"
+    return 1
+  fi
+}
+
+# Check if the required argument is passed
+if [ $# -lt 1 ]; then
+  echo "Usage: $0 output_file input_file1 [input_file2 ...]"
+  exit 1
+fi
+
+# Create a temporary directory for generated files
+mkdir -p tmp
+
+# Extract the output file and remove it from the argument list
+output_file="$1"
+shift
+
+# Convert any DER-encoded p7b files to PEM format
+for file in "$@"; do
+  if [[ "$file" == *der.p7b ]]; then
+    convert_der_p7b_to_pem "$file"
+  fi
+done
+
+# Verify and convert any cer or crt files to PEM format
+for file in "$@"; do
+  if [[ "$file" == *cer || "$file" == *crt ]]; then
+    verify_and_convert_cer_crt_to_pem "$file"
+  fi
+done
+
+# Package all of the files into one p7b file
+openssl crl2pkcs7 -nocrl -certfile "tmp/*.pem" -out "$output_file"
+
+# Clean up any temporary files
+rm -rf tmp
+
+echo "All files packaged into $output_file"

--- a/scripts/generate-p7b-file
+++ b/scripts/generate-p7b-file
@@ -6,8 +6,10 @@
 set -e -o pipefail
 # Function to convert DER-encoded p7b files to PEM format
 function convert_der_p7b_to_pem() {
-  local input_file="$1"
-  local output_file="tmp_certs/$(basename "${input_file%.p7b}.pem")"
+  local input_file
+  input_file="$1"
+  local output_file
+  output_file="tmp_certs/$(basename "${input_file%.p7b}.pem")"
 
   # Check if the input file is DER-encoded
   if ! openssl pkcs7 -inform DER -in "$input_file" -print_certs > /dev/null 2>&1; then
@@ -22,9 +24,10 @@ function convert_der_p7b_to_pem() {
 
 # Function to verify and convert any cer or crt files to PEM format
 function verify_and_convert_cer_crt_to_pem() {
-  local input_file="$1"
-  local output_file="tmp_certs/$(basename "${input_file%.cer}.pem")"
-  output_file="${output_file%.crt}.pem"
+  local input_file
+  input_file="$1"
+  local output_file
+  output_file="tmp_certs/$(basename "${input_file%.cer}.pem")"
 
   # Check if the input file is in PEM format
   if openssl x509 -in "$input_file" -noout > /dev/null 2>&1; then

--- a/scripts/generate-p7b-file
+++ b/scripts/generate-p7b-file
@@ -3,7 +3,7 @@
 # Function to convert DER-encoded p7b files to PEM format
 function convert_der_p7b_to_pem() {
   local input_file="$1"
-  local output_file="tmp/$(basename "${input_file%.p7b}.pem")"
+  local output_file="tmp_certs/$(basename "${input_file%.p7b}.pem")"
 
   # Check if the input file is DER-encoded
   if ! openssl pkcs7 -inform DER -in "$input_file" -print_certs > /dev/null 2>&1; then
@@ -19,7 +19,7 @@ function convert_der_p7b_to_pem() {
 # Function to verify and convert any cer or crt files to PEM format
 function verify_and_convert_cer_crt_to_pem() {
   local input_file="$1"
-  local output_file="tmp/$(basename "${input_file%.cer}.pem")"
+  local output_file="tmp_certs/$(basename "${input_file%.cer}.pem")"
   output_file="${output_file%.crt}.pem"
 
   # Check if the input file is in PEM format
@@ -44,7 +44,7 @@ if [ $# -lt 1 ]; then
 fi
 
 # Create a temporary directory for generated files
-mkdir -p tmp
+mkdir -p tmp_certs
 
 # Extract the output file and remove it from the argument list
 output_file="$1"
@@ -64,10 +64,11 @@ for file in "$@"; do
   fi
 done
 
+cat tmp_certs/*.pem > tmp_certs/merged.pem
 # Package all of the files into one p7b file
-openssl crl2pkcs7 -nocrl -certfile "tmp/*.pem" -out "$output_file"
+openssl crl2pkcs7 -nocrl -certfile tmp_certs/merged.pem -outform DER -out "$output_file"
 
 # Clean up any temporary files
-rm -rf tmp
+rm -rf tmp_certs
 
 echo "All files packaged into $output_file"


### PR DESCRIPTION
Usage:
```sh
./scripts/generate-p7b-file <OUTPUT/FILEPATH>.p7b cert1.pem cert2.der.p7b cert3.cer cert4.crt
```

## Background
our previous usage of p7b files was to just use the `config/tls/Certificates_PKCS7_v5.9_DoD.der.p7b`. When allowing prime API access, we needed to add additional root/intermediate certificates to this file. The purpose of this script is to prevent user error packaging the script together, as a faulty p7b file can break the deploy pipeline.