### PR TITLE
Correct GBLOC returned in payment requests for moves associated with the USMC branch

### DIFF
--- a/pkg/services/invoice/ghc_payment_request_invoice_generator.go
+++ b/pkg/services/invoice/ghc_payment_request_invoice_generator.go
@@ -95,6 +95,14 @@ func (g ghcPaymentRequestInvoiceGenerator) Generate(appCtx appcontext.AppContext
 		}
 	}
 
+	// check service member branch
+	if *moveTaskOrder.Orders.ServiceMember.DutyLocation.Affiliation != "" {
+		err := g.checkMarinesBranch(moveTaskOrder.Orders.ServiceMember)
+		if err != "" {
+			return ediinvoice.Invoice858C{}, nil
+		}
+	}
+
 	currentTime := g.clock.Now()
 
 	interchangeControlNumber, err := g.icnSequencer.NextVal(appCtx)
@@ -852,14 +860,14 @@ func (g ghcPaymentRequestInvoiceGenerator) generatePaymentServiceItemSegments(ap
 	return segments, l3, nil
 }
 
-//func (g ghcPaymentRequestInvoiceGenerator) checkMarinesBranch(serviceMember models.ServiceMember) string {
-//	if *serviceMember.Affiliation == models.AffiliationMARINES {
-//		return "USMC"
-//	}
-//	// May need to be more explicit here about the origin duty location:
-//	//models.FetchDutyLocationTransportationOffice(appCtx.DB(), originDutyLocation.ID)
-//	return serviceMember.DutyLocation.TransportationOffice.Gbloc
-//}
+func (g ghcPaymentRequestInvoiceGenerator) checkMarinesBranch(serviceMember models.ServiceMember) string {
+	if *serviceMember.Affiliation == models.AffiliationMARINES {
+		return "USMC"
+	}
+	// May need to be more explicit here about the origin duty location:
+	//models.FetchDutyLocationTransportationOffice(appCtx.DB(), originDutyLocation.ID)
+	return serviceMember.DutyLocation.TransportationOffice.Gbloc
+}
 
 func msOrCsOnly(paymentServiceItems models.PaymentServiceItems) bool {
 	for _, psi := range paymentServiceItems {

--- a/pkg/services/invoice/ghc_payment_request_invoice_generator.go
+++ b/pkg/services/invoice/ghc_payment_request_invoice_generator.go
@@ -378,7 +378,7 @@ func (g ghcPaymentRequestInvoiceGenerator) createBuyerAndSellerOrganizationNames
 
 	var err error
 	var originDutyLocation models.DutyLocation
-
+	// check if they are Marines here, and add condition to set Gbloc to USMC
 	if orders.OriginDutyLocationID != nil && *orders.OriginDutyLocationID != uuid.Nil {
 		originDutyLocation, err = models.FetchDutyLocation(appCtx.DB(), *orders.OriginDutyLocationID)
 		if err != nil {
@@ -851,6 +851,15 @@ func (g ghcPaymentRequestInvoiceGenerator) generatePaymentServiceItemSegments(ap
 
 	return segments, l3, nil
 }
+
+//func (g ghcPaymentRequestInvoiceGenerator) checkMarinesBranch(serviceMember models.ServiceMember) string {
+//	if *serviceMember.Affiliation == models.AffiliationMARINES {
+//		return "USMC"
+//	}
+//	// May need to be more explicit here about the origin duty location:
+//	//models.FetchDutyLocationTransportationOffice(appCtx.DB(), originDutyLocation.ID)
+//	return serviceMember.DutyLocation.TransportationOffice.Gbloc
+//}
 
 func msOrCsOnly(paymentServiceItems models.PaymentServiceItems) bool {
 	for _, psi := range paymentServiceItems {

--- a/pkg/services/order/order_fetcher.go
+++ b/pkg/services/order/order_fetcher.go
@@ -25,6 +25,7 @@ type QueryOption func(*pop.Query)
 
 func (f orderFetcher) ListOrders(appCtx appcontext.AppContext, officeUserID uuid.UUID, params *services.ListOrderParams) ([]models.Move, int, error) {
 	var moves []models.Move
+	var serviceMemberAffiliation models.ServiceMemberAffiliation
 	var transportationOffice models.TransportationOffice
 	// select the GBLOC associated with the transportation office of the session's current office user
 	err := appCtx.DB().Q().
@@ -64,9 +65,13 @@ func (f orderFetcher) ListOrders(appCtx appcontext.AppContext, officeUserID uuid
 	// If the user is associated with the USMC GBLOC we want to show them ALL the USMC moves, so let's override here.
 	// We also only want to do the gbloc filtering thing if we aren't a USMC user, which we cover with the else.
 	// var gblocQuery QueryOption
+	marinesBranch := serviceMemberAffiliation == "MARINES"
 	var gblocToFilterBy *string
 	if officeUserGbloc == "USMC" && !needsCounseling {
 		branchQuery = branchFilter(swag.String(string(models.AffiliationMARINES)), needsCounseling, ppmCloseoutGblocs)
+		gblocToFilterBy = params.OriginGBLOC
+	} else if officeUserGbloc == "USMC" && marinesBranch {
+		*params.OriginGBLOC = "USMC"
 		gblocToFilterBy = params.OriginGBLOC
 	} else {
 		gblocToFilterBy = &officeUserGbloc

--- a/pkg/services/payment_request/payment_request_list_fetcher.go
+++ b/pkg/services/payment_request/payment_request_list_fetcher.go
@@ -166,15 +166,17 @@ func (f *paymentRequestListFetcher) FetchPaymentRequestListByMove(appCtx appcont
 	var gblocQuery QueryOption
 	if gbloc == "USMC" {
 		branchQuery = branchFilter(swag.String(string(models.AffiliationMARINES)))
+		//} else if gbloc == "CNNQ" && branchQuery == branchFilter(swag.String(string(models.AffiliationMARINES))) {
+		//	gbloc = "USMC"
 	} else {
 		gblocQuery = shipmentGBLOCFilter(&gbloc)
 	}
 	locatorQuery := locatorFilter(&locator)
 
-	marinesBranch := branchFilter(swag.String(string(models.AffiliationMARINES)))
-	if marinesBranch {
-		gbloc == "USMC"
-	}
+	//marinesBranch := branchFilter(swag.String(string(models.AffiliationMARINES)))
+	//if marinesBranch {
+	//	gbloc == "USMC"
+	//}
 
 	options := [3]QueryOption{branchQuery, gblocQuery, locatorQuery}
 

--- a/pkg/services/payment_request/payment_request_list_fetcher.go
+++ b/pkg/services/payment_request/payment_request_list_fetcher.go
@@ -171,6 +171,11 @@ func (f *paymentRequestListFetcher) FetchPaymentRequestListByMove(appCtx appcont
 	}
 	locatorQuery := locatorFilter(&locator)
 
+	marinesBranch := branchFilter(swag.String(string(models.AffiliationMARINES)))
+	if marinesBranch {
+		gbloc == "USMC"
+	}
+
 	options := [3]QueryOption{branchQuery, gblocQuery, locatorQuery}
 
 	for _, option := range options {


### PR DESCRIPTION
## [Jira ticket](https://dp3.atlassian.net/browse/MB-15143) for this change

## Summary

Currently payment requests sent to Syncata reflect the origin duty location GBLOC, however for Marines they must be set to "USMC" so that invoices are sent to the correct office. 

This PR adds a condition in the 858 generator so that the GBLOC is coded correctly for Marines.  

## Setup to Run Your Code

<details>
<summary>💻 You will need to use one terminal to test this locally.  To test in staging, check that the payment requests generated are returning the "USMC" GBLOC for service members affiliated with the Marines branch. </summary>

##### Terminal 1

Start the Storybook locally.

```sh
make storybook
```

##### Terminal 2

Start the UI locally.

```sh
make client_run
```

##### Terminal 3

Start the Go server locally.

```sh
make server_run
```

</details>

### Additional steps

<!-- Fill out the next section as you see fit, these are just suggestions. -->

1. Access the
2. Login as a
3.

## Verification Steps for Author

These are to be checked by the author.

- [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
- [ ] Request review from a member of a different team.
- [ ] Have the Jira acceptance criteria been met for this change?

## Verification Steps for Reviewers

These are to be checked by a reviewer.

<!-- Fill out the next sections as you see fit, these are just suggestions. -->

### Frontend

- [ ] User facing changes have been reviewed by design.
- [ ] There are no aXe warnings for UI.
- [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/main/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
- [ ] There are no new console errors in the browser devtools
- [ ] There are no new console errors in the test output
- [ ] If this PR adds a new component to Storybook, it ensures the component is fully responsive, OR if it is intentionally not, a wrapping div using the `officeApp` class or custom `min-width` styling is used to hide any states the would not be visible to the user.

### Backend

- [ ] Code follows the guidelines for [Logging](https://transcom.github.io/mymove-docs/docs/dev/contributing/backend/Backend-Programming-Guide#logging)
- [ ] The requirements listed in [Querying the Database Safely](https://transcom.github.io/mymove-docs/docs/dev/contributing/backend/Backend-Programming-Guide/#querying-the-database-safely) have been satisfied.

### Database

#### Any new migrations/schema changes:

- [ ] Follows our guidelines for [Zero-Downtime Deploys](https://transcom.github.io/mymove-docs/docs/dev/contributing/database/Database-Migrations#zero-downtime-migrations)
- [ ] Have been communicated to #g-database
- [ ] Secure migrations have been tested following the instructions in our [docs](https://transcom.github.io/mymove-docs/docs/dev/contributing/database/Database-Migrations#secure-migrations)

## Screenshots
