### PR TITLE
MB-14619 factory.BuildServiceMember added as new version of testdatagen.MakeServiceMember

### DIFF
--- a/pkg/db/utilities/utilities_test.go
+++ b/pkg/db/utilities/utilities_test.go
@@ -66,7 +66,7 @@ func (suite *UtilitiesSuite) TestSoftDestroy_ModelWithDeletedAtWithoutAssociatio
 
 func (suite *UtilitiesSuite) TestSoftDestroy_ModelWithoutDeletedAtWithAssociations() {
 	// model without deleted_at with associations
-	serviceMember := testdatagen.MakeDefaultServiceMember(suite.DB())
+	serviceMember := factory.BuildServiceMember(suite.DB(), nil, nil)
 	suite.MustSave(&serviceMember)
 
 	err := utilities.SoftDestroy(suite.DB(), &serviceMember)
@@ -95,7 +95,7 @@ func (suite *UtilitiesSuite) TestSoftDestroy_ModelWithDeletedAtWithHasOneAssocia
 
 func (suite *UtilitiesSuite) TestSoftDestroy_ModelWithDeletedAtWithHasManyAssociations() {
 	// model with deleted_at with "has many" associations
-	serviceMember := testdatagen.MakeDefaultServiceMember(suite.DB())
+	serviceMember := factory.BuildServiceMember(suite.DB(), nil, nil)
 
 	document := testdatagen.MakeDocument(suite.DB(), testdatagen.Assertions{
 		Document: models.Document{

--- a/pkg/factory/service_member_factory.go
+++ b/pkg/factory/service_member_factory.go
@@ -24,11 +24,29 @@ func BuildServiceMember(db *pop.Connection, customs []Customization, traits []Tr
 		}
 	}
 
+	// Find/create the ResidentialAddress
+	tempResAddressCustoms := customs
+	result := findValidCustomization(customs, Addresses.ResidentialAddress)
+	if result != nil {
+		tempResAddressCustoms = convertCustomizationInList(tempResAddressCustoms, Addresses.ResidentialAddress, Address)
+	}
+
+	resAddress := BuildAddress(db, tempResAddressCustoms, nil)
+
+	// Find/create the BackupMailingAddress
+	tempBackupAddressCustoms := customs
+	backupAddressResult := findValidCustomization(customs, Addresses.BackupMailingAddress)
+	if backupAddressResult != nil {
+		tempBackupAddressCustoms = convertCustomizationInList(tempBackupAddressCustoms, Addresses.BackupMailingAddress, Address)
+	}
+
+	backupAddress := BuildAddress(db, tempBackupAddressCustoms, nil)
+
 	// Find/create the user model
 	user := BuildUser(db, customs, traits)
 
-	// Find/create the address model
-	currentAddress := BuildAddress(db, customs, traits)
+	// Find/create the dutyLocation model
+	dutyLocation := BuildDutyLocation(db, customs, traits)
 
 	email := "leo_spaceman_sm@example.com"
 	agency := models.AffiliationARMY
@@ -37,17 +55,21 @@ func BuildServiceMember(db *pop.Connection, customs []Customization, traits []Tr
 	randomEdipi := RandomEdipi()
 
 	serviceMember := models.ServiceMember{
-		UserID:               user.ID,
-		User:                 user,
-		Edipi:                models.StringPointer(randomEdipi),
-		Affiliation:          &agency,
-		FirstName:            models.StringPointer("Leo"),
-		LastName:             models.StringPointer("Spacemen"),
-		Telephone:            models.StringPointer("212-123-4567"),
-		PersonalEmail:        &email,
-		ResidentialAddressID: &currentAddress.ID,
-		ResidentialAddress:   &currentAddress,
-		Rank:                 &rank,
+		UserID:                 user.ID,
+		User:                   user,
+		Edipi:                  models.StringPointer(randomEdipi),
+		Affiliation:            &agency,
+		FirstName:              models.StringPointer("Leo"),
+		LastName:               models.StringPointer("Spacemen"),
+		Telephone:              models.StringPointer("212-123-4567"),
+		PersonalEmail:          &email,
+		ResidentialAddressID:   &resAddress.ID,
+		ResidentialAddress:     &resAddress,
+		BackupMailingAddressID: &backupAddress.ID,
+		BackupMailingAddress:   &backupAddress,
+		DutyLocationID:         &dutyLocation.ID,
+		DutyLocation:           dutyLocation,
+		Rank:                   &rank,
 	}
 
 	// Overwrite values with those from customizations

--- a/pkg/factory/service_member_factory.go
+++ b/pkg/factory/service_member_factory.go
@@ -1,0 +1,60 @@
+package factory
+
+import (
+	"github.com/gobuffalo/pop/v6"
+
+	"github.com/transcom/mymove/pkg/models"
+	"github.com/transcom/mymove/pkg/testdatagen"
+)
+
+// BuildServiceMember creates a single ServiceMember
+// Also creates, if not provided:
+// - Residential Address of the ServiceMember
+// - User
+func BuildServiceMember(db *pop.Connection, customs []Customization, traits []Trait) models.ServiceMember {
+	customs = setupCustomizations(customs, traits)
+
+	// Find ServiceMember customization and extract the custom ServiceMember
+	var cServiceMember models.ServiceMember
+	if result := findValidCustomization(customs, ServiceMember); result != nil {
+		cServiceMember = result.Model.(models.ServiceMember)
+		if result.LinkOnly {
+			return cServiceMember
+		}
+	}
+
+	// Find/create the user model
+	user := BuildUser(db, customs, traits)
+
+	// Find/create the address model
+	currentAddress := BuildAddress(db, customs, traits)
+
+	email := "leo_spaceman_sm@example.com"
+	agency := models.AffiliationARMY
+	rank := models.ServiceMemberRankE1
+
+	randomEdipi := RandomEdipi()
+
+	serviceMember := models.ServiceMember{
+		UserID:               user.ID,
+		User:                 user,
+		Edipi:                models.StringPointer(randomEdipi),
+		Affiliation:          &agency,
+		FirstName:            models.StringPointer("Leo"),
+		LastName:             models.StringPointer("Spacemen"),
+		Telephone:            models.StringPointer("212-123-4567"),
+		PersonalEmail:        &email,
+		ResidentialAddressID: &currentAddress.ID,
+		ResidentialAddress:   &currentAddress,
+		Rank:                 &rank,
+	}
+
+	// Overwrite values with those from customizations
+	testdatagen.MergeModels(&serviceMember, cServiceMember)
+
+	if db != nil {
+		mustCreate(db, &serviceMember)
+	}
+
+	return serviceMember
+}

--- a/pkg/factory/service_member_factory.go
+++ b/pkg/factory/service_member_factory.go
@@ -2,6 +2,7 @@ package factory
 
 import (
 	"github.com/gobuffalo/pop/v6"
+	"github.com/gofrs/uuid"
 
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/testdatagen"
@@ -57,4 +58,20 @@ func BuildServiceMember(db *pop.Connection, customs []Customization, traits []Tr
 	}
 
 	return serviceMember
+}
+
+// GetTraitStubbedServiceMember is a sample GetTraitFunc
+func GetTraitStubbedServiceMember() []Customization {
+	return []Customization{
+		{
+			Model: models.ServiceMember{
+				ID: uuid.Must(uuid.NewV4()),
+			},
+		},
+		{
+			Model: models.User{
+				ID: uuid.Must(uuid.NewV4()),
+			},
+		},
+	}
 }

--- a/pkg/factory/service_member_factory.go
+++ b/pkg/factory/service_member_factory.go
@@ -60,8 +60,9 @@ func BuildServiceMember(db *pop.Connection, customs []Customization, traits []Tr
 	return serviceMember
 }
 
-// GetTraitStubbedServiceMember is a sample GetTraitFunc
-func GetTraitStubbedServiceMember() []Customization {
+// ServiceMemberSetIDs is a sample GetTraitFunc
+// that sets ids for both ServiceMember and User models
+func ServiceMemberSetIDs() []Customization {
 	return []Customization{
 		{
 			Model: models.ServiceMember{

--- a/pkg/factory/service_member_factory.go
+++ b/pkg/factory/service_member_factory.go
@@ -82,9 +82,9 @@ func BuildServiceMember(db *pop.Connection, customs []Customization, traits []Tr
 	return serviceMember
 }
 
-// ServiceMemberSetIDs is a sample GetTraitFunc
+// GetTraitServiceMemberSetIDs is a sample GetTraitFunc
 // that sets ids for both ServiceMember and User models
-func ServiceMemberSetIDs() []Customization {
+func GetTraitServiceMemberSetIDs() []Customization {
 	return []Customization{
 		{
 			Model: models.ServiceMember{

--- a/pkg/factory/service_member_factory_test.go
+++ b/pkg/factory/service_member_factory_test.go
@@ -1,0 +1,154 @@
+package factory
+
+import (
+	"github.com/gofrs/uuid"
+
+	"github.com/transcom/mymove/pkg/models"
+)
+
+func (suite *FactorySuite) TestBuildServiceMember() {
+	defaultEmail := "leo_spaceman_sm@example.com"
+	defaultAgency := models.AffiliationARMY
+	defaultRank := models.ServiceMemberRankE1
+	suite.Run("Successful creation of default ServiceMember", func() {
+		// Under test:      BuildServiceMember
+		// Mocked:          None
+		// Set up:          Create a service member with no customizations or traits
+		// Expected outcome:serviceMember should be created with default values
+
+		// SETUP
+		defaultServiceMember := models.ServiceMember{
+			FirstName:     models.StringPointer("Leo"),
+			LastName:      models.StringPointer("Spacemen"),
+			Telephone:     models.StringPointer("212-123-4567"),
+			Rank:          &defaultRank,
+			PersonalEmail: &defaultEmail,
+			Affiliation:   &defaultAgency,
+		}
+
+		defaultAddress := models.Address{
+			StreetAddress1: "123 Any Street",
+		}
+
+		defaultUser := models.User{
+			LoginGovEmail: "first.last@login.gov.test",
+			Active:        false,
+		}
+
+		// CALL FUNCTION UNDER TEST
+		serviceMember := BuildServiceMember(suite.DB(), nil, nil)
+
+		// VALIDATE RESULTS
+		suite.Equal(defaultServiceMember.FirstName, serviceMember.FirstName)
+		suite.Equal(defaultServiceMember.LastName, serviceMember.LastName)
+		suite.Equal(defaultServiceMember.Rank, serviceMember.Rank)
+		suite.Equal(defaultServiceMember.PersonalEmail, serviceMember.PersonalEmail)
+		suite.Equal(defaultServiceMember.Affiliation, serviceMember.Affiliation)
+
+		// Check that address was hooked in
+		suite.Equal(defaultAddress.StreetAddress1, serviceMember.ResidentialAddress.StreetAddress1)
+
+		// Check that user was hooked in
+		suite.Equal(defaultUser.LoginGovEmail, serviceMember.User.LoginGovEmail)
+		suite.Equal(defaultUser.Active, serviceMember.User.Active)
+	})
+
+	suite.Run("Successful creation of customized ServiceMember", func() {
+		// Under test:      BuildServiceMember
+		// Set up:          Create a Service Member and pass custom fields
+		// Expected outcome:serviceMember should be created with custom fields
+		// SETUP
+		customServiceMember := models.ServiceMember{
+			FirstName:          models.StringPointer("Gregory"),
+			LastName:           models.StringPointer("Van der Heide"),
+			Telephone:          models.StringPointer("999-999-9999"),
+			SecondaryTelephone: models.StringPointer("123-555-9999"),
+			PersonalEmail:      models.StringPointer("peyton@example.com"),
+		}
+
+		customAddress := models.Address{
+			StreetAddress1: "987 Another Street",
+		}
+
+		customUser := models.User{
+			LoginGovEmail: "test_email@email.com",
+		}
+
+		// CALL FUNCTION UNDER TEST
+		serviceMember := BuildServiceMember(suite.DB(), []Customization{
+			{Model: customServiceMember},
+			{Model: customAddress},
+			{Model: customUser},
+		}, nil)
+
+		// VALIDATE RESULTS
+		suite.Equal(customServiceMember.FirstName, serviceMember.FirstName)
+		suite.Equal(customServiceMember.LastName, serviceMember.LastName)
+		suite.Equal(customServiceMember.Telephone, serviceMember.Telephone)
+		suite.Equal(customServiceMember.SecondaryTelephone, serviceMember.SecondaryTelephone)
+		suite.Equal(customServiceMember.PersonalEmail, serviceMember.PersonalEmail)
+
+		// Check that address was customized
+		suite.Equal(customAddress.StreetAddress1, serviceMember.ResidentialAddress.StreetAddress1)
+
+		// Check that user was customized
+		suite.Equal(customUser.LoginGovEmail, serviceMember.User.LoginGovEmail)
+	})
+
+	suite.Run("Successful return of linkOnly ServiceMember", func() {
+		// Under test:       BuildServiceMember
+		// Set up:           Pass in a linkOnly serviceMember
+		// Expected outcome: No new ServiceMember should be created.
+
+		// Check num ServiceMember records
+		precount, err := suite.DB().Count(&models.ServiceMember{})
+		suite.NoError(err)
+
+		id := uuid.Must(uuid.NewV4())
+		serviceMember := BuildServiceMember(suite.DB(), []Customization{
+			{
+				Model: models.ServiceMember{
+					ID: id,
+				},
+				LinkOnly: true,
+			},
+		}, nil)
+		count, err := suite.DB().Count(&models.ServiceMember{})
+		suite.Equal(precount, count)
+		suite.NoError(err)
+		suite.Equal(id, serviceMember.ID)
+	})
+
+	suite.Run("Successful return of stubbed ServiceMember", func() {
+		// Under test:       BuildServiceMember
+		// Set up:           Pass in a linkOnly serviceMember
+		// Expected outcome: No new ServiceMember should be created.
+
+		// Check num ServiceMember records
+		precount, err := suite.DB().Count(&models.ServiceMember{})
+		suite.NoError(err)
+
+		customFirstName := models.StringPointer("Gregory")
+		customLastName := models.StringPointer("Van der Heide")
+		customTelephone := models.StringPointer("999-999-9999")
+
+		// Nil passed in as db
+		serviceMember := BuildServiceMember(nil, []Customization{
+			{
+				Model: models.ServiceMember{
+					FirstName: customFirstName,
+					LastName:  customLastName,
+					Telephone: customTelephone,
+				},
+			},
+		}, nil)
+
+		count, err := suite.DB().Count(&models.ServiceMember{})
+		suite.Equal(precount, count)
+		suite.NoError(err)
+
+		suite.Equal(customFirstName, serviceMember.FirstName)
+		suite.Equal(customLastName, serviceMember.LastName)
+		suite.Equal(customTelephone, serviceMember.Telephone)
+	})
+}

--- a/pkg/factory/service_member_factory_test.go
+++ b/pkg/factory/service_member_factory_test.go
@@ -111,6 +111,64 @@ func (suite *FactorySuite) TestBuildServiceMember() {
 		suite.Equal(customUser.LoginGovEmail, serviceMember.User.LoginGovEmail)
 	})
 
+	suite.Run("Successful creation of service member with customized residential and backup mailing address", func() {
+		// Under test:      BuildServiceMember
+		// Set up:          Create a Service Member with unique residential address and backup mailing address
+		// Expected outcome:serviceMember should be created with custom residential address different from address attached backup mailing address
+
+		// SETUP
+		customRank := models.ServiceMemberRankE3
+		customAffiliation := models.AffiliationAIRFORCE
+
+		customResidentialAddress := models.Address{
+			StreetAddress1: "123 Any Street",
+		}
+
+		customBackupMailingAddress := models.Address{
+			StreetAddress1: "456 Something Else Street",
+		}
+
+		customServiceMember := models.ServiceMember{
+			FirstName:          models.StringPointer("Gregory"),
+			LastName:           models.StringPointer("Van der Heide"),
+			Telephone:          models.StringPointer("999-999-9999"),
+			SecondaryTelephone: models.StringPointer("123-555-9999"),
+			PersonalEmail:      models.StringPointer("peyton@example.com"),
+			Rank:               &customRank,
+			Edipi:              models.StringPointer("1000011111"),
+			Affiliation:        &customAffiliation,
+			Suffix:             models.StringPointer("Random suffix string"),
+			PhoneIsPreferred:   models.BoolPointer(false),
+			EmailIsPreferred:   models.BoolPointer(false),
+		}
+
+		// CALL FUNCTION UNDER TEST
+		serviceMember := BuildServiceMember(suite.DB(), []Customization{
+			{Model: customServiceMember},
+			{Model: customResidentialAddress, Type: &Addresses.ResidentialAddress},
+			{Model: customBackupMailingAddress, Type: &Addresses.BackupMailingAddress},
+		}, nil)
+
+		// VALIDATE RESULTS
+		suite.Equal(customServiceMember.FirstName, serviceMember.FirstName)
+		suite.Equal(customServiceMember.LastName, serviceMember.LastName)
+		suite.Equal(customServiceMember.Telephone, serviceMember.Telephone)
+		suite.Equal(customServiceMember.SecondaryTelephone, serviceMember.SecondaryTelephone)
+		suite.Equal(customServiceMember.PersonalEmail, serviceMember.PersonalEmail)
+		suite.Equal(customServiceMember.Rank, serviceMember.Rank)
+		suite.Equal(customServiceMember.Edipi, serviceMember.Edipi)
+		suite.Equal(customServiceMember.Affiliation, serviceMember.Affiliation)
+		suite.Equal(customServiceMember.Suffix, serviceMember.Suffix)
+		suite.Equal(customServiceMember.PhoneIsPreferred, serviceMember.PhoneIsPreferred)
+		suite.Equal(customServiceMember.EmailIsPreferred, serviceMember.EmailIsPreferred)
+
+		// Check that Residential Address was customized
+		suite.Equal(customResidentialAddress.StreetAddress1, serviceMember.ResidentialAddress.StreetAddress1)
+
+		// Check that Residential Address & Backup Mailing Address are different
+		suite.NotEqual(serviceMember.ResidentialAddress.StreetAddress1, serviceMember.BackupMailingAddress.StreetAddress1)
+	})
+
 	suite.Run("Successful return of linkOnly ServiceMember", func() {
 		// Under test:       BuildServiceMember
 		// Set up:           Pass in a linkOnly serviceMember

--- a/pkg/factory/service_member_factory_test.go
+++ b/pkg/factory/service_member_factory_test.go
@@ -43,6 +43,7 @@ func (suite *FactorySuite) TestBuildServiceMember() {
 		suite.Equal(defaultServiceMember.LastName, serviceMember.LastName)
 		suite.Equal(defaultServiceMember.Rank, serviceMember.Rank)
 		suite.Equal(defaultServiceMember.PersonalEmail, serviceMember.PersonalEmail)
+		suite.Equal(defaultServiceMember.Telephone, serviceMember.Telephone)
 		suite.Equal(defaultServiceMember.Affiliation, serviceMember.Affiliation)
 
 		// Check that address was hooked in
@@ -58,12 +59,21 @@ func (suite *FactorySuite) TestBuildServiceMember() {
 		// Set up:          Create a Service Member and pass custom fields
 		// Expected outcome:serviceMember should be created with custom fields
 		// SETUP
+		customRank := models.ServiceMemberRankE3
+		customAffiliation := models.AffiliationAIRFORCE
+
 		customServiceMember := models.ServiceMember{
 			FirstName:          models.StringPointer("Gregory"),
 			LastName:           models.StringPointer("Van der Heide"),
 			Telephone:          models.StringPointer("999-999-9999"),
 			SecondaryTelephone: models.StringPointer("123-555-9999"),
 			PersonalEmail:      models.StringPointer("peyton@example.com"),
+			Rank:               &customRank,
+			Edipi:              models.StringPointer("1000011111"),
+			Affiliation:        &customAffiliation,
+			Suffix:             models.StringPointer("Random suffix string"),
+			PhoneIsPreferred:   models.BoolPointer(false),
+			EmailIsPreferred:   models.BoolPointer(false),
 		}
 
 		customAddress := models.Address{
@@ -87,6 +97,12 @@ func (suite *FactorySuite) TestBuildServiceMember() {
 		suite.Equal(customServiceMember.Telephone, serviceMember.Telephone)
 		suite.Equal(customServiceMember.SecondaryTelephone, serviceMember.SecondaryTelephone)
 		suite.Equal(customServiceMember.PersonalEmail, serviceMember.PersonalEmail)
+		suite.Equal(customServiceMember.Rank, serviceMember.Rank)
+		suite.Equal(customServiceMember.Edipi, serviceMember.Edipi)
+		suite.Equal(customServiceMember.Affiliation, serviceMember.Affiliation)
+		suite.Equal(customServiceMember.Suffix, serviceMember.Suffix)
+		suite.Equal(customServiceMember.PhoneIsPreferred, serviceMember.PhoneIsPreferred)
+		suite.Equal(customServiceMember.EmailIsPreferred, serviceMember.EmailIsPreferred)
 
 		// Check that address was customized
 		suite.Equal(customAddress.StreetAddress1, serviceMember.ResidentialAddress.StreetAddress1)

--- a/pkg/factory/shared.go
+++ b/pkg/factory/shared.go
@@ -85,6 +85,7 @@ type addressGroup struct {
 	DeliveryAddress          CustomType
 	SecondaryDeliveryAddress CustomType
 	ResidentialAddress       CustomType
+	BackupMailingAddress     CustomType
 	DutyLocationAddress      CustomType
 	DutyLocationTOAddress    CustomType
 }
@@ -95,6 +96,7 @@ var Addresses = addressGroup{
 	DeliveryAddress:          "DeliveryAddress",
 	SecondaryDeliveryAddress: "SecondaryDeliveryAddress",
 	ResidentialAddress:       "ResidentialAddress",
+	BackupMailingAddress:     "BackupMailingAddress",
 	DutyLocationAddress:      "DutyLocationAddress",
 	DutyLocationTOAddress:    "DutyLocationTOAddress",
 }

--- a/pkg/factory/shared.go
+++ b/pkg/factory/shared.go
@@ -348,7 +348,7 @@ func findValidCustomization(customs []Customization, customType CustomType) *Cus
 	}
 
 	// Else check that the customization is valid
-	if err := checkNestedModels(*custom); err != nil {
+	if err := checkNestedModels(*custom); err != nil && !custom.LinkOnly {
 		log.Panic(fmt.Errorf("Errors encountered in customization for %s: %w", *custom.Type, err))
 	}
 	return custom

--- a/pkg/handlers/adminapi/upload_information_test.go
+++ b/pkg/handlers/adminapi/upload_information_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/gofrs/uuid"
 	"github.com/stretchr/testify/mock"
 
+	"github.com/transcom/mymove/pkg/factory"
 	uploadop "github.com/transcom/mymove/pkg/gen/adminapi/adminoperations/uploads"
 	"github.com/transcom/mymove/pkg/handlers"
 	"github.com/transcom/mymove/pkg/models"
@@ -19,7 +20,7 @@ import (
 
 func (suite *HandlerSuite) TestGetUploadHandler() {
 	setupTestData := func() (models.UserUpload, models.Move) {
-		sm := testdatagen.MakeDefaultServiceMember(suite.DB())
+		sm := factory.BuildServiceMember(suite.DB(), nil, nil)
 		suite.MustSave(&sm)
 
 		orders := testdatagen.MakeOrder(suite.DB(), testdatagen.Assertions{

--- a/pkg/handlers/ghcapi/customer_test.go
+++ b/pkg/handlers/ghcapi/customer_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 func (suite *HandlerSuite) TestGetCustomerHandlerIntegration() {
-	customer := testdatagen.MakeDefaultServiceMember(suite.DB())
+	customer := factory.BuildServiceMember(suite.DB(), nil, nil)
 
 	request := httptest.NewRequest("GET", "/customer/{customerID}", nil)
 	params := customerops.GetCustomerParams{

--- a/pkg/handlers/ghcapi/queues_test.go
+++ b/pkg/handlers/ghcapi/queues_test.go
@@ -806,7 +806,7 @@ func (suite *HandlerSuite) TestGetMoveQueuesHandlerUnauthorizedRole() {
 }
 
 func (suite *HandlerSuite) TestGetMoveQueuesHandlerUnauthorizedUser() {
-	serviceUser := testdatagen.MakeDefaultServiceMember(suite.DB())
+	serviceUser := factory.BuildServiceMember(suite.DB(), nil, nil)
 	serviceUser.User.Roles = append(serviceUser.User.Roles, roles.Role{
 		RoleType: roles.RoleTypeCustomer,
 	})

--- a/pkg/handlers/ghcapi/queues_test.go
+++ b/pkg/handlers/ghcapi/queues_test.go
@@ -583,23 +583,25 @@ func (suite *HandlerSuite) TestGetMoveQueuesHandlerCustomerInfoFilters() {
 	hhgMoveType := models.SelectedMoveTypeHHG
 	// Default Origin Duty Location GBLOC is LKNQ
 
-	serviceMember1 := testdatagen.MakeServiceMember(suite.DB(), testdatagen.Assertions{
-		Stub: true,
-		ServiceMember: models.ServiceMember{
-			FirstName: models.StringPointer("Zoya"),
-			LastName:  models.StringPointer("Darvish"),
-			Edipi:     models.StringPointer("11111"),
+	serviceMember1 := factory.BuildServiceMember(nil, []factory.Customization{
+		{
+			Model: models.ServiceMember{
+				FirstName: models.StringPointer("Zoya"),
+				LastName:  models.StringPointer("Darvish"),
+				Edipi:     models.StringPointer("11111"),
+			},
 		},
-	})
+	}, nil)
 
-	serviceMember2 := testdatagen.MakeServiceMember(suite.DB(), testdatagen.Assertions{
-		Stub: true,
-		ServiceMember: models.ServiceMember{
-			FirstName: models.StringPointer("Owen"),
-			LastName:  models.StringPointer("Nance"),
-			Edipi:     models.StringPointer("22222"),
+	serviceMember2 := factory.BuildServiceMember(nil, []factory.Customization{
+		{
+			Model: models.ServiceMember{
+				FirstName: models.StringPointer("Owen"),
+				LastName:  models.StringPointer("Nance"),
+				Edipi:     models.StringPointer("22222"),
+			},
 		},
-	})
+	}, nil)
 
 	move1 := testdatagen.MakeMove(suite.DB(), testdatagen.Assertions{
 		Move: models.Move{

--- a/pkg/handlers/ghcapi/tac_test.go
+++ b/pkg/handlers/ghcapi/tac_test.go
@@ -74,7 +74,7 @@ func (suite *HandlerSuite) TestTacValidation() {
 	})
 
 	suite.Run("Unauthorized user for TAC validation is forbidden", func() {
-		serviceMember := testdatagen.MakeDefaultServiceMember(suite.DB())
+		serviceMember := factory.BuildServiceMember(suite.DB(), nil, nil)
 		unauthorizedUser := serviceMember.User
 		tac := "4EVR"
 		request := httptest.NewRequest("GET", fmt.Sprintf("/tac/valid?tac=%s", tac), nil)

--- a/pkg/handlers/internalapi/backup_contacts_test.go
+++ b/pkg/handlers/internalapi/backup_contacts_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/go-openapi/swag"
 
+	"github.com/transcom/mymove/pkg/factory"
 	contactop "github.com/transcom/mymove/pkg/gen/internalapi/internaloperations/backup_contacts"
 	"github.com/transcom/mymove/pkg/gen/internalmessages"
 	"github.com/transcom/mymove/pkg/handlers"
@@ -17,7 +18,7 @@ import (
 func (suite *HandlerSuite) TestCreateBackupContactHandler() {
 	t := suite.T()
 
-	serviceMember := testdatagen.MakeDefaultServiceMember(suite.DB())
+	serviceMember := factory.BuildServiceMember(suite.DB(), nil, nil)
 
 	newContactPayload := internalmessages.CreateServiceMemberBackupContactPayload{
 		Email:      swag.String("email@example.com"),
@@ -95,7 +96,7 @@ func (suite *HandlerSuite) TestIndexBackupContactsHandlerWrongUser() {
 	t := suite.T()
 
 	contact := testdatagen.MakeDefaultBackupContact(suite.DB())
-	otherServiceMember := testdatagen.MakeDefaultServiceMember(suite.DB())
+	otherServiceMember := factory.BuildServiceMember(suite.DB(), nil, nil)
 
 	indexPath := fmt.Sprintf("/service_member/%v/backup_contacts", contact.ServiceMember.ID.String())
 	req := httptest.NewRequest("GET", indexPath, nil)
@@ -145,7 +146,7 @@ func (suite *HandlerSuite) TestShowBackupContactsHandlerWrongUser() {
 	t := suite.T()
 
 	contact := testdatagen.MakeDefaultBackupContact(suite.DB())
-	otherServiceMember := testdatagen.MakeDefaultServiceMember(suite.DB())
+	otherServiceMember := factory.BuildServiceMember(suite.DB(), nil, nil)
 
 	showPath := fmt.Sprintf("/service_member/%v/backup_contacts/%v", contact.ServiceMember.ID.String(), contact.ID.String())
 	req := httptest.NewRequest("GET", showPath, nil)
@@ -203,7 +204,7 @@ func (suite *HandlerSuite) TestUpdateBackupContactsHandlerWrongUser() {
 	t := suite.T()
 
 	contact := testdatagen.MakeDefaultBackupContact(suite.DB())
-	otherServiceMember := testdatagen.MakeDefaultServiceMember(suite.DB())
+	otherServiceMember := factory.BuildServiceMember(suite.DB(), nil, nil)
 
 	updatePath := fmt.Sprintf("/service_member/%v/backup_contacts/%v", contact.ServiceMember.ID.String(), contact.ID.String())
 	req := httptest.NewRequest("PUT", updatePath, nil)

--- a/pkg/handlers/internalapi/documents_test.go
+++ b/pkg/handlers/internalapi/documents_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/go-openapi/strfmt"
 	"github.com/gofrs/uuid"
 
+	"github.com/transcom/mymove/pkg/factory"
 	documentop "github.com/transcom/mymove/pkg/gen/internalapi/internaloperations/documents"
 	"github.com/transcom/mymove/pkg/gen/internalmessages"
 	"github.com/transcom/mymove/pkg/handlers"
@@ -18,7 +19,7 @@ import (
 func (suite *HandlerSuite) TestCreateDocumentsHandler() {
 	t := suite.T()
 
-	serviceMember := testdatagen.MakeDefaultServiceMember(suite.DB())
+	serviceMember := factory.BuildServiceMember(suite.DB(), nil, nil)
 
 	params := documentop.NewCreateDocumentParams()
 	params.DocumentPayload = &internalmessages.PostDocumentPayload{

--- a/pkg/handlers/internalapi/move_queue_items_test.go
+++ b/pkg/handlers/internalapi/move_queue_items_test.go
@@ -80,7 +80,7 @@ func (suite *HandlerSuite) TestShowQueueHandlerForbidden() {
 	for _, queueType := range statusToQueueMap {
 
 		// Given: A non-office user
-		user := testdatagen.MakeDefaultServiceMember(suite.DB())
+		user := factory.BuildServiceMember(suite.DB(), nil, nil)
 
 		// And: the context contains the auth values
 		path := "/queues/" + queueType

--- a/pkg/handlers/internalapi/moves_test.go
+++ b/pkg/handlers/internalapi/moves_test.go
@@ -450,10 +450,12 @@ func (suite *HandlerSuite) TestShowMoveDatesSummaryHandler() {
 	serviceMember := factory.BuildServiceMember(suite.DB(), []factory.Customization{
 		{
 			Model: models.ServiceMember{
-				Rank:           &rank,
-				DutyLocationID: &dutyLocation.ID,
-				DutyLocation:   dutyLocation,
+				Rank: &rank,
 			},
+		},
+		{
+			Model:    dutyLocation,
+			LinkOnly: true,
 		},
 	}, nil)
 

--- a/pkg/handlers/internalapi/moves_test.go
+++ b/pkg/handlers/internalapi/moves_test.go
@@ -77,7 +77,7 @@ func (suite *HandlerSuite) TestPatchMoveHandlerWrongUser() {
 	// Given: a set of orders, a move, user and servicemember
 	move := testdatagen.MakeDefaultMove(suite.DB())
 	// And: another logged in user
-	anotherUser := testdatagen.MakeDefaultServiceMember(suite.DB())
+	anotherUser := factory.BuildServiceMember(suite.DB(), nil, nil)
 
 	// And: the context contains a different user
 	req := httptest.NewRequest("PATCH", "/moves/some_id", nil)
@@ -104,7 +104,7 @@ func (suite *HandlerSuite) TestPatchMoveHandlerWrongUser() {
 
 func (suite *HandlerSuite) TestPatchMoveHandlerNoMove() {
 	// Given: a logged in user and no Move
-	user := testdatagen.MakeDefaultServiceMember(suite.DB())
+	user := factory.BuildServiceMember(suite.DB(), nil, nil)
 
 	moveUUID := uuid.Must(uuid.NewV4())
 
@@ -223,7 +223,7 @@ func (suite *HandlerSuite) TestShowMoveWrongUser() {
 	// Given: a set of orders, a move, user and servicemember
 	move := testdatagen.MakeDefaultMove(suite.DB())
 	// And: another logged in user
-	anotherUser := testdatagen.MakeDefaultServiceMember(suite.DB())
+	anotherUser := factory.BuildServiceMember(suite.DB(), nil, nil)
 
 	// And: the context contains the auth values for not logged-in user
 	req := httptest.NewRequest("GET", "/moves/some_id", nil)
@@ -562,7 +562,7 @@ func (suite *HandlerSuite) TestShowMoveDatesSummaryForbiddenUser() {
 	// Given: a set of orders, a move, user and servicemember
 	move := testdatagen.MakeDefaultMove(suite.DB())
 	// And: another logged in user
-	anotherUser := testdatagen.MakeDefaultServiceMember(suite.DB())
+	anotherUser := factory.BuildServiceMember(suite.DB(), nil, nil)
 
 	// And: the context contains the auth values for not logged-in user
 	req := httptest.NewRequest("GET", "/moves/some_id/", nil)

--- a/pkg/handlers/internalapi/moves_test.go
+++ b/pkg/handlers/internalapi/moves_test.go
@@ -447,13 +447,15 @@ func (suite *HandlerSuite) TestShowMoveDatesSummaryHandler() {
 	}, nil)
 
 	rank := models.ServiceMemberRankE4
-	serviceMember := testdatagen.MakeServiceMember(suite.DB(), testdatagen.Assertions{
-		ServiceMember: models.ServiceMember{
-			Rank:           &rank,
-			DutyLocationID: &dutyLocation.ID,
-			DutyLocation:   dutyLocation,
+	serviceMember := factory.BuildServiceMember(suite.DB(), []factory.Customization{
+		{
+			Model: models.ServiceMember{
+				Rank:           &rank,
+				DutyLocationID: &dutyLocation.ID,
+				DutyLocation:   dutyLocation,
+			},
 		},
-	})
+	}, nil)
 
 	newDutyLocationAddress := factory.BuildAddress(suite.DB(), []factory.Customization{
 		{

--- a/pkg/handlers/internalapi/moving_expense_test.go
+++ b/pkg/handlers/internalapi/moving_expense_test.go
@@ -398,7 +398,7 @@ func (suite *HandlerSuite) TestDeleteMovingExpenseHandler() {
 
 		subtestData := makeDeleteSubtestData(appCtx, false)
 
-		otherServiceMember := testdatagen.MakeDefaultServiceMember(suite.DB())
+		otherServiceMember := factory.BuildServiceMember(suite.DB(), nil, nil)
 
 		req := subtestData.params.HTTPRequest
 		unauthorizedReq := suite.AuthenticateRequest(req, otherServiceMember)

--- a/pkg/handlers/internalapi/mto_shipment_test.go
+++ b/pkg/handlers/internalapi/mto_shipment_test.go
@@ -81,7 +81,7 @@ func (suite *HandlerSuite) TestCreateMTOShipmentHandler() {
 	makeCreateSubtestData := func(appCtx appcontext.AppContext) (subtestData mtoCreateSubtestData) {
 		db := appCtx.DB()
 
-		subtestData.serviceMember = testdatagen.MakeDefaultServiceMember(db)
+		subtestData.serviceMember = factory.BuildServiceMember(db, nil, nil)
 
 		mto := testdatagen.MakeMove(db, testdatagen.Assertions{
 			Order: models.Order{

--- a/pkg/handlers/internalapi/mto_shipment_test.go
+++ b/pkg/handlers/internalapi/mto_shipment_test.go
@@ -1633,30 +1633,8 @@ func (suite *HandlerSuite) TestDeleteShipmentHandler() {
 	})
 
 	suite.Run("Returns 403 when servicemember ID doesn't match shipment", func() {
-		sm1 := factory.BuildServiceMember(nil, []factory.Customization{
-			{
-				Model: models.ServiceMember{
-					ID: uuid.Must(uuid.NewV4()),
-				},
-			},
-			{
-				Model: models.User{
-					ID: uuid.Must(uuid.NewV4()),
-				},
-			},
-		}, nil)
-		sm2 := factory.BuildServiceMember(nil, []factory.Customization{
-			{
-				Model: models.ServiceMember{
-					ID: uuid.Must(uuid.NewV4()),
-				},
-			},
-			{
-				Model: models.User{
-					ID: uuid.Must(uuid.NewV4()),
-				},
-			},
-		}, nil)
+		sm1 := factory.BuildServiceMember(nil, nil, []factory.Trait{factory.GetTraitStubbedServiceMember})
+		sm2 := factory.BuildServiceMember(nil, nil, []factory.Trait{factory.GetTraitStubbedServiceMember})
 		order := testdatagen.MakeDefaultOrder(suite.DB())
 		move := testdatagen.MakeMove(suite.DB(), testdatagen.Assertions{
 			Order: order,

--- a/pkg/handlers/internalapi/mto_shipment_test.go
+++ b/pkg/handlers/internalapi/mto_shipment_test.go
@@ -1633,8 +1633,8 @@ func (suite *HandlerSuite) TestDeleteShipmentHandler() {
 	})
 
 	suite.Run("Returns 403 when servicemember ID doesn't match shipment", func() {
-		sm1 := factory.BuildServiceMember(nil, nil, []factory.Trait{factory.ServiceMemberSetIDs})
-		sm2 := factory.BuildServiceMember(nil, nil, []factory.Trait{factory.ServiceMemberSetIDs})
+		sm1 := factory.BuildServiceMember(nil, nil, []factory.Trait{factory.GetTraitServiceMemberSetIDs})
+		sm2 := factory.BuildServiceMember(nil, nil, []factory.Trait{factory.GetTraitServiceMemberSetIDs})
 		order := testdatagen.MakeDefaultOrder(suite.DB())
 		move := testdatagen.MakeMove(suite.DB(), testdatagen.Assertions{
 			Order: order,

--- a/pkg/handlers/internalapi/mto_shipment_test.go
+++ b/pkg/handlers/internalapi/mto_shipment_test.go
@@ -1633,8 +1633,8 @@ func (suite *HandlerSuite) TestDeleteShipmentHandler() {
 	})
 
 	suite.Run("Returns 403 when servicemember ID doesn't match shipment", func() {
-		sm1 := factory.BuildServiceMember(nil, nil, []factory.Trait{factory.GetTraitStubbedServiceMember})
-		sm2 := factory.BuildServiceMember(nil, nil, []factory.Trait{factory.GetTraitStubbedServiceMember})
+		sm1 := factory.BuildServiceMember(nil, nil, []factory.Trait{factory.ServiceMemberSetIDs})
+		sm2 := factory.BuildServiceMember(nil, nil, []factory.Trait{factory.ServiceMemberSetIDs})
 		order := testdatagen.MakeDefaultOrder(suite.DB())
 		move := testdatagen.MakeMove(suite.DB(), testdatagen.Assertions{
 			Order: order,

--- a/pkg/handlers/internalapi/mto_shipment_test.go
+++ b/pkg/handlers/internalapi/mto_shipment_test.go
@@ -1633,8 +1633,30 @@ func (suite *HandlerSuite) TestDeleteShipmentHandler() {
 	})
 
 	suite.Run("Returns 403 when servicemember ID doesn't match shipment", func() {
-		sm1 := testdatagen.MakeStubbedServiceMember(suite.DB())
-		sm2 := testdatagen.MakeStubbedServiceMember(suite.DB())
+		sm1 := factory.BuildServiceMember(nil, []factory.Customization{
+			{
+				Model: models.ServiceMember{
+					ID: uuid.Must(uuid.NewV4()),
+				},
+			},
+			{
+				Model: models.User{
+					ID: uuid.Must(uuid.NewV4()),
+				},
+			},
+		}, nil)
+		sm2 := factory.BuildServiceMember(nil, []factory.Customization{
+			{
+				Model: models.ServiceMember{
+					ID: uuid.Must(uuid.NewV4()),
+				},
+			},
+			{
+				Model: models.User{
+					ID: uuid.Must(uuid.NewV4()),
+				},
+			},
+		}, nil)
 		order := testdatagen.MakeDefaultOrder(suite.DB())
 		move := testdatagen.MakeMove(suite.DB(), testdatagen.Assertions{
 			Order: order,

--- a/pkg/handlers/internalapi/office_test.go
+++ b/pkg/handlers/internalapi/office_test.go
@@ -116,7 +116,7 @@ func (suite *HandlerSuite) TestApproveMoveHandlerForbidden() {
 	// Given: a set of orders, a move, office user and servicemember user
 	move := testdatagen.MakeDefaultMove(suite.DB())
 	// Given: an non-office User
-	user := testdatagen.MakeDefaultServiceMember(suite.DB())
+	user := factory.BuildServiceMember(suite.DB(), nil, nil)
 	moveRouter := moverouter.NewMoveRouter()
 
 	// And: the context contains the auth values
@@ -210,7 +210,7 @@ func (suite *HandlerSuite) TestCancelMoveHandlerForbidden() {
 	// Given: a set of orders, a move, office user and servicemember user
 	move := testdatagen.MakeDefaultMove(suite.DB())
 	// Given: an non-office User
-	user := testdatagen.MakeDefaultServiceMember(suite.DB())
+	user := factory.BuildServiceMember(suite.DB(), nil, nil)
 
 	moveRouter := moverouter.NewMoveRouter()
 
@@ -279,7 +279,7 @@ func (suite *HandlerSuite) TestApprovePPMHandler() {
 func (suite *HandlerSuite) TestApprovePPMHandlerForbidden() {
 	// Given: a set of orders, a move, user and servicemember
 	ppm := testdatagen.MakeDefaultPPM(suite.DB())
-	user := testdatagen.MakeDefaultServiceMember(suite.DB())
+	user := factory.BuildServiceMember(suite.DB(), nil, nil)
 
 	// And: the context contains the auth values
 	req := httptest.NewRequest("POST", "/personally_procured_moves/some_id/approve", nil)
@@ -334,7 +334,7 @@ func (suite *HandlerSuite) TestApproveReimbursementHandler() {
 func (suite *HandlerSuite) TestApproveReimbursementHandlerForbidden() {
 	// Given: a set of orders, a move, user and servicemember
 	reimbursement := testdatagen.MakeDefaultRequestedReimbursement(suite.DB())
-	user := testdatagen.MakeDefaultServiceMember(suite.DB())
+	user := factory.BuildServiceMember(suite.DB(), nil, nil)
 
 	// And: the context contains the auth values
 	req := httptest.NewRequest("POST", "/reimbursement/some_id/approve", nil)

--- a/pkg/handlers/internalapi/personally_procured_move_incentive_test.go
+++ b/pkg/handlers/internalapi/personally_procured_move_incentive_test.go
@@ -141,7 +141,7 @@ func (suite *HandlerSuite) TestShowPPMIncentiveHandlerForbidden() {
 		suite.FailNow("failed to run scenario 2: %+v", err)
 	}
 
-	user := testdatagen.MakeDefaultServiceMember(suite.DB())
+	user := factory.BuildServiceMember(suite.DB(), nil, nil)
 	req := httptest.NewRequest("GET", "/personally_procured_moves/incentive", nil)
 	req = suite.AuthenticateRequest(req, user)
 

--- a/pkg/handlers/internalapi/personally_procured_move_test.go
+++ b/pkg/handlers/internalapi/personally_procured_move_test.go
@@ -153,7 +153,7 @@ func (suite *HandlerSuite) setupPersonallyProcuredMoveTest() {
 }
 
 func (suite *HandlerSuite) TestCreatePPMHandler() {
-	user1 := testdatagen.MakeDefaultServiceMember(suite.DB())
+	user1 := factory.BuildServiceMember(suite.DB(), nil, nil)
 	orders := testdatagen.MakeDefaultOrder(suite.DB())
 	factory.FetchOrBuildDefaultContractor(suite.DB(), nil, nil)
 
@@ -412,7 +412,7 @@ func (suite *HandlerSuite) TestPatchPPMHandlerWrongUser() {
 	newMoveDate := time.Date(testdatagen.TestYear, time.November, 10, 23, 0, 0, 0, time.UTC)
 	initialMoveDate := newMoveDate.Add(-2 * 24 * time.Hour)
 
-	user2 := testdatagen.MakeDefaultServiceMember(suite.DB())
+	user2 := factory.BuildServiceMember(suite.DB(), nil, nil)
 	move := testdatagen.MakeDefaultMove(suite.DB())
 
 	ppm1 := models.PersonallyProcuredMove{

--- a/pkg/handlers/internalapi/progear_weight_ticket_test.go
+++ b/pkg/handlers/internalapi/progear_weight_ticket_test.go
@@ -375,7 +375,7 @@ func (suite *HandlerSuite) TestDeleteProgearWeightTicketHandler() {
 
 		subtestData := makeDeleteSubtestData(appCtx, false)
 
-		otherServiceMember := testdatagen.MakeDefaultServiceMember(suite.DB())
+		otherServiceMember := factory.BuildServiceMember(suite.DB(), nil, nil)
 
 		req := subtestData.params.HTTPRequest
 		unauthorizedReq := suite.AuthenticateRequest(req, otherServiceMember)

--- a/pkg/handlers/internalapi/service_members_test.go
+++ b/pkg/handlers/internalapi/service_members_test.go
@@ -60,8 +60,8 @@ func (suite *HandlerSuite) TestShowServiceMemberHandler() {
 
 func (suite *HandlerSuite) TestShowServiceMemberWrongUser() {
 	// Given: Servicemember trying to load another
-	notLoggedInUser := testdatagen.MakeDefaultServiceMember(suite.DB())
-	loggedInUser := testdatagen.MakeDefaultServiceMember(suite.DB())
+	notLoggedInUser := factory.BuildServiceMember(suite.DB(), nil, nil)
+	loggedInUser := factory.BuildServiceMember(suite.DB(), nil, nil)
 
 	req := httptest.NewRequest("GET", fmt.Sprintf("/service_members/%s", notLoggedInUser.ID.String()), nil)
 	req = suite.AuthenticateRequest(req, loggedInUser)

--- a/pkg/handlers/internalapi/uploads_test.go
+++ b/pkg/handlers/internalapi/uploads_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/go-openapi/strfmt"
 	"github.com/gofrs/uuid"
 
+	"github.com/transcom/mymove/pkg/factory"
 	ppmop "github.com/transcom/mymove/pkg/gen/internalapi/internaloperations/ppm"
 	uploadop "github.com/transcom/mymove/pkg/gen/internalapi/internaloperations/uploads"
 	"github.com/transcom/mymove/pkg/handlers"
@@ -147,7 +148,7 @@ func (suite *HandlerSuite) TestCreateUploadsHandlerFailsWithWrongUser() {
 	_, params := createPrereqs(suite, FixturePDF)
 
 	// Create a user that is not associated with the move
-	otherUser := testdatagen.MakeDefaultServiceMember(suite.DB())
+	otherUser := factory.BuildServiceMember(suite.DB(), nil, nil)
 
 	response := makeRequest(suite, params, otherUser, fakeS3)
 	suite.Assertions.IsType(&handlers.ErrResponse{}, response)
@@ -473,7 +474,7 @@ func (suite *HandlerSuite) TestCreatePPMUploadsHandlerFailure() {
 		fakeS3 := storageTest.NewFakeS3Storage(true)
 		_, params := createPPMPrereqs(suite, FixtureXLS)
 
-		serviceMember := testdatagen.MakeDefaultServiceMember(suite.DB())
+		serviceMember := factory.BuildServiceMember(suite.DB(), nil, nil)
 
 		response := makePPMRequest(suite, params, serviceMember, fakeS3)
 

--- a/pkg/handlers/internalapi/weight_ticket_test.go
+++ b/pkg/handlers/internalapi/weight_ticket_test.go
@@ -410,7 +410,7 @@ func (suite *HandlerSuite) TestDeleteWeightTicketHandler() {
 
 		subtestData := makeDeleteSubtestData(appCtx, false)
 
-		otherServiceMember := testdatagen.MakeDefaultServiceMember(suite.DB())
+		otherServiceMember := factory.BuildServiceMember(suite.DB(), nil, nil)
 
 		req := subtestData.params.HTTPRequest
 		unauthorizedReq := suite.AuthenticateRequest(req, otherServiceMember)

--- a/pkg/handlers/supportapi/move_task_order_test.go
+++ b/pkg/handlers/supportapi/move_task_order_test.go
@@ -226,7 +226,7 @@ func (suite *HandlerSuite) TestCreateMoveTaskOrderRequestHandler() {
 		// Create the objects that are already in the db
 		destinationDutyLocation := factory.BuildDutyLocation(suite.DB(), nil, nil)
 		originDutyLocation := factory.BuildDutyLocation(suite.DB(), nil, nil)
-		customer := testdatagen.MakeDefaultServiceMember(suite.DB())
+		customer := factory.BuildServiceMember(suite.DB(), nil, nil)
 		contractor := factory.FetchOrBuildDefaultContractor(suite.DB(), nil, nil)
 		document := testdatagen.MakeDefaultDocument(suite.DB())
 

--- a/pkg/models/backup_contact_test.go
+++ b/pkg/models/backup_contact_test.go
@@ -1,13 +1,27 @@
 package models_test
 
 import (
+	"github.com/gofrs/uuid"
+
 	"github.com/transcom/mymove/pkg/auth"
+	"github.com/transcom/mymove/pkg/factory"
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/testdatagen"
 )
 
 func (suite *ModelSuite) Test_BackupContactCreate() {
-	serviceMember := testdatagen.MakeStubbedServiceMember(suite.DB())
+	serviceMember := factory.BuildServiceMember(nil, []factory.Customization{
+		{
+			Model: models.ServiceMember{
+				ID: uuid.Must(uuid.NewV4()),
+			},
+		},
+		{
+			Model: models.User{
+				ID: uuid.Must(uuid.NewV4()),
+			},
+		},
+	}, nil)
 
 	newContact := models.BackupContact{
 		ServiceMemberID: serviceMember.ID,

--- a/pkg/models/backup_contact_test.go
+++ b/pkg/models/backup_contact_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func (suite *ModelSuite) Test_BackupContactCreate() {
-	serviceMember := factory.BuildServiceMember(nil, nil, []factory.Trait{factory.GetTraitStubbedServiceMember})
+	serviceMember := factory.BuildServiceMember(nil, nil, []factory.Trait{factory.ServiceMemberSetIDs})
 
 	newContact := models.BackupContact{
 		ServiceMemberID: serviceMember.ID,

--- a/pkg/models/backup_contact_test.go
+++ b/pkg/models/backup_contact_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func (suite *ModelSuite) Test_BackupContactCreate() {
-	serviceMember := factory.BuildServiceMember(nil, nil, []factory.Trait{factory.ServiceMemberSetIDs})
+	serviceMember := factory.BuildServiceMember(nil, nil, []factory.Trait{factory.GetTraitServiceMemberSetIDs})
 
 	newContact := models.BackupContact{
 		ServiceMemberID: serviceMember.ID,

--- a/pkg/models/backup_contact_test.go
+++ b/pkg/models/backup_contact_test.go
@@ -4,7 +4,6 @@ import (
 	"github.com/transcom/mymove/pkg/auth"
 	"github.com/transcom/mymove/pkg/factory"
 	"github.com/transcom/mymove/pkg/models"
-	"github.com/transcom/mymove/pkg/testdatagen"
 )
 
 func (suite *ModelSuite) Test_BackupContactCreate() {
@@ -39,8 +38,8 @@ func (suite *ModelSuite) Test_BackupContactValidations() {
 func (suite *ModelSuite) Test_FetchBackupContact() {
 	t := suite.T()
 
-	serviceMember1 := testdatagen.MakeDefaultServiceMember(suite.DB())
-	serviceMember2 := testdatagen.MakeDefaultServiceMember(suite.DB())
+	serviceMember1 := factory.BuildServiceMember(suite.DB(), nil, nil)
+	serviceMember2 := factory.BuildServiceMember(suite.DB(), nil, nil)
 
 	backupContact := models.BackupContact{
 		ServiceMemberID: serviceMember1.ID,

--- a/pkg/models/backup_contact_test.go
+++ b/pkg/models/backup_contact_test.go
@@ -1,8 +1,6 @@
 package models_test
 
 import (
-	"github.com/gofrs/uuid"
-
 	"github.com/transcom/mymove/pkg/auth"
 	"github.com/transcom/mymove/pkg/factory"
 	"github.com/transcom/mymove/pkg/models"
@@ -10,18 +8,7 @@ import (
 )
 
 func (suite *ModelSuite) Test_BackupContactCreate() {
-	serviceMember := factory.BuildServiceMember(nil, []factory.Customization{
-		{
-			Model: models.ServiceMember{
-				ID: uuid.Must(uuid.NewV4()),
-			},
-		},
-		{
-			Model: models.User{
-				ID: uuid.Must(uuid.NewV4()),
-			},
-		},
-	}, nil)
+	serviceMember := factory.BuildServiceMember(nil, nil, []factory.Trait{factory.GetTraitStubbedServiceMember})
 
 	newContact := models.BackupContact{
 		ServiceMemberID: serviceMember.ID,

--- a/pkg/models/document_test.go
+++ b/pkg/models/document_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func (suite *ModelSuite) Test_DocumentCreate() {
-	serviceMember := factory.BuildServiceMember(nil, nil, []factory.Trait{factory.ServiceMemberSetIDs})
+	serviceMember := factory.BuildServiceMember(nil, nil, []factory.Trait{factory.GetTraitServiceMemberSetIDs})
 
 	document := models.Document{
 		ServiceMemberID: serviceMember.ID,

--- a/pkg/models/document_test.go
+++ b/pkg/models/document_test.go
@@ -6,12 +6,24 @@ import (
 	"github.com/gofrs/uuid"
 
 	"github.com/transcom/mymove/pkg/auth"
+	"github.com/transcom/mymove/pkg/factory"
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/testdatagen"
 )
 
 func (suite *ModelSuite) Test_DocumentCreate() {
-	serviceMember := testdatagen.MakeStubbedServiceMember(suite.DB())
+	serviceMember := factory.BuildServiceMember(nil, []factory.Customization{
+		{
+			Model: models.ServiceMember{
+				ID: uuid.Must(uuid.NewV4()),
+			},
+		},
+		{
+			Model: models.User{
+				ID: uuid.Must(uuid.NewV4()),
+			},
+		},
+	}, nil)
 
 	document := models.Document{
 		ServiceMemberID: serviceMember.ID,

--- a/pkg/models/document_test.go
+++ b/pkg/models/document_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func (suite *ModelSuite) Test_DocumentCreate() {
-	serviceMember := factory.BuildServiceMember(nil, nil, []factory.Trait{factory.GetTraitStubbedServiceMember})
+	serviceMember := factory.BuildServiceMember(nil, nil, []factory.Trait{factory.ServiceMemberSetIDs})
 
 	document := models.Document{
 		ServiceMemberID: serviceMember.ID,

--- a/pkg/models/document_test.go
+++ b/pkg/models/document_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/transcom/mymove/pkg/auth"
 	"github.com/transcom/mymove/pkg/factory"
 	"github.com/transcom/mymove/pkg/models"
-	"github.com/transcom/mymove/pkg/testdatagen"
 )
 
 func (suite *ModelSuite) Test_DocumentCreate() {
@@ -37,7 +36,7 @@ func (suite *ModelSuite) Test_DocumentValidations() {
 func (suite *ModelSuite) TestFetchDocument() {
 	t := suite.T()
 
-	serviceMember := testdatagen.MakeDefaultServiceMember(suite.DB())
+	serviceMember := factory.BuildServiceMember(suite.DB(), nil, nil)
 	session := auth.Session{
 		UserID:          serviceMember.UserID,
 		ApplicationName: auth.MilApp,
@@ -64,7 +63,7 @@ func (suite *ModelSuite) TestFetchDocument() {
 func (suite *ModelSuite) TestFetchDeletedDocument() {
 	t := suite.T()
 
-	serviceMember := testdatagen.MakeDefaultServiceMember(suite.DB())
+	serviceMember := factory.BuildServiceMember(suite.DB(), nil, nil)
 	session := auth.Session{
 		UserID:          serviceMember.UserID,
 		ApplicationName: auth.MilApp,

--- a/pkg/models/document_test.go
+++ b/pkg/models/document_test.go
@@ -12,18 +12,7 @@ import (
 )
 
 func (suite *ModelSuite) Test_DocumentCreate() {
-	serviceMember := factory.BuildServiceMember(nil, []factory.Customization{
-		{
-			Model: models.ServiceMember{
-				ID: uuid.Must(uuid.NewV4()),
-			},
-		},
-		{
-			Model: models.User{
-				ID: uuid.Must(uuid.NewV4()),
-			},
-		},
-	}, nil)
+	serviceMember := factory.BuildServiceMember(nil, nil, []factory.Trait{factory.GetTraitStubbedServiceMember})
 
 	document := models.Document{
 		ServiceMemberID: serviceMember.ID,

--- a/pkg/models/order_test.go
+++ b/pkg/models/order_test.go
@@ -178,7 +178,7 @@ func (suite *ModelSuite) TestFetchOrderForUser() {
 	suite.Run("forbidden user cannot fetch order", func() {
 		order := testdatagen.MakeOrder(suite.DB(), testdatagen.Assertions{})
 		// User is forbidden from fetching order
-		serviceMember2 := testdatagen.MakeDefaultServiceMember(suite.DB())
+		serviceMember2 := factory.BuildServiceMember(suite.DB(), nil, nil)
 		session := &auth.Session{
 			ApplicationName: auth.MilApp,
 			UserID:          serviceMember2.UserID,
@@ -239,7 +239,7 @@ func (suite *ModelSuite) TestFetchOrderForUser() {
 }
 
 func (suite *ModelSuite) TestFetchOrderNotForUser() {
-	serviceMember1 := testdatagen.MakeDefaultServiceMember(suite.DB())
+	serviceMember1 := factory.BuildServiceMember(suite.DB(), nil, nil)
 
 	dutyLocation := factory.FetchOrBuildCurrentDutyLocation(suite.DB())
 	issueDate := time.Date(2018, time.March, 10, 0, 0, 0, 0, time.UTC)
@@ -284,7 +284,7 @@ func (suite *ModelSuite) TestFetchOrderNotForUser() {
 }
 
 func (suite *ModelSuite) TestOrderStateMachine() {
-	serviceMember1 := testdatagen.MakeDefaultServiceMember(suite.DB())
+	serviceMember1 := factory.BuildServiceMember(suite.DB(), nil, nil)
 
 	dutyLocation := factory.FetchOrBuildCurrentDutyLocation(suite.DB())
 	issueDate := time.Date(2018, time.March, 10, 0, 0, 0, 0, time.UTC)

--- a/pkg/models/order_test.go
+++ b/pkg/models/order_test.go
@@ -161,7 +161,7 @@ func (suite *ModelSuite) TestFetchOrderForUser() {
 	})
 
 	suite.Run("fetch not found due to bad id", func() {
-		sm := testdatagen.MakeServiceMember(suite.DB(), testdatagen.Assertions{})
+		sm := factory.BuildServiceMember(suite.DB(), nil, nil)
 		session := &auth.Session{
 			ApplicationName: auth.MilApp,
 			UserID:          sm.UserID,

--- a/pkg/models/service_member_test.go
+++ b/pkg/models/service_member_test.go
@@ -167,7 +167,7 @@ func (suite *ModelSuite) TestFetchLatestOrders() {
 
 		user := factory.BuildDefaultUser(suite.DB())
 
-		serviceMember := testdatagen.MakeDefaultServiceMember(suite.DB())
+		serviceMember := factory.BuildServiceMember(suite.DB(), nil, nil)
 
 		dutyLocation := factory.FetchOrBuildCurrentDutyLocation(suite.DB())
 		dutyLocation2 := factory.FetchOrBuildOrdersDutyLocation(suite.DB())

--- a/pkg/models/user_test.go
+++ b/pkg/models/user_test.go
@@ -269,12 +269,14 @@ func (suite *ModelSuite) TestFetchAppUserIdentities() {
 				},
 			}}, nil)
 
-		testdatagen.MakeServiceMember(suite.DB(), testdatagen.Assertions{
-			ServiceMember: ServiceMember{
-				UserID: user.ID,
-				User:   user,
+		factory.BuildServiceMember(suite.DB(), []factory.Customization{
+			{
+				Model: ServiceMember{
+					UserID: user.ID,
+					User:   user,
+				},
 			},
-		})
+		}, nil)
 
 		// This service member will be filtered out from the result because we haven't overridden the default email
 		factory.BuildServiceMember(suite.DB(), nil, nil)

--- a/pkg/models/user_test.go
+++ b/pkg/models/user_test.go
@@ -271,10 +271,8 @@ func (suite *ModelSuite) TestFetchAppUserIdentities() {
 
 		factory.BuildServiceMember(suite.DB(), []factory.Customization{
 			{
-				Model: ServiceMember{
-					UserID: user.ID,
-					User:   user,
-				},
+				Model:    user,
+				LinkOnly: true,
 			},
 		}, nil)
 

--- a/pkg/models/user_test.go
+++ b/pkg/models/user_test.go
@@ -101,7 +101,7 @@ func (suite *ModelSuite) TestFetchUserIdentity() {
 	suite.Nil(identity.ServiceMemberID)
 	suite.Nil(identity.OfficeUserID)
 
-	bob := testdatagen.MakeDefaultServiceMember(suite.DB())
+	bob := factory.BuildServiceMember(suite.DB(), nil, nil)
 	identity, err = FetchUserIdentity(suite.DB(), bob.User.LoginGovUUID.String())
 	suite.Nil(err, "loading bob's identity")
 	suite.NotNil(identity)
@@ -277,7 +277,7 @@ func (suite *ModelSuite) TestFetchAppUserIdentities() {
 		})
 
 		// This service member will be filtered out from the result because we haven't overridden the default email
-		testdatagen.MakeDefaultServiceMember(suite.DB())
+		factory.BuildServiceMember(suite.DB(), nil, nil)
 
 		identities, err := FetchAppUserIdentities(suite.DB(), auth.MilApp, 5)
 

--- a/pkg/notifications/move_payment_reminder_test.go
+++ b/pkg/notifications/move_payment_reminder_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/go-openapi/swag"
 
+	"github.com/transcom/mymove/pkg/factory"
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/testdatagen"
 	"github.com/transcom/mymove/pkg/unit"
@@ -170,7 +171,7 @@ func (suite *NotificationSuite) TestPaymentReminderFetchAlreadySentEmail() {
 }
 
 func (suite *NotificationSuite) TestPaymentReminderOnSuccess() {
-	sm := testdatagen.MakeDefaultServiceMember(suite.DB())
+	sm := factory.BuildServiceMember(suite.DB(), nil, nil)
 	ei := PaymentReminderEmailInfo{
 		ServiceMemberID: sm.ID,
 	}

--- a/pkg/notifications/move_reviewed_test.go
+++ b/pkg/notifications/move_reviewed_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/transcom/mymove/pkg/factory"
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/testdatagen"
 )
@@ -80,7 +81,7 @@ func (suite *NotificationSuite) TestMoveReviewedFetchAlreadySentEmail() {
 
 func (suite *NotificationSuite) TestMoveReviewedOnSuccess() {
 	db := suite.DB()
-	sm := testdatagen.MakeDefaultServiceMember(db)
+	sm := factory.BuildServiceMember(db, nil, nil)
 	ei := EmailInfo{
 		ServiceMemberID: sm.ID,
 	}

--- a/pkg/services/move_task_order/move_task_order_hide_non_fake_test.go
+++ b/pkg/services/move_task_order/move_task_order_hide_non_fake_test.go
@@ -29,20 +29,22 @@ func (suite *MoveTaskOrderServiceSuite) TestMoveTaskOrderHider_Hide() {
 				},
 			},
 		}, nil)
-		serviceMember := testdatagen.MakeServiceMember(suite.DB(), testdatagen.Assertions{
-			ServiceMember: models.ServiceMember{
-				FirstName:          swag.String("Gregory"),
-				LastName:           swag.String("Van der Heide"),
-				Telephone:          swag.String("999-999-9999"),
-				SecondaryTelephone: swag.String("123-555-9999"),
-				PersonalEmail:      swag.String("peyton@example.com"),
+		serviceMember := factory.BuildServiceMember(suite.DB(), []factory.Customization{
+			{
+				Model: models.ServiceMember{
+					FirstName:          models.StringPointer("Gregory"),
+					LastName:           models.StringPointer("Van der Heide"),
+					Telephone:          models.StringPointer("999-999-9999"),
+					SecondaryTelephone: models.StringPointer("123-555-9999"),
+					PersonalEmail:      models.StringPointer("peyton@example.com"),
 
-				ResidentialAddressID:   &validAddress1.ID,
-				ResidentialAddress:     &validAddress1,
-				BackupMailingAddressID: &validAddress2.ID,
-				BackupMailingAddress:   &validAddress2,
+					ResidentialAddressID:   &validAddress1.ID,
+					ResidentialAddress:     &validAddress1,
+					BackupMailingAddressID: &validAddress2.ID,
+					BackupMailingAddress:   &validAddress2,
+				},
 			},
-		})
+		}, nil)
 		return serviceMember
 	}
 
@@ -131,17 +133,18 @@ func (suite *MoveTaskOrderServiceSuite) TestMoveTaskOrderHider_isValidFakeServic
 				},
 			},
 		}, nil)
-		sm := testdatagen.MakeServiceMember(suite.DB(), testdatagen.Assertions{
-			ServiceMember: models.ServiceMember{
-				FirstName:            swag.String("Peyton"),
-				LastName:             swag.String("Wing"),
-				Telephone:            swag.String("999-999-9999"),
-				SecondaryTelephone:   swag.String("999-999-9999"),
-				PersonalEmail:        swag.String("peyton@example.com"),
-				ResidentialAddress:   &address1,
-				BackupMailingAddress: &address2,
-			}},
-		)
+		sm := factory.BuildServiceMember(suite.DB(), []factory.Customization{
+			{
+				Model: models.ServiceMember{
+					FirstName:            models.StringPointer("Peyton"),
+					LastName:             models.StringPointer("Wing"),
+					Telephone:            models.StringPointer("999-999-9999"),
+					SecondaryTelephone:   models.StringPointer("999-999-9999"),
+					PersonalEmail:        models.StringPointer("peyton@example.com"),
+					ResidentialAddress:   &address1,
+					BackupMailingAddress: &address2,
+				},
+			}}, nil)
 		result, reasons, err := IsValidFakeModelServiceMember(sm)
 		suite.NoError(err)
 		suite.Equal(true, result)
@@ -191,34 +194,36 @@ func (suite *MoveTaskOrderServiceSuite) TestMoveTaskOrderHider_isValidFakeServic
 				},
 			},
 		}, nil)
-		validServiceMemberAssertions := testdatagen.Assertions{
-			ServiceMember: models.ServiceMember{
-				FirstName:            swag.String("Peyton"),
-				LastName:             swag.String("Wing"),
-				Telephone:            swag.String("999-999-9999"),
-				SecondaryTelephone:   swag.String("999-999-9999"),
-				PersonalEmail:        swag.String("peyton@example.com"),
-				ResidentialAddress:   &address1,
-				BackupMailingAddress: &address2,
-			}}
-		invalidData := validServiceMemberAssertions
-		if index == 0 {
-			invalidData.ServiceMember.FirstName = swag.String("Britney")
-		} else if index == 1 {
-			invalidData.ServiceMember.LastName = swag.String("Spears")
-		} else if index == 2 {
-			invalidData.ServiceMember.Telephone = swag.String("415-275-9467")
-		} else if index == 3 {
-			invalidData.ServiceMember.SecondaryTelephone = swag.String("510-607-4545")
-		} else if index == 4 {
-			invalidData.ServiceMember.PersonalEmail = swag.String("peyton@gmail.com")
-		} else if index == 5 {
-			invalidData.ServiceMember.ResidentialAddress = &invalidAddress1
-		} else if index == 6 {
-			invalidData.ServiceMember.BackupMailingAddress = &invalidAddress2
+		validServiceMember := models.ServiceMember{
+			FirstName:            models.StringPointer("Peyton"),
+			LastName:             models.StringPointer("Wing"),
+			Telephone:            models.StringPointer("999-999-9999"),
+			SecondaryTelephone:   models.StringPointer("999-999-9999"),
+			PersonalEmail:        models.StringPointer("peyton@example.com"),
+			ResidentialAddress:   &address1,
+			BackupMailingAddress: &address2,
 		}
 
-		invalidSm := testdatagen.MakeServiceMember(suite.DB(), invalidData)
+		invalidData := validServiceMember
+		if index == 0 {
+			invalidData.FirstName = models.StringPointer("Britney")
+		} else if index == 1 {
+			invalidData.LastName = models.StringPointer("Spears")
+		} else if index == 2 {
+			invalidData.Telephone = models.StringPointer("415-275-9467")
+		} else if index == 3 {
+			invalidData.SecondaryTelephone = models.StringPointer("510-607-4545")
+		} else if index == 4 {
+			invalidData.PersonalEmail = models.StringPointer("peyton@gmail.com")
+		} else if index == 5 {
+			invalidData.ResidentialAddress = &invalidAddress1
+		} else if index == 6 {
+			invalidData.BackupMailingAddress = &invalidAddress2
+		}
+
+		invalidSm := factory.BuildServiceMember(suite.DB(), []factory.Customization{
+			{Model: invalidData},
+		}, nil)
 		return invalidSm, invalidFields[index]
 	}
 

--- a/pkg/services/move_task_order/move_task_order_hide_non_fake_test.go
+++ b/pkg/services/move_task_order/move_task_order_hide_non_fake_test.go
@@ -38,11 +38,21 @@ func (suite *MoveTaskOrderServiceSuite) TestMoveTaskOrderHider_Hide() {
 					SecondaryTelephone: models.StringPointer("123-555-9999"),
 					PersonalEmail:      models.StringPointer("peyton@example.com"),
 
-					ResidentialAddressID:   &validAddress1.ID,
-					ResidentialAddress:     &validAddress1,
-					BackupMailingAddressID: &validAddress2.ID,
-					BackupMailingAddress:   &validAddress2,
+					//ResidentialAddressID:   &validAddress1.ID,
+					//ResidentialAddress:     &validAddress1,
+					//BackupMailingAddressID: &validAddress2.ID,
+					//BackupMailingAddress:   &validAddress2,
 				},
+			},
+			{
+				Model:    validAddress1,
+				Type:     &factory.Addresses.ResidentialAddress,
+				LinkOnly: true,
+			},
+			{
+				Model:    validAddress2,
+				Type:     &factory.Addresses.BackupMailingAddress,
+				LinkOnly: true,
 			},
 		}, nil)
 		return serviceMember
@@ -136,14 +146,22 @@ func (suite *MoveTaskOrderServiceSuite) TestMoveTaskOrderHider_isValidFakeServic
 		sm := factory.BuildServiceMember(suite.DB(), []factory.Customization{
 			{
 				Model: models.ServiceMember{
-					FirstName:            models.StringPointer("Peyton"),
-					LastName:             models.StringPointer("Wing"),
-					Telephone:            models.StringPointer("999-999-9999"),
-					SecondaryTelephone:   models.StringPointer("999-999-9999"),
-					PersonalEmail:        models.StringPointer("peyton@example.com"),
-					ResidentialAddress:   &address1,
-					BackupMailingAddress: &address2,
+					FirstName:          models.StringPointer("Peyton"),
+					LastName:           models.StringPointer("Wing"),
+					Telephone:          models.StringPointer("999-999-9999"),
+					SecondaryTelephone: models.StringPointer("999-999-9999"),
+					PersonalEmail:      models.StringPointer("peyton@example.com"),
 				},
+			},
+			{
+				Model:    address1,
+				Type:     &factory.Addresses.ResidentialAddress,
+				LinkOnly: true,
+			},
+			{
+				Model:    address2,
+				Type:     &factory.Addresses.BackupMailingAddress,
+				LinkOnly: true,
 			}}, nil)
 		result, reasons, err := IsValidFakeModelServiceMember(sm)
 		suite.NoError(err)
@@ -195,16 +213,17 @@ func (suite *MoveTaskOrderServiceSuite) TestMoveTaskOrderHider_isValidFakeServic
 			},
 		}, nil)
 		validServiceMember := models.ServiceMember{
-			FirstName:            models.StringPointer("Peyton"),
-			LastName:             models.StringPointer("Wing"),
-			Telephone:            models.StringPointer("999-999-9999"),
-			SecondaryTelephone:   models.StringPointer("999-999-9999"),
-			PersonalEmail:        models.StringPointer("peyton@example.com"),
-			ResidentialAddress:   &address1,
-			BackupMailingAddress: &address2,
+			FirstName:          models.StringPointer("Peyton"),
+			LastName:           models.StringPointer("Wing"),
+			Telephone:          models.StringPointer("999-999-9999"),
+			SecondaryTelephone: models.StringPointer("999-999-9999"),
+			PersonalEmail:      models.StringPointer("peyton@example.com"),
 		}
 
 		invalidData := validServiceMember
+		invalidResAddress := address1
+		invalidBackupAddress := address2
+
 		if index == 0 {
 			invalidData.FirstName = models.StringPointer("Britney")
 		} else if index == 1 {
@@ -216,13 +235,23 @@ func (suite *MoveTaskOrderServiceSuite) TestMoveTaskOrderHider_isValidFakeServic
 		} else if index == 4 {
 			invalidData.PersonalEmail = models.StringPointer("peyton@gmail.com")
 		} else if index == 5 {
-			invalidData.ResidentialAddress = &invalidAddress1
+			invalidResAddress = invalidAddress1
 		} else if index == 6 {
-			invalidData.BackupMailingAddress = &invalidAddress2
+			invalidBackupAddress = invalidAddress2
 		}
 
 		invalidSm := factory.BuildServiceMember(suite.DB(), []factory.Customization{
 			{Model: invalidData},
+			{
+				Model:    invalidResAddress,
+				LinkOnly: true,
+				Type:     &factory.Addresses.ResidentialAddress,
+			},
+			{
+				Model:    invalidBackupAddress,
+				LinkOnly: true,
+				Type:     &factory.Addresses.BackupMailingAddress,
+			},
 		}, nil)
 		return invalidSm, invalidFields[index]
 	}

--- a/pkg/services/move_task_order/move_task_order_hide_non_fake_test.go
+++ b/pkg/services/move_task_order/move_task_order_hide_non_fake_test.go
@@ -37,11 +37,6 @@ func (suite *MoveTaskOrderServiceSuite) TestMoveTaskOrderHider_Hide() {
 					Telephone:          models.StringPointer("999-999-9999"),
 					SecondaryTelephone: models.StringPointer("123-555-9999"),
 					PersonalEmail:      models.StringPointer("peyton@example.com"),
-
-					//ResidentialAddressID:   &validAddress1.ID,
-					//ResidentialAddress:     &validAddress1,
-					//BackupMailingAddressID: &validAddress2.ID,
-					//BackupMailingAddress:   &validAddress2,
 				},
 			},
 			{

--- a/pkg/services/moving_expense/moving_expense_creator_test.go
+++ b/pkg/services/moving_expense/moving_expense_creator_test.go
@@ -5,12 +5,13 @@ import (
 
 	"github.com/transcom/mymove/pkg/apperror"
 	"github.com/transcom/mymove/pkg/auth"
+	"github.com/transcom/mymove/pkg/factory"
 	"github.com/transcom/mymove/pkg/testdatagen"
 )
 
 func (suite *MovingExpenseSuite) TestMovingExpenseCreator() {
 	suite.Run("Successfully creates a MovingExpense", func() {
-		serviceMember := testdatagen.MakeDefaultServiceMember(suite.DB())
+		serviceMember := factory.BuildServiceMember(suite.DB(), nil, nil)
 		session := &auth.Session{
 			ServiceMemberID: serviceMember.ID,
 		}
@@ -27,7 +28,7 @@ func (suite *MovingExpenseSuite) TestMovingExpenseCreator() {
 	})
 
 	suite.Run("Fails when an invalid ppmShipmentID is used", func() {
-		serviceMember := testdatagen.MakeDefaultServiceMember(suite.DB())
+		serviceMember := factory.BuildServiceMember(suite.DB(), nil, nil)
 		session := &auth.Session{
 			ServiceMemberID: serviceMember.ID,
 		}

--- a/pkg/services/moving_expense/moving_expense_deleter_test.go
+++ b/pkg/services/moving_expense/moving_expense_deleter_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/transcom/mymove/pkg/appcontext"
 	"github.com/transcom/mymove/pkg/apperror"
+	"github.com/transcom/mymove/pkg/factory"
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/testdatagen"
 )
@@ -15,7 +16,7 @@ import (
 func (suite *MovingExpenseSuite) TestDeleteMovingExpense() {
 
 	setupForTest := func(appCtx appcontext.AppContext, overrides *models.MovingExpense, hasDocumentUploads bool) *models.MovingExpense {
-		serviceMember := testdatagen.MakeDefaultServiceMember(suite.DB())
+		serviceMember := factory.BuildServiceMember(suite.DB(), nil, nil)
 		ppmShipment := testdatagen.MakeMinimalPPMShipment(suite.DB(), testdatagen.Assertions{
 			Order: models.Order{
 				ServiceMemberID: serviceMember.ID,

--- a/pkg/services/moving_expense/moving_expense_updater_test.go
+++ b/pkg/services/moving_expense/moving_expense_updater_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/transcom/mymove/pkg/appcontext"
 	"github.com/transcom/mymove/pkg/apperror"
 	"github.com/transcom/mymove/pkg/etag"
+	"github.com/transcom/mymove/pkg/factory"
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/testdatagen"
 	"github.com/transcom/mymove/pkg/unit"
@@ -17,7 +18,7 @@ import (
 func (suite *MovingExpenseSuite) TestUpdateMovingExpense() {
 
 	setupForTest := func(appCtx appcontext.AppContext, overrides *models.MovingExpense, hasDocumentUploads bool) *models.MovingExpense {
-		serviceMember := testdatagen.MakeDefaultServiceMember(suite.DB())
+		serviceMember := factory.BuildServiceMember(suite.DB(), nil, nil)
 		ppmShipment := testdatagen.MakeMinimalPPMShipment(suite.DB(), testdatagen.Assertions{
 			Order: models.Order{
 				ServiceMemberID: serviceMember.ID,

--- a/pkg/services/office_user/customer/customer_test.go
+++ b/pkg/services/office_user/customer/customer_test.go
@@ -1,11 +1,11 @@
 package customer
 
 import (
-	"github.com/transcom/mymove/pkg/testdatagen"
+	"github.com/transcom/mymove/pkg/factory"
 )
 
 func (suite *CustomerServiceSuite) TestCustomerFetcher() {
-	customer := testdatagen.MakeDefaultServiceMember(suite.DB())
+	customer := factory.BuildServiceMember(suite.DB(), nil, nil)
 	mtoFetcher := NewCustomerFetcher()
 
 	actualCustomer, err := mtoFetcher.FetchCustomer(suite.AppContextForTest(), customer.ID)

--- a/pkg/services/progear_weight_ticket/progear_weight_ticket_creator_test.go
+++ b/pkg/services/progear_weight_ticket/progear_weight_ticket_creator_test.go
@@ -5,12 +5,13 @@ import (
 
 	"github.com/transcom/mymove/pkg/apperror"
 	"github.com/transcom/mymove/pkg/auth"
+	"github.com/transcom/mymove/pkg/factory"
 	"github.com/transcom/mymove/pkg/testdatagen"
 )
 
 func (suite *ProgearWeightTicketSuite) TestProgearWeightTicketCreator() {
 	suite.Run("Successfully creates a ProgearWeightTicket", func() {
-		serviceMember := testdatagen.MakeDefaultServiceMember(suite.DB())
+		serviceMember := factory.BuildServiceMember(suite.DB(), nil, nil)
 		session := &auth.Session{
 			ServiceMemberID: serviceMember.ID,
 		}
@@ -27,7 +28,7 @@ func (suite *ProgearWeightTicketSuite) TestProgearWeightTicketCreator() {
 	})
 
 	suite.Run("Fails when an invalid ppmShipmentID is used", func() {
-		serviceMember := testdatagen.MakeDefaultServiceMember(suite.DB())
+		serviceMember := factory.BuildServiceMember(suite.DB(), nil, nil)
 		session := &auth.Session{
 			ServiceMemberID: serviceMember.ID,
 		}

--- a/pkg/services/progear_weight_ticket/progear_weight_ticket_deleter_test.go
+++ b/pkg/services/progear_weight_ticket/progear_weight_ticket_deleter_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/transcom/mymove/pkg/appcontext"
 	"github.com/transcom/mymove/pkg/apperror"
+	"github.com/transcom/mymove/pkg/factory"
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/testdatagen"
 )
@@ -15,7 +16,7 @@ import (
 func (suite *ProgearWeightTicketSuite) TestDeleteProgearWeightTicket() {
 
 	setupForTest := func(appCtx appcontext.AppContext, overrides *models.ProgearWeightTicket, hasDocumentUploads bool) *models.ProgearWeightTicket {
-		serviceMember := testdatagen.MakeDefaultServiceMember(suite.DB())
+		serviceMember := factory.BuildServiceMember(suite.DB(), nil, nil)
 		ppmShipment := testdatagen.MakeMinimalPPMShipment(suite.DB(), testdatagen.Assertions{
 			Order: models.Order{
 				ServiceMemberID: serviceMember.ID,

--- a/pkg/services/progear_weight_ticket/progear_weight_ticket_updater_test.go
+++ b/pkg/services/progear_weight_ticket/progear_weight_ticket_updater_test.go
@@ -9,13 +9,14 @@ import (
 	"github.com/transcom/mymove/pkg/appcontext"
 	"github.com/transcom/mymove/pkg/apperror"
 	"github.com/transcom/mymove/pkg/etag"
+	"github.com/transcom/mymove/pkg/factory"
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/testdatagen"
 )
 
 func (suite *ProgearWeightTicketSuite) TestUpdateProgearWeightTicket() {
 	setupForTest := func(appCtx appcontext.AppContext, overrides *models.ProgearWeightTicket, hasdocFiles bool) *models.ProgearWeightTicket {
-		serviceMember := testdatagen.MakeDefaultServiceMember(suite.DB())
+		serviceMember := factory.BuildServiceMember(suite.DB(), nil, nil)
 		ppmShipment := testdatagen.MakeMinimalDefaultPPMShipment(suite.DB())
 
 		baseDocumentAssertions := testdatagen.Assertions{

--- a/pkg/services/weight_ticket/weight_ticket_creator_test.go
+++ b/pkg/services/weight_ticket/weight_ticket_creator_test.go
@@ -5,12 +5,13 @@ import (
 
 	"github.com/transcom/mymove/pkg/apperror"
 	"github.com/transcom/mymove/pkg/auth"
+	"github.com/transcom/mymove/pkg/factory"
 	"github.com/transcom/mymove/pkg/testdatagen"
 )
 
 func (suite *WeightTicketSuite) TestWeightTicketCreator() {
 	suite.Run("Successfully creates a WeightTicket", func() {
-		serviceMember := testdatagen.MakeDefaultServiceMember(suite.DB())
+		serviceMember := factory.BuildServiceMember(suite.DB(), nil, nil)
 		session := &auth.Session{
 			ServiceMemberID: serviceMember.ID,
 		}
@@ -31,7 +32,7 @@ func (suite *WeightTicketSuite) TestWeightTicketCreator() {
 	})
 
 	suite.Run("Fails when an invalid ppmShipmentID is used", func() {
-		serviceMember := testdatagen.MakeDefaultServiceMember(suite.DB())
+		serviceMember := factory.BuildServiceMember(suite.DB(), nil, nil)
 		session := &auth.Session{
 			ServiceMemberID: serviceMember.ID,
 		}

--- a/pkg/services/weight_ticket/weight_ticket_deleter_test.go
+++ b/pkg/services/weight_ticket/weight_ticket_deleter_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/transcom/mymove/pkg/apperror"
 	"github.com/transcom/mymove/pkg/auth"
+	"github.com/transcom/mymove/pkg/factory"
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/services/mocks"
 	"github.com/transcom/mymove/pkg/testdatagen"
@@ -18,7 +19,7 @@ import (
 func (suite *WeightTicketSuite) TestDeleteWeightTicket() {
 
 	setupForTest := func(overrides *models.WeightTicket, hasDocumentUploads bool) *models.WeightTicket {
-		serviceMember := testdatagen.MakeDefaultServiceMember(suite.DB())
+		serviceMember := factory.BuildServiceMember(suite.DB(), nil, nil)
 		ppmShipment := testdatagen.MakeMinimalPPMShipment(suite.DB(), testdatagen.Assertions{
 			Order: models.Order{
 				ServiceMemberID: serviceMember.ID,

--- a/pkg/services/weight_ticket/weight_ticket_updater_test.go
+++ b/pkg/services/weight_ticket/weight_ticket_updater_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/transcom/mymove/pkg/appcontext"
 	"github.com/transcom/mymove/pkg/apperror"
 	"github.com/transcom/mymove/pkg/etag"
+	"github.com/transcom/mymove/pkg/factory"
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/services"
 	"github.com/transcom/mymove/pkg/services/mocks"
@@ -20,7 +21,7 @@ func (suite *WeightTicketSuite) TestUpdateWeightTicket() {
 	ppmShipmentUpdater := mocks.PPMShipmentUpdater{}
 
 	setupForTest := func(appCtx appcontext.AppContext, overrides *models.WeightTicket, hasEmptyFiles bool, hasFullFiles bool, hasProofFiles bool) *models.WeightTicket {
-		serviceMember := testdatagen.MakeDefaultServiceMember(suite.DB())
+		serviceMember := factory.BuildServiceMember(suite.DB(), nil, nil)
 		ppmShipment := testdatagen.MakeMinimalDefaultPPMShipment(suite.DB())
 
 		baseDocumentAssertions := testdatagen.Assertions{

--- a/pkg/testdatagen/scenario/e2ebasic.go
+++ b/pkg/testdatagen/scenario/e2ebasic.go
@@ -324,12 +324,12 @@ func userWithTOOandTIORole(appCtx appcontext.AppContext) {
 			},
 		},
 	}, nil)
-	testdatagen.MakeServiceMember(appCtx.DB(), testdatagen.Assertions{
-		ServiceMember: models.ServiceMember{
-			User:   user,
-			UserID: user.ID,
+	factory.BuildServiceMember(appCtx.DB(), []factory.Customization{
+		{
+			Model:    user,
+			LinkOnly: true,
 		},
-	})
+	}, nil)
 }
 
 func userWithTOOandTIOandQAECSRRole(appCtx appcontext.AppContext) {
@@ -377,12 +377,12 @@ func userWithTOOandTIOandQAECSRRole(appCtx appcontext.AppContext) {
 			},
 		},
 	}, nil)
-	testdatagen.MakeServiceMember(appCtx.DB(), testdatagen.Assertions{
-		ServiceMember: models.ServiceMember{
-			User:   user,
-			UserID: user.ID,
+	factory.BuildServiceMember(appCtx.DB(), []factory.Customization{
+		{
+			Model:    user,
+			LinkOnly: true,
 		},
-	})
+	}, nil)
 }
 func userWithTOOandTIOandServicesCounselorRole(appCtx appcontext.AppContext) {
 	tooRole := roles.Role{}
@@ -429,12 +429,13 @@ func userWithTOOandTIOandServicesCounselorRole(appCtx appcontext.AppContext) {
 			},
 		},
 	}, nil)
-	testdatagen.MakeServiceMember(appCtx.DB(), testdatagen.Assertions{
-		ServiceMember: models.ServiceMember{
-			User:   user,
-			UserID: user.ID,
+
+	factory.BuildServiceMember(appCtx.DB(), []factory.Customization{
+		{
+			Model:    user,
+			LinkOnly: true,
 		},
-	})
+	}, nil)
 }
 
 func userWithPrimeSimulatorRole(appCtx appcontext.AppContext) {
@@ -1787,11 +1788,13 @@ func serviceMemberWithOrdersAndPPMMove06(appCtx appcontext.AppContext, userUploa
 }
 
 func serviceMemberWithOrdersAndPPMMove07(appCtx appcontext.AppContext, userUploader *uploader.UserUploader) {
-	customer := testdatagen.MakeServiceMember(appCtx.DB(), testdatagen.Assertions{
-		ServiceMember: models.ServiceMember{
-			ID: uuid.FromStringOrNil("1a13ee6b-3e21-4170-83bc-0d41f60edb99"),
+	customer := factory.BuildServiceMember(appCtx.DB(), []factory.Customization{
+		{
+			Model: models.ServiceMember{
+				ID: uuid.FromStringOrNil("1a13ee6b-3e21-4170-83bc-0d41f60edb99"),
+			},
 		},
-	})
+	}, nil)
 	orders := testdatagen.MakeOrder(appCtx.DB(), testdatagen.Assertions{
 		Order: models.Order{
 			ID:              uuid.FromStringOrNil("8779beda-f69a-43bf-8606-ebd22973d474"),
@@ -1810,11 +1813,13 @@ func serviceMemberWithOrdersAndPPMMove07(appCtx appcontext.AppContext, userUploa
 }
 
 func serviceMemberWithOrdersAndPPMMove08(appCtx appcontext.AppContext, userUploader *uploader.UserUploader) {
-	customer := testdatagen.MakeServiceMember(appCtx.DB(), testdatagen.Assertions{
-		ServiceMember: models.ServiceMember{
-			ID: uuid.FromStringOrNil("25a90fef-301e-4682-9758-60f0c76ea8b4"),
+	customer := factory.BuildServiceMember(appCtx.DB(), []factory.Customization{
+		{
+			Model: models.ServiceMember{
+				ID: uuid.FromStringOrNil("25a90fef-301e-4682-9758-60f0c76ea8b4"),
+			},
 		},
-	})
+	}, nil)
 	orders := testdatagen.MakeOrder(appCtx.DB(), testdatagen.Assertions{
 		Order: models.Order{
 			ID:              uuid.FromStringOrNil("f2473488-2504-4872-a6b6-dd385dad4bf9"),
@@ -1989,11 +1994,13 @@ func createMoveWithServiceItemsandPaymentRequests01(appCtx appcontext.AppContext
 	dlhCost := unit.Cents(99999)
 	csCost := unit.Cents(25000)
 	fscCost := unit.Cents(55555)
-	customer := testdatagen.MakeServiceMember(appCtx.DB(), testdatagen.Assertions{
-		ServiceMember: models.ServiceMember{
-			ID: uuid.FromStringOrNil("4e6e4023-b089-4614-a65a-cac48027ffc2"),
+	customer := factory.BuildServiceMember(appCtx.DB(), []factory.Customization{
+		{
+			Model: models.ServiceMember{
+				ID: uuid.FromStringOrNil("4e6e4023-b089-4614-a65a-cac48027ffc2"),
+			},
 		},
-	})
+	}, nil)
 
 	orders := testdatagen.MakeOrder(appCtx.DB(), testdatagen.Assertions{
 		Order: models.Order{
@@ -2365,11 +2372,13 @@ func createMoveWithServiceItemsandPaymentRequests01(appCtx appcontext.AppContext
 func createMoveWithServiceItemsandPaymentRequests02(appCtx appcontext.AppContext, userUploader *uploader.UserUploader) {
 	msCost := unit.Cents(10000)
 
-	customer8 := testdatagen.MakeServiceMember(appCtx.DB(), testdatagen.Assertions{
-		ServiceMember: models.ServiceMember{
-			ID: uuid.FromStringOrNil("9e8da3c7-ffe5-4f7f-b45a-8f01ccc56591"),
+	customer8 := factory.BuildServiceMember(appCtx.DB(), []factory.Customization{
+		{
+			Model: models.ServiceMember{
+				ID: uuid.FromStringOrNil("9e8da3c7-ffe5-4f7f-b45a-8f01ccc56591"),
+			},
 		},
-	})
+	}, nil)
 	orders8 := testdatagen.MakeOrder(appCtx.DB(), testdatagen.Assertions{
 		Order: models.Order{
 			ID:              uuid.FromStringOrNil("1d49bb07-d9dd-4308-934d-baad94f2de9b"),
@@ -2891,11 +2900,13 @@ func createHHGMoveWithServiceItemsAndPaymentRequestsAndFiles(appCtx appcontext.A
 
 func createMoveWithSinceParamater(appCtx appcontext.AppContext, userUploader *uploader.UserUploader) {
 	// A more recent MTO for demonstrating the since parameter
-	customer6 := testdatagen.MakeServiceMember(appCtx.DB(), testdatagen.Assertions{
-		ServiceMember: models.ServiceMember{
-			ID: uuid.FromStringOrNil("6ac40a00-e762-4f5f-b08d-3ea72a8e4b61"),
+	customer6 := factory.BuildServiceMember(appCtx.DB(), []factory.Customization{
+		{
+			Model: models.ServiceMember{
+				ID: uuid.FromStringOrNil("6ac40a00-e762-4f5f-b08d-3ea72a8e4b61"),
+			},
 		},
-	})
+	}, nil)
 	orders6 := testdatagen.MakeOrder(appCtx.DB(), testdatagen.Assertions{
 		Order: models.Order{
 			ID:              uuid.FromStringOrNil("6fca843a-a87e-4752-b454-0fac67aa4981"),
@@ -3257,7 +3268,7 @@ func createNTSRMoveWithServiceItemsAndPaymentRequest(appCtx appcontext.AppContex
 	sac2 := "4444"
 
 	// Create Customer
-	customer := testdatagen.MakeServiceMember(appCtx.DB(), testdatagen.Assertions{})
+	customer := factory.BuildServiceMember(appCtx.DB(), nil, nil)
 
 	// Create Orders
 	orders := testdatagen.MakeOrder(appCtx.DB(), testdatagen.Assertions{
@@ -3778,7 +3789,7 @@ func createNTSRMoveWithPaymentRequest(appCtx appcontext.AppContext, userUploader
 	tac := "1111"
 
 	// Create Customer
-	customer := testdatagen.MakeServiceMember(appCtx.DB(), testdatagen.Assertions{})
+	customer := factory.BuildServiceMember(appCtx.DB(), nil, nil)
 
 	// Create Orders
 	orders := testdatagen.MakeOrder(appCtx.DB(), testdatagen.Assertions{

--- a/pkg/testdatagen/scenario/shared.go
+++ b/pkg/testdatagen/scenario/shared.go
@@ -4273,11 +4273,13 @@ func createHHGMoveWith10ServiceItems(appCtx appcontext.AppContext, userUploader 
 	db := appCtx.DB()
 	msCost := unit.Cents(10000)
 
-	customer8 := testdatagen.MakeServiceMember(db, testdatagen.Assertions{
-		ServiceMember: models.ServiceMember{
-			ID: uuid.FromStringOrNil("9e8da3c7-ffe5-4f7f-b45a-8f01ccc56591"),
+	customer8 := factory.BuildServiceMember(db, []factory.Customization{
+		{
+			Model: models.ServiceMember{
+				ID: uuid.FromStringOrNil("9e8da3c7-ffe5-4f7f-b45a-8f01ccc56591"),
+			},
 		},
-	})
+	}, nil)
 	orders8 := testdatagen.MakeOrder(db, testdatagen.Assertions{
 		Order: models.Order{
 			ID:              uuid.FromStringOrNil("1d49bb07-d9dd-4308-934d-baad94f2de9b"),
@@ -4612,11 +4614,13 @@ func createHHGMoveWith10ServiceItems(appCtx appcontext.AppContext, userUploader 
 func createHHGMoveWith2PaymentRequests(appCtx appcontext.AppContext, userUploader *uploader.UserUploader) {
 	db := appCtx.DB()
 	/* Customer with two payment requests */
-	customer7 := testdatagen.MakeServiceMember(db, testdatagen.Assertions{
-		ServiceMember: models.ServiceMember{
-			ID: uuid.FromStringOrNil("4e6e4023-b089-4614-a65a-cac48027ffc2"),
+	customer7 := factory.BuildServiceMember(db, []factory.Customization{
+		{
+			Model: models.ServiceMember{
+				ID: uuid.FromStringOrNil("4e6e4023-b089-4614-a65a-cac48027ffc2"),
+			},
 		},
-	})
+	}, nil)
 
 	orders7 := testdatagen.MakeOrder(db, testdatagen.Assertions{
 		Order: models.Order{
@@ -6406,12 +6410,12 @@ func createTXO(appCtx appcontext.AppContext) {
 			},
 		},
 	}, nil)
-	testdatagen.MakeServiceMember(db, testdatagen.Assertions{
-		ServiceMember: models.ServiceMember{
-			User:   user,
-			UserID: user.ID,
+	factory.BuildServiceMember(db, []factory.Customization{
+		{
+			Model:    user,
+			LinkOnly: true,
 		},
-	})
+	}, nil)
 }
 
 func createTXOUSMC(appCtx appcontext.AppContext) {

--- a/pkg/testdatagen/testharness/make_office_user.go
+++ b/pkg/testdatagen/testharness/make_office_user.go
@@ -54,10 +54,8 @@ func MakeOfficeUserWithTOOAndTIO(appCtx appcontext.AppContext) models.User {
 
 	factory.BuildServiceMember(appCtx.DB(), []factory.Customization{
 		{
-			Model: models.ServiceMember{
-				User:   user,
-				UserID: user.ID,
-			},
+			Model:    user,
+			LinkOnly: true,
 		},
 	}, nil)
 

--- a/pkg/testdatagen/testharness/make_office_user.go
+++ b/pkg/testdatagen/testharness/make_office_user.go
@@ -52,12 +52,14 @@ func MakeOfficeUserWithTOOAndTIO(appCtx appcontext.AppContext) models.User {
 		},
 	}, []roles.RoleType{roles.RoleTypeTOO, roles.RoleTypeTIO})
 
-	testdatagen.MakeServiceMember(appCtx.DB(), testdatagen.Assertions{
-		ServiceMember: models.ServiceMember{
-			User:   user,
-			UserID: user.ID,
+	factory.BuildServiceMember(appCtx.DB(), []factory.Customization{
+		{
+			Model: models.ServiceMember{
+				User:   user,
+				UserID: user.ID,
+			},
 		},
-	})
+	}, nil)
 
 	return user
 }


### PR DESCRIPTION
## [Jira ticket](https://dp3.atlassian.net/browse/MB-14619) for this change

## Summary

This ticket adds a factory package with function BuildServiceMember intended to be an eventual replacement for testdatagen.MakeServiceMember
* Created BuildServiceMember and shared functions
* Created tests for BuildServiceMember. 
* Replaces instances in code where `MakeServiceMember` and `MakeDefaultServiceMember` exists with `BuildServiceMember`

## Setup to Run Your Code

`make server_test` should be enough. 

### Frontend

- No frontend changes

### Backend

- [x] Code follows the guidelines for [Logging](https://transcom.github.io/mymove-docs/docs/dev/contributing/backend/Backend-Programming-Guide#logging)
- [x] The requirements listed in [Querying the Database Safely](https://transcom.github.io/mymove-docs/docs/dev/contributing/backend/Backend-Programming-Guide/#querying-the-database-safely) have been satisfied.

### Database

#### Any new migrations/schema changes:

- No schema changes

