### PR TITLE
[ MB-12170 ] Edit PPM net weight query invalidation clarification

### DIFF
--- a/src/components/Office/PPM/EditNetWeights/EditPPMNetWeight.jsx
+++ b/src/components/Office/PPM/EditNetWeights/EditPPMNetWeight.jsx
@@ -11,10 +11,10 @@ import MaskedTextField from 'components/form/fields/MaskedTextField/MaskedTextFi
 import { ErrorMessage } from 'components/form/ErrorMessage';
 import { formatWeight } from 'utils/formatters';
 import { calculateWeightTicketWeightDifference, getWeightTicketNetWeight } from 'utils/shipmentWeights';
-import { useCalculatedWeightRequested } from 'hooks/custom';
+import { calculateWeightRequested } from 'hooks/custom';
 import { patchWeightTicket } from 'services/ghcApi';
 import { ShipmentShape, WeightTicketShape } from 'types/shipment';
-import { DOCUMENTS, MTO_SHIPMENTS } from 'constants/queryKeys';
+import { DOCUMENTS } from 'constants/queryKeys';
 
 // Labels & constants
 
@@ -106,9 +106,6 @@ const EditPPMNetWeightForm = ({ onCancel, initialValues, weightTicket }) => {
     onSuccess: () => {
       queryClient.invalidateQueries({
         queryKey: [DOCUMENTS],
-      });
-      queryClient.invalidateQueries({
-        queryKey: [MTO_SHIPMENTS],
       });
     },
   });
@@ -202,7 +199,7 @@ const EditPPMNetWeight = ({ weightTicket, weightAllowance, shipments }) => {
   // Original weight is the full weight - empty weight
   const originalWeight = calculateWeightTicketWeightDifference(weightTicket);
   // moveWeightTotal = Sum of all ppm weights + sum of all non-ppm shipments
-  const moveWeightTotal = useCalculatedWeightRequested(shipments);
+  const moveWeightTotal = calculateWeightRequested(shipments);
   const excessWeight = moveWeightTotal - weightAllowance;
   const hasExcessWeight = Boolean(excessWeight > 0);
   const netWeight = getWeightTicketNetWeight(weightTicket);
@@ -250,7 +247,6 @@ const EditPPMNetWeight = ({ weightTicket, weightAllowance, shipments }) => {
               initialValues={{
                 adjustedNetWeight: String(netWeight),
                 netWeightRemarks: weightTicket.netWeightRemarks,
-                fullWeight: weightTicket.fullWeight,
               }}
               weightTicket={weightTicket}
               onCancel={toggleEditForm}


### PR DESCRIPTION
## [Jira ticket](https://dp3.atlassian.net/browse/MB-12170) for this change

## Summary

Removed the reference to useMemo for the weight calculation allows for the weight calculation to get refreshed when only the Documents query gets invalidated. This way we don't have to invalidate the MTO shipments query.

I also removed the addition of the full weight to the initial values of the form since it is unnecessary for the validation check.

## Setup to Run Your Code

<details>
<summary>💻 You will need to use three separate terminals to test this locally.</summary>

##### Terminal 1

Start the UI locally.

```sh
make client_run
```

##### Terminal 2

Start the Go server locally.

```sh
make server_run
```

</details>

### Additional steps

<!-- Fill out the next section as you see fit, these are just suggestions. -->

1. Access the office app
2. Login as a services counselor
3. Access a PPM closeout move with excess weight (Move code XSWT01 is a good one)
4. click the review documents button at the bottom of the ppm shipment card
5. click on the edit net weight button 
![image](https://user-images.githubusercontent.com/110134470/227326594-b54862ee-9c27-40df-9619-88e571faa998.png)
6. edit the  net weight to be greater or equal to the full weight
7. you should see an error message
![image](https://user-images.githubusercontent.com/110134470/227327279-76cee002-fd9a-4607-90ca-a16ce5312976.png)
8. Edit the net weight to make the move not overweight and click save
9. You should not see the warning on the net weight and the weights should have been refreshed in the calculations.
![image](https://user-images.githubusercontent.com/110134470/227328396-b20d5e33-3e1b-40a6-853e-9986cc1ed5e5.png)

