### PR TITLE
[MB-15446] accounting for adjusted net weight in calculations

### DIFF
--- a/pkg/services/weight_ticket/weight_ticket_updater.go
+++ b/pkg/services/weight_ticket/weight_ticket_updater.go
@@ -124,12 +124,17 @@ func hasTotalWeightChanged(originalWeightTicket, newWeightTicket models.WeightTi
 	var newWeight unit.Pound
 	var oldWeight unit.Pound
 
-	if newWeightTicket.FullWeight != nil && newWeightTicket.EmptyWeight != nil {
+	if newWeightTicket.AdjustedNetWeight != nil {
+		newWeight = *newWeightTicket.AdjustedNetWeight
+	} else if newWeightTicket.FullWeight != nil && newWeightTicket.EmptyWeight != nil {
 		newWeight = *newWeightTicket.FullWeight - *newWeightTicket.EmptyWeight
 	}
-	if originalWeightTicket.FullWeight != nil && originalWeightTicket.EmptyWeight != nil {
+
+	if originalWeightTicket.AdjustedNetWeight != nil {
+		oldWeight = *originalWeightTicket.AdjustedNetWeight
+	} else if originalWeightTicket.FullWeight != nil && originalWeightTicket.EmptyWeight != nil {
 		oldWeight = *originalWeightTicket.FullWeight - *originalWeightTicket.EmptyWeight
 	}
-	//TODO: account for adjustedNetWeight
+
 	return newWeight != oldWeight
 }


### PR DESCRIPTION
## [Jira ticket](https://dp3.atlassian.net/browse/MB-15446) for this change

## Summary

There was one more weight check function that needed updating - this PR ensures they take adjustedNetWeight into account 🎉 

## Setup to Run Your Code

<details>
<summary>💻 You will need to use three separate terminals to test this locally.</summary>

##### Terminal 1

Start the Storybook locally.

```sh
make storybook
```

##### Terminal 2

Start the UI locally.

```sh
make client_run
```

##### Terminal 3

Start the Go server locally.

```sh
make server_run
```

</details>

### Additional steps

<!-- Fill out the next section as you see fit, these are just suggestions. -->

1. Run `make server_test`
2. New test should pass, it takes adjustedNetWeight into account

## Verification Steps for Author

These are to be checked by the author.

- [x] Have the Jira acceptance criteria been met for this change?

## Verification Steps for Reviewers

These are to be checked by a reviewer.

<!-- Fill out the next sections as you see fit, these are just suggestions. -->

### Backend

- [ ] Code follows the guidelines for [Logging](https://transcom.github.io/mymove-docs/docs/dev/contributing/backend/Backend-Programming-Guide#logging)
- [ ] The requirements listed in [Querying the Database Safely](https://transcom.github.io/mymove-docs/docs/dev/contributing/backend/Backend-Programming-Guide/#querying-the-database-safely) have been satisfied.

