### PR TITLE
[ MB-12170 ] Changes to edit net weight component

### DIFF
--- a/src/components/Office/PPM/EditNetWeights/EditPPMNetWeight.test.jsx
+++ b/src/components/Office/PPM/EditNetWeights/EditPPMNetWeight.test.jsx
@@ -174,19 +174,23 @@ describe('EditNetPPMWeight', () => {
       await act(() => userEvent.click(screen.getByRole('button', { name: 'Edit' })));
       expect(await screen.getByRole('button', { name: 'Save changes' })).toBeDisabled();
     });
-    it('shows an error if there is incomplete fields in the form', async () => {
+    it('shows validation errors in the form', async () => {
       await render(
         <ReactQueryWrapper>
           <EditPPMNetWeight {...excessWeight} />
         </ReactQueryWrapper>,
       );
-      // Weight Input
+      // Weight Input is required
       await act(() => userEvent.click(screen.getByRole('button', { name: 'Edit' })));
       const textInput = await screen.findByTestId('weightInput');
       await act(() => userEvent.clear(textInput));
       expect(screen.getByText('Required'));
+
+      // Weight input cannot be greater than full weight
+      await act(() => userEvent.type(textInput, '10000'));
+      expect(screen.getByText('Net weight must be less than or equal to the full weight'));
       await act(() => userEvent.type(textInput, '1000'));
-      // Remarks
+      // Remarks Input is required
       const remarksField = await screen.findByTestId('formRemarks');
       await act(() => userEvent.clear(remarksField));
       await fireEvent.blur(remarksField);
@@ -195,7 +199,7 @@ describe('EditNetPPMWeight', () => {
     });
     it('saves changes when editing the form', async () => {
       const netWeightRemarks = 'Reduced by as much as I can';
-      const adjustedNetWeight = 2600;
+      const adjustedNetWeight = 0;
       render(
         <ReactQueryWrapper>
           <EditPPMNetWeight {...reduceWeight} />


### PR DESCRIPTION
Two small changes made when looking over the user story 
- Invalidating MTO Shipment query to recalculate the weights and warnings
- Adding a weight validation that mirrors one on the backend

## [Jira ticket](https://dp3.atlassian.net/browse/MB-12170) for this change

## Summary

[Here is a video of the two issues before these changes were made](https://dp3.atlassian.net/browse/MB-12170?focusedCommentId=26105).

## Setup to Run Your Code

<details>
<summary>💻 You will need to use three separate terminals to test this locally.</summary>

##### Terminal 1


Start the UI locally.

```sh
make client_run
```

##### Terminal 2

Start the Go server locally.

```sh
make server_run
```

</details>

### Additional steps

<!-- Fill out the next section as you see fit, these are just suggestions. -->

1. Access the office app
2. Login as a services counselor
3. Access a PPM closeout move with excess weight (Move code XSWT01 is a good one)
4. click the review documents button at the bottom of the ppm shipment card
5. click on the edit net weight button 
![image](https://user-images.githubusercontent.com/110134470/227326594-b54862ee-9c27-40df-9619-88e571faa998.png)
6. edit the  net weight to be greater or equal to the full weight
7. you should see an error message
![image](https://user-images.githubusercontent.com/110134470/227327279-76cee002-fd9a-4607-90ca-a16ce5312976.png)
8. Edit the net weight to make the move not overweight and click save
9. You should not see the warning on the net weight and the weights should have been refreshed in the calculations.
![image](https://user-images.githubusercontent.com/110134470/227328396-b20d5e33-3e1b-40a6-853e-9986cc1ed5e5.png)

