### PR TITLE
MB-15737 Add Truss IS3 as codeowners for the eslintrc files for shared and scenes

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -52,3 +52,5 @@ src/pages/PrimeUI/
 .eslintrc.js @transcom/Truss-IS3
 /eslint-plugin-ato/ @transcom/Truss-IS3
 /pkg/ato-linter/ @transcom/Truss-IS3
+src/scenes/.eslintrc @transcom/Truss-IS3
+src/shared/.eslintrc @transcom/Truss-IS3


### PR DESCRIPTION
## [Jira ticket](https://dp3.atlassian.net/browse/MB-15737) for this change

## Summary

Add Truss is3 as codeowners for the two eslintrc files inside of shared and scenes since those should probably have the same rules as the eslintrc file in src

# How to test

I'm not sure? This might have to be a merge and test with a PR. There's #10465 to see if it will trigger, but that might not happen until this one gets merged first?

## Verification Steps for Author

These are to be checked by the author.

- [x] Request review from a member of a different team.
- [x] Have the Jira acceptance criteria been met for this change?
