### PR TITLE
Start date and label changes

### DIFF
--- a/src/components/Office/ShipmentSITDisplay/ShipmentSITDisplay.module.scss
+++ b/src/components/Office/ShipmentSITDisplay/ShipmentSITDisplay.module.scss
@@ -10,7 +10,6 @@
   @include u-border('1px');
   @include u-radius('05');
   background-color: $bg-gray;
-
   .title {
     display: flex;
     justify-content: space-between;
@@ -18,11 +17,12 @@
 
     p {
       @include u-margin-y(0);
-      @include u-font-size('body', '3xs');
+      @include u-font-size('body', 'sm');
 
       :global .usa-tag {
-        @include u-font-size('body', '3xs');
+        @include u-font-size('body', 'sm');
       }
+      font-weight: bold;
     }
 
     button {
@@ -81,5 +81,11 @@
     dd {
       margin-left: 5px;
     }
+  }
+}
+.sitHistoryHeader {
+  color: $base-darker;
+  span {
+    font-weight: 400;
   }
 }


### PR DESCRIPTION


## [Jira ticket](https://dp3.atlassian.net/browse/MB-14977) for this change

## Summary
As a TOO, I want the language on the SIT Dashboard and Edit modules to remove references to an increase or decrease of SIT dates

- [ ] Updates the SIT Display component
- [ ] Updates Test
- [ ] Updates Storybook

| Old copy | New copy | Before | After|
| --| --|----|----|
|  Total days of SIT  |  Total days of SIT approved  |     |       |
|  used  |  Total days used  |     |       |
|  Current location:   | Current location: ___ SIT  |     |       |
|  Date entered SIT  |  SIT start date  |     |       |
|  Ends  |   SIT authorized end date  |     |       |
|  SIT extensions  |  SIT history |     |       |
|  _ days added  |  Total days of SIT approved  |     |       |
|  on `DD MMM YYYY`  |  updated on `DD MMM YYYY` |     |       |

| Before | After|
|----|----|
|<img width="623" alt="Screenshot 2023-03-29 at 6 42 31 PM" src="https://user-images.githubusercontent.com/28371460/229244335-a800ce3e-9f52-4e5e-a34f-2264777196b3.png"> |        |

## Setup to Run Your Code

<details>
<summary>💻 You will need to use three separate terminals to test this locally.</summary>

##### Terminal 1

Start the Storybook locally.

```sh
make storybook
```

##### Terminal 2

Start the UI locally.

```sh
make client_run
```

##### Terminal 3

Start the Go server locally.

```sh
make server_run
```

</details>

### Additional steps

<!-- Fill out the next section as you see fit, these are just suggestions. -->

1. Access the Office app
2. Login as a TOO
3. Navigate to `3000/moves/SITEXT/mto`
   - [ ] Label changes above are seen

## Screenshots
