### PR TITLE
MB-15175 - Modify weight calculations

### DIFF
--- a/src/components/Customer/PPM/Closeout/FinalCloseoutForm/FinalCloseoutForm.jsx
+++ b/src/components/Customer/PPM/Closeout/FinalCloseoutForm/FinalCloseoutForm.jsx
@@ -13,7 +13,7 @@ import { formatCents, formatWeight } from 'utils/formatters';
 import { calculateTotalMovingExpensesAmount } from 'utils/ppmCloseout';
 import {
   calculateTotalNetWeightForProGearWeightTickets,
-  calculateTotalNetWeightForWeightTickets,
+  getTotalNetWeightForWeightTickets,
 } from 'utils/shipmentWeights';
 import SectionWrapper from 'components/Customer/SectionWrapper';
 import TextField from 'components/form/fields/TextField/TextField';
@@ -25,7 +25,7 @@ const validationSchema = Yup.object().shape({
 });
 
 const FinalCloseoutForm = ({ initialValues, mtoShipment, onBack, onSubmit, affiliation, selectedMove }) => {
-  const totalNetWeight = calculateTotalNetWeightForWeightTickets(mtoShipment?.ppmShipment?.weightTickets);
+  const totalNetWeight = getTotalNetWeightForWeightTickets(mtoShipment?.ppmShipment?.weightTickets);
   const totalProGearWeight = calculateTotalNetWeightForProGearWeightTickets(
     mtoShipment?.ppmShipment?.proGearWeightTickets,
   );

--- a/src/components/Office/PPM/EditNetWeights/EditPPMNetWeight.jsx
+++ b/src/components/Office/PPM/EditNetWeights/EditPPMNetWeight.jsx
@@ -9,7 +9,7 @@ import styles from './EditPPMNetWeight.module.scss';
 import MaskedTextField from 'components/form/fields/MaskedTextField/MaskedTextField';
 import { ErrorMessage } from 'components/form/ErrorMessage';
 import { formatWeight } from 'utils/formatters';
-import { calculateNetWeightForWeightTicket } from 'utils/shipmentWeights';
+import { calculateWeightTicketWeightDifference } from 'utils/shipmentWeights';
 import { useCalculatedWeightRequested } from 'hooks/custom';
 
 // Labels & constants
@@ -153,7 +153,7 @@ const EditPPMNetWeight = ({ netWeightRemarks, weightTicket, weightAllowance, shi
     setShowEditForm(!showEditForm);
   };
   // Original weight is the full weight - empty weight
-  const originalWeight = calculateNetWeightForWeightTicket(weightTicket);
+  const originalWeight = calculateWeightTicketWeightDifference(weightTicket);
   // moveWeightTotal = Sum of all ppm weights + sum of all non-ppm shipments
   const moveWeightTotal = useCalculatedWeightRequested(shipments);
   const excessWeight = moveWeightTotal - weightAllowance;

--- a/src/hooks/custom.js
+++ b/src/hooks/custom.js
@@ -24,8 +24,8 @@ export const useCalculatedTotalBillableWeight = (mtoShipments) => {
   }, [mtoShipments]);
 };
 
-export const useCalculatedWeightRequested = (mtoShipments) => {
-  return useMemo(() => {
+export const calculateWeightRequested = (mtoShipments) => {
+  if (mtoShipments?.some((s) => includedStatusesForCalculatingWeights(s.status) && calculateShipmentNetWeight(s))) {
     return (
       mtoShipments
         ?.filter((s) => includedStatusesForCalculatingWeights(s.status))
@@ -33,6 +33,13 @@ export const useCalculatedWeightRequested = (mtoShipments) => {
           return prev + (calculateShipmentNetWeight(current) || 0);
         }, 0) || null
     );
+  }
+  return null;
+};
+
+export const useCalculatedWeightRequested = (mtoShipments) => {
+  return useMemo(() => {
+    return calculateWeightRequested(mtoShipments);
   }, [mtoShipments]);
 };
 

--- a/src/hooks/custom.js
+++ b/src/hooks/custom.js
@@ -1,7 +1,7 @@
 import { useMemo } from 'react';
 
 import { shipmentStatuses } from 'constants/shipments';
-import { calculateShipmentNetWeight } from 'utils/shipmentWeights';
+import { calculateShipmentNetWeight, getShipmentEstimatedWeight } from 'utils/shipmentWeights';
 
 // only sum estimated/actual/reweigh weights for shipments in these statuses
 export const includedStatusesForCalculatingWeights = (status) => {
@@ -37,11 +37,11 @@ export const useCalculatedWeightRequested = (mtoShipments) => {
 };
 
 export const calculateEstimatedWeight = (mtoShipments) => {
-  if (mtoShipments?.some((s) => includedStatusesForCalculatingWeights(s.status) && s.primeEstimatedWeight)) {
+  if (mtoShipments?.some((s) => includedStatusesForCalculatingWeights(s.status) && getShipmentEstimatedWeight(s))) {
     return mtoShipments
-      ?.filter((s) => includedStatusesForCalculatingWeights(s.status) && s.primeEstimatedWeight)
+      ?.filter((s) => includedStatusesForCalculatingWeights(s.status) && getShipmentEstimatedWeight(s))
       .reduce((prev, current) => {
-        return prev + current.primeEstimatedWeight;
+        return prev + getShipmentEstimatedWeight(current);
       }, 0);
   }
   return null;

--- a/src/pages/MyMove/PPM/Closeout/Review/Review.jsx
+++ b/src/pages/MyMove/PPM/Closeout/Review/Review.jsx
@@ -23,7 +23,7 @@ import {
 } from 'utils/ppmCloseout';
 import {
   calculateTotalNetWeightForProGearWeightTickets,
-  calculateTotalNetWeightForWeightTickets,
+  getTotalNetWeightForWeightTickets,
 } from 'utils/shipmentWeights';
 import LoadingPlaceholder from 'shared/LoadingPlaceholder';
 import { formatCents, formatWeight } from 'utils/formatters';
@@ -143,7 +143,7 @@ const Review = () => {
     handleDelete,
   );
 
-  const weightTicketsTotal = calculateTotalNetWeightForWeightTickets(weightTickets);
+  const weightTicketsTotal = getTotalNetWeightForWeightTickets(weightTickets);
 
   const canAdvance =
     hasCompletedAllWeightTickets(weightTickets) && hasCompletedAllExpenses(expenses) && hasCompletedAllProGear(proGear);

--- a/src/pages/Office/ServicesCounselingReviewShipmentWeights/ServicesCounselingReviewShipmentWeights.jsx
+++ b/src/pages/Office/ServicesCounselingReviewShipmentWeights/ServicesCounselingReviewShipmentWeights.jsx
@@ -8,20 +8,26 @@ import styles from './ServicesCounselingReviewShipmentWeights.module.scss';
 
 import { useReviewShipmentWeightsQuery } from 'hooks/queries';
 import WeightDisplay from 'components/Office/WeightDisplay/WeightDisplay';
-import { calculateEstimatedWeight, useCalculatedWeightRequested } from 'hooks/custom';
+import { calculateEstimatedWeight, calculateWeightRequested } from 'hooks/custom';
 import hasRiskOfExcess from 'utils/hasRiskOfExcess';
 import { servicesCounselingRoutes } from 'constants/routes';
 
 const ServicesCounselingReviewShipmentWeights = ({ moveCode }) => {
-  const { orders, mtoShipments } = useReviewShipmentWeightsQuery(moveCode);
+  const { orders, mtoShipments, documents } = useReviewShipmentWeightsQuery(moveCode);
   const [estimatedWeightTotal, setEstimatedWeightTotal] = useState(null);
   const [externalVendorShipmentCount, setExternalVendorShipmentCount] = useState(0);
-  const moveWeightTotal = useCalculatedWeightRequested(mtoShipments);
+  const [moveWeightTotal, setMoveWeightTotal] = useState(null);
   const order = Object.values(orders)?.[0];
 
   useEffect(() => {
     setEstimatedWeightTotal(calculateEstimatedWeight(mtoShipments));
   }, [mtoShipments]);
+
+  // documents are a dependency of this useEffect because they are appended to the mtoShipments
+  // to calculate the net weight, but this doesn't trigger the useEffect automatically
+  useEffect(() => {
+    setMoveWeightTotal(calculateWeightRequested(mtoShipments));
+  }, [mtoShipments, documents]);
 
   useEffect(() => {
     if (mtoShipments) {

--- a/src/utils/shipmentWeights.js
+++ b/src/utils/shipmentWeights.js
@@ -46,9 +46,11 @@ export const getWeightTicketNetWeight = (weightTicket) => {
 };
 
 export const getTotalNetWeightForWeightTickets = (weightTickets = []) => {
-  return weightTickets.reduce((prev, curr) => {
-    return prev + getWeightTicketNetWeight(curr);
-  }, 0);
+  return weightTickets
+    ? weightTickets.reduce((prev, curr) => {
+        return prev + getWeightTicketNetWeight(curr);
+      }, 0)
+    : 0;
 };
 
 export const calculatePPMShipmentNetWeight = (shipment) => {

--- a/src/utils/shipmentWeights.js
+++ b/src/utils/shipmentWeights.js
@@ -14,7 +14,21 @@ export const getShipmentEstimatedWeight = (shipment) => {
   return shipment.primeEstimatedWeight ?? 0;
 };
 
-export const calculateNetWeightForWeightTicket = (weightTicket) => {
+export const calculateNetWeightForProGearWeightTicket = (weightTicket) => {
+  if (weightTicket.weight == null || Number.isNaN(Number(weightTicket.weight))) {
+    return 0;
+  }
+
+  return weightTicket.weight;
+};
+
+export const calculateTotalNetWeightForProGearWeightTickets = (proGearWeightTickets = []) => {
+  return proGearWeightTickets.reduce((prev, curr) => {
+    return prev + calculateNetWeightForProGearWeightTicket(curr);
+  }, 0);
+};
+
+export const calculateWeightTicketWeightDifference = (weightTicket) => {
   if (
     weightTicket.emptyWeight == null ||
     weightTicket.fullWeight == null ||
@@ -27,28 +41,18 @@ export const calculateNetWeightForWeightTicket = (weightTicket) => {
   return weightTicket.fullWeight - weightTicket.emptyWeight;
 };
 
-export const calculateNetWeightForProGearWeightTicket = (weightTicket) => {
-  if (weightTicket.weight == null || Number.isNaN(Number(weightTicket.weight))) {
-    return 0;
-  }
-
-  return weightTicket.weight;
+export const getWeightTicketNetWeight = (weightTicket) => {
+  return weightTicket.adjustedNetWeight ?? calculateWeightTicketWeightDifference(weightTicket);
 };
 
-export const calculateTotalNetWeightForWeightTickets = (weightTickets = []) => {
+export const getTotalNetWeightForWeightTickets = (weightTickets = []) => {
   return weightTickets.reduce((prev, curr) => {
-    return prev + calculateNetWeightForWeightTicket(curr);
-  }, 0);
-};
-
-export const calculateTotalNetWeightForProGearWeightTickets = (proGearWeightTickets = []) => {
-  return proGearWeightTickets.reduce((prev, curr) => {
-    return prev + calculateNetWeightForProGearWeightTicket(curr);
+    return prev + getWeightTicketNetWeight(curr);
   }, 0);
 };
 
 export const calculatePPMShipmentNetWeight = (shipment) => {
-  return calculateTotalNetWeightForWeightTickets(shipment?.ppmShipment?.weightTickets);
+  return getTotalNetWeightForWeightTickets(shipment?.ppmShipment?.weightTickets);
 };
 
 export const calculateNonPPMShipmentNetWeight = (shipment) => {

--- a/src/utils/shipmentWeights.js
+++ b/src/utils/shipmentWeights.js
@@ -7,6 +7,12 @@ import returnLowestValue from './returnLowestValue';
 export function shipmentIsOverweight(estimatedWeight, weightCap) {
   return weightCap > estimatedWeight * 1.1;
 }
+export const getShipmentEstimatedWeight = (shipment) => {
+  if (shipment.ppmShipment) {
+    return shipment.ppmShipment.estimatedWeight ?? 0;
+  }
+  return shipment.primeEstimatedWeight ?? 0;
+};
 
 export const calculateNetWeightForWeightTicket = (weightTicket) => {
   if (

--- a/src/utils/shipmentWeights.test.js
+++ b/src/utils/shipmentWeights.test.js
@@ -6,6 +6,7 @@ import {
   calculateShipmentNetWeight,
   calculateTotalNetWeightForProGearWeightTickets,
   calculateTotalNetWeightForWeightTickets,
+  getShipmentEstimatedWeight,
   shipmentIsOverweight,
 } from './shipmentWeights';
 import { createCompleteProGearWeightTicket } from './test/factories/proGearWeightTicket';
@@ -206,7 +207,7 @@ describe('calculateTotalNetWeightForProGearWeightTickets', () => {
   });
 });
 
-describe('Calculating shipment weights', () => {
+describe('Calculating shipment net weights', () => {
   const ppmShipments = [
     {
       ppmShipment: {
@@ -278,5 +279,67 @@ describe('Calculating shipment weights', () => {
       .map((s) => calculateShipmentNetWeight(s))
       .reduce((accumulator, current) => accumulator + current, 0);
     expect(totalMoveWeight).toEqual(netWeightOfPPMShipments + netWeightOfNonPPMShipments);
+  });
+});
+
+describe('Calculating shipment estimated weights', () => {
+  const ppmShipments = [
+    {
+      ppmShipment: {
+        estimatedWeight: 5000,
+      },
+    },
+    {
+      ppmShipment: {
+        estimatedWeight: 11000,
+      },
+    },
+    {
+      ppmShipment: {
+        weightTickets: [
+          { emptyWeight: 14000, fullWeight: 19000 },
+          { emptyWeight: 12000, fullWeight: 18000 },
+          { emptyWeight: 10000, fullWeight: 20000 },
+        ],
+      },
+    },
+  ];
+
+  const hhgShipments = [
+    {
+      primeEstimatedWeight: 10,
+    },
+    {
+      primeEstimatedWeight: 2000,
+    },
+    {
+      primeEstimatedWeight: 100,
+    },
+    {
+      primeEstimatedWeight: 1000,
+    },
+    {
+      reweigh: {
+        weight: 3000,
+      },
+    },
+  ];
+
+  it('gets the estimated weight of a ppm shipment properly', () => {
+    expect(getShipmentEstimatedWeight(ppmShipments[0])).toEqual(5000);
+  });
+
+  it('gets the estimated weight of a non-ppm shipment properly', () => {
+    expect(getShipmentEstimatedWeight(hhgShipments[0])).toEqual(10);
+  });
+
+  it('calculates the sum net weight of a move with varied shipment types', () => {
+    const estimatedWeightOfPPMShipments = 16000;
+    const estimatedWeightOfNonPPMShipments = 3110;
+
+    const totalEstimatedWeight = [...ppmShipments, ...hhgShipments]
+      .map((s) => getShipmentEstimatedWeight(s))
+      .reduce((accumulator, current) => accumulator + current, 0);
+    expect(totalEstimatedWeight).toEqual(estimatedWeightOfPPMShipments + estimatedWeightOfNonPPMShipments);
   });
 });

--- a/src/utils/shipmentWeights.test.js
+++ b/src/utils/shipmentWeights.test.js
@@ -1,13 +1,14 @@
 import {
   calculateNetWeightForProGearWeightTicket,
-  calculateNetWeightForWeightTicket,
+  calculateWeightTicketWeightDifference,
   calculateNonPPMShipmentNetWeight,
   calculatePPMShipmentNetWeight,
   calculateShipmentNetWeight,
   calculateTotalNetWeightForProGearWeightTickets,
-  calculateTotalNetWeightForWeightTickets,
+  getTotalNetWeightForWeightTickets,
   getShipmentEstimatedWeight,
   shipmentIsOverweight,
+  getWeightTicketNetWeight,
 } from './shipmentWeights';
 import { createCompleteProGearWeightTicket } from './test/factories/proGearWeightTicket';
 import { createCompleteWeightTicket } from './test/factories/weightTicket';
@@ -52,7 +53,7 @@ describe('calculateNetWeightForWeightTicket', () => {
         },
       );
 
-      expect(calculateNetWeightForWeightTicket(weightTicket)).toEqual(expectedNetWeight);
+      expect(calculateWeightTicketWeightDifference(weightTicket)).toEqual(expectedNetWeight);
     },
   );
 });
@@ -151,6 +152,13 @@ describe('calculateTotalNetWeightForWeightTickets', () => {
       ],
       0,
     ],
+    [
+      [
+        { emptyWeight: 'not a number', fullWeight: 'not a number' },
+        { emptyWeight: 'not a number', fullWeight: 'not a number', adjustedNetWeight: 1000 },
+      ],
+      1000,
+    ],
     [[], 0],
   ])(`calculates total net weight properly`, (weightTicketsFields, expectedNetWeight) => {
     const weightTickets = [];
@@ -159,7 +167,18 @@ describe('calculateTotalNetWeightForWeightTickets', () => {
       weightTickets.push(createCompleteWeightTicket({}, fieldOverrides));
     });
 
-    expect(calculateTotalNetWeightForWeightTickets(weightTickets)).toEqual(expectedNetWeight);
+    expect(getTotalNetWeightForWeightTickets(weightTickets)).toEqual(expectedNetWeight);
+  });
+});
+
+describe('getWeightTicketNetWeight', () => {
+  it('returns the adjusted net weight if present', () => {
+    const weightTicket = { emptyWeight: 4, fullWeight: 10, adjustedNetWeight: 1000 };
+    expect(getWeightTicketNetWeight(weightTicket)).toEqual(1000);
+  });
+  it('returns the calculated weight difference if the net weight has not been adjusted', () => {
+    const weightTicket = { emptyWeight: 4, fullWeight: 10, adjustedNetWeight: null };
+    expect(getWeightTicketNetWeight(weightTicket)).toEqual(6);
   });
 });
 


### PR DESCRIPTION
## [Jira ticket](https://dp3.atlassian.net/browse/MB-15175) for this change

## Summary

This PR should accomplish two changes to our weight calculations:
1. Include adjusted weights in weight ticket net weight calculations
2. Include PPM estimated weights in shipment estimated weight calculations

Things to look out for:
1. Do the new calculations make sense?
2. Do all usages of the functions in shipmentWeights.js make sense? Pages like MoveTaskOrder.jsx and EditPPMNetWeight.jsx will have different values in their weight calculations now for certain scenarios.
3. Does it make sense to export all of the functions in shipmentWeights.js? I left them public because I think their unit tests are valuable and there may be use cases to import them elsewhere in the future.

## Setup to Run Your Code

<details>
<summary>💻 You will need to use three separate terminals to test this locally.</summary>

##### Terminal 1

Start the Storybook locally.

```sh
make storybook
```

##### Terminal 2

Start the UI locally.

```sh
make client_run
```

##### Terminal 3

Start the Go server locally.

```sh
make server_run
```

</details>

### Additional steps

<!-- Fill out the next section as you see fit, these are just suggestions. -->

1. You can run the front end tests with `make client_test` and validate that they pass.

## Verification Steps for Author

These are to be checked by the author.

- [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
- [ ] Request review from a member of a different team.
- [ ] Have the Jira acceptance criteria been met for this change?

## Verification Steps for Reviewers

These are to be checked by a reviewer.

<!-- Fill out the next sections as you see fit, these are just suggestions. -->

### Frontend

- [ ] User facing changes have been reviewed by design.
- [ ] There are no aXe warnings for UI.
- [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/main/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
- [ ] There are no new console errors in the browser devtools
- [ ] There are no new console errors in the test output
- [ ] If this PR adds a new component to Storybook, it ensures the component is fully responsive, OR if it is intentionally not, a wrapping div using the `officeApp` class or custom `min-width` styling is used to hide any states the would not be visible to the user.
