### PR TITLE
[MB-15220] Add a11y checks to all waitForPage nav functions on the customer side.

### DIFF
--- a/playwright/tests/utils/baseTest.js
+++ b/playwright/tests/utils/baseTest.js
@@ -119,14 +119,15 @@ export class BaseTestPage {
       .filter((name) => name !== 'constructor')
       .forEach((name) => {
         // eslint-disable-next-line security/detect-object-injection
-        if (typeof WaitForPage.prototype[name] === 'function') {
-          // eslint-disable-next-line security/detect-object-injection
-          WaitForPage.prototype[name] = async (...args) => {
+        const value = WaitForPage.prototype[name];
+        if (typeof value === 'function') {
+          const wrappedMethod = async (args) => {
             await this.runAccessibilityAudit();
-            // eslint-disable-next-line security/detect-object-injection
-            await WaitForPage.prototype[name](...args);
+            await value.apply(this, args);
             await this.runAccessibilityAudit();
           };
+          Reflect.deleteProperty(WaitForPage.prototype, name);
+          Reflect.defineProperty(WaitForPage.prototype, name, { value: wrappedMethod });
         }
       });
   }

--- a/playwright/tests/utils/baseTest.js
+++ b/playwright/tests/utils/baseTest.js
@@ -121,10 +121,10 @@ export class BaseTestPage {
         // eslint-disable-next-line security/detect-object-injection
         if (typeof WaitForPage.prototype[name] === 'function') {
           // eslint-disable-next-line security/detect-object-injection
-          WaitForPage.prototype[name] = async () => {
+          WaitForPage.prototype[name] = async (...args) => {
             await this.runAccessibilityAudit();
             // eslint-disable-next-line security/detect-object-injection
-            await WaitForPage.prototype[name]();
+            await WaitForPage.prototype[name](...args);
             await this.runAccessibilityAudit();
           };
         }

--- a/playwright/tests/utils/customerTest.js
+++ b/playwright/tests/utils/customerTest.js
@@ -26,6 +26,7 @@ export class CustomerPage extends BaseTestPage {
    */
   constructor(page, request) {
     super(page, request);
+    this.injectAccessibilityTestsInWaitForPage();
     this.waitForPage = new WaitForPage(page);
   }
 


### PR DESCRIPTION
## [Jira ticket](https://dp3.atlassian.net/jira/software/c/projects/MB/boards/26?modal=detail&selectedIssue=MB-15220) for this change

## Summary

This PR injects the Playwright Axe tests on both sides of any function call in the `WaitForPage` class, behind the `A11Y_AUDIT` feature flag. Assuming this class is used broadly in e2e tests, this provides very broad coverage both before and after navigations on the customer side.

This also assumes that `WaitForPage`s will not have functions that do not expect something of the page; however, even if they do, they will only provide no or redundant issues, and they will not error, since `runAccessibilityAudit()`'s only dependency is `this.page`, which will always be present.

This PR is also opinionated about the use of `WaitForPage`; it _should_ be used as broadly as possible.

## Setup to Run Your Code

<details>
<summary>💻 You will need to use three separate terminals to test this locally.</summary>

##### Terminal 1

Start the UI locally.

```sh
make client_run
```

##### Terminal 2


Start the Go server locally.

```sh
make server_run
```

</details>

### Additional steps

`A11Y_AUDIT=true yarn playwright test playwright/tests/my/mymove`

## Verification Steps for Author

These are to be checked by the author.

- [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
- [ ] Request review from a member of a different team.
- [ ] Have the Jira acceptance criteria been met for this change?

## Verification Steps for Reviewers

These are to be checked by a reviewer.

<!-- Fill out the next sections as you see fit, these are just suggestions. -->

### Frontend

- [ ] User facing changes have been reviewed by design.
- [ ] There are no aXe warnings for UI.
- [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/main/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
- [ ] There are no new console errors in the browser devtools
- [ ] There are no new console errors in the test output
- [ ] If this PR adds a new component to Storybook, it ensures the component is fully responsive, OR if it is intentionally not, a wrapping div using the `officeApp` class or custom `min-width` styling is used to hide any states the would not be visible to the user.

### Backend

- [ ] Code follows the guidelines for [Logging](https://transcom.github.io/mymove-docs/docs/dev/contributing/backend/Backend-Programming-Guide#logging)
- [ ] The requirements listed in [Querying the Database Safely](https://transcom.github.io/mymove-docs/docs/dev/contributing/backend/Backend-Programming-Guide/#querying-the-database-safely) have been satisfied.

### Database

#### Any new migrations/schema changes:

- [ ] Follows our guidelines for [Zero-Downtime Deploys](https://transcom.github.io/mymove-docs/docs/dev/contributing/database/Database-Migrations#zero-downtime-migrations)
- [ ] Have been communicated to #g-database
- [ ] Secure migrations have been tested following the instructions in our [docs](https://transcom.github.io/mymove-docs/docs/dev/contributing/database/Database-Migrations#secure-migrations)

## Screenshots
