### PR TITLE
Add CAC migration to get access to support APIs

### DIFF
--- a/migrations/app/migrations_manifest.txt
+++ b/migrations/app/migrations_manifest.txt
@@ -800,3 +800,4 @@
 20230413164702_add_uniqueness_constraint_to_contractor_type.up.sql
 20230413192301_delete_400ng_tables.up.sql
 20230414201902_update_sit_extensions_comments.up.sql
+20230420144546_ronak_cac.up.sql

--- a/migrations/app/secure/20230420144546_ronak_cac.up.sql
+++ b/migrations/app/secure/20230420144546_ronak_cac.up.sql
@@ -1,0 +1,4 @@
+-- Local test migration.
+-- This will be run on development environments.
+-- It should mirror what you intend to apply on prd/stg/exp/demo
+-- DO NOT include any sensitive data.


### PR DESCRIPTION
## Summary

I added a migration for my CAC so I could utilize the support API in other environments.
