### PR TITLE
MB-15135 Ensure ppm document overview contains all docs

### DIFF
--- a/pkg/testdatagen/scenario/shared.go
+++ b/pkg/testdatagen/scenario/shared.go
@@ -1271,18 +1271,20 @@ func createApprovedMoveWithPPMCloseoutCompleteWithAllDocTypes(appCtx appcontext.
 		UserUploader:  userUploader,
 	}
 
-	testdatagen.MakeWeightTicket(appCtx.DB(), weightTicketAssertions)
+	testdatagen.MakeWeightTicketWithConstructedWeight(appCtx.DB(), weightTicketAssertions)
 
 	testdatagen.MakeMovingExpense(appCtx.DB(), testdatagen.Assertions{
 		ServiceMember: shipment.Shipment.MoveTaskOrder.Orders.ServiceMember,
 		PPMShipment:   shipment,
 		UserUploader:  userUploader,
+		File:          factory.FixtureOpen("test.png"),
 	})
 
 	testdatagen.MakeProgearWeightTicket(appCtx.DB(), testdatagen.Assertions{
 		ServiceMember: shipment.Shipment.MoveTaskOrder.Orders.ServiceMember,
 		PPMShipment:   shipment,
 		UserUploader:  userUploader,
+		File:          factory.FixtureOpen("test.jpg"),
 	})
 }
 

--- a/pkg/testdatagen/scenario/shared.go
+++ b/pkg/testdatagen/scenario/shared.go
@@ -1081,6 +1081,7 @@ func createApprovedMoveWithPPMCloseoutComplete(appCtx appcontext.AppContext, use
 
 	approvedAt := time.Date(2022, 4, 15, 12, 30, 0, 0, time.UTC)
 	address := factory.BuildAddress(appCtx.DB(), nil, nil)
+	approvedAdvanceStatus := models.PPMAdvanceStatusApproved
 
 	assertions := testdatagen.Assertions{
 		UserUploader: userUploader,
@@ -1099,6 +1100,7 @@ func createApprovedMoveWithPPMCloseoutComplete(appCtx appcontext.AppContext, use
 			ActualMoveDate:              models.TimePointer(time.Date(testdatagen.GHCTestYear, time.March, 16, 0, 0, 0, 0, time.UTC)),
 			ActualPickupPostalCode:      models.StringPointer("42444"),
 			ActualDestinationPostalCode: models.StringPointer("30813"),
+			AdvanceStatus:               &approvedAdvanceStatus,
 			HasReceivedAdvance:          models.BoolPointer(true),
 			AdvanceAmountReceived:       models.CentPointer(unit.Cents(340000)),
 			W2Address:                   &address,
@@ -1129,6 +1131,7 @@ func createApprovedMoveWithPPMCloseoutCompleteMultipleWeightTickets(appCtx appco
 
 	approvedAt := time.Date(2022, 4, 15, 12, 30, 0, 0, time.UTC)
 	address := factory.BuildAddress(appCtx.DB(), nil, nil)
+	approvedAdvanceStatus := models.PPMAdvanceStatusApproved
 
 	assertions := testdatagen.Assertions{
 		UserUploader: userUploader,
@@ -1147,6 +1150,7 @@ func createApprovedMoveWithPPMCloseoutCompleteMultipleWeightTickets(appCtx appco
 			ActualMoveDate:              models.TimePointer(time.Date(testdatagen.GHCTestYear, time.March, 16, 0, 0, 0, 0, time.UTC)),
 			ActualPickupPostalCode:      models.StringPointer("42444"),
 			ActualDestinationPostalCode: models.StringPointer("30813"),
+			AdvanceStatus:               &approvedAdvanceStatus,
 			HasReceivedAdvance:          models.BoolPointer(true),
 			AdvanceAmountReceived:       models.CentPointer(unit.Cents(340000)),
 			W2Address:                   &address,
@@ -1179,6 +1183,7 @@ func createApprovedMoveWithPPMCloseoutCompleteWithExpenses(appCtx appcontext.App
 
 	approvedAt := time.Date(2022, 4, 15, 12, 30, 0, 0, time.UTC)
 	address := factory.BuildAddress(appCtx.DB(), nil, nil)
+	approvedAdvanceStatus := models.PPMAdvanceStatusApproved
 
 	assertions := testdatagen.Assertions{
 		UserUploader: userUploader,
@@ -1197,6 +1202,7 @@ func createApprovedMoveWithPPMCloseoutCompleteWithExpenses(appCtx appcontext.App
 			ActualMoveDate:              models.TimePointer(time.Date(testdatagen.GHCTestYear, time.March, 16, 0, 0, 0, 0, time.UTC)),
 			ActualPickupPostalCode:      models.StringPointer("42444"),
 			ActualDestinationPostalCode: models.StringPointer("30813"),
+			AdvanceStatus:               &approvedAdvanceStatus,
 			HasReceivedAdvance:          models.BoolPointer(true),
 			AdvanceAmountReceived:       models.CentPointer(unit.Cents(340000)),
 			W2Address:                   &address,
@@ -1239,6 +1245,7 @@ func createApprovedMoveWithPPMCloseoutCompleteWithAllDocTypes(appCtx appcontext.
 
 	approvedAt := time.Date(2022, 4, 15, 12, 30, 0, 0, time.UTC)
 	address := factory.BuildAddress(appCtx.DB(), nil, nil)
+	approvedAdvanceStatus := models.PPMAdvanceStatusApproved
 
 	assertions := testdatagen.Assertions{
 		UserUploader: userUploader,
@@ -1257,6 +1264,7 @@ func createApprovedMoveWithPPMCloseoutCompleteWithAllDocTypes(appCtx appcontext.
 			ActualMoveDate:              models.TimePointer(time.Date(testdatagen.GHCTestYear, time.March, 16, 0, 0, 0, 0, time.UTC)),
 			ActualPickupPostalCode:      models.StringPointer("42444"),
 			ActualDestinationPostalCode: models.StringPointer("30813"),
+			AdvanceStatus:               &approvedAdvanceStatus,
 			HasReceivedAdvance:          models.BoolPointer(true),
 			AdvanceAmountReceived:       models.CentPointer(unit.Cents(340000)),
 			W2Address:                   &address,

--- a/src/components/Office/PPM/ReviewDocumentsSidePanel/ReviewDocumentsSidePanel.test.jsx
+++ b/src/components/Office/PPM/ReviewDocumentsSidePanel/ReviewDocumentsSidePanel.test.jsx
@@ -1,23 +1,28 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
+import { v4 } from 'uuid';
 
 import ReviewDocumentsSidePanel from './ReviewDocumentsSidePanel';
 
 import { createCompleteWeightTicket } from 'utils/test/factories/weightTicket';
 import PPMDocumentsStatus from 'constants/ppms';
+import { createCompleteProGearWeightTicket } from 'utils/test/factories/proGearWeightTicket';
+import { createCompleteMovingExpense } from 'utils/test/factories/movingExpense';
+import { expenseTypes } from 'constants/ppmExpenseTypes';
 
+const serviceMemberId = v4();
 const mockWeightTickets = [
   createCompleteWeightTicket(
-    {},
+    { serviceMemberId },
     {
       status: PPMDocumentsStatus.APPROVED,
     },
   ),
   createCompleteWeightTicket(
-    {},
+    { serviceMemberId },
     {
       status: PPMDocumentsStatus.REJECTED,
-      reason: 'Rejection reason',
+      reason: 'No weight ticket',
     },
   ),
 ];
@@ -29,14 +34,76 @@ describe('ReviewDocumentsSidePanel', () => {
     expect(h3).toBeInTheDocument();
   });
 
-  it('shows the appropriate statuses once weight tickets are reviewed', async () => {
-    render(<ReviewDocumentsSidePanel weightTickets={mockWeightTickets} />);
+  it('shows the appropriate statuses when multiple documents have been reviewed', async () => {
+    const progearWeightTickets = [
+      createCompleteProGearWeightTicket({ serviceMemberId }, { status: PPMDocumentsStatus.APPROVED }),
+      createCompleteProGearWeightTicket(
+        { serviceMemberId },
+        { status: PPMDocumentsStatus.REJECTED, reason: 'Invalid weight ticket' },
+      ),
+    ];
+
+    const movingExpenses = [
+      createCompleteMovingExpense({ serviceMemberId }, { status: PPMDocumentsStatus.APPROVED }),
+      createCompleteMovingExpense(
+        { serviceMemberId },
+        { status: PPMDocumentsStatus.REJECTED, reason: "We don't cover that expense." },
+      ),
+      createCompleteMovingExpense(
+        { serviceMemberId },
+        { movingExpenseType: expenseTypes.STORAGE, status: PPMDocumentsStatus.APPROVED },
+      ),
+      createCompleteMovingExpense(
+        { serviceMemberId },
+        { movingExpenseType: expenseTypes.STORAGE, status: PPMDocumentsStatus.EXCLUDED, reason: 'Invalid storage' },
+      ),
+    ];
+
+    render(
+      <ReviewDocumentsSidePanel
+        weightTickets={mockWeightTickets}
+        proGearTickets={progearWeightTickets}
+        expenseTickets={movingExpenses}
+      />,
+    );
+
     const listItems = await screen.getAllByRole('listitem');
-    expect(listItems).toHaveLength(2);
+    expect(listItems).toHaveLength(8);
+
+    // weight ticket 1
     expect(listItems[0]).toHaveTextContent(/Trip 1/);
     expect(listItems[0]).toHaveTextContent(/Accept/);
+
+    // weight ticket 2
     expect(listItems[1]).toHaveTextContent(/Trip 2/);
     expect(listItems[1]).toHaveTextContent(/Reject/);
-    expect(listItems[1]).toHaveTextContent(/Rejection reason/);
+    expect(listItems[1]).toHaveTextContent(/No weight ticket/);
+
+    // progear ticket 1
+    expect(listItems[2]).toHaveTextContent(/Pro-gear 1/);
+    expect(listItems[2]).toHaveTextContent(/Accept/);
+
+    // progear ticket 2
+    expect(listItems[3]).toHaveTextContent(/Pro-gear 2/);
+    expect(listItems[1]).toHaveTextContent(/Reject/);
+    expect(listItems[3]).toHaveTextContent(/Invalid weight ticket/);
+
+    // moving expense 1 - non-storage 1
+    expect(listItems[4]).toHaveTextContent(/Receipt 1/);
+    expect(listItems[4]).toHaveTextContent(/Accept/);
+
+    // moving expense 2 - non-storage 2
+    expect(listItems[5]).toHaveTextContent(/Receipt 2/);
+    expect(listItems[1]).toHaveTextContent(/Reject/);
+    expect(listItems[5]).toHaveTextContent(/We don't cover that expense./);
+
+    // moving expense 3 - storage 1
+    expect(listItems[6]).toHaveTextContent(/Storage 1/);
+    expect(listItems[6]).toHaveTextContent(/Accept/);
+
+    // moving expense 4 - storage 2
+    expect(listItems[7]).toHaveTextContent(/Storage 2/);
+    expect(listItems[1]).toHaveTextContent(/Reject/);
+    expect(listItems[7]).toHaveTextContent(/Invalid storage/);
   });
 });

--- a/src/pages/Office/PPM/ReviewDocuments/ReviewDocuments.jsx
+++ b/src/pages/Office/PPM/ReviewDocuments/ReviewDocuments.jsx
@@ -136,6 +136,12 @@ export const ReviewDocuments = ({ match }) => {
     }
   };
 
+  const getAllUploads = () => {
+    return documentSets.reduce((acc, documentSet) => {
+      return acc.concat(documentSet.uploads);
+    }, []);
+  };
+
   const onConfirmSuccess = () => {
     history.push(generatePath(servicesCounselingRoutes.MOVE_VIEW_PATH, { moveCode }));
   };
@@ -164,7 +170,7 @@ export const ReviewDocuments = ({ match }) => {
   return (
     <div data-testid="ReviewDocuments" className={styles.ReviewDocuments}>
       <div className={styles.embed}>
-        <DocumentViewer files={currentDocumentSet.uploads} allowDownload />
+        <DocumentViewer files={showOverview ? getAllUploads() : currentDocumentSet.uploads} allowDownload />
       </div>
       <DocumentViewerSidebar
         title="Review documents"

--- a/src/pages/Office/PPM/ReviewDocuments/ReviewDocuments.jsx
+++ b/src/pages/Office/PPM/ReviewDocuments/ReviewDocuments.jsx
@@ -176,7 +176,9 @@ export const ReviewDocuments = ({ match }) => {
         title="Review documents"
         onClose={onClose}
         className={styles.sidebar}
-        supertitle={`${documentSetIndex + 1} of ${documentSets.length} Document Sets`}
+        supertitle={
+          showOverview ? 'All Document Sets' : `${documentSetIndex + 1} of ${documentSets.length} Document Sets`
+        }
         defaultH3
         hyperlink={reviewShipmentWeightsLink}
       >

--- a/src/pages/Office/PPM/ReviewDocuments/ReviewDocuments.jsx
+++ b/src/pages/Office/PPM/ReviewDocuments/ReviewDocuments.jsx
@@ -189,6 +189,7 @@ export const ReviewDocuments = ({ match }) => {
               <ReviewDocumentsSidePanel
                 ppmShipment={mtoShipment.ppmShipment}
                 weightTickets={weightTickets}
+                proGearTickets={proGearWeightTickets}
                 expenseTickets={movingExpenses}
                 onError={onError}
                 onSuccess={onConfirmSuccess}

--- a/src/pages/Office/PPM/ReviewDocuments/ReviewDocuments.test.jsx
+++ b/src/pages/Office/PPM/ReviewDocuments/ReviewDocuments.test.jsx
@@ -56,14 +56,33 @@ const mtoShipment = createPPMShipmentWithFinalIncentive({
   ppmShipment: { status: ppmShipmentStatuses.NEEDS_PAYMENT_APPROVAL },
 });
 
+const weightTicketEmptyDocumentCreatedDate = new Date();
 // The factory used above doesn't handle overrides for uploads correctly, so we need to do it manually.
-const weightTicketEmptyDocumentUpload = createUpload({ fileName: 'emptyWeightTicket.pdf' });
+const weightTicketEmptyDocumentUpload = createUpload({
+  fileName: 'emptyWeightTicket.pdf',
+  createdAtDate: weightTicketEmptyDocumentCreatedDate,
+});
+
+const weightTicketFullDocumentCreatedDate = new Date(weightTicketEmptyDocumentCreatedDate);
+weightTicketFullDocumentCreatedDate.setDate(weightTicketFullDocumentCreatedDate.getDate() + 1);
 const weightTicketFullDocumentUpload = createUpload(
-  { fileName: 'fullWeightTicket.xls' },
+  { fileName: 'fullWeightTicket.xls', createdAtDate: weightTicketFullDocumentCreatedDate },
   { contentType: 'application/vnd.ms-excel' },
 );
-const progearWeightTicketDocumentUpload = createUpload({ fileName: 'progearWeightTicket.pdf' });
-const movingExpenseDocumentUpload = createUpload({ fileName: 'movingExpense.jpg' }, { contentType: 'image/jpeg' });
+
+const progearWeightTicketDocumentCreatedDate = new Date(weightTicketFullDocumentCreatedDate);
+progearWeightTicketDocumentCreatedDate.setDate(progearWeightTicketDocumentCreatedDate.getDate() + 1);
+const progearWeightTicketDocumentUpload = createUpload({
+  fileName: 'progearWeightTicket.pdf',
+  createdAtDate: progearWeightTicketDocumentCreatedDate,
+});
+
+const movingExpenseDocumentCreatedDate = new Date(progearWeightTicketDocumentCreatedDate);
+movingExpenseDocumentCreatedDate.setDate(movingExpenseDocumentCreatedDate.getDate() + 1);
+const movingExpenseDocumentUpload = createUpload(
+  { fileName: 'movingExpense.jpg', createdAtDate: movingExpenseDocumentCreatedDate },
+  { contentType: 'image/jpeg' },
+);
 
 mtoShipment.ppmShipment.weightTickets[0].emptyDocument.uploads = [weightTicketEmptyDocumentUpload];
 mtoShipment.ppmShipment.weightTickets[0].fullDocument.uploads = [weightTicketFullDocumentUpload];
@@ -382,6 +401,71 @@ describe('ReviewDocuments', () => {
       expect(within(uploadList).queryByRole('button', { name: /movingExpense\.jpg.*/i })).not.toBeInTheDocument();
 
       expect(screen.getByRole('heading', { level: 2, name: '1 of 3 Document Sets' })).toBeInTheDocument();
+    });
+
+    it('shows uploads for all documents on the summary page', async () => {
+      usePPMShipmentDocsQueries.mockReturnValue(usePPMShipmentDocsQueriesReturnValueAllDocs);
+      useReviewShipmentWeightsQuery.mockReturnValue(useReviewShipmentWeightsQueryReturnValueAll);
+
+      render(<ReviewDocuments {...requiredProps} />, { wrapper: MockProviders });
+
+      expect(await screen.findByRole('heading', { name: 'Trip 1', level: 3 })).toBeInTheDocument();
+      await userEvent.click(screen.getByLabelText('Accept'));
+      await userEvent.click(screen.getByRole('button', { name: 'Continue' }));
+
+      expect(await screen.findByRole('heading', { name: 'Pro-gear 1', level: 3 })).toBeInTheDocument();
+      await userEvent.click(screen.getByLabelText('Accept'));
+      await userEvent.click(screen.getByRole('button', { name: 'Continue' }));
+
+      expect(await screen.findByRole('heading', { name: 'Receipt 1', level: 3 })).toBeInTheDocument();
+      await userEvent.click(screen.getByLabelText('Accept'));
+      await userEvent.click(screen.getByRole('button', { name: 'Continue' }));
+
+      expect(await screen.findByRole('heading', { name: 'Send to customer?', level: 3 })).toBeInTheDocument();
+
+      const docMenuButton = await screen.findByRole('button', { name: /open menu/i });
+      expect(docMenuButton).toBeInTheDocument();
+
+      // We don't really have a great way to grab the list of uploads so we'll grab the parent element and go from there
+      const docViewer = screen.getByTestId('DocViewerMenu');
+
+      await userEvent.click(docMenuButton);
+
+      expect(docViewer).not.toHaveClass('collapsed');
+
+      const uploadList = within(docViewer).getByRole('list');
+      expect(uploadList).toBeInTheDocument();
+
+      const uploadsButtons = within(uploadList).getAllByRole('listitem');
+      expect(uploadsButtons.length).toBe(4);
+
+      const allUploads = [
+        weightTicketEmptyDocumentUpload,
+        weightTicketFullDocumentUpload,
+        progearWeightTicketDocumentUpload,
+        movingExpenseDocumentUpload,
+      ];
+
+      // we expect uploads to be sorted in descending order by updatedAt
+      allUploads.sort((a, b) => {
+        if (a.updatedAt < b.updatedAt) {
+          return 1;
+        }
+
+        if (a.updatedAt > b.updatedAt) {
+          return -1;
+        }
+
+        return 0;
+      });
+
+      for (let i = 0; i < allUploads.length; i += 1) {
+        // checking for text content because otherwise we'd have to form a regex to use the {name:} option of getByRole
+        // and our linters don't like a regex that is formed using a variable because of the
+        // security/detect-non-literal-regexp rule. Not super important to use it here, so we'll do this instead of
+        // doing the IS3 process.
+        expect(within(uploadsButtons[i]).getByRole('button')).toHaveTextContent(allUploads[i].filename);
+      }
     });
 
     it('handles moving from weight tickets the summary page when there are multiple types of documents', async () => {

--- a/src/pages/Office/PPM/ReviewDocuments/ReviewDocuments.test.jsx
+++ b/src/pages/Office/PPM/ReviewDocuments/ReviewDocuments.test.jsx
@@ -488,6 +488,8 @@ describe('ReviewDocuments', () => {
 
       expect(await screen.findByRole('heading', { name: 'Send to customer?', level: 3 })).toBeInTheDocument();
       expect(await screen.getByRole('button', { name: 'Back' })).toBeEnabled();
+
+      expect(screen.getByRole('heading', { level: 2, name: /All Document Sets/ })).toBeInTheDocument();
     });
 
     const usePPMShipmentDocsQueriesReturnValueProGearOnly = {


### PR DESCRIPTION
## [Jira ticket](https://dp3.atlassian.net/browse/MB-15135) for this change

## Summary

This PR is focused on wrapping up the data displayed for the Services Counselors on the PPM document review summary page. Some of the work was done in previous tickets/prs, but a few things were missing like showing pro-gear, showing all uploads on the summary page, and changing the heading text from "x of y Document Sets" to "All Document Sets"

## Testing Changes

<details>
<summary>💻 You will need to use three separate terminals to test this locally.</summary>

### Populate Dev Data

```sh
make db_dev_e2e_populate
```

### Run Office Client

```sh
make office_client_run
```

### Run Server

```sh
make server_run
```

</details>

### Additional steps

<!-- Fill out the next section as you see fit, these are just suggestions. -->

1. Access the [local office app](http://officelocal:3000).
    1. Alternatively, you can use the [ephemeral office app](https://office-milmove-pr-10438.mymove.sandbox.truss.coffee/).
2. Create an account as a services counselor in the KKFA GBLOC.
3. Click into the "PPM Closeout" tab.
4. Select the move with the "CLOSE2" move code.
5. Click on the "Review documents" button for the PPM shipment.
6. Accept/reject each of the documents as you see fit and continue until you get to the summary page.
7. On the summary page, you should see:
    1. the weight ticket, pro-gear weight ticket, and moving expense with their corresponding statuses.
    2. the text on the right above "Review documents" should say "ALL DOCUMENT SETS"
    3. the hamburger menu on the left that shows uploads should contain all the document uploads for this shipment.

## Verification Steps for Author

These are to be checked by the author.

- [ ] Request review from a member of a different team.
- [ ] Have the Jira acceptance criteria been met for this change?

## Verification Steps for Reviewers

These are to be checked by a reviewer.

<!-- Fill out the next sections as you see fit, these are just suggestions. -->

### Frontend

- [ ] User facing changes have been reviewed by design.
- [ ] There are no aXe warnings for UI.
- [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/main/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
- [ ] There are no new console errors in the browser devtools
- [ ] There are no new console errors in the test output

### Backend

- [ ] Code follows the guidelines for [Logging](https://transcom.github.io/mymove-docs/docs/dev/contributing/backend/Backend-Programming-Guide#logging)
- [ ] The requirements listed in [Querying the Database Safely](https://transcom.github.io/mymove-docs/docs/dev/contributing/backend/Backend-Programming-Guide/#querying-the-database-safely) have been satisfied.

## Screenshots

![image](https://user-images.githubusercontent.com/35938642/231308415-3878dd90-8b4b-46e8-ac28-e8f7870a178d.png)
