### PR TITLE
feat (make): add targets for deploying/reverting deploys to non-ATO envs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1150,4 +1150,39 @@ anti_virus: ## Scan repo with anti-virus service
 # ----- END ANTI VIRUS TARGETS -----
 #
 
+#
+# ----- START NON-ATO DEPLOYMENT TARGETS -----
+#
+
+.PHONY: prepare_for_deploy
+prepare_for_deploy:  ## Replace placeholders in config to deploy to a non-ATO env. Requires DEPLOY_ENV to be set to exp, loadtest, or demo.
+ifeq ($(DEPLOY_ENV), exp)
+	@echo "Preparing for deploy to experimental"
+else ifeq ($(DEPLOY_ENV), loadtest)
+	@echo "Preparing for deploy to loadtest"
+else ifeq ($(DEPLOY_ENV), demo)
+	@echo "Preparing for deploy to demo"
+else
+	$(error DEPLOY_ENV must be exp, loadtest, or demo)
+endif
+	sed -E -i '' "s#(&dp3-branch) placeholder_branch_name#\1 $(GIT_BRANCH)#" .circleci/config.yml
+	sed -E -i '' "s#(&integration-ignore-branch) placeholder_branch_name#\1 $(GIT_BRANCH)#" .circleci/config.yml
+	sed -E -i '' "s#(&integration-mtls-ignore-branch) placeholder_branch_name#\1 $(GIT_BRANCH)#" .circleci/config.yml
+	sed -E -i '' "s#(&client-ignore-branch) placeholder_branch_name#\1 $(GIT_BRANCH)#" .circleci/config.yml
+	sed -E -i '' "s#(&server-ignore-branch) placeholder_branch_name#\1 $(GIT_BRANCH)#" .circleci/config.yml
+	sed -E -i '' "s#(&dp3-env) placeholder_env#\1 $(DEPLOY_ENV)#" .circleci/config.yml
+
+.PHONY: restore_from_deploy
+restore_from_deploy:  ## Restore placeholders in config after deploy to a non-ATO env
+	sed -E -i '' "s#(&dp3-branch) $(GIT_BRANCH)#\1 placeholder_branch_name#" .circleci/config.yml
+	sed -E -i '' "s#(&integration-ignore-branch) $(GIT_BRANCH)#\1 placeholder_branch_name#" .circleci/config.yml
+	sed -E -i '' "s#(&integration-mtls-ignore-branch) $(GIT_BRANCH)#\1 placeholder_branch_name#" .circleci/config.yml
+	sed -E -i '' "s#(&client-ignore-branch) $(GIT_BRANCH)#\1 placeholder_branch_name#" .circleci/config.yml
+	sed -E -i '' "s#(&server-ignore-branch) $(GIT_BRANCH)#\1 placeholder_branch_name#" .circleci/config.yml
+	sed -E -i '' "s#(&dp3-env) (exp|loadtest|demo)#\1 placeholder_env#" .circleci/config.yml
+
+#
+# ----- END NON-ATO DEPLOYMENT TARGETS -----
+#
+
 default: help

--- a/Makefile
+++ b/Makefile
@@ -1154,8 +1154,8 @@ anti_virus: ## Scan repo with anti-virus service
 # ----- START NON-ATO DEPLOYMENT TARGETS -----
 #
 
-.PHONY: prepare_for_deploy
-prepare_for_deploy:  ## Replace placeholders in config to deploy to a non-ATO env. Requires DEPLOY_ENV to be set to exp, loadtest, or demo.
+.PHONY: nonato_deploy_prepare
+nonato_deploy_prepare:  ## Replace placeholders in config to deploy to a non-ATO env. Requires DEPLOY_ENV to be set to exp, loadtest, or demo.
 ifeq ($(DEPLOY_ENV), exp)
 	@echo "Preparing for deploy to experimental"
 else ifeq ($(DEPLOY_ENV), loadtest)
@@ -1171,9 +1171,11 @@ endif
 	sed -E -i '' "s#(&client-ignore-branch) placeholder_branch_name#\1 $(GIT_BRANCH)#" .circleci/config.yml
 	sed -E -i '' "s#(&server-ignore-branch) placeholder_branch_name#\1 $(GIT_BRANCH)#" .circleci/config.yml
 	sed -E -i '' "s#(&dp3-env) placeholder_env#\1 $(DEPLOY_ENV)#" .circleci/config.yml
+	@git --no-pager diff .circleci/config.yml
+	@echo "Please make sure to commit the changes in .circleci/config.yml in order to have CircleCI deploy $(GIT_BRANCH) to the Non-ATO $(DEPLOY_ENV) environment."
 
-.PHONY: restore_from_deploy
-restore_from_deploy:  ## Restore placeholders in config after deploy to a non-ATO env
+.PHONY: nonato_deploy_restore
+nonato_deploy_restore:  ## Restore placeholders in config after deploy to a non-ATO env
 	sed -E -i '' "s#(&dp3-branch) $(GIT_BRANCH)#\1 placeholder_branch_name#" .circleci/config.yml
 	sed -E -i '' "s#(&integration-ignore-branch) $(GIT_BRANCH)#\1 placeholder_branch_name#" .circleci/config.yml
 	sed -E -i '' "s#(&integration-mtls-ignore-branch) $(GIT_BRANCH)#\1 placeholder_branch_name#" .circleci/config.yml


### PR DESCRIPTION
## Summary

This came up as a nice-to-have improvement while testing out deployment failures. [First pass](https://github.com/transcom/mymove/pull/10183/commits/8abb9ececf9db10c28b0c912230b907baa886a1b) at this had used `:` as a separator. I switched it to `#` because I was trying to use a non-capturing group, which didn't end up working, but at that point I didn't see a reason to switch back. Lmk if you think I should switch back to it though. The original version also was only for the `exp` env, but this version should work for the three non-ATO envs we can deploy to.
