### PR TITLE
fix: enable DTOD mocking in staging to let user exercise continue

### DIFF
--- a/config/env/stg.app.env
+++ b/config/env/stg.app.env
@@ -8,6 +8,7 @@ DB_USER=crud
 DEBUG_PPROF=false
 DEVLOCAL_AUTH=false
 DOD_CA_PACKAGE=/config/tls/milmove-cert-bundle.p7b
+DTOD_USE_MOCK=true
 EMAIL_BACKEND=ses
 GEX_SEND_PROD_INVOICE=false
 GEX_URL=https://gexb.gw.daas.dla.mil/msg_data/submit/


### PR DESCRIPTION
This is meant to be reverted once we can get DTOD working again.
