### PR TITLE
MB-14757 add and implement factory.BuildDocument

### DIFF
--- a/pkg/db/utilities/utilities_test.go
+++ b/pkg/db/utilities/utilities_test.go
@@ -97,12 +97,7 @@ func (suite *UtilitiesSuite) TestSoftDestroy_ModelWithDeletedAtWithHasManyAssoci
 	// model with deleted_at with "has many" associations
 	serviceMember := factory.BuildServiceMember(suite.DB(), nil, nil)
 
-	document := testdatagen.MakeDocument(suite.DB(), testdatagen.Assertions{
-		Document: models.Document{
-			ServiceMemberID: serviceMember.ID,
-			ServiceMember:   serviceMember,
-		},
-	})
+	document := factory.BuildDocumentLinkServiceMember(suite.DB(), serviceMember)
 	suite.MustSave(&document)
 	suite.Nil(document.DeletedAt)
 

--- a/pkg/factory/document_factory.go
+++ b/pkg/factory/document_factory.go
@@ -1,0 +1,54 @@
+package factory
+
+import (
+	"github.com/gobuffalo/pop/v6"
+
+	"github.com/transcom/mymove/pkg/models"
+	"github.com/transcom/mymove/pkg/testdatagen"
+)
+
+// BuildDocument creates a single Document.
+// Also creates, if not provided
+// - ServiceMember
+// Params:
+// - customs is a slice that will be modified by the factory
+// - db can be set to nil to create a stubbed model that is not stored in DB.
+func BuildDocument(db *pop.Connection, customs []Customization, traits []Trait) models.Document {
+	customs = setupCustomizations(customs, traits)
+
+	// Find Document assertion and convert to models.Document
+	var cDocument models.Document
+	if result := findValidCustomization(customs, Document); result != nil {
+		cDocument = result.Model.(models.Document)
+		if result.LinkOnly {
+			return cDocument
+		}
+	}
+
+	// Find/create the ServiceMember model
+	serviceMember := BuildServiceMember(db, customs, traits)
+
+	// Create document
+	document := models.Document{
+		ServiceMemberID: serviceMember.ID,
+		ServiceMember:   serviceMember,
+	}
+
+	// Overwrite values with those from customizations
+	testdatagen.MergeModels(&document, cDocument)
+
+	// If db is false, it's a stub. No need to create in database
+	if db != nil {
+		mustCreate(db, &document)
+	}
+	return document
+}
+
+func BuildDocumentLinkServiceMember(db *pop.Connection, serviceMember models.ServiceMember) models.Document {
+	return BuildDocument(db, []Customization{
+		{
+			Model:    serviceMember,
+			LinkOnly: true,
+		},
+	}, nil)
+}

--- a/pkg/factory/document_factory_test.go
+++ b/pkg/factory/document_factory_test.go
@@ -1,0 +1,134 @@
+package factory
+
+import (
+	"github.com/gofrs/uuid"
+
+	"github.com/transcom/mymove/pkg/models"
+)
+
+func (suite *FactorySuite) TestBuildDocument() {
+	suite.Run("Successful creation of default Document", func() {
+		// Under test:      BuildDocument
+		// Mocked:          None
+		// Set up:          Create a Document with no customizations or traits
+		// Expected outcome:Document should be created with default values
+
+		// SETUP
+		defaultServiceMember := BuildServiceMember(nil, nil, nil)
+		defaultDocument := models.Document{
+			ServiceMember: defaultServiceMember,
+		}
+
+		// CALL FUNCTION UNDER TEST
+		document := BuildDocument(suite.DB(), nil, nil)
+
+		// VALIDATE RESULTS
+		suite.NotNil(document.ServiceMember)
+		suite.NotNil(document.CreatedAt)
+
+		// Check that service member was hooked in
+		suite.Equal(*defaultDocument.ServiceMember.FirstName, *document.ServiceMember.FirstName)
+		suite.Equal(*defaultDocument.ServiceMember.LastName, *document.ServiceMember.LastName)
+		suite.Equal(*defaultDocument.ServiceMember.Telephone, *document.ServiceMember.Telephone)
+
+	})
+
+	suite.Run("Successful creation of customized Document", func() {
+		// Under test:      BuildDocument
+		// Set up:          Create a Document and pass custom fields
+		// Expected outcome:Document should be created with custom fields
+
+		// SETUP
+		customDocument := models.Document{
+			ID: uuid.Must(uuid.NewV4()),
+		}
+
+		customServiceMember := models.ServiceMember{
+			FirstName: models.StringPointer("Jason"),
+			LastName:  models.StringPointer("Ash"),
+		}
+
+		// CALL FUNCTION UNDER TEST
+		document := BuildDocument(suite.DB(), []Customization{
+			{Model: customDocument},
+			{Model: customServiceMember},
+		}, nil)
+
+		// VALIDATE RESULTS
+		suite.Equal(customDocument.ID, document.ID)
+
+		// Check that the service member was customized
+		suite.Equal(*customServiceMember.FirstName, *document.ServiceMember.FirstName)
+		suite.Equal(*customServiceMember.LastName, *document.ServiceMember.LastName)
+	})
+
+	suite.Run("Successful return of linkOnly Document", func() {
+		// Under test:       BuildDocument
+		// Set up:           Pass in a linkOnly Document
+		// Expected outcome: No new Document should be created.
+
+		// Check num Document records
+		precount, err := suite.DB().Count(&models.Document{})
+		suite.NoError(err)
+
+		id := uuid.Must(uuid.NewV4())
+		document := BuildDocument(suite.DB(), []Customization{
+			{
+				Model: models.Document{
+					ID: id,
+				},
+				LinkOnly: true,
+			},
+		}, nil)
+		count, err := suite.DB().Count(&models.Document{})
+		suite.Equal(precount, count)
+		suite.NoError(err)
+		suite.Equal(id, document.ID)
+
+	})
+	suite.Run("Successful return of stubbed Document", func() {
+		// Under test:       BuildDocument
+		// Set up:           Create a Document with nil DB
+		// Expected outcome: No new Document should be created.
+
+		// Check num Document records
+		precount, err := suite.DB().Count(&models.Document{})
+		suite.NoError(err)
+
+		// Nil passed in as db
+		id := uuid.Must(uuid.NewV4())
+		document := BuildDocument(nil, []Customization{
+			{
+				Model: models.Document{
+					ID: id,
+				},
+			},
+		}, nil)
+		count, err := suite.DB().Count(&models.Document{})
+		suite.Equal(precount, count)
+		suite.NoError(err)
+		suite.Equal(id, document.ID)
+	})
+
+	suite.Run("Successful creation of Document using BuildDocumentLinkServiceMember", func() {
+		// Under test:       BuildDocumentLinkServiceMember
+		// Set up:           Create a Document
+		// Expected outcome: No new Document should be created.
+
+		serviceMember := BuildServiceMember(suite.DB(), []Customization{
+			{
+				Model: models.ServiceMember{
+					FirstName: models.StringPointer("Jason"),
+					LastName:  models.StringPointer("Ash"),
+				},
+			},
+		}, nil)
+
+		// CALL FUNCTION UNDER TEST
+		document := BuildDocumentLinkServiceMember(suite.DB(), serviceMember)
+
+		// Check that the service member was hooked in
+		suite.Equal(*serviceMember.FirstName, *document.ServiceMember.FirstName)
+		suite.Equal(*serviceMember.LastName, *document.ServiceMember.LastName)
+	})
+}

--- a/pkg/factory/shared.go
+++ b/pkg/factory/shared.go
@@ -38,6 +38,7 @@ var Address CustomType = "Address"
 var AdminUser CustomType = "AdminUser"
 var BackupContact CustomType = "BackupContact"
 var Contractor CustomType = "Contractor"
+var Document CustomType = "Document"
 var DutyLocation CustomType = "DutyLocation"
 var Entitlement CustomType = "Entitlement"
 var OfficePhoneLine CustomType = "OfficePhoneLine"
@@ -61,6 +62,7 @@ var defaultTypesMap = map[string]CustomType{
 	"models.AdminUser":            AdminUser,
 	"models.BackupContact":        BackupContact,
 	"models.Contractor":           Contractor,
+	"models.Document":             Document,
 	"models.DutyLocation":         DutyLocation,
 	"models.Entitlement":          Entitlement,
 	"models.OfficePhoneLine":      OfficePhoneLine,

--- a/pkg/handlers/adminapi/upload_information_test.go
+++ b/pkg/handlers/adminapi/upload_information_test.go
@@ -39,12 +39,7 @@ func (suite *HandlerSuite) TestGetUploadHandler() {
 		})
 		suite.MustSave(&move)
 
-		document := testdatagen.MakeDocument(suite.DB(), testdatagen.Assertions{
-			Document: models.Document{
-				ServiceMember:   sm,
-				ServiceMemberID: sm.ID,
-			},
-		})
+		document := factory.BuildDocumentLinkServiceMember(suite.DB(), sm)
 		suite.MustSave(&document)
 
 		uploadID, _ := uuid.NewV4()

--- a/pkg/handlers/ghcapi/orders_test.go
+++ b/pkg/handlers/ghcapi/orders_test.go
@@ -194,7 +194,7 @@ func (suite *HandlerSuite) makeUpdateOrderHandlerAmendedUploadSubtestData() (sub
 	var err error
 	subtestData.userUploader, err = uploader.NewUserUploader(subtestData.handlerConfig.FileStorer(), 100*uploader.MB)
 	assert.NoError(suite.T(), err, "failed to create user uploader for amended orders")
-	amendedDocument := testdatagen.MakeDocument(suite.DB(), testdatagen.Assertions{})
+	amendedDocument := factory.BuildDocument(suite.DB(), nil, nil)
 	amendedUpload := testdatagen.MakeUserUpload(suite.DB(), testdatagen.Assertions{
 		UserUpload: models.UserUpload{
 			DocumentID: &amendedDocument.ID,
@@ -247,7 +247,7 @@ func (suite *HandlerSuite) TestUpdateOrderHandlerWithAmendedUploads() {
 		destinationDutyLocation := subtestData.destinationDutyLocation
 		originDutyLocation := subtestData.originDutyLocation
 
-		document := testdatagen.MakeDocument(suite.DB(), testdatagen.Assertions{})
+		document := factory.BuildDocument(suite.DB(), nil, nil)
 		upload := testdatagen.MakeUserUpload(suite.DB(), testdatagen.Assertions{
 			UserUpload: models.UserUpload{
 				DocumentID: &document.ID,

--- a/pkg/handlers/internalapi/moves_test.go
+++ b/pkg/handlers/internalapi/moves_test.go
@@ -715,7 +715,7 @@ func (suite *HandlerSuite) TestShowShipmentSummaryWorksheet() {
 func (suite *HandlerSuite) TestSubmitAmendedOrdersHandler() {
 	suite.Run("Submits move with amended orders for review", func() {
 		// Given: a set of orders, a move, user and service member
-		document := testdatagen.MakeDefaultDocument(suite.DB())
+		document := factory.BuildDocument(suite.DB(), nil, nil)
 		order := testdatagen.MakeOrder(suite.DB(), testdatagen.Assertions{
 			Order: models.Order{
 				UploadedAmendedOrders:   &document,

--- a/pkg/handlers/internalapi/uploads_test.go
+++ b/pkg/handlers/internalapi/uploads_test.go
@@ -36,7 +36,7 @@ const FixtureXLSX = "Weight Estimator.xlsx"
 const FixtureEmpty = "empty.pdf"
 
 func createPrereqs(suite *HandlerSuite, fixtureFile string) (models.Document, uploadop.CreateUploadParams) {
-	document := testdatagen.MakeDefaultDocument(suite.DB())
+	document := factory.BuildDocument(suite.DB(), nil, nil)
 
 	params := uploadop.NewCreateUploadParams()
 	params.DocumentID = handlers.FmtUUID(document.ID)
@@ -459,7 +459,7 @@ func (suite *HandlerSuite) TestCreatePPMUploadsHandlerFailure() {
 		fakeS3 := storageTest.NewFakeS3Storage(true)
 		_, params := createPPMPrereqs(suite, FixtureXLS)
 
-		document := testdatagen.MakeDefaultDocument(suite.DB())
+		document := factory.BuildDocument(suite.DB(), nil, nil)
 		params.DocumentID = strfmt.UUID(document.ID.String())
 
 		response := makePPMRequest(suite, params, document.ServiceMember, fakeS3)

--- a/pkg/handlers/supportapi/move_task_order_test.go
+++ b/pkg/handlers/supportapi/move_task_order_test.go
@@ -228,7 +228,7 @@ func (suite *HandlerSuite) TestCreateMoveTaskOrderRequestHandler() {
 		originDutyLocation := factory.BuildDutyLocation(suite.DB(), nil, nil)
 		customer := factory.BuildServiceMember(suite.DB(), nil, nil)
 		contractor := factory.FetchOrBuildDefaultContractor(suite.DB(), nil, nil)
-		document := testdatagen.MakeDefaultDocument(suite.DB())
+		document := factory.BuildDocument(suite.DB(), nil, nil)
 
 		// Create the mto payload we will be requesting to create
 		issueDate := swag.Time(time.Now())

--- a/pkg/models/moving_expense_test.go
+++ b/pkg/models/moving_expense_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/gofrs/uuid"
 
+	"github.com/transcom/mymove/pkg/factory"
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/testdatagen"
 )
@@ -75,12 +76,7 @@ func (suite *ModelSuite) TestMovingExpenseValidation() {
 
 		serviceMember := ppmShipment.Shipment.MoveTaskOrder.Orders.ServiceMember
 
-		document := testdatagen.MakeDocument(suite.DB(), testdatagen.Assertions{
-			Document: models.Document{
-				ServiceMemberID: serviceMember.ID,
-				ServiceMember:   serviceMember,
-			},
-		})
+		document := factory.BuildDocumentLinkServiceMember(suite.DB(), serviceMember)
 
 		movingExpense := models.MovingExpense{
 			PPMShipmentID: ppmShipment.ID,

--- a/pkg/models/user_upload_test.go
+++ b/pkg/models/user_upload_test.go
@@ -6,12 +6,13 @@ import (
 
 	"github.com/transcom/mymove/pkg/auth"
 	"github.com/transcom/mymove/pkg/db/dberr"
+	"github.com/transcom/mymove/pkg/factory"
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/testdatagen"
 )
 
 func (suite *ModelSuite) Test_UserUploadCreate() {
-	document := testdatagen.MakeDefaultDocument(suite.DB())
+	document := factory.BuildDocument(suite.DB(), nil, nil)
 
 	upload := models.Upload{
 		Filename:    "test.pdf",
@@ -44,7 +45,7 @@ func (suite *ModelSuite) Test_UserUploadValidations() {
 }
 
 func (suite *ModelSuite) TestCreateUserUploadWithNoUpload() {
-	document := testdatagen.MakeDefaultDocument(suite.DB())
+	document := factory.BuildDocument(suite.DB(), nil, nil)
 
 	uploadUser := models.UserUpload{
 		DocumentID: &document.ID,

--- a/pkg/paperwork/generator_test.go
+++ b/pkg/paperwork/generator_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/pdfcpu/pdfcpu/pkg/pdfcpu/validate"
 	"github.com/spf13/afero"
 
+	"github.com/transcom/mymove/pkg/factory"
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/testdatagen"
 	"github.com/transcom/mymove/pkg/uploader"
@@ -50,7 +51,7 @@ func (suite *PaperworkSuite) sha256ForPath(path string, fs *afero.Afero) (string
 func (suite *PaperworkSuite) setupOrdersDocument() (*Generator, models.Order) {
 	order := testdatagen.MakeDefaultOrder(suite.DB())
 
-	document := testdatagen.MakeDefaultDocument(suite.DB())
+	document := factory.BuildDocument(suite.DB(), nil, nil)
 
 	generator, err := NewGenerator(suite.userUploader.Uploader())
 	suite.FatalNil(err)

--- a/pkg/services/move/move_router_test.go
+++ b/pkg/services/move/move_router_test.go
@@ -103,7 +103,7 @@ func (suite *MoveServiceSuite) TestMoveSubmission() {
 		// Under test: MoveRouter.RouteAfterAmendingOrders
 		// Set up: Submit an approved move with an orders record
 		// Expected outcome: move status updated to APPROVALSREQUESTED
-		document := testdatagen.MakeDefaultDocument(suite.DB())
+		document := factory.BuildDocument(suite.DB(), nil, nil)
 		order := testdatagen.MakeOrder(suite.DB(), testdatagen.Assertions{
 			Order: models.Order{
 				ID:                    uuid.Must(uuid.NewV4()),
@@ -126,7 +126,7 @@ func (suite *MoveServiceSuite) TestMoveSubmission() {
 		// Under test: MoveRouter.RouteAfterAmendingOrders
 		// Set up: Create a CANCELLED move without an OrdersID
 		// Expected outcome: Error on ordersID
-		document := testdatagen.MakeDefaultDocument(suite.DB())
+		document := factory.BuildDocument(suite.DB(), nil, nil)
 		order := testdatagen.MakeOrder(suite.DB(), testdatagen.Assertions{
 			Order: models.Order{
 				ID:                    uuid.Must(uuid.NewV4()),
@@ -149,7 +149,7 @@ func (suite *MoveServiceSuite) TestMoveSubmission() {
 		// Under test: MoveRouter.RouteAfterAmendingOrders
 		// Set up: Create a move amended orders acknowledged, then submit with amended orders
 		// Expected outcome: Status goes to APPROVALSREQUESTED and timestamp is cleared
-		document := testdatagen.MakeDefaultDocument(suite.DB())
+		document := factory.BuildDocument(suite.DB(), nil, nil)
 		order := testdatagen.MakeOrder(suite.DB(), testdatagen.Assertions{
 			Order: models.Order{
 				ID:                    uuid.Must(uuid.NewV4()),
@@ -591,7 +591,7 @@ func (suite *MoveServiceSuite) TestApproveOrRequestApproval() {
 		storer := storageTest.NewFakeS3Storage(true)
 		userUploader, err := uploader.NewUserUploader(storer, 100*uploader.MB)
 		suite.NoError(err)
-		amendedDocument := testdatagen.MakeDocument(suite.DB(), testdatagen.Assertions{})
+		amendedDocument := factory.BuildDocument(suite.DB(), nil, nil)
 		amendedUpload := testdatagen.MakeUserUpload(suite.DB(), testdatagen.Assertions{
 			UserUpload: models.UserUpload{
 				DocumentID: &amendedDocument.ID,

--- a/pkg/services/moving_expense/moving_expense_deleter_test.go
+++ b/pkg/services/moving_expense/moving_expense_deleter_test.go
@@ -24,11 +24,7 @@ func (suite *MovingExpenseSuite) TestDeleteMovingExpense() {
 			},
 		})
 
-		expenseDocument := testdatagen.MakeDocument(appCtx.DB(), testdatagen.Assertions{
-			Document: models.Document{
-				ServiceMemberID: serviceMember.ID,
-			},
-		})
+		expenseDocument := factory.BuildDocumentLinkServiceMember(suite.DB(), serviceMember)
 
 		if hasDocumentUploads {
 			for i := 0; i < 2; i++ {

--- a/pkg/services/moving_expense/moving_expense_deleter_test.go
+++ b/pkg/services/moving_expense/moving_expense_deleter_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/gofrs/uuid"
 
-	"github.com/transcom/mymove/pkg/appcontext"
 	"github.com/transcom/mymove/pkg/apperror"
 	"github.com/transcom/mymove/pkg/factory"
 	"github.com/transcom/mymove/pkg/models"
@@ -15,7 +14,7 @@ import (
 
 func (suite *MovingExpenseSuite) TestDeleteMovingExpense() {
 
-	setupForTest := func(appCtx appcontext.AppContext, overrides *models.MovingExpense, hasDocumentUploads bool) *models.MovingExpense {
+	setupForTest := func(overrides *models.MovingExpense, hasDocumentUploads bool) *models.MovingExpense {
 		serviceMember := factory.BuildServiceMember(suite.DB(), nil, nil)
 		ppmShipment := testdatagen.MakeMinimalPPMShipment(suite.DB(), testdatagen.Assertions{
 			Order: models.Order{
@@ -32,7 +31,7 @@ func (suite *MovingExpenseSuite) TestDeleteMovingExpense() {
 				if i == 1 {
 					deletedAt = models.TimePointer(time.Now())
 				}
-				testdatagen.MakeUserUpload(appCtx.DB(), testdatagen.Assertions{
+				testdatagen.MakeUserUpload(suite.DB(), testdatagen.Assertions{
 					UserUpload: models.UserUpload{
 						UploaderID: serviceMember.UserID,
 						DocumentID: &expenseDocument.ID,
@@ -53,7 +52,7 @@ func (suite *MovingExpenseSuite) TestDeleteMovingExpense() {
 			testdatagen.MergeModels(&originalMovingExpense, overrides)
 		}
 
-		verrs, err := appCtx.DB().ValidateAndCreate(&originalMovingExpense)
+		verrs, err := suite.DB().ValidateAndCreate(&originalMovingExpense)
 
 		suite.NoVerrs(verrs)
 		suite.Nil(err)
@@ -78,14 +77,12 @@ func (suite *MovingExpenseSuite) TestDeleteMovingExpense() {
 	})
 
 	suite.Run("Successfully deletes as a customer's moving expense", func() {
-		appCtx := suite.AppContextForTest()
-
-		originalMovingExpense := setupForTest(appCtx, nil, true)
+		originalMovingExpense := setupForTest(nil, true)
 
 		deleter := NewMovingExpenseDeleter()
 
 		suite.Nil(originalMovingExpense.DeletedAt)
-		err := deleter.DeleteMovingExpense(appCtx, originalMovingExpense.ID)
+		err := deleter.DeleteMovingExpense(suite.AppContextForTest(), originalMovingExpense.ID)
 		suite.NoError(err)
 
 		var movingExpenseInDB models.MovingExpense

--- a/pkg/services/moving_expense/moving_expense_updater_test.go
+++ b/pkg/services/moving_expense/moving_expense_updater_test.go
@@ -26,11 +26,7 @@ func (suite *MovingExpenseSuite) TestUpdateMovingExpense() {
 			},
 		})
 
-		expenseDocument := testdatagen.MakeDocument(appCtx.DB(), testdatagen.Assertions{
-			Document: models.Document{
-				ServiceMemberID: serviceMember.ID,
-			},
-		})
+		expenseDocument := factory.BuildDocumentLinkServiceMember(suite.DB(), serviceMember)
 
 		if hasDocumentUploads {
 			for i := 0; i < 2; i++ {

--- a/pkg/services/mto_service_item/mto_service_item_updater_test.go
+++ b/pkg/services/mto_service_item/mto_service_item_updater_test.go
@@ -320,7 +320,7 @@ func (suite *MTOServiceItemServiceSuite) createServiceItemForMoveWithUnacknowled
 	storer := storageTest.NewFakeS3Storage(true)
 	userUploader, err := uploader.NewUserUploader(storer, 100*uploader.MB)
 	suite.NoError(err)
-	amendedDocument := testdatagen.MakeDocument(suite.DB(), testdatagen.Assertions{})
+	amendedDocument := factory.BuildDocument(suite.DB(), nil, nil)
 	amendedUpload := testdatagen.MakeUserUpload(suite.DB(), testdatagen.Assertions{
 		UserUpload: models.UserUpload{
 			DocumentID: &amendedDocument.ID,

--- a/pkg/services/order/excess_weight_risk_manager_test.go
+++ b/pkg/services/order/excess_weight_risk_manager_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/transcom/mymove/pkg/apperror"
 	"github.com/transcom/mymove/pkg/etag"
+	"github.com/transcom/mymove/pkg/factory"
 	"github.com/transcom/mymove/pkg/models"
 	moverouter "github.com/transcom/mymove/pkg/services/move"
 	storageTest "github.com/transcom/mymove/pkg/storage/test"
@@ -77,7 +78,7 @@ func (suite *OrderServiceSuite) TestUpdateBillableWeightAsTOO() {
 		storer := storageTest.NewFakeS3Storage(true)
 		userUploader, err := uploader.NewUserUploader(storer, 100*uploader.MB)
 		suite.NoError(err)
-		amendedDocument := testdatagen.MakeDocument(suite.DB(), testdatagen.Assertions{})
+		amendedDocument := factory.BuildDocument(suite.DB(), nil, nil)
 		amendedUpload := testdatagen.MakeUserUpload(suite.DB(), testdatagen.Assertions{
 			UserUpload: models.UserUpload{
 				DocumentID: &amendedDocument.ID,
@@ -270,7 +271,7 @@ func (suite *OrderServiceSuite) TestUpdateBillableWeightAsTIO() {
 		storer := storageTest.NewFakeS3Storage(true)
 		userUploader, err := uploader.NewUserUploader(storer, 100*uploader.MB)
 		suite.NoError(err)
-		amendedDocument := testdatagen.MakeDocument(suite.DB(), testdatagen.Assertions{})
+		amendedDocument := factory.BuildDocument(suite.DB(), nil, nil)
 		amendedUpload := testdatagen.MakeUserUpload(suite.DB(), testdatagen.Assertions{
 			UserUpload: models.UserUpload{
 				DocumentID: &amendedDocument.ID,
@@ -461,7 +462,7 @@ func (suite *OrderServiceSuite) TestAcknowledgeExcessWeightRisk() {
 		storer := storageTest.NewFakeS3Storage(true)
 		userUploader, err := uploader.NewUserUploader(storer, 100*uploader.MB)
 		suite.NoError(err)
-		amendedDocument := testdatagen.MakeDocument(suite.DB(), testdatagen.Assertions{})
+		amendedDocument := factory.BuildDocument(suite.DB(), nil, nil)
 		amendedUpload := testdatagen.MakeUserUpload(suite.DB(), testdatagen.Assertions{
 			UserUpload: models.UserUpload{
 				DocumentID: &amendedDocument.ID,

--- a/pkg/services/order/order_updater_test.go
+++ b/pkg/services/order/order_updater_test.go
@@ -878,7 +878,7 @@ func (suite *OrderServiceSuite) TestUploadAmendedOrdersForCustomer() {
 		var moves models.Moves
 		mto := testdatagen.MakeMove(suite.DB(), testdatagen.Assertions{})
 
-		document := testdatagen.MakeDocument(suite.DB(), testdatagen.Assertions{})
+		document := factory.BuildDocument(suite.DB(), nil, nil)
 		order := testdatagen.MakeOrder(suite.DB(), testdatagen.Assertions{
 			Order: models.Order{
 				OriginDutyLocation:      &dutyLocation,

--- a/pkg/services/progear_weight_ticket/progear_weight_ticket_deleter_test.go
+++ b/pkg/services/progear_weight_ticket/progear_weight_ticket_deleter_test.go
@@ -24,11 +24,7 @@ func (suite *ProgearWeightTicketSuite) TestDeleteProgearWeightTicket() {
 			},
 		})
 
-		progearDocument := testdatagen.MakeDocument(appCtx.DB(), testdatagen.Assertions{
-			Document: models.Document{
-				ServiceMemberID: serviceMember.ID,
-			},
-		})
+		progearDocument := factory.BuildDocumentLinkServiceMember(suite.DB(), serviceMember)
 
 		if hasDocumentUploads {
 			for i := 0; i < 2; i++ {

--- a/pkg/services/progear_weight_ticket/progear_weight_ticket_updater_test.go
+++ b/pkg/services/progear_weight_ticket/progear_weight_ticket_updater_test.go
@@ -19,13 +19,7 @@ func (suite *ProgearWeightTicketSuite) TestUpdateProgearWeightTicket() {
 		serviceMember := factory.BuildServiceMember(suite.DB(), nil, nil)
 		ppmShipment := testdatagen.MakeMinimalDefaultPPMShipment(suite.DB())
 
-		baseDocumentAssertions := testdatagen.Assertions{
-			Document: models.Document{
-				ServiceMemberID: serviceMember.ID,
-			},
-		}
-
-		document := testdatagen.MakeDocument(appCtx.DB(), baseDocumentAssertions)
+		document := factory.BuildDocumentLinkServiceMember(suite.DB(), serviceMember)
 
 		now := time.Now()
 		if hasdocFiles {

--- a/pkg/services/weight_ticket/weight_ticket_deleter_test.go
+++ b/pkg/services/weight_ticket/weight_ticket_deleter_test.go
@@ -27,21 +27,9 @@ func (suite *WeightTicketSuite) TestDeleteWeightTicket() {
 			},
 		})
 
-		emptyDocument := testdatagen.MakeDocument(suite.DB(), testdatagen.Assertions{
-			Document: models.Document{
-				ServiceMemberID: serviceMember.ID,
-			},
-		})
-		fullDocument := testdatagen.MakeDocument(suite.DB(), testdatagen.Assertions{
-			Document: models.Document{
-				ServiceMemberID: serviceMember.ID,
-			},
-		})
-		trailerDocument := testdatagen.MakeDocument(suite.DB(), testdatagen.Assertions{
-			Document: models.Document{
-				ServiceMemberID: serviceMember.ID,
-			},
-		})
+		emptyDocument := factory.BuildDocumentLinkServiceMember(suite.DB(), serviceMember)
+		fullDocument := factory.BuildDocumentLinkServiceMember(suite.DB(), serviceMember)
+		trailerDocument := factory.BuildDocumentLinkServiceMember(suite.DB(), serviceMember)
 
 		if hasDocumentUploads {
 			for i := 0; i < 2; i++ {

--- a/pkg/services/weight_ticket/weight_ticket_updater_test.go
+++ b/pkg/services/weight_ticket/weight_ticket_updater_test.go
@@ -25,15 +25,9 @@ func (suite *WeightTicketSuite) TestUpdateWeightTicket() {
 		serviceMember := factory.BuildServiceMember(suite.DB(), nil, nil)
 		ppmShipment := testdatagen.MakeMinimalDefaultPPMShipment(suite.DB())
 
-		baseDocumentAssertions := testdatagen.Assertions{
-			Document: models.Document{
-				ServiceMemberID: serviceMember.ID,
-			},
-		}
-
-		emptyDocument := testdatagen.MakeDocument(appCtx.DB(), baseDocumentAssertions)
-		fullDocument := testdatagen.MakeDocument(appCtx.DB(), baseDocumentAssertions)
-		proofOfOwnership := testdatagen.MakeDocument(appCtx.DB(), baseDocumentAssertions)
+		emptyDocument := factory.BuildDocumentLinkServiceMember(suite.DB(), serviceMember)
+		fullDocument := factory.BuildDocumentLinkServiceMember(suite.DB(), serviceMember)
+		proofOfOwnership := factory.BuildDocumentLinkServiceMember(suite.DB(), serviceMember)
 
 		now := time.Now()
 		if hasEmptyFiles {

--- a/pkg/testdatagen/scenario/bandwidth.go
+++ b/pkg/testdatagen/scenario/bandwidth.go
@@ -68,12 +68,7 @@ func makeServiceMember(appCtx appcontext.AppContext) models.ServiceMember {
 }
 
 func makeAmendedOrders(appCtx appcontext.AppContext, order models.Order, userUploader *uploader.UserUploader, fileNames *[]string) models.Order {
-	document := testdatagen.MakeDocument(appCtx.DB(), testdatagen.Assertions{
-		Document: models.Document{
-			ServiceMemberID: order.ServiceMemberID,
-			ServiceMember:   order.ServiceMember,
-		},
-	})
+	document := factory.BuildDocumentLinkServiceMember(appCtx.DB(), order.ServiceMember)
 
 	// Creates order upload documents from the files in this directory:
 	// pkg/testdatagen/testdata/bandwidth_test_docs

--- a/pkg/testdatagen/scenario/shared.go
+++ b/pkg/testdatagen/scenario/shared.go
@@ -139,12 +139,7 @@ func createGenericPPMRelatedMove(appCtx appcontext.AppContext, moveInfo MoveCrea
 }
 
 func makeOrdersForServiceMember(appCtx appcontext.AppContext, serviceMember models.ServiceMember, userUploader *uploader.UserUploader, fileNames *[]string) models.Order {
-	document := testdatagen.MakeDocument(appCtx.DB(), testdatagen.Assertions{
-		Document: models.Document{
-			ServiceMemberID: serviceMember.ID,
-			ServiceMember:   serviceMember,
-		},
-	})
+	document := factory.BuildDocumentLinkServiceMember(appCtx.DB(), serviceMember)
 
 	// Creates order upload documents from the files in this directory:
 	// pkg/testdatagen/testdata/bandwidth_test_docs

--- a/pkg/uploader/user_uploader_test.go
+++ b/pkg/uploader/user_uploader_test.go
@@ -11,13 +11,13 @@ package uploader_test
 import (
 	"io"
 
+	"github.com/transcom/mymove/pkg/factory"
 	"github.com/transcom/mymove/pkg/storage/test"
-	"github.com/transcom/mymove/pkg/testdatagen"
 	"github.com/transcom/mymove/pkg/uploader"
 )
 
 func (suite *UploaderSuite) TestUserUploadFromLocalFile() {
-	document := testdatagen.MakeDefaultDocument(suite.DB())
+	document := factory.BuildDocument(suite.DB(), nil, nil)
 
 	userUploader, err := uploader.NewUserUploader(suite.storer, 25*uploader.MB)
 	suite.NoError(err)
@@ -31,7 +31,7 @@ func (suite *UploaderSuite) TestUserUploadFromLocalFile() {
 }
 
 func (suite *UploaderSuite) TestUserUploadFromLocalFileZeroLength() {
-	document := testdatagen.MakeDefaultDocument(suite.DB())
+	document := factory.BuildDocument(suite.DB(), nil, nil)
 
 	userUploader, err := uploader.NewUserUploader(suite.storer, 25*uploader.MB)
 	suite.NoError(err)
@@ -46,7 +46,7 @@ func (suite *UploaderSuite) TestUserUploadFromLocalFileZeroLength() {
 }
 
 func (suite *UploaderSuite) TestUserUploadFromLocalFileWrongContentType() {
-	document := testdatagen.MakeDefaultDocument(suite.DB())
+	document := factory.BuildDocument(suite.DB(), nil, nil)
 
 	userUploader, err := uploader.NewUserUploader(suite.storer, 25*uploader.MB)
 	suite.NoError(err)
@@ -62,7 +62,7 @@ func (suite *UploaderSuite) TestUserUploadFromLocalFileWrongContentType() {
 }
 
 func (suite *UploaderSuite) TestTooLargeUserUploadFromLocalFile() {
-	document := testdatagen.MakeDefaultDocument(suite.DB())
+	document := factory.BuildDocument(suite.DB(), nil, nil)
 
 	userUploader, err := uploader.NewUserUploader(suite.storer, 25*uploader.MB)
 	suite.NoError(err)
@@ -77,7 +77,7 @@ func (suite *UploaderSuite) TestTooLargeUserUploadFromLocalFile() {
 }
 
 func (suite *UploaderSuite) TestUserUploadStorerCalledWithTags() {
-	document := testdatagen.MakeDefaultDocument(suite.DB())
+	document := factory.BuildDocument(suite.DB(), nil, nil)
 	fakeS3 := test.NewFakeS3Storage(true)
 
 	userUploader, err := uploader.NewUserUploader(fakeS3, 25*uploader.MB)
@@ -96,7 +96,7 @@ func (suite *UploaderSuite) TestUserUploadStorerCalledWithTags() {
 }
 
 func (suite *UploaderSuite) TestCreateUserUploadNoDocument() {
-	document := testdatagen.MakeDefaultDocument(suite.DB())
+	document := factory.BuildDocument(suite.DB(), nil, nil)
 	userID := document.ServiceMember.UserID
 
 	userUploader, err := uploader.NewUserUploader(suite.storer, 25*uploader.MB)


### PR DESCRIPTION
## [Jira ticket](https://dp3.atlassian.net/browse/MB-14757) for this change

## Summary

This ticket adds a factory to build documents and replaces calls to testdatagen.MakeDocuments functions with the new factory functions.

## Setup to Run Your Code
Run make server_test and make sure tests pass

## Verification Steps for Author

These are to be checked by the author.

- [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
- [ ] Request review from a member of a different team.
- [ ] Have the Jira acceptance criteria been met for this change?

## Verification Steps for Reviewers

These are to be checked by a reviewer.

<!-- Fill out the next sections as you see fit, these are just suggestions. -->

### Frontend

- [ ] User facing changes have been reviewed by design.
- [ ] There are no aXe warnings for UI.
- [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/main/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
- [ ] There are no new console errors in the browser devtools
- [ ] There are no new console errors in the test output
- [ ] If this PR adds a new component to Storybook, it ensures the component is fully responsive, OR if it is intentionally not, a wrapping div using the `officeApp` class or custom `min-width` styling is used to hide any states the would not be visible to the user.

### Backend

- [ ] Code follows the guidelines for [Logging](https://transcom.github.io/mymove-docs/docs/dev/contributing/backend/Backend-Programming-Guide#logging)
- [ ] The requirements listed in [Querying the Database Safely](https://transcom.github.io/mymove-docs/docs/dev/contributing/backend/Backend-Programming-Guide/#querying-the-database-safely) have been satisfied.

### Database

#### Any new migrations/schema changes:

- [ ] Follows our guidelines for [Zero-Downtime Deploys](https://transcom.github.io/mymove-docs/docs/dev/contributing/database/Database-Migrations#zero-downtime-migrations)
- [ ] Have been communicated to #g-database
- [ ] Secure migrations have been tested following the instructions in our [docs](https://transcom.github.io/mymove-docs/docs/dev/contributing/database/Database-Migrations#secure-migrations)

## Screenshots
