### PR TITLE
MB-14506: update files to use Zaptest New Logger update to new zaptest logger

### DIFF
--- a/pkg/auth/auth_test.go
+++ b/pkg/auth/auth_test.go
@@ -1,11 +1,11 @@
 package auth
 
 import (
-	"log"
 	"testing"
 
 	"github.com/stretchr/testify/suite"
 	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest"
 )
 
 const (
@@ -39,10 +39,8 @@ type authSuite struct {
 }
 
 func TestAuthSuite(t *testing.T) {
-	logger, err := zap.NewDevelopment()
-	if err != nil {
-		log.Panic(err)
-	}
+	logger := zaptest.NewLogger(t)
+
 	hs := &authSuite{logger: logger}
 	suite.Run(t, hs)
 }

--- a/pkg/handlers/spa_handler_test.go
+++ b/pkg/handlers/spa_handler_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/suite"
 	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest"
 
 	"github.com/transcom/mymove/pkg/testingsuite"
 )
@@ -57,10 +58,7 @@ func setupMockFileSystem() *afero.HttpFs {
 }
 
 func TestSpaHandlerSuite(t *testing.T) {
-	logger, err := zap.NewDevelopment()
-	if err != nil {
-		log.Panic(err)
-	}
+	logger := zaptest.NewLogger(t)
 
 	mfs := setupMockFileSystem()
 


### PR DESCRIPTION
## [Jira ticket](https://dp3.atlassian.net/browse/MB-14506) for this change

## Summary

This ticket adds a updates some files that use the old logger to the new `zaptest.NewLogger` instead

## Setup to Run Your Code

`make server_test` should be enough. 

### Frontend

- No frontend changes

### Backend

- [x] Code follows the guidelines for [Logging](https://transcom.github.io/mymove-docs/docs/dev/contributing/backend/Backend-Programming-Guide#logging)
- [x] The requirements listed in [Querying the Database Safely](https://transcom.github.io/mymove-docs/docs/dev/contributing/backend/Backend-Programming-Guide/#querying-the-database-safely) have been satisfied.

### Database

#### Any new migrations/schema changes:

- No schema changes

