### PR TITLE
[ MB-15134 ] Adding documentation to date formatter

### DIFF
--- a/src/utils/formatters.js
+++ b/src/utils/formatters.js
@@ -264,9 +264,21 @@ export const formatAgeToDays = (age) => {
   return `${Math.floor(age)} days`;
 };
 
-// Format dates for review shipment weights page (ex. Dec 25 2020)
+/**
+ * @name formatReviewShipmentWeightsDate
+ * @description Format dates for review shipment weights page (ex. 25-Dec-23)
+ * @param {string} date A string representing a date in the `DD-MMM-YY` format.
+ */
 export function formatReviewShipmentWeightsDate(date) {
-  return moment(date).format('MMM DD YYYY');
+  /**
+   * @const INCOMING_DATE_FORMAT
+   * @description This is the format of the incoming `date` parameter. The
+   * reason this is passed into Moment is due to a quirk around browser
+   * support for parsing strings. Read more about *String + Format* here:
+   * <https://momentjs.com/docs/#/parsing/string/>
+   */
+  const INCOMING_DATE_FORMAT = 'DD-MMM-YY';
+  return moment(date, INCOMING_DATE_FORMAT).format('MMM DD YYYY');
 }
 // Format dates for customer app (ex. 25 Dec 2020)
 export function formatCustomerDate(date) {


### PR DESCRIPTION
## [Jira ticket](https://dp3.atlassian.net/browse/MB-15134) for this change

## Summary

According to the Moment documentation, we should be providing a date
format to parse the string. This fixes that, but also adds more
documentation around this function and the new constant.
