### PR TITLE
Added scenarios to devseed data generation for excess weights

### DIFF
--- a/pkg/testdatagen/scenario/subscenarios.go
+++ b/pkg/testdatagen/scenario/subscenarios.go
@@ -157,6 +157,20 @@ func subScenarioPPMCustomerFlow(appCtx appcontext.AppContext, userUploader *uplo
 		createApprovedMoveWithPPMWithAboutFormComplete6(appCtx, userUploader)
 		createApprovedMoveWithPPM2(appCtx, userUploader)
 		createApprovedMoveWithPPMWeightTicket(appCtx, userUploader)
+		createApprovedMoveWithPPMExcessWeight(appCtx, userUploader,
+			MoveCreatorInfo{
+				UserID:      uuid.Must(uuid.NewV4()),
+				Email:       "excessweightsPPM@ppm.approved",
+				SmID:        uuid.Must(uuid.NewV4()),
+				FirstName:   "PPM",
+				LastName:    "ExcessWeights",
+				MoveID:      uuid.Must(uuid.NewV4()),
+				MoveLocator: "XSWT01",
+			})
+		createApprovedMoveWithPPMExcessWeightsAnd2WeightTickets(appCtx, userUploader)
+		createApprovedMoveWith2PPMShipmentsAndExcessWeights(appCtx, userUploader)
+		createApprovedMoveWithPPMAndHHGShipmentsAndExcessWeights(appCtx, userUploader)
+		createApprovedMoveWithAllShipmentTypesAndExcessWeights(appCtx, userUploader)
 		createApprovedMoveWithPPMMovingExpense(appCtx, nil, userUploader)
 		createApprovedMoveWithPPMProgearWeightTicket(appCtx, userUploader)
 		createApprovedMoveWithPPMProgearWeightTicket2(appCtx, userUploader)


### PR DESCRIPTION
## [Jira ticket](https://dp3.atlassian.net/browse/MB-15257) for this change

## Summary

Added 5 new scenarios to the devseed data that will be flagged as having excess PPM weight.

## Setup to Run Your Code

<details>
<summary>💻 You will need to use three separate terminals to test this locally.</summary>

##### Terminal 1

populate the devseed data
`make db_dev_e2e_populate`

##### Terminal 2

Start the UI locally.

```sh
make client_run
```

##### Terminal 3

Start the Go server locally.

```sh
make server_run
```

</details>

### Additional steps

<!-- Fill out the next section as you see fit, these are just suggestions. -->

1. Access the office app
2. Login as a services counselor
3. go to the PPM closeout tab
4. Verify that there are 5 new scenarios with Move Codes `XSWT01` through `XSWT05`. You can see them easily by clicking on the move code column header twice to sort decending
5. Verify that the net weight on the weight tickets is higher than the 8000 lbs that is the default move weight allowance.


## Screenshots
![image](https://user-images.githubusercontent.com/110134470/221934297-bfa2870f-8f86-4b5b-963e-9f8d3b8d04ee.png)


![image](https://user-images.githubusercontent.com/110134470/221934419-2a3f708d-3ebc-4c3f-a3c7-eac3bb29e558.png)
