### PR TITLE
MB-15131 - End-to-end tests for SC document review

### DIFF
--- a/pkg/testdatagen/testharness/dispatch.go
+++ b/pkg/testdatagen/testharness/dispatch.go
@@ -131,6 +131,9 @@ var actionDispatcher = map[string]actionFunc{
 	"ApprovedMoveWithPPMMovingExpenseOffice": func(appCtx appcontext.AppContext) testHarnessResponse {
 		return MakeApprovedMoveWithPPMMovingExpenseOffice(appCtx)
 	},
+	"ApprovedMoveWithPPMAllDocTypesOffice": func(appCtx appcontext.AppContext) testHarnessResponse {
+		return MakeApprovedMoveWithPPMAllDocTypesOffice(appCtx)
+	},
 	"DraftMoveWithPPMWithDepartureDate": func(appCtx appcontext.AppContext) testHarnessResponse {
 		return MakeDraftMoveWithPPMWithDepartureDate(appCtx)
 	},

--- a/pkg/testdatagen/testharness/make_move.go
+++ b/pkg/testdatagen/testharness/make_move.go
@@ -3012,6 +3012,71 @@ func MakeApprovedMoveWithPPMMovingExpenseOffice(appCtx appcontext.AppContext) mo
 	return *newmove
 }
 
+func MakeApprovedMoveWithPPMAllDocTypesOffice(appCtx appcontext.AppContext) models.Move {
+	userUploader := newUserUploader(appCtx)
+	closeoutOffice := factory.BuildTransportationOffice(appCtx.DB(), []factory.Customization{
+		{
+			Model: models.TransportationOffice{Gbloc: "KKFA", ProvidesCloseout: true},
+		},
+	}, nil)
+
+	userInfo := newUserInfo("customer")
+	moveInfo := scenario.MoveCreatorInfo{
+		UserID:           uuid.Must(uuid.NewV4()),
+		Email:            userInfo.email,
+		SmID:             uuid.Must(uuid.NewV4()),
+		FirstName:        userInfo.firstName,
+		LastName:         userInfo.lastName,
+		MoveID:           uuid.Must(uuid.NewV4()),
+		MoveLocator:      models.GenerateLocator(),
+		CloseoutOfficeID: &closeoutOffice.ID,
+	}
+
+	approvedAt := time.Date(2022, 4, 15, 12, 30, 0, 0, time.UTC)
+	address := factory.BuildAddress(appCtx.DB(), nil, nil)
+
+	assertions := testdatagen.Assertions{
+		UserUploader: userUploader,
+		Move: models.Move{
+			Status: models.MoveStatusAPPROVED,
+		},
+		MTOShipment: models.MTOShipment{
+			ID:     uuid.Must(uuid.NewV4()),
+			Status: models.MTOShipmentStatusApproved,
+		},
+		PPMShipment: models.PPMShipment{
+			ID:                          uuid.Must(uuid.NewV4()),
+			ApprovedAt:                  &approvedAt,
+			Status:                      models.PPMShipmentStatusNeedsPaymentApproval,
+			ActualMoveDate:              models.TimePointer(time.Date(testdatagen.GHCTestYear, time.March, 16, 0, 0, 0, 0, time.UTC)),
+			ActualPickupPostalCode:      models.StringPointer("42444"),
+			ActualDestinationPostalCode: models.StringPointer("30813"),
+			HasReceivedAdvance:          models.BoolPointer(true),
+			AdvanceAmountReceived:       models.CentPointer(unit.Cents(340000)),
+			W2Address:                   &address,
+		},
+	}
+
+	move, shipment := scenario.CreateGenericMoveWithPPMShipment(appCtx, moveInfo, false, assertions)
+
+	ppmCloseoutAssertions := testdatagen.Assertions{
+		PPMShipment:   shipment,
+		ServiceMember: move.Orders.ServiceMember,
+	}
+	testdatagen.MakeWeightTicket(appCtx.DB(), ppmCloseoutAssertions)
+	testdatagen.MakeProgearWeightTicket(appCtx.DB(), ppmCloseoutAssertions)
+	testdatagen.MakeMovingExpense(appCtx.DB(), ppmCloseoutAssertions)
+
+	// re-fetch the move so that we ensure we have exactly what is in
+	// the db
+	newmove, err := models.FetchMove(appCtx.DB(), &auth.Session{}, move.ID)
+	if err != nil {
+		log.Panic(fmt.Errorf("Failed to fetch move: %w", err))
+	}
+
+	return *newmove
+}
+
 // the old serviceMemberWithOrdersAndPPMMove
 func MakeDraftMoveWithPPMWithDepartureDate(appCtx appcontext.AppContext) models.Move {
 	userUploader := newUserUploader(appCtx)

--- a/playwright/tests/office/servicescounseling/servicesCounselingFlows.spec.js
+++ b/playwright/tests/office/servicescounseling/servicesCounselingFlows.spec.js
@@ -218,4 +218,33 @@ test.describe('Services counselor user', () => {
       await expect(page.locator('[data-testid="requestedShipmentsTag"]')).toContainText('2');
     });
   });
+
+  test('can complete review of PPM shipment documents', async ({ page, scPage }) => {
+    const move = await scPage.testHarness.buildApprovedMoveWithPPMAllDocTypesOffice();
+    await scPage.navigateToCloseoutMove(move.locator);
+
+    // Navigate to the "Review documents" page
+    await expect(page.getByRole('button', { name: 'Review documents' })).toBeVisible();
+    await page.getByRole('button', { name: 'Review documents' }).click();
+
+    await scPage.waitForPage.reviewWeightTicket();
+    await page.getByText('Accept').click();
+    await page.getByRole('button', { name: 'Continue' }).click();
+
+    await scPage.waitForPage.reviewProGear();
+    await page.getByText('Accept').click();
+    await page.getByRole('button', { name: 'Continue' }).click();
+
+    await scPage.waitForPage.reviewReceipt();
+    await expect(page.getByText('Accept')).toBeVisible();
+    await page.getByText('Accept').click();
+    await page.getByRole('button', { name: 'Continue' }).click();
+
+    await scPage.waitForPage.reviewDocumentsConfirmation();
+
+    await page.getByRole('button', { name: 'Confirm' }).click();
+    await scPage.waitForPage.moveDetails();
+
+    await expect(page.getByTestId('ShipmentContainer').getByTestId('tag')).toContainText('packet ready for download');
+  });
 });

--- a/playwright/tests/office/servicescounseling/servicesCounselingMovingExpenses.spec.js
+++ b/playwright/tests/office/servicescounseling/servicesCounselingMovingExpenses.spec.js
@@ -7,7 +7,7 @@ test('A service counselor can approve/reject moving expenses', async ({ page, sc
 
   // Navigate to the "Review documents" page
   await page.getByRole('button', { name: 'Review documents' }).click();
-  await scPage.waitForPage.reviewDocuments();
+  await scPage.waitForPage.reviewWeightTicket();
 
   // Weight ticket is first in the order of docs. Click "Accept" on the weight ticket, then proceed
   await page.getByText('Accept').click();
@@ -33,7 +33,7 @@ test('A service counselor can approve/reject moving expenses', async ({ page, sc
 
   // Return to the expenses ticket and verify that it's approved
   // await page.getByRole('button', { name: 'Review documents' }).click();
-  // await scPage.waitForPage.reviewDocuments();
+  // await scPage.waitForPage.reviewWeightTicket();
 
   // // Weight ticket is first. Need to skip over to expense ticket
   // await page.getByRole('button', { name: 'Continue' }).click();
@@ -58,7 +58,7 @@ test('A service counselor can approve/reject moving expenses', async ({ page, sc
 
   // // Return to the expense and verify that it's been rejected
   // await page.getByRole('button', { name: 'Review documents' }).click();
-  // await scPage.waitForPage.reviewDocuments();
+  // await scPage.waitForPage.reviewWeightTicket();
   // await page.getByRole('button', { name: 'Continue' }).click();
 
   // await expect(page.getByRole('heading', { name: 'Review receipt 1' })).toBeVisible();
@@ -81,7 +81,7 @@ test('A service counselor can approve/reject moving expenses', async ({ page, sc
 
   // // Return to the expense and verify that it's been excluded
   // await page.getByRole('button', { name: 'Review documents' }).click();
-  // await scPage.waitForPage.reviewDocuments();
+  // await scPage.waitForPage.reviewWeightTicket();
   // await page.getByRole('button', { name: 'Continue' }).click();
 
   // await expect(page.getByRole('heading', { name: 'Review receipt 1' })).toBeVisible();

--- a/playwright/tests/office/servicescounseling/servicesCounselingProGearTickets.spec.js
+++ b/playwright/tests/office/servicescounseling/servicesCounselingProGearTickets.spec.js
@@ -7,7 +7,7 @@ test('A service counselor can approve/reject pro-gear weight tickets', async ({ 
 
   // Navigate to the "Review documents" page
   await page.getByRole('button', { name: 'Review documents' }).click();
-  await scPage.waitForPage.reviewDocuments();
+  await scPage.waitForPage.reviewWeightTicket();
 
   // Weight ticket is first in the order of docs. Click "Accept" on the weight ticket, then proceed
   await page.getByText('Accept').click();
@@ -28,7 +28,7 @@ test('A service counselor can approve/reject pro-gear weight tickets', async ({ 
 
   // Return to the pro-gear ticket and verify that it's approved
   // await page.getByRole('button', { name: 'Review documents' }).click();
-  // await scPage.waitForPage.reviewDocuments();
+  // await scPage.waitForPage.reviewWeightTicket();
 
   // // Weight ticket is first. Need to skip over to Pro-gear ticket
   // await page.getByRole('button', { name: 'Continue' }).click();
@@ -45,7 +45,7 @@ test('A service counselor can approve/reject pro-gear weight tickets', async ({ 
 
   // // Return to the pro-gear ticket and verify that it's been edited
   // await page.getByRole('button', { name: 'Review documents' }).click();
-  // await scPage.waitForPage.reviewDocuments();
+  // await scPage.waitForPage.reviewWeightTicket();
   // await page.getByRole('button', { name: 'Continue' }).click();
 
   // await expect(page.getByRole('radio', { name: 'Reject' })).toBeChecked();

--- a/playwright/tests/office/servicescounseling/servicesCounselingTestFixture.js
+++ b/playwright/tests/office/servicescounseling/servicesCounselingTestFixture.js
@@ -51,8 +51,14 @@ export class ServiceCounselorPage extends OfficePage {
     moveOrders: async () => {
       await expect(this.page.getByRole('heading', { level: 2, name: 'View orders' })).toBeVisible();
     },
-    reviewDocuments: async () => {
+    reviewWeightTicket: async () => {
       await expect(this.page.getByRole('heading', { name: 'Review trip 1', level: 3 })).toBeVisible();
+    },
+    reviewProGear: async () => {
+      await expect(this.page.getByRole('heading', { name: 'Review pro-gear 1', level: 3 })).toBeVisible();
+    },
+    reviewReceipt: async () => {
+      await expect(this.page.getByRole('heading', { name: 'Review pro-gear 1', level: 3 })).toBeVisible();
     },
     reviewDocumentsConfirmation: async () => {
       await expect(this.page.getByRole('heading', { name: 'Send to customer?', level: 3 })).toBeVisible();

--- a/playwright/tests/office/servicescounseling/servicesCounselingWeightTickets.spec.js
+++ b/playwright/tests/office/servicescounseling/servicesCounselingWeightTickets.spec.js
@@ -8,7 +8,7 @@ test('A service counselor can approve/reject weight tickets', async ({ page, scP
 
   // Navigate to the "Review documents" page
   await page.getByRole('button', { name: 'Review documents' }).click();
-  await scPage.waitForPage.reviewDocuments();
+  await scPage.waitForPage.reviewWeightTicket();
 
   // Click "Accept" on the weight ticket, then proceed
   await page.getByText('Accept').click();
@@ -24,7 +24,7 @@ test('A service counselor can approve/reject weight tickets', async ({ page, scP
 
   // Return to the weight ticket and verify that it's approved
   // await page.getByRole('button', { name: 'Review documents' }).click();
-  // await scPage.waitForPage.reviewDocuments();
+  // await scPage.waitForPage.reviewWeightTicket();
   // await expect(page.getByRole('radio', { name: 'Accept' })).toBeChecked();
 
   // // Click "Reject" on the weight ticket, provide a reason, then save
@@ -37,7 +37,7 @@ test('A service counselor can approve/reject weight tickets', async ({ page, scP
 
   // // Return to the weight ticket and verify that it's been edited
   // await page.getByRole('button', { name: 'Review documents' }).click();
-  // await scPage.waitForPage.reviewDocuments();
+  // await scPage.waitForPage.reviewWeightTicket();
   // await expect(page.getByRole('radio', { name: 'Reject' })).toBeChecked();
   // await expect(page.getByLabel('Reason')).toHaveValue('Justification for rejection');
 });
@@ -64,7 +64,7 @@ test('A services counselor can reduce PPM weights for a move with excess weight'
 
   // navigate to review-documents page and decrease ppm shipment weight below threshold
   await page.getByRole('link', { name: 'Review Documents' }).click();
-  await scPage.waitForPage.reviewDocuments();
+  await scPage.waitForPage.reviewWeightTicket();
 
   await page.getByTestId('net-weight-display').getByTestId('button').click();
   await page.getByTestId('weightInput').fill('0');

--- a/playwright/tests/utils/testharness.js
+++ b/playwright/tests/utils/testharness.js
@@ -333,6 +333,14 @@ export class TestHarness {
   }
 
   /**
+   * Use testharness to build submitted move with ppm and all doc types
+   * @returns {Promise<Object>}
+   */
+  async buildApprovedMoveWithPPMAllDocTypesOffice() {
+    return this.buildDefault('ApprovedMoveWithPPMAllDocTypesOffice');
+  }
+
+  /**
    * Use testharness to build approved move with two ppm shipments and excess weight
    * @returns {Promise<Move>}
    */


### PR DESCRIPTION
## [Jira ticket](https://dp3.atlassian.net/browse/MB-15131) for this change

## Summary

This adds a test for a service counselor's complete PPM document review flow.

Since there are analogous methods for waiting for the review page of expenses and pro gear, I also refactored `reviewDocuments`, which was waiting on the `Trip 1` text that is only present for weight tickets, to `reviewWeightTicket()`.

## Setup to Run Your Code

<details>
<summary>💻 You will need to use three separate terminals to test this locally.</summary>

##### Terminal 1

Start the Storybook locally.

```sh
make client_run
```

##### Terminal 2

Start the UI locally.

```sh
make server_run
```

</details>

### Additional steps

<!-- Fill out the next section as you see fit, these are just suggestions. -->

Run the test individually:

`yarn playwright test -g "can complete review of PPM shipment documents"`

Run all the tests:

`make e2e_test`

## Verification Steps for Author

These are to be checked by the author.

- [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
- [ ] Request review from a member of a different team.
- [ ] Have the Jira acceptance criteria been met for this change?

## Verification Steps for Reviewers

These are to be checked by a reviewer.

<!-- Fill out the next sections as you see fit, these are just suggestions. -->

### Frontend

- [ ] User facing changes have been reviewed by design.
- [ ] There are no aXe warnings for UI.
- [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/main/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
- [ ] There are no new console errors in the browser devtools
- [ ] There are no new console errors in the test output
- [ ] If this PR adds a new component to Storybook, it ensures the component is fully responsive, OR if it is intentionally not, a wrapping div using the `officeApp` class or custom `min-width` styling is used to hide any states the would not be visible to the user.

### Backend

- [ ] Code follows the guidelines for [Logging](https://transcom.github.io/mymove-docs/docs/dev/contributing/backend/Backend-Programming-Guide#logging)
- [ ] The requirements listed in [Querying the Database Safely](https://transcom.github.io/mymove-docs/docs/dev/contributing/backend/Backend-Programming-Guide/#querying-the-database-safely) have been satisfied.

### Database

#### Any new migrations/schema changes:

- [ ] Follows our guidelines for [Zero-Downtime Deploys](https://transcom.github.io/mymove-docs/docs/dev/contributing/database/Database-Migrations#zero-downtime-migrations)
- [ ] Have been communicated to #g-database
- [ ] Secure migrations have been tested following the instructions in our [docs](https://transcom.github.io/mymove-docs/docs/dev/contributing/database/Database-Migrations#secure-migrations)

## Screenshots
