### PR TITLE
[ on-call ] Removing old environment constants

### DIFF
--- a/pkg/cli/environment.go
+++ b/pkg/cli/environment.go
@@ -16,10 +16,6 @@ const (
 	// ReviewBaseDomainDefault is the default base domain for review apps
 	ReviewBaseDomainDefault = "review.localhost"
 
-	// EnvironmentProd is the Production Environment name
-	EnvironmentProd string = "prod"
-	// EnvironmentStaging is the Staging Environment name
-	EnvironmentStaging string = "staging"
 	// EnvironmentExperimental is the Experimental Environment name
 	EnvironmentExperimental string = "experimental"
 	// EnvironmentTest is the Test Environment name
@@ -41,8 +37,6 @@ const (
 )
 
 var environments = []string{
-	EnvironmentProd,
-	EnvironmentStaging,
 	EnvironmentExperimental,
 	EnvironmentTest,
 	EnvironmentDevelopment,

--- a/pkg/cli/session.go
+++ b/pkg/cli/session.go
@@ -36,7 +36,7 @@ func CheckSession(v *viper.Viper) error {
 func ValidateSessionTimeout(v *viper.Viper, flagname string) error {
 	timeout := v.GetInt(flagname)
 
-	if v.GetString(EnvironmentFlag) == EnvironmentProd {
+	if v.GetString(EnvironmentFlag) == EnvironmentPrd {
 		if timeout < 15 || timeout > 60 {
 			return errors.Errorf("%s must be an integer between 15 and 60, got %d", SessionIdleTimeoutInMinutesFlag, timeout)
 		}


### PR DESCRIPTION
## Summary

There were references to `prod` and `staging` environments which were 4 years
old in the codebase. I removed all references to these variables and ran the
server tests locally to ensure these old variables were not being used anymore.
The new names for production and staging are `prd` and `stg` respectively.

