### PR TITLE
Fixing syntax issue in `yarn run prettier` command

### DIFF
--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
     "test:debug": "react-app-rewired --inspect-brk test --runInBand --env=jsdom",
     "test:coverage": "react-app-rewired test --coverage --reporters=default --reporters=jest-junit --env=jsdom --coverageDirectory=coverage --runInBand --watchAll=false",
     "test:e2e": "playwright test --trace=on",
-    "prettier": "prettier --write --loglevel warn 'src/**/*.{js,jsx}' playwright/tests/**/*.js'",
+    "prettier": "prettier --write --loglevel warn 'src/**/*.{js,jsx}' playwright/tests/**/*.js",
     "prettier-ci": "prettier --check 'src/**/*.{js,jsx}' playwright/tests/**/*.js",
     "lint": "eslint --ext .js,.jsx --max-warnings=0 src playwright/tests",
     "lint:production": "NODE_ENV=production yarn lint",


### PR DESCRIPTION
Fixing the `yarn run prettier` command so others can leverage this tool locally
outside of their editors.

## Testing this

Run `yarn prettier` locally and it should work. Try running it on `main` or not
this branch and see it failing.
