### PR TITLE
MB-15096 factory.BuildMTOServiceItemDimension added as new version of testdatagen.MakeMTOServiceItemDimension

### DIFF
--- a/pkg/factory/mto_service_item_dimension_factory.go
+++ b/pkg/factory/mto_service_item_dimension_factory.go
@@ -1,0 +1,47 @@
+package factory
+
+import (
+	"time"
+
+	"github.com/gobuffalo/pop/v6"
+
+	"github.com/transcom/mymove/pkg/models"
+	"github.com/transcom/mymove/pkg/testdatagen"
+)
+
+func BuildMTOServiceItemDimension(db *pop.Connection, customs []Customization, traits []Trait) models.MTOServiceItemDimension {
+	customs = setupCustomizations(customs, traits)
+
+	// Find MTOServiceItemDimension customization and extract the custom model
+	var cMTOServiceItemDimension models.MTOServiceItemDimension
+	if result := findValidCustomization(customs, MTOServiceItemDimension); result != nil {
+		cMTOServiceItemDimension = result.Model.(models.MTOServiceItemDimension)
+		if result.LinkOnly {
+			return cMTOServiceItemDimension
+		}
+	}
+
+	mtoServiceItem := BuildMTOServiceItem(db, customs, traits)
+
+	// create default MTOServiceItemDimension
+	mTOServiceItemDimension := models.MTOServiceItemDimension{
+		MTOServiceItem:   mtoServiceItem,
+		MTOServiceItemID: mtoServiceItem.ID,
+		Type:             models.DimensionTypeItem,
+		Length:           12000,
+		Height:           12000,
+		Width:            12000,
+		CreatedAt:        time.Now(),
+		UpdatedAt:        time.Now(),
+	}
+
+	// Overwrite values with those from customizations
+	testdatagen.MergeModels(&mTOServiceItemDimension, cMTOServiceItemDimension)
+
+	// If db is false, it's a stub. No need to create in database.
+	if db != nil {
+		mustCreate(db, &mTOServiceItemDimension)
+	}
+
+	return mTOServiceItemDimension
+}

--- a/pkg/factory/mto_service_item_dimension_test.go
+++ b/pkg/factory/mto_service_item_dimension_test.go
@@ -1,0 +1,83 @@
+package factory
+
+import (
+	"github.com/gofrs/uuid"
+
+	"github.com/transcom/mymove/pkg/models"
+	"github.com/transcom/mymove/pkg/unit"
+)
+
+func (suite *FactorySuite) TestBuildMTOServiceItemDimension() {
+	suite.Run("Successful creation of default MTOServiceItemDimension", func() {
+		// Under test:      BuildMTOServiceItemDimension
+		// Mocked:          None
+		// Set up:          Create a service item dimension with no customizations or traits
+		// Expected outcome:mtoServiceItemDimension should be created with default values
+
+		// SETUP
+		// CALL FUNCTION UNDER TEST
+		mTOServiceItemDimension := BuildMTOServiceItemDimension(suite.DB(), nil, nil)
+
+		suite.NotNil(mTOServiceItemDimension.MTOServiceItem)
+		suite.NotNil(mTOServiceItemDimension.MTOServiceItemID)
+		suite.Equal(models.DimensionTypeItem, mTOServiceItemDimension.Type)
+		suite.Equal(unit.ThousandthInches(12000), mTOServiceItemDimension.Length)
+		suite.Equal(unit.ThousandthInches(12000), mTOServiceItemDimension.Height)
+		suite.Equal(unit.ThousandthInches(12000), mTOServiceItemDimension.Width)
+	})
+
+	suite.Run("Successful creation of customized MTOServiceItemDimension", func() {
+		// Under test:      BuildMTOServiceItemDimension
+		// Mocked:          None
+		// Set up:          Create a service item dimension and pass custom fields
+		// Expected outcome:mtoServiceItemDimension should be created with custom values
+
+		// SETUP
+		customLength := unit.ThousandthInches(16*12*1000 + 1000)
+		customHeight := unit.ThousandthInches(8 * 12 * 1000)
+		customWidth := unit.ThousandthInches(9 * 12 * 1000)
+
+		customServiceItemDimension := models.MTOServiceItemDimension{
+			Type:   models.DimensionTypeCrate,
+			Length: customLength,
+			Height: customHeight,
+			Width:  customWidth,
+		}
+
+		// CALL FUNCTION UNDER TEST
+		serviceItemDimension := BuildMTOServiceItemDimension(suite.DB(), []Customization{
+			{
+				Model: customServiceItemDimension,
+			},
+		}, nil)
+
+		suite.Equal(models.DimensionTypeCrate, serviceItemDimension.Type)
+		suite.Equal(customLength, serviceItemDimension.Length)
+		suite.Equal(customWidth, serviceItemDimension.Width)
+		suite.Equal(customHeight, serviceItemDimension.Height)
+	})
+
+	suite.Run("Successful return of linkOnly MTOServiceItemDimension", func() {
+		// Under test:       BuildMTOServiceItemDimension
+		// Set up:           Pass in a linkOnly mtoServiceItemDimension
+		// Expected outcome: No new MTOServiceItemDimension should be created.
+
+		// Check num MTOServiceItemDimension records
+		precount, err := suite.DB().Count(&models.MTOServiceItemDimension{})
+		suite.NoError(err)
+
+		id := uuid.Must(uuid.NewV4())
+		serviceItemDimension := BuildMTOServiceItemDimension(suite.DB(), []Customization{
+			{
+				Model: models.MTOServiceItemDimension{
+					ID: id,
+				},
+				LinkOnly: true,
+			},
+		}, nil)
+		count, err := suite.DB().Count(&models.MTOServiceItemDimension{})
+		suite.Equal(precount, count)
+		suite.NoError(err)
+		suite.Equal(id, serviceItemDimension.ID)
+	})
+}

--- a/pkg/factory/shared.go
+++ b/pkg/factory/shared.go
@@ -44,6 +44,7 @@ var DutyLocation CustomType = "DutyLocation"
 var Entitlement CustomType = "Entitlement"
 var Move CustomType = "Move"
 var MTOServiceItem CustomType = "MTOServiceItem"
+var MTOServiceItemDimension CustomType = "MTOServiceItemDimension"
 var MTOShipment CustomType = "MTOShipment"
 var Notification CustomType = "Notification"
 var OfficePhoneLine CustomType = "OfficePhoneLine"
@@ -67,36 +68,37 @@ var UsersRoles CustomType = "UsersRoles"
 
 // defaultTypesMap allows us to assign CustomTypes for most default types
 var defaultTypesMap = map[string]CustomType{
-	"models.Address":               Address,
-	"models.AdminUser":             AdminUser,
-	"models.BackupContact":         BackupContact,
-	"models.Contractor":            Contractor,
-	"models.CustomerSupportRemark": CustomerSupportRemark,
-	"models.Document":              Document,
-	"models.DutyLocation":          DutyLocation,
-	"models.Entitlement":           Entitlement,
-	"models.Move":                  Move,
-	"models.MTOServiceItem":        MTOServiceItem,
-	"models.MTOShipment":           MTOShipment,
-	"models.Notification":          Notification,
-	"models.OfficePhoneLine":       OfficePhoneLine,
-	"models.OfficeUser":            OfficeUser,
-	"models.Order":                 Order,
-	"models.Organization":          Organization,
-	"models.PPMShipment":           PPMShipment,
-	"models.PostalCodeToGBLOC":     PostalCodeToGBLOC,
-	"models.ReService":             ReService,
-	"models.ServiceItemParamKey":   ServiceItemParamKey,
-	"models.ServiceMember":         ServiceMember,
-	"models.SignedCertification":   SignedCertification,
-	"models.StorageFacility":       StorageFacility,
-	"models.Tariff400ngZip3":       Tariff400ngZip3,
-	"models.TransportationOffice":  TransportationOffice,
-	"models.Upload":                Upload,
-	"models.UserUpload":            UserUpload,
-	"models.User":                  User,
-	"models.UsersRoles":            UsersRoles,
-	"roles.Role":                   Role,
+	"models.Address":                 Address,
+	"models.AdminUser":               AdminUser,
+	"models.BackupContact":           BackupContact,
+	"models.Contractor":              Contractor,
+	"models.CustomerSupportRemark":   CustomerSupportRemark,
+	"models.Document":                Document,
+	"models.DutyLocation":            DutyLocation,
+	"models.Entitlement":             Entitlement,
+	"models.Move":                    Move,
+	"models.MTOServiceItem":          MTOServiceItem,
+	"models.MTOServiceItemDimension": MTOServiceItemDimension,
+	"models.MTOShipment":             MTOShipment,
+	"models.Notification":            Notification,
+	"models.OfficePhoneLine":         OfficePhoneLine,
+	"models.OfficeUser":              OfficeUser,
+	"models.Order":                   Order,
+	"models.Organization":            Organization,
+	"models.PPMShipment":             PPMShipment,
+	"models.PostalCodeToGBLOC":       PostalCodeToGBLOC,
+	"models.ReService":               ReService,
+	"models.ServiceItemParamKey":     ServiceItemParamKey,
+	"models.ServiceMember":           ServiceMember,
+	"models.SignedCertification":     SignedCertification,
+	"models.StorageFacility":         StorageFacility,
+	"models.Tariff400ngZip3":         Tariff400ngZip3,
+	"models.TransportationOffice":    TransportationOffice,
+	"models.Upload":                  Upload,
+	"models.UserUpload":              UserUpload,
+	"models.User":                    User,
+	"models.UsersRoles":              UsersRoles,
+	"roles.Role":                     Role,
 }
 
 // Instead of nesting structs, we create specific CustomTypes here to give devs

--- a/pkg/payment_request/service_param_value_lookups/cubic_feet_billed_lookup_test.go
+++ b/pkg/payment_request/service_param_value_lookups/cubic_feet_billed_lookup_test.go
@@ -24,8 +24,7 @@ func (suite *ServiceParamValueLookupsSuite) TestCubicFeetBilledLookup() {
 		cratingDimension := factory.BuildMTOServiceItemDimension(suite.DB(), []factory.Customization{
 			{
 				Model: models.MTOServiceItemDimension{
-					MTOServiceItemID: mtoServiceItem.ID,
-					Type:             models.DimensionTypeCrate,
+					Type: models.DimensionTypeCrate,
 					// These dimensions are chosen to overflow 32bit ints if multiplied, and give a fractional result
 					// when converted to cubic feet.
 					Length:    16*12*1000 + 1000,
@@ -35,18 +34,25 @@ func (suite *ServiceParamValueLookupsSuite) TestCubicFeetBilledLookup() {
 					UpdatedAt: time.Time{},
 				},
 			},
+			{
+				Model:    mtoServiceItem,
+				LinkOnly: true,
+			},
 		}, nil)
 		itemDimension := factory.BuildMTOServiceItemDimension(suite.DB(), []factory.Customization{
 			{
 				Model: models.MTOServiceItemDimension{
-					MTOServiceItemID: mtoServiceItem.ID,
-					Type:             models.DimensionTypeItem,
-					Length:           12000,
-					Height:           12000,
-					Width:            12000,
-					CreatedAt:        time.Time{},
-					UpdatedAt:        time.Time{},
+					Type:      models.DimensionTypeItem,
+					Length:    12000,
+					Height:    12000,
+					Width:     12000,
+					CreatedAt: time.Time{},
+					UpdatedAt: time.Time{},
 				},
+			},
+			{
+				Model:    mtoServiceItem,
+				LinkOnly: true,
 			},
 		}, nil)
 		mtoServiceItem.Dimensions = []models.MTOServiceItemDimension{itemDimension, cratingDimension}
@@ -71,27 +77,33 @@ func (suite *ServiceParamValueLookupsSuite) TestCubicFeetBilledLookup() {
 		cratingDimension := factory.BuildMTOServiceItemDimension(suite.DB(), []factory.Customization{
 			{
 				Model: models.MTOServiceItemDimension{
-					MTOServiceItemID: mtoServiceItem.ID,
-					Type:             models.DimensionTypeCrate,
-					Length:           1000,
-					Height:           1000,
-					Width:            1000,
-					CreatedAt:        time.Time{},
-					UpdatedAt:        time.Time{},
+					Type:      models.DimensionTypeCrate,
+					Length:    1000,
+					Height:    1000,
+					Width:     1000,
+					CreatedAt: time.Time{},
+					UpdatedAt: time.Time{},
 				},
+			},
+			{
+				Model:    mtoServiceItem,
+				LinkOnly: true,
 			},
 		}, nil)
 		itemDimension := factory.BuildMTOServiceItemDimension(suite.DB(), []factory.Customization{
 			{
 				Model: models.MTOServiceItemDimension{
-					MTOServiceItemID: mtoServiceItem.ID,
-					Type:             models.DimensionTypeItem,
-					Length:           100,
-					Height:           100,
-					Width:            100,
-					CreatedAt:        time.Time{},
-					UpdatedAt:        time.Time{},
+					Type:      models.DimensionTypeItem,
+					Length:    100,
+					Height:    100,
+					Width:     100,
+					CreatedAt: time.Time{},
+					UpdatedAt: time.Time{},
 				},
+			},
+			{
+				Model:    mtoServiceItem,
+				LinkOnly: true,
 			},
 		}, nil)
 		mtoServiceItem.Dimensions = []models.MTOServiceItemDimension{itemDimension, cratingDimension}

--- a/pkg/payment_request/service_param_value_lookups/cubic_feet_billed_lookup_test.go
+++ b/pkg/payment_request/service_param_value_lookups/cubic_feet_billed_lookup_test.go
@@ -21,30 +21,34 @@ func (suite *ServiceParamValueLookupsSuite) TestCubicFeetBilledLookup() {
 				},
 			},
 		}, nil)
-		cratingDimension := testdatagen.MakeMTOServiceItemDimension(suite.DB(), testdatagen.Assertions{
-			MTOServiceItemDimension: models.MTOServiceItemDimension{
-				MTOServiceItemID: mtoServiceItem.ID,
-				Type:             models.DimensionTypeCrate,
-				// These dimensions are chosen to overflow 32bit ints if multiplied, and give a fractional result
-				// when converted to cubic feet.
-				Length:    16*12*1000 + 1000,
-				Height:    8 * 12 * 1000,
-				Width:     8 * 12 * 1000,
-				CreatedAt: time.Time{},
-				UpdatedAt: time.Time{},
+		cratingDimension := factory.BuildMTOServiceItemDimension(suite.DB(), []factory.Customization{
+			{
+				Model: models.MTOServiceItemDimension{
+					MTOServiceItemID: mtoServiceItem.ID,
+					Type:             models.DimensionTypeCrate,
+					// These dimensions are chosen to overflow 32bit ints if multiplied, and give a fractional result
+					// when converted to cubic feet.
+					Length:    16*12*1000 + 1000,
+					Height:    8 * 12 * 1000,
+					Width:     8 * 12 * 1000,
+					CreatedAt: time.Time{},
+					UpdatedAt: time.Time{},
+				},
 			},
-		})
-		itemDimension := testdatagen.MakeMTOServiceItemDimension(suite.DB(), testdatagen.Assertions{
-			MTOServiceItemDimension: models.MTOServiceItemDimension{
-				MTOServiceItemID: mtoServiceItem.ID,
-				Type:             models.DimensionTypeItem,
-				Length:           12000,
-				Height:           12000,
-				Width:            12000,
-				CreatedAt:        time.Time{},
-				UpdatedAt:        time.Time{},
+		}, nil)
+		itemDimension := factory.BuildMTOServiceItemDimension(suite.DB(), []factory.Customization{
+			{
+				Model: models.MTOServiceItemDimension{
+					MTOServiceItemID: mtoServiceItem.ID,
+					Type:             models.DimensionTypeItem,
+					Length:           12000,
+					Height:           12000,
+					Width:            12000,
+					CreatedAt:        time.Time{},
+					UpdatedAt:        time.Time{},
+				},
 			},
-		})
+		}, nil)
 		mtoServiceItem.Dimensions = []models.MTOServiceItemDimension{itemDimension, cratingDimension}
 		suite.MustSave(&mtoServiceItem)
 		paramLookup, err := ServiceParamLookupInitialize(suite.AppContextForTest(), suite.planner, mtoServiceItem, uuid.Must(uuid.NewV4()), uuid.Must(uuid.NewV4()), nil)
@@ -64,28 +68,32 @@ func (suite *ServiceParamValueLookupsSuite) TestCubicFeetBilledLookup() {
 				},
 			},
 		}, nil)
-		cratingDimension := testdatagen.MakeMTOServiceItemDimension(suite.DB(), testdatagen.Assertions{
-			MTOServiceItemDimension: models.MTOServiceItemDimension{
-				MTOServiceItemID: mtoServiceItem.ID,
-				Type:             models.DimensionTypeCrate,
-				Length:           1000,
-				Height:           1000,
-				Width:            1000,
-				CreatedAt:        time.Time{},
-				UpdatedAt:        time.Time{},
+		cratingDimension := factory.BuildMTOServiceItemDimension(suite.DB(), []factory.Customization{
+			{
+				Model: models.MTOServiceItemDimension{
+					MTOServiceItemID: mtoServiceItem.ID,
+					Type:             models.DimensionTypeCrate,
+					Length:           1000,
+					Height:           1000,
+					Width:            1000,
+					CreatedAt:        time.Time{},
+					UpdatedAt:        time.Time{},
+				},
 			},
-		})
-		itemDimension := testdatagen.MakeMTOServiceItemDimension(suite.DB(), testdatagen.Assertions{
-			MTOServiceItemDimension: models.MTOServiceItemDimension{
-				MTOServiceItemID: mtoServiceItem.ID,
-				Type:             models.DimensionTypeItem,
-				Length:           100,
-				Height:           100,
-				Width:            100,
-				CreatedAt:        time.Time{},
-				UpdatedAt:        time.Time{},
+		}, nil)
+		itemDimension := factory.BuildMTOServiceItemDimension(suite.DB(), []factory.Customization{
+			{
+				Model: models.MTOServiceItemDimension{
+					MTOServiceItemID: mtoServiceItem.ID,
+					Type:             models.DimensionTypeItem,
+					Length:           100,
+					Height:           100,
+					Width:            100,
+					CreatedAt:        time.Time{},
+					UpdatedAt:        time.Time{},
+				},
 			},
-		})
+		}, nil)
 		mtoServiceItem.Dimensions = []models.MTOServiceItemDimension{itemDimension, cratingDimension}
 		suite.MustSave(&mtoServiceItem)
 		paramLookup, err := ServiceParamLookupInitialize(suite.AppContextForTest(), suite.planner, mtoServiceItem, uuid.Must(uuid.NewV4()), uuid.Must(uuid.NewV4()), nil)

--- a/pkg/payment_request/service_param_value_lookups/cubic_feet_crating_lookup_test.go
+++ b/pkg/payment_request/service_param_value_lookups/cubic_feet_crating_lookup_test.go
@@ -21,30 +21,34 @@ func (suite *ServiceParamValueLookupsSuite) TestCubicFeetCratingLookup() {
 				},
 			},
 		}, nil)
-		cratingDimension := testdatagen.MakeMTOServiceItemDimension(suite.DB(), testdatagen.Assertions{
-			MTOServiceItemDimension: models.MTOServiceItemDimension{
-				MTOServiceItemID: mtoServiceItem.ID,
-				Type:             models.DimensionTypeCrate,
-				// These dimensions are chosen to overflow 32bit ints if multiplied, and give a fractional result
-				// when converted to cubic feet.
-				Length:    16*12*1000 + 1000,
-				Height:    8 * 12 * 1000,
-				Width:     8 * 12 * 1000,
-				CreatedAt: time.Time{},
-				UpdatedAt: time.Time{},
+		cratingDimension := factory.BuildMTOServiceItemDimension(suite.DB(), []factory.Customization{
+			{
+				Model: models.MTOServiceItemDimension{
+					MTOServiceItemID: mtoServiceItem.ID,
+					Type:             models.DimensionTypeCrate,
+					// These dimensions are chosen to overflow 32bit ints if multiplied, and give a fractional result
+					// when converted to cubic feet.
+					Length:    16*12*1000 + 1000,
+					Height:    8 * 12 * 1000,
+					Width:     8 * 12 * 1000,
+					CreatedAt: time.Time{},
+					UpdatedAt: time.Time{},
+				},
 			},
-		})
-		itemDimension := testdatagen.MakeMTOServiceItemDimension(suite.DB(), testdatagen.Assertions{
-			MTOServiceItemDimension: models.MTOServiceItemDimension{
-				MTOServiceItemID: mtoServiceItem.ID,
-				Type:             models.DimensionTypeItem,
-				Length:           12000,
-				Height:           12000,
-				Width:            12000,
-				CreatedAt:        time.Time{},
-				UpdatedAt:        time.Time{},
+		}, nil)
+		itemDimension := factory.BuildMTOServiceItemDimension(suite.DB(), []factory.Customization{
+			{
+				Model: models.MTOServiceItemDimension{
+					MTOServiceItemID: mtoServiceItem.ID,
+					Type:             models.DimensionTypeItem,
+					Length:           12000,
+					Height:           12000,
+					Width:            12000,
+					CreatedAt:        time.Time{},
+					UpdatedAt:        time.Time{},
+				},
 			},
-		})
+		}, nil)
 		mtoServiceItem.Dimensions = []models.MTOServiceItemDimension{itemDimension, cratingDimension}
 		suite.MustSave(&mtoServiceItem)
 		paramLookup, err := ServiceParamLookupInitialize(suite.AppContextForTest(), suite.planner, mtoServiceItem, uuid.Must(uuid.NewV4()), uuid.Must(uuid.NewV4()), nil)

--- a/pkg/payment_request/service_param_value_lookups/cubic_feet_crating_lookup_test.go
+++ b/pkg/payment_request/service_param_value_lookups/cubic_feet_crating_lookup_test.go
@@ -24,8 +24,7 @@ func (suite *ServiceParamValueLookupsSuite) TestCubicFeetCratingLookup() {
 		cratingDimension := factory.BuildMTOServiceItemDimension(suite.DB(), []factory.Customization{
 			{
 				Model: models.MTOServiceItemDimension{
-					MTOServiceItemID: mtoServiceItem.ID,
-					Type:             models.DimensionTypeCrate,
+					Type: models.DimensionTypeCrate,
 					// These dimensions are chosen to overflow 32bit ints if multiplied, and give a fractional result
 					// when converted to cubic feet.
 					Length:    16*12*1000 + 1000,
@@ -35,18 +34,25 @@ func (suite *ServiceParamValueLookupsSuite) TestCubicFeetCratingLookup() {
 					UpdatedAt: time.Time{},
 				},
 			},
+			{
+				Model:    mtoServiceItem,
+				LinkOnly: true,
+			},
 		}, nil)
 		itemDimension := factory.BuildMTOServiceItemDimension(suite.DB(), []factory.Customization{
 			{
 				Model: models.MTOServiceItemDimension{
-					MTOServiceItemID: mtoServiceItem.ID,
-					Type:             models.DimensionTypeItem,
-					Length:           12000,
-					Height:           12000,
-					Width:            12000,
-					CreatedAt:        time.Time{},
-					UpdatedAt:        time.Time{},
+					Type:      models.DimensionTypeItem,
+					Length:    12000,
+					Height:    12000,
+					Width:     12000,
+					CreatedAt: time.Time{},
+					UpdatedAt: time.Time{},
 				},
+			},
+			{
+				Model:    mtoServiceItem,
+				LinkOnly: true,
 			},
 		}, nil)
 		mtoServiceItem.Dimensions = []models.MTOServiceItemDimension{itemDimension, cratingDimension}

--- a/pkg/payment_request/service_param_value_lookups/dimension_height_lookup_test.go
+++ b/pkg/payment_request/service_param_value_lookups/dimension_height_lookup_test.go
@@ -22,30 +22,34 @@ func (suite *ServiceParamValueLookupsSuite) TestDimensionHeightLookup() {
 				},
 			},
 		}, nil)
-		cratingDimension := testdatagen.MakeMTOServiceItemDimension(suite.DB(), testdatagen.Assertions{
-			MTOServiceItemDimension: models.MTOServiceItemDimension{
-				MTOServiceItemID: mtoServiceItem.ID,
-				Type:             models.DimensionTypeCrate,
-				// These dimensions are chosen to overflow 32bit ints if multiplied, and give a fractional result
-				// when converted to cubic feet.
-				Length:    16*12*1000 + 1000,
-				Height:    8 * 12 * 1000,
-				Width:     9 * 12 * 1000,
-				CreatedAt: time.Time{},
-				UpdatedAt: time.Time{},
+		cratingDimension := factory.BuildMTOServiceItemDimension(suite.DB(), []factory.Customization{
+			{
+				Model: models.MTOServiceItemDimension{
+					MTOServiceItemID: mtoServiceItem.ID,
+					Type:             models.DimensionTypeCrate,
+					// These dimensions are chosen to overflow 32bit ints if multiplied, and give a fractional result
+					// when converted to cubic feet.
+					Length:    16*12*1000 + 1000,
+					Height:    8 * 12 * 1000,
+					Width:     9 * 12 * 1000,
+					CreatedAt: time.Time{},
+					UpdatedAt: time.Time{},
+				},
 			},
-		})
-		itemDimension := testdatagen.MakeMTOServiceItemDimension(suite.DB(), testdatagen.Assertions{
-			MTOServiceItemDimension: models.MTOServiceItemDimension{
-				MTOServiceItemID: mtoServiceItem.ID,
-				Type:             models.DimensionTypeItem,
-				Length:           12000,
-				Height:           12000,
-				Width:            12000,
-				CreatedAt:        time.Time{},
-				UpdatedAt:        time.Time{},
+		}, nil)
+		itemDimension := factory.BuildMTOServiceItemDimension(suite.DB(), []factory.Customization{
+			{
+				Model: models.MTOServiceItemDimension{
+					MTOServiceItemID: mtoServiceItem.ID,
+					Type:             models.DimensionTypeItem,
+					Length:           12000,
+					Height:           12000,
+					Width:            12000,
+					CreatedAt:        time.Time{},
+					UpdatedAt:        time.Time{},
+				},
 			},
-		})
+		}, nil)
 		mtoServiceItem.Dimensions = []models.MTOServiceItemDimension{itemDimension, cratingDimension}
 		suite.MustSave(&mtoServiceItem)
 		paramLookup, err := ServiceParamLookupInitialize(suite.AppContextForTest(), suite.planner, mtoServiceItem, uuid.Must(uuid.NewV4()), uuid.Must(uuid.NewV4()), nil)

--- a/pkg/payment_request/service_param_value_lookups/dimension_height_lookup_test.go
+++ b/pkg/payment_request/service_param_value_lookups/dimension_height_lookup_test.go
@@ -25,8 +25,7 @@ func (suite *ServiceParamValueLookupsSuite) TestDimensionHeightLookup() {
 		cratingDimension := factory.BuildMTOServiceItemDimension(suite.DB(), []factory.Customization{
 			{
 				Model: models.MTOServiceItemDimension{
-					MTOServiceItemID: mtoServiceItem.ID,
-					Type:             models.DimensionTypeCrate,
+					Type: models.DimensionTypeCrate,
 					// These dimensions are chosen to overflow 32bit ints if multiplied, and give a fractional result
 					// when converted to cubic feet.
 					Length:    16*12*1000 + 1000,
@@ -36,18 +35,25 @@ func (suite *ServiceParamValueLookupsSuite) TestDimensionHeightLookup() {
 					UpdatedAt: time.Time{},
 				},
 			},
+			{
+				Model:    mtoServiceItem,
+				LinkOnly: true,
+			},
 		}, nil)
 		itemDimension := factory.BuildMTOServiceItemDimension(suite.DB(), []factory.Customization{
 			{
 				Model: models.MTOServiceItemDimension{
-					MTOServiceItemID: mtoServiceItem.ID,
-					Type:             models.DimensionTypeItem,
-					Length:           12000,
-					Height:           12000,
-					Width:            12000,
-					CreatedAt:        time.Time{},
-					UpdatedAt:        time.Time{},
+					Type:      models.DimensionTypeItem,
+					Length:    12000,
+					Height:    12000,
+					Width:     12000,
+					CreatedAt: time.Time{},
+					UpdatedAt: time.Time{},
 				},
+			},
+			{
+				Model:    mtoServiceItem,
+				LinkOnly: true,
 			},
 		}, nil)
 		mtoServiceItem.Dimensions = []models.MTOServiceItemDimension{itemDimension, cratingDimension}

--- a/pkg/payment_request/service_param_value_lookups/dimension_length_lookup_test.go
+++ b/pkg/payment_request/service_param_value_lookups/dimension_length_lookup_test.go
@@ -25,8 +25,7 @@ func (suite *ServiceParamValueLookupsSuite) TestDimensionLengthLookup() {
 		cratingDimension := factory.BuildMTOServiceItemDimension(suite.DB(), []factory.Customization{
 			{
 				Model: models.MTOServiceItemDimension{
-					MTOServiceItemID: mtoServiceItem.ID,
-					Type:             models.DimensionTypeCrate,
+					Type: models.DimensionTypeCrate,
 					// These dimensions are chosen to overflow 32bit ints if multiplied, and give a fractional result
 					// when converted to cubic feet.
 					Length:    16*12*1000 + 1000,
@@ -36,18 +35,25 @@ func (suite *ServiceParamValueLookupsSuite) TestDimensionLengthLookup() {
 					UpdatedAt: time.Time{},
 				},
 			},
+			{
+				Model:    mtoServiceItem,
+				LinkOnly: true,
+			},
 		}, nil)
 		itemDimension := factory.BuildMTOServiceItemDimension(suite.DB(), []factory.Customization{
 			{
 				Model: models.MTOServiceItemDimension{
-					MTOServiceItemID: mtoServiceItem.ID,
-					Type:             models.DimensionTypeItem,
-					Length:           12000,
-					Height:           12000,
-					Width:            12000,
-					CreatedAt:        time.Time{},
-					UpdatedAt:        time.Time{},
+					Type:      models.DimensionTypeItem,
+					Length:    12000,
+					Height:    12000,
+					Width:     12000,
+					CreatedAt: time.Time{},
+					UpdatedAt: time.Time{},
 				},
+			},
+			{
+				Model:    mtoServiceItem,
+				LinkOnly: true,
 			},
 		}, nil)
 		mtoServiceItem.Dimensions = []models.MTOServiceItemDimension{itemDimension, cratingDimension}

--- a/pkg/payment_request/service_param_value_lookups/dimension_length_lookup_test.go
+++ b/pkg/payment_request/service_param_value_lookups/dimension_length_lookup_test.go
@@ -22,30 +22,34 @@ func (suite *ServiceParamValueLookupsSuite) TestDimensionLengthLookup() {
 				},
 			},
 		}, nil)
-		cratingDimension := testdatagen.MakeMTOServiceItemDimension(suite.DB(), testdatagen.Assertions{
-			MTOServiceItemDimension: models.MTOServiceItemDimension{
-				MTOServiceItemID: mtoServiceItem.ID,
-				Type:             models.DimensionTypeCrate,
-				// These dimensions are chosen to overflow 32bit ints if multiplied, and give a fractional result
-				// when converted to cubic feet.
-				Length:    16*12*1000 + 1000,
-				Height:    8 * 12 * 1000,
-				Width:     9 * 12 * 1000,
-				CreatedAt: time.Time{},
-				UpdatedAt: time.Time{},
+		cratingDimension := factory.BuildMTOServiceItemDimension(suite.DB(), []factory.Customization{
+			{
+				Model: models.MTOServiceItemDimension{
+					MTOServiceItemID: mtoServiceItem.ID,
+					Type:             models.DimensionTypeCrate,
+					// These dimensions are chosen to overflow 32bit ints if multiplied, and give a fractional result
+					// when converted to cubic feet.
+					Length:    16*12*1000 + 1000,
+					Height:    8 * 12 * 1000,
+					Width:     9 * 12 * 1000,
+					CreatedAt: time.Time{},
+					UpdatedAt: time.Time{},
+				},
 			},
-		})
-		itemDimension := testdatagen.MakeMTOServiceItemDimension(suite.DB(), testdatagen.Assertions{
-			MTOServiceItemDimension: models.MTOServiceItemDimension{
-				MTOServiceItemID: mtoServiceItem.ID,
-				Type:             models.DimensionTypeItem,
-				Length:           12000,
-				Height:           12000,
-				Width:            12000,
-				CreatedAt:        time.Time{},
-				UpdatedAt:        time.Time{},
+		}, nil)
+		itemDimension := factory.BuildMTOServiceItemDimension(suite.DB(), []factory.Customization{
+			{
+				Model: models.MTOServiceItemDimension{
+					MTOServiceItemID: mtoServiceItem.ID,
+					Type:             models.DimensionTypeItem,
+					Length:           12000,
+					Height:           12000,
+					Width:            12000,
+					CreatedAt:        time.Time{},
+					UpdatedAt:        time.Time{},
+				},
 			},
-		})
+		}, nil)
 		mtoServiceItem.Dimensions = []models.MTOServiceItemDimension{itemDimension, cratingDimension}
 		suite.MustSave(&mtoServiceItem)
 		paramLookup, err := ServiceParamLookupInitialize(suite.AppContextForTest(), suite.planner, mtoServiceItem, uuid.Must(uuid.NewV4()), uuid.Must(uuid.NewV4()), nil)

--- a/pkg/payment_request/service_param_value_lookups/dimension_width_lookup_test.go
+++ b/pkg/payment_request/service_param_value_lookups/dimension_width_lookup_test.go
@@ -25,8 +25,7 @@ func (suite *ServiceParamValueLookupsSuite) TestDimensionWidthLookup() {
 		cratingDimension := factory.BuildMTOServiceItemDimension(suite.DB(), []factory.Customization{
 			{
 				Model: models.MTOServiceItemDimension{
-					MTOServiceItemID: mtoServiceItem.ID,
-					Type:             models.DimensionTypeCrate,
+					Type: models.DimensionTypeCrate,
 					// These dimensions are chosen to overflow 32bit ints if multiplied, and give a fractional result
 					// when converted to cubic feet.
 					Length:    16*12*1000 + 1000,
@@ -36,18 +35,25 @@ func (suite *ServiceParamValueLookupsSuite) TestDimensionWidthLookup() {
 					UpdatedAt: time.Time{},
 				},
 			},
+			{
+				Model:    mtoServiceItem,
+				LinkOnly: true,
+			},
 		}, nil)
 		itemDimension := factory.BuildMTOServiceItemDimension(suite.DB(), []factory.Customization{
 			{
 				Model: models.MTOServiceItemDimension{
-					MTOServiceItemID: mtoServiceItem.ID,
-					Type:             models.DimensionTypeItem,
-					Length:           12000,
-					Height:           12000,
-					Width:            12000,
-					CreatedAt:        time.Time{},
-					UpdatedAt:        time.Time{},
+					Type:      models.DimensionTypeItem,
+					Length:    12000,
+					Height:    12000,
+					Width:     12000,
+					CreatedAt: time.Time{},
+					UpdatedAt: time.Time{},
 				},
+			},
+			{
+				Model:    mtoServiceItem,
+				LinkOnly: true,
 			},
 		}, nil)
 		mtoServiceItem.Dimensions = []models.MTOServiceItemDimension{itemDimension, cratingDimension}

--- a/pkg/payment_request/service_param_value_lookups/dimension_width_lookup_test.go
+++ b/pkg/payment_request/service_param_value_lookups/dimension_width_lookup_test.go
@@ -22,30 +22,34 @@ func (suite *ServiceParamValueLookupsSuite) TestDimensionWidthLookup() {
 				},
 			},
 		}, nil)
-		cratingDimension := testdatagen.MakeMTOServiceItemDimension(suite.DB(), testdatagen.Assertions{
-			MTOServiceItemDimension: models.MTOServiceItemDimension{
-				MTOServiceItemID: mtoServiceItem.ID,
-				Type:             models.DimensionTypeCrate,
-				// These dimensions are chosen to overflow 32bit ints if multiplied, and give a fractional result
-				// when converted to cubic feet.
-				Length:    16*12*1000 + 1000,
-				Height:    8 * 12 * 1000,
-				Width:     9 * 12 * 1000,
-				CreatedAt: time.Time{},
-				UpdatedAt: time.Time{},
+		cratingDimension := factory.BuildMTOServiceItemDimension(suite.DB(), []factory.Customization{
+			{
+				Model: models.MTOServiceItemDimension{
+					MTOServiceItemID: mtoServiceItem.ID,
+					Type:             models.DimensionTypeCrate,
+					// These dimensions are chosen to overflow 32bit ints if multiplied, and give a fractional result
+					// when converted to cubic feet.
+					Length:    16*12*1000 + 1000,
+					Height:    8 * 12 * 1000,
+					Width:     9 * 12 * 1000,
+					CreatedAt: time.Time{},
+					UpdatedAt: time.Time{},
+				},
 			},
-		})
-		itemDimension := testdatagen.MakeMTOServiceItemDimension(suite.DB(), testdatagen.Assertions{
-			MTOServiceItemDimension: models.MTOServiceItemDimension{
-				MTOServiceItemID: mtoServiceItem.ID,
-				Type:             models.DimensionTypeItem,
-				Length:           12000,
-				Height:           12000,
-				Width:            12000,
-				CreatedAt:        time.Time{},
-				UpdatedAt:        time.Time{},
+		}, nil)
+		itemDimension := factory.BuildMTOServiceItemDimension(suite.DB(), []factory.Customization{
+			{
+				Model: models.MTOServiceItemDimension{
+					MTOServiceItemID: mtoServiceItem.ID,
+					Type:             models.DimensionTypeItem,
+					Length:           12000,
+					Height:           12000,
+					Width:            12000,
+					CreatedAt:        time.Time{},
+					UpdatedAt:        time.Time{},
+				},
 			},
-		})
+		}, nil)
 		mtoServiceItem.Dimensions = []models.MTOServiceItemDimension{itemDimension, cratingDimension}
 		suite.MustSave(&mtoServiceItem)
 		paramLookup, err := ServiceParamLookupInitialize(suite.AppContextForTest(), suite.planner, mtoServiceItem, uuid.Must(uuid.NewV4()), uuid.Must(uuid.NewV4()), nil)

--- a/pkg/payment_request/service_param_value_lookups/service_params_cache_test.go
+++ b/pkg/payment_request/service_param_value_lookups/service_params_cache_test.go
@@ -246,8 +246,7 @@ func (suite *ServiceParamValueLookupsSuite) makeSubtestData() (subtestData *para
 	_ = factory.BuildMTOServiceItemDimension(suite.DB(), []factory.Customization{
 		{
 			Model: models.MTOServiceItemDimension{
-				MTOServiceItemID: subtestData.mtoServiceItemCrate1.ID,
-				Type:             models.DimensionTypeCrate,
+				Type: models.DimensionTypeCrate,
 				// These dimensions are chosen to overflow 32bit ints if multiplied, and give a fractional result
 				// when converted to cubic feet.
 				Length:    16*12*1000 + 1000,
@@ -257,18 +256,25 @@ func (suite *ServiceParamValueLookupsSuite) makeSubtestData() (subtestData *para
 				UpdatedAt: time.Time{},
 			},
 		},
+		{
+			Model:    subtestData.mtoServiceItemCrate1,
+			LinkOnly: true,
+		},
 	}, nil)
 	_ = factory.BuildMTOServiceItemDimension(suite.DB(), []factory.Customization{
 		{
 			Model: models.MTOServiceItemDimension{
-				MTOServiceItemID: subtestData.mtoServiceItemCrate1.ID,
-				Type:             models.DimensionTypeItem,
-				Length:           12000,
-				Height:           12000,
-				Width:            12000,
-				CreatedAt:        time.Time{},
-				UpdatedAt:        time.Time{},
+				Type:      models.DimensionTypeItem,
+				Length:    12000,
+				Height:    12000,
+				Width:     12000,
+				CreatedAt: time.Time{},
+				UpdatedAt: time.Time{},
 			},
+		},
+		{
+			Model:    subtestData.mtoServiceItemCrate1,
+			LinkOnly: true,
 		},
 	}, nil)
 	subtestData.mtoServiceItemCrate2 = factory.BuildMTOServiceItem(suite.DB(), []factory.Customization{
@@ -288,8 +294,7 @@ func (suite *ServiceParamValueLookupsSuite) makeSubtestData() (subtestData *para
 	_ = factory.BuildMTOServiceItemDimension(suite.DB(), []factory.Customization{
 		{
 			Model: models.MTOServiceItemDimension{
-				MTOServiceItemID: subtestData.mtoServiceItemCrate2.ID,
-				Type:             models.DimensionTypeCrate,
+				Type: models.DimensionTypeCrate,
 				// These dimensions are chosen to overflow 32bit ints if multiplied, and give a fractional result
 				// when converted to cubic feet.
 				Length:    7000,
@@ -299,18 +304,25 @@ func (suite *ServiceParamValueLookupsSuite) makeSubtestData() (subtestData *para
 				UpdatedAt: time.Time{},
 			},
 		},
+		{
+			Model:    subtestData.mtoServiceItemCrate2,
+			LinkOnly: true,
+		},
 	}, nil)
 	_ = factory.BuildMTOServiceItemDimension(suite.DB(), []factory.Customization{
 		{
 			Model: models.MTOServiceItemDimension{
-				MTOServiceItemID: subtestData.mtoServiceItemCrate2.ID,
-				Type:             models.DimensionTypeItem,
-				Length:           6000,
-				Height:           6000,
-				Width:            6000,
-				CreatedAt:        time.Time{},
-				UpdatedAt:        time.Time{},
+				Type:      models.DimensionTypeItem,
+				Length:    6000,
+				Height:    6000,
+				Width:     6000,
+				CreatedAt: time.Time{},
+				UpdatedAt: time.Time{},
 			},
+		},
+		{
+			Model:    subtestData.mtoServiceItemCrate2,
+			LinkOnly: true,
 		},
 	}, nil)
 	subtestData.paramKeyDimensionHeight = factory.BuildServiceItemParamKey(suite.DB(), []factory.Customization{

--- a/pkg/payment_request/service_param_value_lookups/service_params_cache_test.go
+++ b/pkg/payment_request/service_param_value_lookups/service_params_cache_test.go
@@ -243,30 +243,34 @@ func (suite *ServiceParamValueLookupsSuite) makeSubtestData() (subtestData *para
 			LinkOnly: true,
 		},
 	}, nil)
-	_ = testdatagen.MakeMTOServiceItemDimension(suite.DB(), testdatagen.Assertions{
-		MTOServiceItemDimension: models.MTOServiceItemDimension{
-			MTOServiceItemID: subtestData.mtoServiceItemCrate1.ID,
-			Type:             models.DimensionTypeCrate,
-			// These dimensions are chosen to overflow 32bit ints if multiplied, and give a fractional result
-			// when converted to cubic feet.
-			Length:    16*12*1000 + 1000,
-			Height:    8 * 12 * 1000,
-			Width:     8 * 12 * 1000,
-			CreatedAt: time.Time{},
-			UpdatedAt: time.Time{},
+	_ = factory.BuildMTOServiceItemDimension(suite.DB(), []factory.Customization{
+		{
+			Model: models.MTOServiceItemDimension{
+				MTOServiceItemID: subtestData.mtoServiceItemCrate1.ID,
+				Type:             models.DimensionTypeCrate,
+				// These dimensions are chosen to overflow 32bit ints if multiplied, and give a fractional result
+				// when converted to cubic feet.
+				Length:    16*12*1000 + 1000,
+				Height:    8 * 12 * 1000,
+				Width:     8 * 12 * 1000,
+				CreatedAt: time.Time{},
+				UpdatedAt: time.Time{},
+			},
 		},
-	})
-	_ = testdatagen.MakeMTOServiceItemDimension(suite.DB(), testdatagen.Assertions{
-		MTOServiceItemDimension: models.MTOServiceItemDimension{
-			MTOServiceItemID: subtestData.mtoServiceItemCrate1.ID,
-			Type:             models.DimensionTypeItem,
-			Length:           12000,
-			Height:           12000,
-			Width:            12000,
-			CreatedAt:        time.Time{},
-			UpdatedAt:        time.Time{},
+	}, nil)
+	_ = factory.BuildMTOServiceItemDimension(suite.DB(), []factory.Customization{
+		{
+			Model: models.MTOServiceItemDimension{
+				MTOServiceItemID: subtestData.mtoServiceItemCrate1.ID,
+				Type:             models.DimensionTypeItem,
+				Length:           12000,
+				Height:           12000,
+				Width:            12000,
+				CreatedAt:        time.Time{},
+				UpdatedAt:        time.Time{},
+			},
 		},
-	})
+	}, nil)
 	subtestData.mtoServiceItemCrate2 = factory.BuildMTOServiceItem(suite.DB(), []factory.Customization{
 		{
 			Model:    subtestData.move,
@@ -281,30 +285,34 @@ func (suite *ServiceParamValueLookupsSuite) makeSubtestData() (subtestData *para
 			LinkOnly: true,
 		},
 	}, nil)
-	_ = testdatagen.MakeMTOServiceItemDimension(suite.DB(), testdatagen.Assertions{
-		MTOServiceItemDimension: models.MTOServiceItemDimension{
-			MTOServiceItemID: subtestData.mtoServiceItemCrate2.ID,
-			Type:             models.DimensionTypeCrate,
-			// These dimensions are chosen to overflow 32bit ints if multiplied, and give a fractional result
-			// when converted to cubic feet.
-			Length:    7000,
-			Height:    7000,
-			Width:     7000,
-			CreatedAt: time.Time{},
-			UpdatedAt: time.Time{},
+	_ = factory.BuildMTOServiceItemDimension(suite.DB(), []factory.Customization{
+		{
+			Model: models.MTOServiceItemDimension{
+				MTOServiceItemID: subtestData.mtoServiceItemCrate2.ID,
+				Type:             models.DimensionTypeCrate,
+				// These dimensions are chosen to overflow 32bit ints if multiplied, and give a fractional result
+				// when converted to cubic feet.
+				Length:    7000,
+				Height:    7000,
+				Width:     7000,
+				CreatedAt: time.Time{},
+				UpdatedAt: time.Time{},
+			},
 		},
-	})
-	_ = testdatagen.MakeMTOServiceItemDimension(suite.DB(), testdatagen.Assertions{
-		MTOServiceItemDimension: models.MTOServiceItemDimension{
-			MTOServiceItemID: subtestData.mtoServiceItemCrate2.ID,
-			Type:             models.DimensionTypeItem,
-			Length:           6000,
-			Height:           6000,
-			Width:            6000,
-			CreatedAt:        time.Time{},
-			UpdatedAt:        time.Time{},
+	}, nil)
+	_ = factory.BuildMTOServiceItemDimension(suite.DB(), []factory.Customization{
+		{
+			Model: models.MTOServiceItemDimension{
+				MTOServiceItemID: subtestData.mtoServiceItemCrate2.ID,
+				Type:             models.DimensionTypeItem,
+				Length:           6000,
+				Height:           6000,
+				Width:            6000,
+				CreatedAt:        time.Time{},
+				UpdatedAt:        time.Time{},
+			},
 		},
-	})
+	}, nil)
 	subtestData.paramKeyDimensionHeight = factory.BuildServiceItemParamKey(suite.DB(), []factory.Customization{
 		{
 			Model: models.ServiceItemParamKey{

--- a/pkg/services/event/notification_test.go
+++ b/pkg/services/event/notification_test.go
@@ -141,14 +141,17 @@ func (suite *EventServiceSuite) Test_MTOServiceItemPayload() {
 		crateDimension1 := factory.BuildMTOServiceItemDimension(suite.DB(), []factory.Customization{
 			{
 				Model: models.MTOServiceItemDimension{
-					MTOServiceItemID: mtoServiceItemDCRT.ID,
-					Type:             models.DimensionTypeCrate,
-					Length:           2000,
-					Height:           2000,
-					Width:            2000,
-					CreatedAt:        time.Time{},
-					UpdatedAt:        time.Time{},
+					Type:      models.DimensionTypeCrate,
+					Length:    2000,
+					Height:    2000,
+					Width:     2000,
+					CreatedAt: time.Time{},
+					UpdatedAt: time.Time{},
 				},
+			},
+			{
+				Model:    mtoServiceItemDCRT,
+				LinkOnly: true,
 			},
 		}, nil)
 		data := &primemessages.MTOServiceItemDomesticCrating{}

--- a/pkg/services/event/notification_test.go
+++ b/pkg/services/event/notification_test.go
@@ -121,29 +121,36 @@ func (suite *EventServiceSuite) Test_MTOServiceItemPayload() {
 			},
 		}, nil)
 
-		itemDimension1 := testdatagen.MakeMTOServiceItemDimension(suite.DB(), testdatagen.Assertions{
-			MTOServiceItemDimension: models.MTOServiceItemDimension{
-				Type:      models.DimensionTypeItem,
-				Length:    900,
-				Height:    900,
-				Width:     900,
-				CreatedAt: time.Time{},
-				UpdatedAt: time.Time{},
+		itemDimension1 := factory.BuildMTOServiceItemDimension(suite.DB(), []factory.Customization{
+			{
+				Model: models.MTOServiceItemDimension{
+					Type:      models.DimensionTypeItem,
+					Length:    900,
+					Height:    900,
+					Width:     900,
+					CreatedAt: time.Time{},
+					UpdatedAt: time.Time{},
+				},
 			},
-			MTOServiceItem: mtoServiceItemDCRT,
-		})
+			{
+				Model:    mtoServiceItemDCRT,
+				LinkOnly: true,
+			},
+		}, nil)
 
-		crateDimension1 := testdatagen.MakeMTOServiceItemDimension(suite.DB(), testdatagen.Assertions{
-			MTOServiceItemDimension: models.MTOServiceItemDimension{
-				MTOServiceItemID: mtoServiceItemDCRT.ID,
-				Type:             models.DimensionTypeCrate,
-				Length:           2000,
-				Height:           2000,
-				Width:            2000,
-				CreatedAt:        time.Time{},
-				UpdatedAt:        time.Time{},
+		crateDimension1 := factory.BuildMTOServiceItemDimension(suite.DB(), []factory.Customization{
+			{
+				Model: models.MTOServiceItemDimension{
+					MTOServiceItemID: mtoServiceItemDCRT.ID,
+					Type:             models.DimensionTypeCrate,
+					Length:           2000,
+					Height:           2000,
+					Width:            2000,
+					CreatedAt:        time.Time{},
+					UpdatedAt:        time.Time{},
+				},
 			},
-		})
+		}, nil)
 		data := &primemessages.MTOServiceItemDomesticCrating{}
 
 		payload, assemblePayloadErr := assembleMTOServiceItemPayload(suite.AppContextForTest(), mtoServiceItemDCRT.ID)


### PR DESCRIPTION
## [Jira ticket](https://dp3.atlassian.net/browse/MB-15096) for this change

## Summary

This ticket adds a factory package with function BuildMTOServiceItemDimension intended to be an eventual replacement for testdatagen.MakeMTOServiceItemDimension
* Created BuildMTOServiceItemDimension and shared functions
* Created tests for BuildMTOServiceItemDimension. 
* Replaces instances in code where `MakeMTOServiceItemDimension` and `MakeDefaultMTOServiceItemDimension` exists with `BuildMTOServiceItemDimension`

## Setup to Run Your Code

`make server_test` should be enough. 

### Frontend

- No frontend changes

### Backend

- [x] Code follows the guidelines for [Logging](https://transcom.github.io/mymove-docs/docs/dev/contributing/backend/Backend-Programming-Guide#logging)
- [x] The requirements listed in [Querying the Database Safely](https://transcom.github.io/mymove-docs/docs/dev/contributing/backend/Backend-Programming-Guide/#querying-the-database-safely) have been satisfied.

### Database

#### Any new migrations/schema changes:

- No schema changes

