### PR TITLE
[MB-14962] gbloc output for prime

### DIFF
--- a/pkg/gen/primeapi/embedded_spec.go
+++ b/pkg/gen/primeapi/embedded_spec.go
@@ -2711,6 +2711,10 @@ func init() {
         "originDutyLocation": {
           "$ref": "#/definitions/DutyLocation"
         },
+        "originDutyLocationGBLOC": {
+          "type": "string",
+          "example": "KKFA"
+        },
         "rank": {
           "type": "string",
           "example": "E_5"
@@ -7098,6 +7102,10 @@ func init() {
         },
         "originDutyLocation": {
           "$ref": "#/definitions/DutyLocation"
+        },
+        "originDutyLocationGBLOC": {
+          "type": "string",
+          "example": "KKFA"
         },
         "rank": {
           "type": "string",

--- a/pkg/gen/primemessages/order.go
+++ b/pkg/gen/primemessages/order.go
@@ -56,6 +56,10 @@ type Order struct {
 	// origin duty location
 	OriginDutyLocation *DutyLocation `json:"originDutyLocation,omitempty"`
 
+	// origin duty location g b l o c
+	// Example: KKFA
+	OriginDutyLocationGBLOC string `json:"originDutyLocationGBLOC,omitempty"`
+
 	// rank
 	// Example: E_5
 	// Required: true

--- a/pkg/handlers/primeapi/payloads/model_to_payload.go
+++ b/pkg/handlers/primeapi/payloads/model_to_payload.go
@@ -140,6 +140,7 @@ func Order(order *models.Order) *primemessages.Order {
 		Entitlement:             Entitlement(order.Entitlement),
 		ID:                      strfmt.UUID(order.ID.String()),
 		OriginDutyLocation:      originDutyLocation,
+		OriginDutyLocationGBLOC: swag.StringValue(order.OriginDutyLocationGBLOC),
 		OrderNumber:             order.OrdersNumber,
 		LinesOfAccounting:       order.TAC,
 		Rank:                    order.Grade,

--- a/pkg/handlers/primeapi/payloads/model_to_payload.go
+++ b/pkg/handlers/primeapi/payloads/model_to_payload.go
@@ -149,6 +149,10 @@ func Order(order *models.Order) *primemessages.Order {
 		OrdersType:              primemessages.OrdersType(order.OrdersType),
 	}
 
+	if payload.Customer.Branch == "Marines" {
+		payload.OriginDutyLocationGBLOC = "USMC"
+	}
+
 	return &payload
 }
 

--- a/pkg/handlers/primeapi/payloads/model_to_payload_test.go
+++ b/pkg/handlers/primeapi/payloads/model_to_payload_test.go
@@ -26,6 +26,7 @@ func (suite *PayloadsSuite) TestMoveTaskOrder() {
 	excessWeightAcknowledgedAt := time.Now()
 	excessWeightUploadID := uuid.Must(uuid.NewV4())
 	ordersType := primemessages.OrdersTypeRETIREMENT
+	originDutyGBLOC := "KKFA"
 
 	basicMove := models.Move{
 		ID:                         moveTaskOrderID,
@@ -33,7 +34,7 @@ func (suite *PayloadsSuite) TestMoveTaskOrder() {
 		CreatedAt:                  time.Now(),
 		AvailableToPrimeAt:         &primeTime,
 		OrdersID:                   ordersID,
-		Orders:                     models.Order{OrdersType: internalmessages.OrdersType(ordersType)},
+		Orders:                     models.Order{OrdersType: internalmessages.OrdersType(ordersType), OriginDutyLocationGBLOC: &originDutyGBLOC},
 		ReferenceID:                &referenceID,
 		PaymentRequests:            models.PaymentRequests{},
 		SubmittedAt:                &submittedAt,
@@ -59,6 +60,7 @@ func (suite *PayloadsSuite) TestMoveTaskOrder() {
 		suite.Equal(handlers.FmtDateTimePtr(basicMove.AvailableToPrimeAt), returnedModel.AvailableToPrimeAt)
 		suite.Equal(strfmt.UUID(basicMove.OrdersID.String()), returnedModel.OrderID)
 		suite.Equal(ordersType, returnedModel.Order.OrdersType)
+		suite.Equal(originDutyGBLOC, returnedModel.Order.OriginDutyLocationGBLOC)
 		suite.Equal(referenceID, returnedModel.ReferenceID)
 		suite.Equal(strfmt.DateTime(basicMove.UpdatedAt), returnedModel.UpdatedAt)
 		suite.NotEmpty(returnedModel.ETag)

--- a/swagger-def/prime.yaml
+++ b/swagger-def/prime.yaml
@@ -2075,6 +2075,9 @@ definitions:
         $ref: '#/definitions/DutyLocation'
       originDutyLocation:
         $ref: '#/definitions/DutyLocation'
+      originDutyLocationGBLOC:
+        type: string
+        example: 'KKFA'
       rank:
         type: string
         example: 'E_5'

--- a/swagger/prime.yaml
+++ b/swagger/prime.yaml
@@ -2359,6 +2359,9 @@ definitions:
         $ref: '#/definitions/DutyLocation'
       originDutyLocation:
         $ref: '#/definitions/DutyLocation'
+      originDutyLocationGBLOC:
+        type: string
+        example: KKFA
       rank:
         type: string
         example: E_5


### PR DESCRIPTION
## [Jira ticket](https://dp3.atlassian.net/browse/MB-14962) for this change

## Summary

Adding the GBLOC to the Orders response payload in the Prime API 

## Setup to Run Your Code

<details>
<summary>💻 You will need to use two separate terminals to test this locally.</summary>

##### Terminal 1

Start the UI locally.

```sh
make client_run
```

##### Terminal 3

Start the Go server locally.

```sh
make server_run
```

</details>

### Additional steps

<!-- Fill out the next section as you see fit, these are just suggestions. -->

1. Access the office app
2. Login as a prime user
3. Select a move and open the network tab of the developer console
4. Verify that the response object includes `OriginDutyLocationGBLOC` with the correct GBLOC

## Verification Steps for Author

These are to be checked by the author.

- [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
- [ ] Request review from a member of a different team.
- [ ] Have the Jira acceptance criteria been met for this change?

## Verification Steps for Reviewers

These are to be checked by a reviewer.

<!-- Fill out the next sections as you see fit, these are just suggestions. -->

## Screenshots
<img width="382" alt="Screenshot 2023-03-31 at 1 03 02 PM" src="https://user-images.githubusercontent.com/110431091/229207530-b77df311-cf0f-4f56-beb5-c4222734c914.png">
