### PR TITLE
[MB-15339] fixes a missing semicolon in the uat cert migration that causes a failure

### DIFF
--- a/migrations/app/secure/20230421202012_fix_movehq_uat_cert.up.sql
+++ b/migrations/app/secure/20230421202012_fix_movehq_uat_cert.up.sql
@@ -10,7 +10,7 @@
 -- BEGIN
 
 -- 	movehq_user_id := '<UUID>';
--- 	new_movehq_sha256 := '<SHA256>'
+-- 	new_movehq_sha256 := '<SHA256>';
 -- 	movehq_client_cert_id := '<UUID>';
 
 -- 	UPDATE users


### PR DESCRIPTION
same change has been uploaded to the stg S3 bucket.