### PR TITLE
MB-15611: add factory for OriginDutyLocationGBLOC and use in BuildOrders

### DIFF
--- a/pkg/factory/duty_location_factory.go
+++ b/pkg/factory/duty_location_factory.go
@@ -47,6 +47,10 @@ func BuildDutyLocation(db *pop.Connection, customs []Customization, traits []Tra
 	}
 	dlAddress := BuildAddress(db, tempAddressCustoms, []Trait{GetTraitAddress3})
 
+	if db != nil {
+		FindOrBuildPostalCodeToGBLOC(db, dlAddress.PostalCode, "KKFA")
+	}
+
 	// Find/create the transportationOffice Model
 	tempTOAddressCustoms := customs
 	dltoAddress := findValidCustomization(customs, Addresses.DutyLocationTOAddress)

--- a/pkg/factory/duty_location_factory.go
+++ b/pkg/factory/duty_location_factory.go
@@ -48,7 +48,7 @@ func BuildDutyLocation(db *pop.Connection, customs []Customization, traits []Tra
 	dlAddress := BuildAddress(db, tempAddressCustoms, []Trait{GetTraitAddress3})
 
 	if db != nil {
-		FindOrBuildPostalCodeToGBLOC(db, dlAddress.PostalCode, "KKFA")
+		FetchOrBuildPostalCodeToGBLOC(db, dlAddress.PostalCode, "KKFA")
 	}
 
 	// Find/create the transportationOffice Model

--- a/pkg/factory/duty_location_factory_test.go
+++ b/pkg/factory/duty_location_factory_test.go
@@ -51,6 +51,10 @@ func (suite *FactorySuite) TestBuildDutyLocation() {
 		suite.Equal(defaultOffice.Gbloc, dutyLocation.TransportationOffice.Gbloc)
 		suite.Equal(defaultOffice.Latitude, dutyLocation.TransportationOffice.Latitude)
 		suite.Equal(defaultOffice.Longitude, dutyLocation.TransportationOffice.Longitude)
+
+		gblocForPostalCode, err := models.FetchGBLOCForPostalCode(suite.DB(), dutyLocation.Address.PostalCode)
+		suite.NoError(err)
+		suite.Equal(gblocForPostalCode.GBLOC, defaultOffice.Gbloc)
 	})
 
 	suite.Run("Successful creation of customized DutyLocation", func() {

--- a/pkg/factory/order_factory.go
+++ b/pkg/factory/order_factory.go
@@ -1,7 +1,6 @@
 package factory
 
 import (
-	"log"
 	"time"
 
 	"github.com/gobuffalo/pop/v6"
@@ -199,7 +198,7 @@ func buildOrderWithBuildType(db *pop.Connection, customs []Customization, traits
 	}
 
 	if db != nil {
-		postalCodeToGBLOC := FindOrBuildPostalCodeToGBLOC(db, originDutyLocation.Address.PostalCode, "KKFA")
+		postalCodeToGBLOC := FetchOrBuildPostalCodeToGBLOC(db, originDutyLocation.Address.PostalCode, "KKFA")
 		originDutyLocationGbloc = &postalCodeToGBLOC.GBLOC
 	}
 
@@ -228,8 +227,6 @@ func buildOrderWithBuildType(db *pop.Connection, customs []Customization, traits
 		OriginDutyLocationGBLOC: originDutyLocationGbloc,
 	}
 
-	log.Printf("DREW DEBUG orders.odlgbloc %#v", order.OriginDutyLocationGBLOC)
-
 	if amendedOrdersDocument != nil {
 		order.UploadedAmendedOrders = amendedOrdersDocument
 		order.UploadedAmendedOrdersID = &amendedOrdersDocument.ID
@@ -238,14 +235,10 @@ func buildOrderWithBuildType(db *pop.Connection, customs []Customization, traits
 	// Overwrite values with those from assertions
 	testdatagen.MergeModels(&order, cOrder)
 
-	log.Printf("DREW DEBUG orders.odlgbloc 2 %#v", order.OriginDutyLocationGBLOC)
-
 	// If db is false, it's a stub. No need to create in database
 	if db != nil {
 		mustCreate(db, &order)
 	}
-
-	log.Printf("DREW DEBUG orders.odlgbloc 3 %#v", order.OriginDutyLocationGBLOC)
 
 	return order
 }

--- a/pkg/factory/order_factory_test.go
+++ b/pkg/factory/order_factory_test.go
@@ -22,6 +22,7 @@ func (suite *FactorySuite) TestBuildOrder() {
 	testYear := 2018
 	defaultIssueDate := time.Date(testYear, time.March, 15, 0, 0, 0, 0, time.UTC)
 	defaultReportByDate := time.Date(testYear, time.August, 1, 0, 0, 0, 0, time.UTC)
+	defaultGBLOC := "KKFA"
 
 	suite.Run("Successful creation of default order", func() {
 		// Under test:      BuildOrder
@@ -46,6 +47,7 @@ func (suite *FactorySuite) TestBuildOrder() {
 		suite.Equal(defaultStatus, order.Status)
 		suite.Equal(defaultIssueDate, order.IssueDate)
 		suite.Equal(defaultReportByDate, order.ReportByDate)
+		suite.Equal(defaultGBLOC, *order.OriginDutyLocationGBLOC)
 
 		// extended service members have backup contacts
 		suite.False(order.ServiceMemberID.IsNil())

--- a/pkg/factory/postal_code_to_gbloc_factory.go
+++ b/pkg/factory/postal_code_to_gbloc_factory.go
@@ -41,7 +41,7 @@ func BuildPostalCodeToGBLOC(db *pop.Connection, customs []Customization, traits 
 	return postalCodeToGBLOC
 }
 
-func FindOrBuildPostalCodeToGBLOC(db *pop.Connection, postalCode string, gbloc string) models.PostalCodeToGBLOC {
+func FetchOrBuildPostalCodeToGBLOC(db *pop.Connection, postalCode string, gbloc string) models.PostalCodeToGBLOC {
 	gblocForPostalCode, err := models.FetchGBLOCForPostalCode(db, postalCode)
 	if err != nil && err != models.ErrFetchNotFound {
 		log.Panicf("Cannot fetch gbloc for postal code %s: %s", postalCode, err)

--- a/pkg/factory/postal_code_to_gbloc_factory.go
+++ b/pkg/factory/postal_code_to_gbloc_factory.go
@@ -1,0 +1,60 @@
+package factory
+
+import (
+	"log"
+
+	"github.com/gobuffalo/pop/v6"
+
+	"github.com/transcom/mymove/pkg/models"
+	"github.com/transcom/mymove/pkg/testdatagen"
+)
+
+// BuildPostalCodeToGBLOC creates a single PostalCodeToGBLOC entry.
+// Params:
+// - customs is a slice that will be modified by the factory
+// - db can be set to nil to create a stubbed model that is not stored in DB.
+func BuildPostalCodeToGBLOC(db *pop.Connection, customs []Customization, traits []Trait) models.PostalCodeToGBLOC {
+	customs = setupCustomizations(customs, traits)
+
+	// Find PostalCodeToGBLOC assertion and convert to models.PostalCodeToGBLOC
+	var cPostalCodeToGBLOC models.PostalCodeToGBLOC
+	if result := findValidCustomization(customs, PostalCodeToGBLOC); result != nil {
+		cPostalCodeToGBLOC = result.Model.(models.PostalCodeToGBLOC)
+		if result.LinkOnly {
+			return cPostalCodeToGBLOC
+		}
+	}
+
+	// Create PostalCodeToGBLOC
+	postalCodeToGBLOC := models.PostalCodeToGBLOC{
+		PostalCode: "90210",
+		GBLOC:      "KKFA",
+	}
+
+	// Overwrite values with those from customizations
+	testdatagen.MergeModels(&postalCodeToGBLOC, cPostalCodeToGBLOC)
+
+	// If db is false, it's a stub. No need to create in database
+	if db != nil {
+		mustCreate(db, &postalCodeToGBLOC)
+	}
+	return postalCodeToGBLOC
+}
+
+func FindOrBuildPostalCodeToGBLOC(db *pop.Connection, postalCode string, gbloc string) models.PostalCodeToGBLOC {
+	gblocForPostalCode, err := models.FetchGBLOCForPostalCode(db, postalCode)
+	if err != nil && err != models.ErrFetchNotFound {
+		log.Panicf("Cannot fetch gbloc for postal code %s: %s", postalCode, err)
+	}
+	if gblocForPostalCode.GBLOC == "" || err != nil {
+		gblocForPostalCode = BuildPostalCodeToGBLOC(db, []Customization{
+			{
+				Model: models.PostalCodeToGBLOC{
+					PostalCode: postalCode,
+					GBLOC:      gbloc,
+				},
+			},
+		}, nil)
+	}
+	return gblocForPostalCode
+}

--- a/pkg/factory/postal_code_to_gbloc_factory_test.go
+++ b/pkg/factory/postal_code_to_gbloc_factory_test.go
@@ -1,0 +1,52 @@
+package factory
+
+import (
+	"github.com/transcom/mymove/pkg/models"
+)
+
+func (suite *FactorySuite) TestBuildPostalCodeToGBLOC() {
+	suite.Run("Successful creation of default BuildPostalCodeToGBLOC", func() {
+		// Under test:      BuildPostalCodeToGBLOC
+		// Mocked:          None
+		// Set up:          Create a BuildPostalCodeToGBLOC with no customizations or traits
+		// Expected outcome:BuildPostalCodeToGBLOC should be created with default values
+
+		defaultPostalCode := "90210"
+		defaultGBLOC := "KKFA"
+		// CALL FUNCTION UNDER TEST
+		postalCodeToGBLOC := BuildPostalCodeToGBLOC(suite.DB(), nil, nil)
+
+		// VALIDATE RESULTS
+		suite.False(postalCodeToGBLOC.ID.IsNil())
+		suite.Equal(defaultPostalCode, postalCodeToGBLOC.PostalCode)
+		suite.Equal(defaultGBLOC, postalCodeToGBLOC.GBLOC)
+	})
+
+	suite.Run("Successful return of stubbed PostalCodeToGBLOC", func() {
+		// Under test:       BuildPostalCodeToGBLOC
+		// Set up:           Create a PostalCodeToGBLOC with nil DB
+		// Expected outcome: No new PostalCodeToGBLOC should be created.
+
+		// Check num PostalCodeToGBLOC records
+		precount, err := suite.DB().Count(&models.PostalCodeToGBLOC{})
+		suite.NoError(err)
+
+		defaultSettings := models.PostalCodeToGBLOC{
+			PostalCode: "11111",
+			GBLOC:      "ABCD",
+		}
+		// Nil passed in as db
+		postalCodeToGBLOC := BuildPostalCodeToGBLOC(nil, []Customization{
+			{
+				Model: defaultSettings,
+			},
+		}, nil)
+		suite.True(postalCodeToGBLOC.ID.IsNil())
+		suite.Equal(defaultSettings.PostalCode, postalCodeToGBLOC.PostalCode)
+		suite.Equal(defaultSettings.GBLOC, postalCodeToGBLOC.GBLOC)
+
+		count, err := suite.DB().Count(&models.PostalCodeToGBLOC{})
+		suite.Equal(precount, count)
+		suite.NoError(err)
+	})
+}

--- a/pkg/factory/shared.go
+++ b/pkg/factory/shared.go
@@ -45,6 +45,7 @@ var OfficePhoneLine CustomType = "OfficePhoneLine"
 var OfficeUser CustomType = "OfficeUser"
 var Order CustomType = "Order"
 var Organization CustomType = "Organization"
+var PostalCodeToGBLOC CustomType = "PostalCodeToGBLOC"
 var ReService CustomType = "ReService"
 var ServiceItemParamKey CustomType = "ServiceItemParamKey"
 var ServiceMember CustomType = "ServiceMember"
@@ -70,6 +71,7 @@ var defaultTypesMap = map[string]CustomType{
 	"models.OfficeUser":           OfficeUser,
 	"models.Order":                Order,
 	"models.Organization":         Organization,
+	"models.PostalCodeToGBLOC":    PostalCodeToGBLOC,
 	"models.ReService":            ReService,
 	"models.ServiceItemParamKey":  ServiceItemParamKey,
 	"models.ServiceMember":        ServiceMember,

--- a/pkg/handlers/ghcapi/queues_test.go
+++ b/pkg/handlers/ghcapi/queues_test.go
@@ -246,7 +246,7 @@ func (suite *HandlerSuite) TestGetMoveQueuesHandlerStatuses() {
 			RejectionReason: &rejectionReason,
 		},
 	})
-	testdatagen.MakePostalCodeToGBLOC(suite.DB(), "06001", "AGFM")
+	factory.FetchOrBuildPostalCodeToGBLOC(suite.DB(), "06001", "AGFM")
 
 	// Create an order with an origin duty location outside of office user GBLOC
 	testdatagen.MakeMTOShipment(suite.DB(), testdatagen.Assertions{
@@ -1199,7 +1199,7 @@ func (suite *HandlerSuite) makeServicesCounselingSubtestData() (subtestData *ser
 	}, nil)
 
 	// Create a custom postal code to GBLOC
-	testdatagen.MakePostalCodeToGBLOC(suite.DB(), dutyLocationAddress.PostalCode, "UUUU")
+	factory.FetchOrBuildPostalCodeToGBLOC(suite.DB(), dutyLocationAddress.PostalCode, "UUUU")
 	originDutyLocation := factory.BuildDutyLocation(suite.DB(), []factory.Customization{
 		{
 			Model: models.DutyLocation{

--- a/pkg/handlers/internalapi/orders_test.go
+++ b/pkg/handlers/internalapi/orders_test.go
@@ -22,7 +22,7 @@ import (
 func (suite *HandlerSuite) TestCreateOrder() {
 	sm := factory.BuildExtendedServiceMember(suite.DB(), nil, nil)
 	dutyLocation := factory.FetchOrBuildCurrentDutyLocation(suite.DB())
-	testdatagen.MakePostalCodeToGBLOC(suite.DB(), dutyLocation.Address.PostalCode, "KKFA")
+	factory.FetchOrBuildPostalCodeToGBLOC(suite.DB(), dutyLocation.Address.PostalCode, "KKFA")
 	factory.FetchOrBuildDefaultContractor(suite.DB(), nil, nil)
 
 	req := httptest.NewRequest("POST", "/orders", nil)

--- a/pkg/handlers/internalapi/service_members_test.go
+++ b/pkg/handlers/internalapi/service_members_test.go
@@ -227,7 +227,7 @@ func (suite *HandlerSuite) TestPatchServiceMemberHandler() {
 	}, nil)
 
 	// Create a custom postal code to GBLOC
-	newGBLOC := testdatagen.MakePostalCodeToGBLOC(suite.DB(), newDutyLocationAddress.PostalCode, "UUUU")
+	newGBLOC := factory.FetchOrBuildPostalCodeToGBLOC(suite.DB(), newDutyLocationAddress.PostalCode, "UUUU")
 	newDutyLocation := factory.BuildDutyLocation(suite.DB(), []factory.Customization{
 		{
 			Model: models.DutyLocation{

--- a/pkg/models/postal_code_to_gbloc_test.go
+++ b/pkg/models/postal_code_to_gbloc_test.go
@@ -1,13 +1,13 @@
 package models_test
 
 import (
+	"github.com/transcom/mymove/pkg/factory"
 	"github.com/transcom/mymove/pkg/models"
-	"github.com/transcom/mymove/pkg/testdatagen"
 )
 
 func (suite *ModelSuite) Test_FetchGBLOCForPostalCode() {
 	t := suite.T()
-	postalCodeToGBLOC := testdatagen.MakePostalCodeToGBLOC(suite.DB(), "77777", "UUUU")
+	postalCodeToGBLOC := factory.FetchOrBuildPostalCodeToGBLOC(suite.DB(), "77777", "UUUU")
 
 	gbloc, err := models.FetchGBLOCForPostalCode(suite.DB(), postalCodeToGBLOC.PostalCode)
 	if err != nil {

--- a/pkg/services/order/order_fetcher_test.go
+++ b/pkg/services/order/order_fetcher_test.go
@@ -77,7 +77,7 @@ func (suite *OrderServiceSuite) TestListOrders() {
 		move := testdatagen.MakeHHGMoveWithShipment(suite.DB(), testdatagen.Assertions{})
 
 		// Make a postal code and GBLOC → AGFM
-		testdatagen.MakePostalCodeToGBLOC(suite.DB(), agfmPostalCode, "AGFM")
+		factory.FetchOrBuildPostalCodeToGBLOC(suite.DB(), agfmPostalCode, "AGFM")
 
 		return officeUser, move
 	}
@@ -1043,10 +1043,10 @@ func (suite *OrderServiceSuite) TestListOrdersNeedingServicesCounselingWithPPMCl
 	setupTestData := func() models.OfficeUser {
 		// Make an office user → GBLOC X
 		officeUser := factory.BuildOfficeUserWithRoles(suite.DB(), nil, []roles.RoleType{roles.RoleTypeTOO})
-		testdatagen.MakePostalCodeToGBLOC(suite.DB(), "50309", officeUser.TransportationOffice.Gbloc)
+		factory.FetchOrBuildPostalCodeToGBLOC(suite.DB(), "50309", officeUser.TransportationOffice.Gbloc)
 
 		// Ensure there's an entry connecting the default shipment pickup postal code with the office user's gbloc
-		testdatagen.MakePostalCodeToGBLOC(suite.DB(),
+		factory.FetchOrBuildPostalCodeToGBLOC(suite.DB(),
 			defaultShipmentPickupPostalCode,
 			officeUser.TransportationOffice.Gbloc)
 
@@ -1317,7 +1317,7 @@ func (suite *OrderServiceSuite) TestListOrdersNeedingServicesCounselingWithGBLOC
 			},
 		}, nil)
 
-		testdatagen.MakePostalCodeToGBLOC(suite.DB(), dutyLocationAddress2.PostalCode, "ZANY")
+		factory.FetchOrBuildPostalCodeToGBLOC(suite.DB(), dutyLocationAddress2.PostalCode, "ZANY")
 		originDutyLocation2 := factory.BuildDutyLocation(suite.DB(), []factory.Customization{
 			{
 				Model: models.DutyLocation{
@@ -1389,7 +1389,7 @@ func (suite *OrderServiceSuite) TestListOrdersForTOOWithPPM() {
 	// Make a TOO user.
 	tooOfficeUser := factory.BuildOfficeUserWithRoles(suite.DB(), nil, []roles.RoleType{roles.RoleTypeTOO})
 	// GBLOC for the below doesn't really matter, it just means the query for the moves passes the inner join in ListOrders
-	testdatagen.MakePostalCodeToGBLOC(suite.DB(), ppmShipment.PickupPostalCode, tooOfficeUser.TransportationOffice.Gbloc)
+	factory.FetchOrBuildPostalCodeToGBLOC(suite.DB(), ppmShipment.PickupPostalCode, tooOfficeUser.TransportationOffice.Gbloc)
 
 	orderFetcher := NewOrderFetcher()
 	moves, moveCount, err := orderFetcher.ListOrders(suite.AppContextForTest(), tooOfficeUser.ID, &services.ListOrderParams{})

--- a/pkg/services/order/order_updater_test.go
+++ b/pkg/services/order/order_updater_test.go
@@ -103,7 +103,7 @@ func (suite *OrderServiceSuite) TestUpdateOrderAsTOO() {
 				},
 			},
 		}, nil)
-		updatedGbloc := testdatagen.MakePostalCodeToGBLOC(suite.DB(), updatedOriginDutyLocation.Address.PostalCode, "UUUU")
+		updatedGbloc := factory.FetchOrBuildPostalCodeToGBLOC(suite.DB(), updatedOriginDutyLocation.Address.PostalCode, "UUUU")
 		ordersType := ghcmessages.OrdersTypeSEPARATION
 		deptIndicator := ghcmessages.DeptIndicatorCOASTGUARD
 		ordersTypeDetail := ghcmessages.OrdersTypeDetail("INSTRUCTION_20_WEEKS")


### PR DESCRIPTION
## [Jira ticket](https://dp3.atlassian.net/browse/MB-15611) for this change

## Summary

Orders now have `OriginDutyLocationGBLOC`, set it and add factory

## Setup to Run Your Code

<details>
<summary>💻 You will need to use one terminalsto test this locally.</summary>

##### Terminal 1

Run the factory tests
```sh
go test -count 1 ./pkg/factory/...
```

</details>

