### PR TITLE
Mb 15311 remove factory control

### DIFF
--- a/pkg/factory/shared.go
+++ b/pkg/factory/shared.go
@@ -172,8 +172,9 @@ func linkOnlyHasID(clist []Customization) error {
 // by applying and merging the traits.
 // customs is a slice that will be modified by setupCustomizations.
 //
-//   - Assigns default types to all default customizations
+//   - Ensures linkOnly customizations have ID
 //   - Merges customizations and traits
+//   - Assigns default types to all default customizations
 //   - Ensure there's only one customization per type
 func setupCustomizations(customs []Customization, traits []Trait) []Customization {
 
@@ -191,7 +192,7 @@ func setupCustomizations(customs []Customization, traits []Trait) []Customizatio
 	if err != nil {
 		log.Panic(err)
 	}
-	// Store the validation result
+
 	return customs
 
 }

--- a/pkg/factory/shared.go
+++ b/pkg/factory/shared.go
@@ -33,7 +33,6 @@ type CustomType string
 // This does not have to match the model type but generally will
 // You can have CustomType like ResidentialAddress to define specifically
 // where this address will get created and nested
-var control CustomType = "Control"
 var Address CustomType = "Address"
 var AdminUser CustomType = "AdminUser"
 var Contractor CustomType = "Contractor"
@@ -124,12 +123,6 @@ var DutyLocations = dutyLocationsGroup{
 	NewDutyLocation:    "NewDutyLocation",
 }
 
-// controlObject is a struct used to control the global behavior of a
-// set of customizations
-type controlObject struct {
-	isValid bool // has this set of customizations been validated
-}
-
 // Trait is a function that returns a set of customizations
 // Every Trait should start with GetTrait for discoverability
 type Trait func() []Customization
@@ -179,30 +172,11 @@ func linkOnlyHasID(clist []Customization) error {
 // by applying and merging the traits.
 // customs is a slice that will be modified by setupCustomizations.
 //
-//   - Ensures a control object has been created
 //   - Assigns default types to all default customizations
 //   - Merges customizations and traits
 //   - Ensure there's only one customization per type
 func setupCustomizations(customs []Customization, traits []Trait) []Customization {
 
-	// If a valid control object does not exist, create
-	_, controlCustom := findCustomWithIdx(customs, control)
-	if controlCustom == nil {
-		controlCustom = &Customization{
-			Model: controlObject{
-				isValid: false,
-			},
-			Type: &control,
-		}
-		customs = append(customs, *controlCustom)
-	}
-	// If it exists and is valid, return, this list has been setup and validated
-	controller := controlCustom.Model.(controlObject)
-	if controller.isValid {
-		return customs
-	}
-
-	// If not valid:
 	// Ensure LinkOnly customizations all have ID
 	err := linkOnlyHasID(customs)
 	if err != nil {
@@ -218,7 +192,6 @@ func setupCustomizations(customs []Customization, traits []Trait) []Customizatio
 		log.Panic(err)
 	}
 	// Store the validation result
-	controller.isValid = true
 	return customs
 
 }

--- a/pkg/factory/shared_test.go
+++ b/pkg/factory/shared_test.go
@@ -424,12 +424,6 @@ func (suite *FactorySuite) TestSetupCustomizations() {
 						StreetAddress1: streetAddress,
 					},
 				},
-				{
-					Model: controlObject{
-						isValid: false,
-					},
-					Type: &control,
-				},
 			},
 			// User and ServiceMember customization
 			[]Trait{
@@ -437,8 +431,8 @@ func (suite *FactorySuite) TestSetupCustomizations() {
 			},
 		)
 
-		// Expect to get 4 customizations, address, user, servicemember and control
-		suite.Len(result, 4)
+		// Expect to get 3 customizations, address, user, servicemember
+		suite.Len(result, 3)
 
 		// Find Address, check details
 		_, custom := findCustomWithIdx(result, Address)
@@ -486,36 +480,6 @@ func (suite *FactorySuite) TestSetupCustomizations() {
 
 }
 func (suite *FactorySuite) TestValidateCustomizations() {
-	suite.Run("Control obj added if missing", func() {
-		// Under test:       setupCustomizations
-		// Set up:           Create some customizations without a control object
-		// Expected outcome: A control object should be added to the list
-
-		customs := getTraitActiveArmy()
-		suite.Len(customs, 2)
-
-		customs = setupCustomizations(customs, nil)
-		suite.Len(customs, 3) // ← one was added
-		_, controlCustom := findCustomWithIdx(customs, control)
-		suite.NotNil(controlCustom)
-	})
-
-	suite.Run("Control obj not added if not missing", func() {
-		// Under test:       setupCustomizations
-		// Set up:           Create some customizations with a control object
-		// Expected outcome: No objects should be added to the list
-		customs := getTraitActiveArmy()
-		customs = append(customs, Customization{
-			Model: controlObject{},
-			Type:  &control,
-		})
-		suite.Len(customs, 3)
-
-		customs = setupCustomizations(customs, nil)
-		suite.Len(customs, 3) // ← nothing added
-		_, controlCustom := findCustomWithIdx(customs, control)
-		suite.NotNil(controlCustom)
-	})
 
 	suite.Run("Pass if customizations not repeated", func() {
 		// Under test:       uniqueCustomizations checks that there's only one


### PR DESCRIPTION
## [Jira ticket](https://dp3.atlassian.net/browse/MB-15311) for this change

After some consideration I think we don't need the "control object" in the customization list. I figured it would be useful to track some global status of the factory process but it seems unnecessary and so I'm deleting it for simplicity.