### PR TITLE
MB-15716 factory.BuildPaymentServiceItemParam added as new version of testdatagen.MakePaymentServiceItemParam

### DIFF
--- a/pkg/factory/payment_service_item_param_factory.go
+++ b/pkg/factory/payment_service_item_param_factory.go
@@ -1,0 +1,100 @@
+package factory
+
+import (
+	"github.com/gobuffalo/pop/v6"
+
+	"github.com/transcom/mymove/pkg/models"
+	"github.com/transcom/mymove/pkg/testdatagen"
+)
+
+// CreatePaymentServiceItemParams helper struct to facilitate creation of multiple payment service item params
+type CreatePaymentServiceItemParams struct {
+	Key     models.ServiceItemParamName
+	KeyType models.ServiceItemParamType
+	Value   string
+}
+
+func BuildPaymentServiceItemParam(db *pop.Connection, customs []Customization, traits []Trait) models.PaymentServiceItemParam {
+	customs = setupCustomizations(customs, traits)
+
+	// Find PaymentServiceItemParam customization and convert to models.PaymentServiceItemParam
+	var cPaymentServiceItemParam models.PaymentServiceItemParam
+	if result := findValidCustomization(customs, PaymentServiceItemParam); result != nil {
+		cPaymentServiceItemParam = result.Model.(models.PaymentServiceItemParam)
+		if result.LinkOnly {
+			return cPaymentServiceItemParam
+		}
+	}
+
+	paymentServiceItem := BuildPaymentServiceItem(db, customs, traits)
+
+	serviceItemParamKey := FetchOrBuildServiceItemParamKey(db, customs, traits)
+
+	// Create PaymentServiceItemParam
+	paymentServiceItemParam := models.PaymentServiceItemParam{
+		PaymentServiceItem:    paymentServiceItem,
+		PaymentServiceItemID:  paymentServiceItem.ID,
+		ServiceItemParamKey:   serviceItemParamKey,
+		ServiceItemParamKeyID: serviceItemParamKey.ID,
+		Value:                 "123",
+	}
+
+	// Overwrite values with those from customizations
+	testdatagen.MergeModels(&paymentServiceItemParam, cPaymentServiceItemParam)
+
+	// If db is false, it's a stub. No need to create in database
+	if db != nil {
+		mustCreate(db, &paymentServiceItemParam)
+	}
+	return paymentServiceItemParam
+
+}
+
+func BuildPaymentServiceItemWithParams(db *pop.Connection, serviceCode models.ReServiceCode, paramsToCreate []CreatePaymentServiceItemParams, customs []Customization, traits []Trait) models.PaymentServiceItem {
+	var params models.PaymentServiceItemParams
+
+	// Make customizations for PaymentServiceItem
+	paymentServiceItemCustoms := customs
+	paymentServiceItemCustoms = append(paymentServiceItemCustoms, Customization{
+		Model: models.ReService{
+			Code: serviceCode,
+		},
+	})
+	paymentServiceItem := BuildPaymentServiceItem(db, paymentServiceItemCustoms, traits)
+
+	for _, param := range paramsToCreate {
+		// Make customizations for ServiceItemParamKey
+		serviceItemCustoms := customs
+		serviceItemCustoms = append(serviceItemCustoms, Customization{
+			Model: models.ServiceItemParamKey{
+				Key:  param.Key,
+				Type: param.KeyType,
+			},
+		})
+		serviceItemParamKey := FetchOrBuildServiceItemParamKey(db, serviceItemCustoms, traits)
+
+		// Make customizations for PaymentServiceItemParam
+		newPaymentServiceItemParamCustoms := []Customization{
+			{
+				Model:    serviceItemParamKey,
+				LinkOnly: true,
+			},
+			{
+				Model: models.PaymentServiceItemParam{
+					Value: param.Value,
+				},
+			},
+			{
+				Model:    paymentServiceItem,
+				LinkOnly: true,
+			},
+		}
+
+		paymentServiceItemParam := BuildPaymentServiceItemParam(db, newPaymentServiceItemParamCustoms, traits)
+		params = append(params, paymentServiceItemParam)
+	}
+
+	paymentServiceItem.PaymentServiceItemParams = params
+
+	return paymentServiceItem
+}

--- a/pkg/factory/payment_service_item_param_factory_test.go
+++ b/pkg/factory/payment_service_item_param_factory_test.go
@@ -1,0 +1,171 @@
+package factory
+
+import (
+	"github.com/benbjohnson/clock"
+	"github.com/gofrs/uuid"
+
+	"github.com/transcom/mymove/pkg/models"
+	"github.com/transcom/mymove/pkg/unit"
+)
+
+func (suite *FactorySuite) TestBuildPaymentServiceItemParam() {
+	suite.Run("Successful creation of default PaymentServiceItemParam", func() {
+		// Under test:      BuildPaymentServiceItemParam
+		// Mocked:          None
+		// Set up:          Create a payment service item param with no customizations or traits
+		// Expected outcome:paymentServiceItemParam should be created with default values
+
+		// SETUP
+		defaultPaymentServiceItemParam := models.PaymentServiceItemParam{
+			Value: "123",
+		}
+
+		// CALL FUNCTION UNDER TEST
+		paymentServiceItemParam := BuildPaymentServiceItemParam(suite.DB(), nil, nil)
+
+		// VALIDATE RESULTS
+		suite.Equal(defaultPaymentServiceItemParam.Value, paymentServiceItemParam.Value)
+		suite.NotNil(paymentServiceItemParam.PaymentServiceItemID)
+		suite.NotNil(paymentServiceItemParam.ServiceItemParamKeyID)
+	})
+
+	suite.Run("Successful creation of customized PaymentServiceItemParam", func() {
+		// Under test:      BuildPaymentServiceItemParam
+		// Set up:          Create a payment service item param and pass custom fields
+		// Expected outcome:paymentServiceItemParam should be created with custom fields
+
+		// SETUP
+		customPaymentServiceItemParam := models.PaymentServiceItemParam{
+			Value: "456",
+		}
+
+		// CALL FUNCTION UNDER TEST
+		paymentServiceItemParam := BuildPaymentServiceItemParam(suite.DB(), []Customization{
+			{
+				Model: customPaymentServiceItemParam,
+			},
+		}, nil)
+
+		// VALIDATE RESULTS
+		suite.Equal(customPaymentServiceItemParam.Value, paymentServiceItemParam.Value)
+	})
+
+	suite.Run("Successful creation of payment service item param with customized payment service item and service item param key", func() {
+		// Under test:      BuildPaymentServiceItemParam
+		// Set up:          Create a payment service item param and pass custom fields
+		// Expected outcome:paymentServiceItemParam should be created with custom payment service item and service item param key
+
+		// SETUP
+		customPaymentServiceItemParam := models.PaymentServiceItemParam{
+			Value: "456",
+		}
+
+		customPaymentServiceItem := models.PaymentServiceItem{
+			Status: models.PaymentServiceItemStatusApproved,
+		}
+		customServiceItemParam := models.ServiceItemParamKey{
+			Key:  models.ServiceItemParamNameRequestedPickupDate,
+			Type: models.ServiceItemParamTypeDate,
+		}
+
+		// CALL FUNCTION UNDER TEST
+		paymentServiceItemParam := BuildPaymentServiceItemParam(suite.DB(), []Customization{
+			{
+				Model: customPaymentServiceItemParam,
+			},
+			{
+				Model: customPaymentServiceItem,
+			},
+			{
+				Model: customServiceItemParam,
+			},
+		}, nil)
+
+		// VALIDATE RESULTS
+		suite.Equal(customPaymentServiceItemParam.Value, paymentServiceItemParam.Value)
+
+		suite.Equal(customPaymentServiceItem.Status, paymentServiceItemParam.PaymentServiceItem.Status)
+		suite.Equal(customServiceItemParam.Key, paymentServiceItemParam.ServiceItemParamKey.Key)
+		suite.Equal(customServiceItemParam.Type, paymentServiceItemParam.ServiceItemParamKey.Type)
+	})
+
+	suite.Run("Successful return of linkOnly paymentServiceItemParam", func() {
+		// Under test:       BuildPaymentServiceItemParam
+		// Set up:           Pass in a linkOnly paymentServiceItemParam
+		// Expected outcome: No new paymentServiceItemParam should be created.
+
+		// Check num PaymentServiceItemParam records
+		precount, err := suite.DB().Count(&models.PaymentServiceItemParam{})
+		suite.NoError(err)
+
+		id := uuid.Must(uuid.NewV4())
+		paymentServiceItemParam := BuildPaymentServiceItemParam(suite.DB(), []Customization{
+			{
+				Model: models.PaymentServiceItemParam{
+					ID: id,
+				},
+				LinkOnly: true,
+			},
+		}, nil)
+		count, err := suite.DB().Count(&models.PaymentServiceItemParam{})
+		suite.Equal(precount, count)
+		suite.NoError(err)
+		suite.Equal(id, paymentServiceItemParam.ID)
+	})
+
+	suite.Run("Successful creation of customized paymentServiceItem with params", func() {
+		// Under test:      BuildPaymentServiceItemWithParams
+		//
+		// Set up: Create a Payment Service Item with custom serviceItemParamKey, paymentServiceItem,
+		// & list of params to create
+		//
+		// Expected outcome:paymentServiceItem should be created with multiple paymentServiceItemParams
+
+		// SETUP
+		const testDateFormat = "20060102"
+		priceCents := unit.Cents(800)
+		currentTime := clock.NewMock().Now()
+		serviceCode := models.ReServiceCodeCS
+
+		customPaymentServiceItem := models.PaymentServiceItem{
+			Status:     models.PaymentServiceItemStatusApproved,
+			PriceCents: &priceCents,
+		}
+
+		paymentServiceItemParams := []CreatePaymentServiceItemParams{
+			{
+				Key:     models.ServiceItemParamNameContractCode,
+				KeyType: models.ServiceItemParamTypeString,
+				Value:   "Test_value",
+			},
+			{
+				Key:     models.ServiceItemParamNameReferenceDate,
+				KeyType: models.ServiceItemParamTypeDate,
+				Value:   currentTime.Format(testDateFormat),
+			},
+			{
+				Key:     models.ServiceItemParamNameWeightBilled,
+				KeyType: models.ServiceItemParamTypeInteger,
+				Value:   "4242",
+			},
+			{
+				Key:     models.ServiceItemParamNameDistanceZip,
+				KeyType: models.ServiceItemParamTypeInteger,
+				Value:   "24246",
+			},
+		}
+
+		// CALL FUNCTION UNDER TEST
+		paymentServiceItem := BuildPaymentServiceItemWithParams(suite.DB(), serviceCode, paymentServiceItemParams, []Customization{
+			{
+				Model: customPaymentServiceItem,
+			},
+		}, nil)
+
+		// VALIDATE RESULTS
+		suite.Equal(customPaymentServiceItem.Status, paymentServiceItem.Status)
+		suite.Equal(customPaymentServiceItem.PriceCents, paymentServiceItem.PriceCents)
+
+		suite.Equal(4, len(paymentServiceItem.PaymentServiceItemParams))
+	})
+}

--- a/pkg/factory/shared.go
+++ b/pkg/factory/shared.go
@@ -56,6 +56,7 @@ var Organization CustomType = "Organization"
 var PPMShipment CustomType = "PPMShipment"
 var PaymentRequest CustomType = "PaymentRequest"
 var PaymentServiceItem CustomType = "PaymentServiceItem"
+var PaymentServiceItemParam CustomType = "PaymentServiceItemParam"
 var PostalCodeToGBLOC CustomType = "PostalCodeToGBLOC"
 var ProofOfServiceDoc CustomType = "ProofOfServiceDoc"
 var ReService CustomType = "ReService"
@@ -96,6 +97,7 @@ var defaultTypesMap = map[string]CustomType{
 	"models.Organization":            Organization,
 	"models.PaymentRequest":          PaymentRequest,
 	"models.PaymentServiceItem":      PaymentServiceItem,
+	"models.PaymentServiceItemParam": PaymentServiceItemParam,
 	"models.PPMShipment":             PPMShipment,
 	"models.PostalCodeToGBLOC":       PostalCodeToGBLOC,
 	"models.ProofOfServiceDoc":       ProofOfServiceDoc,

--- a/pkg/testdatagen/make_payment_service_item_param.go
+++ b/pkg/testdatagen/make_payment_service_item_param.go
@@ -41,11 +41,6 @@ func MakePaymentServiceItemParam(db *pop.Connection, assertions Assertions) mode
 	return paymentServiceItemParam
 }
 
-// MakeDefaultPaymentServiceItemParam makes a PaymentServiceItemParam with default values
-func MakeDefaultPaymentServiceItemParam(db *pop.Connection) models.PaymentServiceItemParam {
-	return MakePaymentServiceItemParam(db, Assertions{})
-}
-
 // MakePaymentServiceItemWithParams creates more than one payment service item param at a time
 func MakePaymentServiceItemWithParams(db *pop.Connection, serviceCode models.ReServiceCode, paramsToCreate []CreatePaymentServiceItemParams, assertions Assertions) models.PaymentServiceItem {
 	var params models.PaymentServiceItemParams


### PR DESCRIPTION
## [Jira ticket](https://dp3.atlassian.net/browse/MB-15716) for this change

## Summary

This ticket adds a factory package with function BuildPaymentServiceItemParam intended to be an eventual replacement for testdatagen.MakePaymentServiceItemParam
* Created BuildPaymentServiceItemParam and shared functions
* Created tests for BuildPaymentServiceItemParam. 
* Replaces instances in code where `MakePaymentServiceItemParam` and `MakePaymentServiceItemWithParams` exists with `BuildPaymentServiceItemParam` and `BuildPaymentServiceItemWithParams`

## Setup to Run Your Code

`make server_test` should be enough. 

### Frontend

- No frontend changes

### Backend

- [x] Code follows the guidelines for [Logging](https://transcom.github.io/mymove-docs/docs/dev/contributing/backend/Backend-Programming-Guide#logging)
- [x] The requirements listed in [Querying the Database Safely](https://transcom.github.io/mymove-docs/docs/dev/contributing/backend/Backend-Programming-Guide/#querying-the-database-safely) have been satisfied.

### Database

#### Any new migrations/schema changes:

- No schema changes

