### PR TITLE
[ MB-14939 ] Clarifying diversion logic for approving mto-shipments

### DIFF
--- a/src/components/Office/RequestedShipments/SubmittedRequestedShipments.jsx
+++ b/src/components/Office/RequestedShipments/SubmittedRequestedShipments.jsx
@@ -105,7 +105,7 @@ const SubmittedRequestedShipments = ({
                 filteredShipments.map((shipment) => {
                   let operationPath = 'shipment.approveShipment';
 
-                  if (shipment.approvedDate) {
+                  if (shipment.approvedDate && moveTaskOrder.availableToPrimeAt) {
                     operationPath = 'shipment.approveShipmentDiversion';
                   }
                   return approveMTOShipment(


### PR DESCRIPTION
## [Jira ticket](https://dp3.atlassian.net/browse/MB-14939) for this change

## Summary
Some of our test and dev scenarios create a shipment that has an ApprovedDate when the status is not Approved. [Example here](https://github.com/transcom/mymove/blob/6b0509ba3cdba7a7f041f593646b84146db6a05c/pkg/testdatagen/scenario/e2ebasic.go#L1017), test it out by trying to approve a shipment as a TOO for move locator “COMBOS”. 

When the TOO tries to approve these scenarios they run into a 500 error because these moves are erroneously routed to DIVERSION. This did not happen before [PR 9843](https://github.com/transcom/mymove/pull/9843) was merged. 

When the logic for this was changed [in this line of the PR](https://github.com/transcom/mymove/pull/9843/files#diff-799ea02ef21dfa5570e102049e2b561e13091ad34869701bf3e0c4078d600dadR104) where the available to prime status was removed from consideration. Adding this back would avoid the changes for the test data scenarios and would be more accurate for determining whether the shipment should be directed to DIVERSION.

## Setup to Run Your Code

<details>
<summary>💻 You will need to use three separate terminals to test this locally.</summary>

##### Terminal 1

Start the UI locally.

```sh
make client_run
```

##### Terminal 2

Start the Go server locally.

```sh
make server_run
```

</details>

### Additional steps

<!-- Fill out the next section as you see fit, these are just suggestions. -->

1. Access the office app 
2. Login as a TOO
3. Approve a shipment with move locator `COMBOS`
4. Approve a shipment with move locator `DVRS0N`
