### PR TITLE
Revert "Bump webpack from 5.75.0 to 5.76.0"

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -20587,9 +20587,9 @@ webpack@4:
     webpack-sources "^1.4.1"
 
 webpack@5, "webpack@>=4.43.0 <6.0.0", webpack@^5.64.4, webpack@^5.9.0:
-  version "5.76.0"
-  resolved "https://registry.yarnpkg.com/webpack/-/webpack-5.76.0.tgz#f9fb9fb8c4a7dbdcd0d56a98e56b8a942ee2692c"
-  integrity sha512-l5sOdYBDunyf72HW8dF23rFtWq/7Zgvt/9ftMof71E/yUb1YLOBmTgA2K4vQthB3kotMrSj609txVE0dnr2fjA==
+  version "5.75.0"
+  resolved "https://registry.yarnpkg.com/webpack/-/webpack-5.75.0.tgz#1e440468647b2505860e94c9ff3e44d5b582c152"
+  integrity sha512-piaIaoVJlqMsPtX/+3KTTO6jfvrSYgauFVdt8cr9LTHKmcq/AMd4mhzsiP7ZF/PGRNPGA8336jldh9l2Kt2ogQ==
   dependencies:
     "@types/eslint-scope" "^3.7.3"
     "@types/estree" "^0.0.51"


### PR DESCRIPTION
Reverts transcom/mymove#10233

We are having problems with ephemeral deploys failing (but not staging or local) and we think this might be the dependency that's the root cause.  I'm deploying this PR as an [ephemeral deploy](https://trussworks.slack.com/archives/C01T40WC4G1/p1678477170751979) to see if it deploys successfully.  If so, I'll get this merged into main to get us green on ephemeral deploys and buy us some time to research the upgrade further.

Update: the ephemeral deploy worked, so let's move forward with reverting.