### PR TITLE
Mb 15731 l102 l103 dependency field edi nt

### DIFF
--- a/pkg/edi/segment/l1.go
+++ b/pkg/edi/segment/l1.go
@@ -19,6 +19,9 @@ func (s *L1) StringArray() []string {
 	if s.FreightRate != nil {
 		freightRate = strconv.FormatFloat(*s.FreightRate, 'f', 2, 64)
 	}
+	if s.FreightRate == nil {
+		s.RateValueQualifier = ""
+	}
 	return []string{
 		"L1",
 		strconv.Itoa(s.LadingLineItemNumber),

--- a/pkg/edi/segment/l1_test.go
+++ b/pkg/edi/segment/l1_test.go
@@ -43,6 +43,22 @@ func (suite *SegmentSuite) TestValidateL1() {
 		suite.ValidateErrorLen(err, 4)
 	})
 
+	suite.Run("validate nil freightRate", func() {
+		l1 := L1{
+			// LadingLineItemNumber:          // required
+			FreightRate:        nil,
+			RateValueQualifier: "", // oneof
+			// Charge:                        // required
+		}
+
+		err := suite.validator.Struct(l1)
+		suite.ValidateError(err, "LadingLineItemNumber", "required")
+		suite.ValidateError(err, "FreightRate", "")
+		suite.ValidateError(err, "RateValueQualifier", "")
+		suite.ValidateError(err, "Charge", "required")
+		suite.ValidateErrorLen(err, 4)
+	})
+
 	suite.Run("validate failure 2", func() {
 		l1 := validL1
 		l1.LadingLineItemNumber = 1000 // max

--- a/pkg/services/invoice/ghc_payment_request_invoice_generator.go
+++ b/pkg/services/invoice/ghc_payment_request_invoice_generator.go
@@ -714,6 +714,8 @@ func (g ghcPaymentRequestInvoiceGenerator) generatePaymentServiceItemSegments(ap
 			newSegment.L1 = edisegment.L1{
 				LadingLineItemNumber: hierarchicalIDNumber,
 				Charge:               serviceItem.PriceCents.Int64(),
+				FreightRate:          nil,
+				RateValueQualifier:   "",
 			}
 
 		// following service items have weight and no distance

--- a/pkg/services/invoice/ghc_payment_request_invoice_generator_test.go
+++ b/pkg/services/invoice/ghc_payment_request_invoice_generator_test.go
@@ -776,6 +776,15 @@ func (suite *GHCInvoiceSuite) TestAllGenerateEdi() {
 					suite.Equal("D", l5.CommodityCodeQualifier)
 				})
 
+				suite.Run("adds l1 service item segment", func() {
+					charge := result.ServiceItems[segmentOffset].L1.Charge
+					l1 := result.ServiceItems[segmentOffset].L1
+					suite.Equal(hierarchicalNumberInt, l1.LadingLineItemNumber)
+					suite.Equal(int(charge), l1.Charge)
+					suite.Equal(nil, l1.FreightRate)
+					suite.Equal("", l1.RateValueQualifier)
+				})
+
 				suite.Run("adds l0 service item segment", func() {
 					l0 := result.ServiceItems[segmentOffset].L0
 					suite.Equal(hierarchicalNumberInt, l0.LadingLineItemNumber)


### PR DESCRIPTION
## [Jira ticket](https://dp3.atlassian.net/browse/MB-15731)

## Summary

This PR investigates the error that was received by US Bank with a missing L103.

```
Timestamp: 1/19/23 17:03

127250273, did not process because a paired element was missing. If the L102 is present, the L103 must also be included (but was missing). L1*2*0**2235300
```

Typically an L102 and L103 fields must be present together, however, US Bank received an invoice with only the L102.  There were several places in the code where the L103 was hard coded but not the L103 and vice versa, and I filled in those places in this PR. 

Tests were added as well.

## Verification Steps for the Author

These are to be checked by the author.

- [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
- [ ] Have the Jira acceptance criteria been met for this change?

## Verification Steps for Reviewers

These are to be checked by a reviewer.

### Setup to Run the Code

- [Instructions for starting the MilMove application](https://transcom.github.io/mymove-docs/docs/about/application-setup/milmove-local-client/)
- [Instructions for running tests](https://transcom.github.io/mymove-docs/docs/about/development/testing)

### How to test

1. Access the
2. Login as a
3.

#### Run tests:
```
go test ./pkg/services/invoice/ghc_payment_request_invoice_generator_test.go --testify.m TestAllGenerateEdi -v
```

```
go test ./pkg/edi/segment/l1_test.go --testify
```


### Backend

- [ ] Code follows the guidelines for [Logging](https://transcom.github.io/mymove-docs/docs/about/development/logging).
- [ ] The requirements listed in [Querying the Database Safely](https://transcom.github.io/mymove-docs/docs/backend/guides/golang-guide#querying-the-database-safely) have been satisfied.

