### PR TITLE
Add closeout office to new playwright test

### DIFF
--- a/pkg/testdatagen/testharness/make_move.go
+++ b/pkg/testdatagen/testharness/make_move.go
@@ -2787,14 +2787,22 @@ func MakeDraftMoveWithPPMWithDepartureDate(appCtx appcontext.AppContext) models.
 
 func MakeApprovedMoveWithPPMShipmentAndExcessWeight(appCtx appcontext.AppContext) models.Move {
 	userUploader := newUserUploader(appCtx)
+
+	closeoutOffice := factory.BuildTransportationOffice(appCtx.DB(), []factory.Customization{
+		{
+			Model: models.TransportationOffice{Gbloc: "KKFA", ProvidesCloseout: true},
+		},
+	}, nil)
+
 	moveInfo := scenario.MoveCreatorInfo{
-		UserID:      uuid.Must(uuid.NewV4()),
-		Email:       "excessweightsPPM@ppm.approved",
-		SmID:        uuid.Must(uuid.NewV4()),
-		FirstName:   "One PPM",
-		LastName:    "ExcessWeights",
-		MoveID:      uuid.Must(uuid.NewV4()),
-		MoveLocator: models.GenerateLocator(),
+		UserID:           uuid.Must(uuid.NewV4()),
+		Email:            "excessweightsPPM@ppm.approved",
+		SmID:             uuid.Must(uuid.NewV4()),
+		FirstName:        "One PPM",
+		LastName:         "ExcessWeights",
+		MoveID:           uuid.Must(uuid.NewV4()),
+		MoveLocator:      models.GenerateLocator(),
+		CloseoutOfficeID: &closeoutOffice.ID,
 	}
 	approvedAt := time.Date(2022, 4, 15, 12, 30, 0, 0, time.UTC)
 	address := factory.BuildAddress(appCtx.DB(), nil, nil)


### PR DESCRIPTION

## Summary

Add closeout office to new playwright test

## Setup to Run Your Code

<details>
<summary>💻 You will need to use three separate terminals to test this locally.</summary>

##### Terminal 1

Start the Storybook locally.

```sh
make storybook
```

##### Terminal 2

Start the UI locally.

```sh
make client_run
```

##### Terminal 3

Start the Go server locally.

```sh
make server_run
```

</details>

### Additional steps

<!-- Fill out the next section as you see fit, these are just suggestions. -->

1. Access the
2. Login as a
3.

## Verification Steps for Author

These are to be checked by the author.

- [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
- [ ] Request review from a member of a different team.
- [ ] Have the Jira acceptance criteria been met for this change?

## Verification Steps for Reviewers

These are to be checked by a reviewer.

<!-- Fill out the next sections as you see fit, these are just suggestions. -->

### Frontend

- [ ] User facing changes have been reviewed by design.
- [ ] There are no aXe warnings for UI.
- [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/main/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
- [ ] There are no new console errors in the browser devtools
- [ ] There are no new console errors in the test output
- [ ] If this PR adds a new component to Storybook, it ensures the component is fully responsive, OR if it is intentionally not, a wrapping div using the `officeApp` class or custom `min-width` styling is used to hide any states the would not be visible to the user.

### Backend

- [ ] Code follows the guidelines for [Logging](https://transcom.github.io/mymove-docs/docs/dev/contributing/backend/Backend-Programming-Guide#logging)
- [ ] The requirements listed in [Querying the Database Safely](https://transcom.github.io/mymove-docs/docs/dev/contributing/backend/Backend-Programming-Guide/#querying-the-database-safely) have been satisfied.

### Database

#### Any new migrations/schema changes:

- [ ] Follows our guidelines for [Zero-Downtime Deploys](https://transcom.github.io/mymove-docs/docs/dev/contributing/database/Database-Migrations#zero-downtime-migrations)
- [ ] Have been communicated to #g-database
- [ ] Secure migrations have been tested following the instructions in our [docs](https://transcom.github.io/mymove-docs/docs/dev/contributing/database/Database-Migrations#secure-migrations)

## Screenshots
