### PR TITLE
MB-15247-Remove-the-link-from-transportation-office

### DIFF
--- a/src/pages/Admin/OfficeUsers/OfficeUserList.jsx
+++ b/src/pages/Admin/OfficeUsers/OfficeUserList.jsx
@@ -57,7 +57,7 @@ const OfficeUserList = (props) => (
       <TextField source="email" />
       <TextField source="firstName" />
       <TextField source="lastName" />
-      <ReferenceField label="Transportation Office" source="transportationOfficeId" reference="offices">
+      <ReferenceField label="Transportation Office" source="transportationOfficeId" reference="offices" link={false}>
         <TextField source="name" />
       </ReferenceField>
       <TextField source="userId" label="User Id" />


### PR DESCRIPTION
## [Jira ticket](https://dp3.atlassian.net/browse/MB-15274) for this change

## Summary
Currently, when a user presses the transportation office link, they are shown a list with all transportation offices which is not useful for them.

This ticket removes the link to transportation offices, and only display the name of the office.

## Verification Steps for Author and Reviewer

These are to be checked by the author.

- [ ] In the admin app, navigate to office users
- [ ] Check that the transportation office field is not a link.
- [ ] Click on the transportation office detail, verify it shows office user metadata.

## Screenshots
**Before (Link Transportation Office Field )**
<img width="1331" alt="Screenshot 2023-02-28 at 12 52 50 PM" src="https://user-images.githubusercontent.com/111006369/221938412-f67fc7f7-7a57-4e62-8e2e-346a6325875e.png">

**Before (User clicks Transportation office field)**
<img width="1201" alt="Screenshot 2023-02-28 at 12 52 36 PM" src="https://user-images.githubusercontent.com/111006369/221938331-7d44bf22-d20e-4f5c-b6f8-d2859ceeb498.png">

**After ( Non-link Transportation Office Field)**
<img width="1153" alt="Screenshot 2023-02-28 at 12 53 04 PM" src="https://user-images.githubusercontent.com/111006369/221937980-409ca0d6-65ed-449e-98a2-fc14145e2d66.png">

**After (User clicks Transportation office field)**
<img width="266" alt="Screenshot 2023-02-28 at 12 53 18 PM" src="https://user-images.githubusercontent.com/111006369/221938578-11112cee-28fb-4ff8-b78f-fab1cebd9e30.png">


