### PR TITLE
MB-15501 Add optional chaining to submittedShipments and approvedOrCanceledShipments.

### DIFF
--- a/src/pages/Office/MoveDetails/MoveDetails.jsx
+++ b/src/pages/Office/MoveDetails/MoveDetails.jsx
@@ -212,11 +212,11 @@ const MoveDetails = ({
 
   const { customer, entitlement: allowances } = order;
 
-  if (submittedShipments.length > 0 && approvedOrCanceledShipments.length > 0) {
+  if (submittedShipments?.length > 0 && approvedOrCanceledShipments?.length > 0) {
     sections = ['requested-shipments', 'approved-shipments', ...sections];
-  } else if (approvedOrCanceledShipments.length > 0) {
+  } else if (approvedOrCanceledShipments?.length > 0) {
     sections = ['approved-shipments', ...sections];
-  } else if (submittedShipments.length > 0) {
+  } else if (submittedShipments?.length > 0) {
     sections = ['requested-shipments', ...sections];
   }
 
@@ -291,7 +291,7 @@ const MoveDetails = ({
             showTag={!shipmentMissingRequiredInformation}
             testID="requestedShipmentsTag"
           >
-            {submittedShipments?.length}
+            {submittedShipments?.length || 0}
           </LeftNavTag>
           <LeftNavTag
             className="usa-tag usa-tag--alert"
@@ -332,7 +332,7 @@ const MoveDetails = ({
               </Grid>
             )}
           </Grid>
-          {submittedShipments.length > 0 && (
+          {submittedShipments?.length > 0 && (
             <div className={styles.section} id="requested-shipments">
               <SubmittedRequestedShipments
                 mtoShipments={submittedShipments}
@@ -351,7 +351,7 @@ const MoveDetails = ({
               />
             </div>
           )}
-          {approvedOrCanceledShipments.length > 0 && (
+          {approvedOrCanceledShipments?.length > 0 && (
             <div className={styles.section} id="approved-shipments">
               <ApprovedRequestedShipments
                 mtoShipments={approvedOrCanceledShipments}

--- a/src/pages/Office/MoveDetails/MoveDetails.test.jsx
+++ b/src/pages/Office/MoveDetails/MoveDetails.test.jsx
@@ -703,6 +703,11 @@ const approvedMoveDetailsQuery = {
   ],
 };
 
+const undefinedMTOShipmentsMoveDetailsQuery = {
+  ...requestedMoveDetailsQuery,
+  mtoShipments: undefined,
+};
+
 const loadingReturnValue = {
   isLoading: true,
   isError: false,
@@ -1037,6 +1042,25 @@ describe('MoveDetails page', () => {
 
       expect(await screen.getByRole('link', { name: 'View allowances' })).toBeInTheDocument();
       expect(screen.queryByRole('link', { name: 'Edit allowances' })).not.toBeInTheDocument();
+    });
+  });
+
+  describe('when MTO shipments are not yet defined', () => {
+    it('does not show the "Something Went Wrong" error', () => {
+      useMoveDetailsQueries.mockReturnValue(undefinedMTOShipmentsMoveDetailsQuery);
+
+      render(
+        <MockProviders initialEntries={[`/moves/${mockRequestedMoveCode}/details`]}>
+          <MoveDetails
+            setUnapprovedShipmentCount={setUnapprovedShipmentCount}
+            setUnapprovedServiceItemCount={setUnapprovedServiceItemCount}
+            setExcessWeightRiskCount={setExcessWeightRiskCount}
+            setUnapprovedSITExtensionCount={setUnapprovedSITExtensionCount}
+          />
+        </MockProviders>,
+      );
+
+      expect(screen.queryByText('Something went wrong')).not.toBeInTheDocument();
     });
   });
 });


### PR DESCRIPTION
## [Jira ticket](https://dp3.atlassian.net/browse/MB-15501) for this change

## Summary

This adds optional chaining to `submittedShipments` and `approvedOrCanceledShipments` to fix a bug where `length` was being accessed on them, but they were still `undefined`. I assume that the underlying error is the effect of a race condition; since both of these eventually resolve to an array, though, optionally chaining them in the meantime should be a viable fix: if either is temporarily `undefined`, their components just don't render, instead of throwing an error.

## Setup to Run Your Code

<details>
<summary>💻 You will need to use three separate terminals to test this locally.</summary>

##### Terminal 1

Start the UI locally.

```sh
make client_run
```

##### Terminal 2

Start the Go server locally.

```sh
make server_run
```

</details>

### Additional steps

<!-- Fill out the next section as you see fit, these are just suggestions. -->

1. Access the office environment
2. Login as a TIO
3. Select a move, then if necessary, select Move Details
4. Confirm that no "Something Went Wrong" error appears, and that no errors appear in the console

Note: this issue was initially discovered on the Demo environment and wasn't necessarily reproducible locally. However, the fix should apply there just as well.

## Verification Steps for Author

These are to be checked by the author.

- [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
- [ ] Request review from a member of a different team.
- [ ] Have the Jira acceptance criteria been met for this change?

## Verification Steps for Reviewers

These are to be checked by a reviewer.

<!-- Fill out the next sections as you see fit, these are just suggestions. -->

### Frontend

- [ ] User facing changes have been reviewed by design.
- [ ] There are no aXe warnings for UI.
- [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/main/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
- [ ] There are no new console errors in the browser devtools
- [ ] There are no new console errors in the test output
- [ ] If this PR adds a new component to Storybook, it ensures the component is fully responsive, OR if it is intentionally not, a wrapping div using the `officeApp` class or custom `min-width` styling is used to hide any states the would not be visible to the user.

### Backend

- [ ] Code follows the guidelines for [Logging](https://transcom.github.io/mymove-docs/docs/dev/contributing/backend/Backend-Programming-Guide#logging)
- [ ] The requirements listed in [Querying the Database Safely](https://transcom.github.io/mymove-docs/docs/dev/contributing/backend/Backend-Programming-Guide/#querying-the-database-safely) have been satisfied.

### Database

#### Any new migrations/schema changes:

- [ ] Follows our guidelines for [Zero-Downtime Deploys](https://transcom.github.io/mymove-docs/docs/dev/contributing/database/Database-Migrations#zero-downtime-migrations)
- [ ] Have been communicated to #g-database
- [ ] Secure migrations have been tested following the instructions in our [docs](https://transcom.github.io/mymove-docs/docs/dev/contributing/database/Database-Migrations#secure-migrations)

## Screenshots
