### PR TITLE
MB-13693 - Add sit display conditions and tests, fix end date.

### DIFF
--- a/src/components/Office/ShipmentDetails/ShipmentDetails.stories.jsx
+++ b/src/components/Office/ShipmentDetails/ShipmentDetails.stories.jsx
@@ -128,7 +128,6 @@ export const Default = () => {
       serviceOrderNumber: values.serviceOrderNumber,
     });
   };
-
   return (
     <div className="officeApp">
       <MockProviders initialEntries={['/moves/HGNTSR/mto']} permissions={[permissionTypes.updateShipment]}>

--- a/src/components/Office/ShipmentDetails/ShipmentDetailsMain.jsx
+++ b/src/components/Office/ShipmentDetails/ShipmentDetailsMain.jsx
@@ -156,14 +156,16 @@ const ShipmentDetailsMain = ({
           sitStatus={sitStatus}
         />
       )}
-      <ShipmentSITDisplay
-        sitExtensions={sitExtensions}
-        sitStatus={sitStatus}
-        storageInTransit={storageInTransit}
-        shipment={shipment}
-        className={styles.shipmentSITSummary}
-        openModalButton={openModalButton}
-      />
+      {(sitStatus || shipment.sitDaysAllowance) && (
+        <ShipmentSITDisplay
+          sitExtensions={sitExtensions}
+          sitStatus={sitStatus}
+          storageInTransit={storageInTransit}
+          shipment={shipment}
+          className={styles.shipmentSITSummary}
+          openModalButton={openModalButton}
+        />
+      )}
       <ImportantShipmentDates
         requestedPickupDate={formatDate(requestedPickupDate)}
         scheduledPickupDate={scheduledPickupDate ? formatDate(scheduledPickupDate) : null}

--- a/src/components/Office/ShipmentDetails/ShipmentDetailsMain.test.jsx
+++ b/src/components/Office/ShipmentDetails/ShipmentDetailsMain.test.jsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+
+import { futureSITShipment, noSITShipment, SITShipment } from '../ShipmentSITDisplay/ShipmentSITDisplayTestParams';
+
+import ShipmentDetailsMain from './ShipmentDetailsMain';
+
+import { MockProviders } from 'testUtils';
+
+const shipmentDetailsMainParams = {
+  handleDivertShipment: () => {},
+  handleRequestReweighModal: () => {},
+  handleReviewSITExtension: () => {},
+  handleSubmitSITExtension: () => {},
+  dutyLocationAddresses: {
+    originDutyLocationAddress: {
+      address: null,
+    },
+    destinationDutyLocationAddress: {
+      address: null,
+    },
+  },
+};
+
+describe('Shipment Details Main', () => {
+  it('displays SIT when there is a sitStatus', () => {
+    render(
+      <MockProviders>
+        <ShipmentDetailsMain {...shipmentDetailsMainParams} shipment={SITShipment} />
+      </MockProviders>,
+    );
+
+    expect(screen.getByText('SIT (STORAGE IN TRANSIT)')).toBeInTheDocument();
+  });
+  it('displays SIT when the shipment has sitDaysAllowance', () => {
+    render(
+      <MockProviders>
+        <ShipmentDetailsMain {...shipmentDetailsMainParams} shipment={futureSITShipment} />
+      </MockProviders>,
+    );
+
+    expect(screen.getByText('SIT (STORAGE IN TRANSIT)')).toBeInTheDocument();
+  });
+  it('does not display SIT when there is no sitStatus and no sit days allowance', () => {
+    render(
+      <MockProviders>
+        <ShipmentDetailsMain {...shipmentDetailsMainParams} shipment={noSITShipment} />
+      </MockProviders>,
+    );
+
+    expect(screen.queryByText('SIT (STORAGE IN TRANSIT)')).not.toBeInTheDocument();
+  });
+});

--- a/src/components/Office/ShipmentSITDisplay/ShipmentSITDisplay.jsx
+++ b/src/components/Office/ShipmentSITDisplay/ShipmentSITDisplay.jsx
@@ -62,7 +62,7 @@ const SitStatusTables = ({ shipment, sitExtensions, sitStatus, openModalButton }
   const sitStartDateElement = <p>{formatDate(sitStartDate, utcDateFormat, 'DD MMM YYYY')}</p>;
 
   const sitEndDate = sitStatus
-    ? moment().utc().add(sitStatus?.totalDaysRemaining, 'days')
+    ? moment(sitStartDate).utc().add(sitStatus.totalDaysRemaining, 'days')
     : moment(sitStartDate).utc().add(shipment.sitDaysAllowance, 'days');
   const sitEndDateElement = formatDate(sitEndDate, utcDateFormat, 'DD MMM YYYY');
 
@@ -82,7 +82,7 @@ const SitStatusTables = ({ shipment, sitExtensions, sitStatus, openModalButton }
   const currentLocation = sitStatus?.location === LOCATION_TYPES.DESTINATION ? 'destination SIT' : 'origin SIT';
 
   const totalSITDaysUsed = sitStatus?.totalSITDaysUsed || 0;
-  const totalDaysRemaining = sitStatus?.totalDaysRemaining || shipment.sitDaysAllowance;
+  const totalDaysRemaining = sitStatus ? sitStatus.totalDaysRemaining : shipment.sitDaysAllowance;
 
   return (
     <>

--- a/src/components/Office/ShipmentSITDisplay/ShipmentSITDisplayTestParams.js
+++ b/src/components/Office/ShipmentSITDisplay/ShipmentSITDisplayTestParams.js
@@ -154,7 +154,7 @@ export const SITStatusWithPastSITServiceItems = {
   ],
 };
 
-export const SITShipment = {
+export const noSITShipment = {
   actualPickupDate: '2020-03-16',
   approvedDate: '2020-03-20T00:00:00.000Z',
   calculatedBillableWeight: 980,
@@ -190,9 +190,13 @@ export const SITShipment = {
   requestedPickupDate: '2020-03-15',
   scheduledPickupDate: '2020-03-16',
   shipmentType: 'HHG',
-  sitDaysAllowance: 270,
   status: 'APPROVED',
   updatedAt: '2021-09-22T14:48:37.546Z',
+};
+
+export const SITShipment = {
+  ...noSITShipment,
+  sitDaysAllowance: 270,
 };
 
 export const futureSITShipment = {

--- a/src/hooks/custom.js
+++ b/src/hooks/custom.js
@@ -24,7 +24,9 @@ export const useCalculatedTotalBillableWeight = (mtoShipments) => {
   return useMemo(() => {
     return (
       mtoShipments
-        ?.filter((s) => includedStatusesForCalculatingWeights(s.status) && s.calculatedBillableWeight)
+        ?.filter((s) => {
+          return includedStatusesForCalculatingWeights(s.status) && s.calculatedBillableWeight;
+        })
         .reduce((prev, current) => {
           return prev + current.calculatedBillableWeight;
         }, 0) || null


### PR DESCRIPTION
## [Jira ticket](https://dp3.atlassian.net/browse/MB-13693)

## Summary

This PR addresses two issues with the previous work for MB-13693:
- The SIT module was showing for moves with no SIT (e.g. `BILWEI`)
- A new Happo diff was appearing every day on subsequent commits

## Verification Steps for the Author

These are to be checked by the author.

- [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
- [ ] Have the Jira acceptance criteria been met for this change?

## Verification Steps for Reviewers

These are to be checked by a reviewer.

### Setup to Run the Code

- [Instructions for starting storybook](https://transcom.github.io/mymove-docs/docs/frontend/setup/run-storybook)
- [Instructions for starting the MilMove application](https://transcom.github.io/mymove-docs/docs/about/application-setup/milmove-local-client/)
- [Instructions for running tests](https://transcom.github.io/mymove-docs/docs/about/development/testing)

### How to test

Log in as a TOO and note that:
- For moves `SITEXT`, `SITFUT`, and `PENDNG`, expect the SIT module to be on the Move Task Order page.
- For move `BILWEI`, expect the SIT module not to be on the MTO page.

Expect Happo diffs to be deterministic -- note that the diffs for this PR point to a fixed date in the past, rather than a varying date in the future. (Note, this was an issue with the implementation of the original work.)

`make client_test`

### Frontend

- [ ] There are no aXe warnings for UI.
- [ ] This works in [Supported Browsers and their phone views](https://transcom.github.io/mymove-docs/docs/about/supported-browsers) (Chrome, Firefox, Edge).
- [ ] There are no new console errors in the browser devtools.
- [ ] There are no new console errors in the test output.
- [ ] If this PR adds a new component to Storybook, it ensures the component is fully responsive, OR if it is intentionally not, a wrapping div using the `officeApp` class or custom `min-width` styling is used to hide any states the would not be visible to the user.
