### PR TITLE
[MB-15791] add initial sit destination address column

### DIFF
--- a/migrations/app/migrations_manifest.txt
+++ b/migrations/app/migrations_manifest.txt
@@ -806,3 +806,4 @@
 20230421202012_fix_movehq_uat_cert.up.sql
 20230424173425_add_daycos_and_movehq_prod_certs.up.sql
 20230427142553_drop_400ng_zip_tables.up.sql
+20230503233423_adding_sit_destination_initial_address_column.up.sql

--- a/migrations/app/schema/20230503233423_adding_sit_destination_initial_address_column.up.sql
+++ b/migrations/app/schema/20230503233423_adding_sit_destination_initial_address_column.up.sql
@@ -1,0 +1,6 @@
+-- New Column
+ALTER TABLE mto_service_items
+ADD COLUMN sit_destination_original_address_id uuid CONSTRAINT mto_service_items_sit_destination_original_address_id_fkey REFERENCES addresses (id);
+
+-- Column Comment
+COMMENT ON COLUMN mto_service_items.sit_destination_original_address_id IS 'This is to capture the first sit destination address. Once this is captured, the initial address cannot be changed. Any subsequent updates to the sit destination address should be set by the sit_destination_final_address_id';


### PR DESCRIPTION
## [Jira ticket](https://dp3.atlassian.net/browse/MB-15791)

## Summary

This PR includes a migration to add the new `sit_destination_original_address_id` column to the `mto_service_items` table along with a reference to the `address` table where the actual value will be stored similar to the `sit_destination_final_address_id` column. 

## Verification Steps for the Author

These are to be checked by the author.

- [x] Have the Jira acceptance criteria been met for this change?

## Verification Steps for Reviewers

These are to be checked by a reviewer.

### Setup to Run the Code

- [Instructions for starting storybook](https://transcom.github.io/mymove-docs/docs/frontend/setup/run-storybook)
- [Instructions for starting the MilMove application](https://transcom.github.io/mymove-docs/docs/about/application-setup/milmove-local-client/)
- [Instructions for running tests](https://transcom.github.io/mymove-docs/docs/about/development/testing)

### How to test

1. Run `make db_dev_migrate`
2. Check the `mto_service_items` table with your favorite db software and you should see the the column now exists 🎉 
3.  You can also run `make server_test` to verify all tests still pass

### Backend

- [ ] Code follows the guidelines for [Logging](https://transcom.github.io/mymove-docs/docs/about/development/logging).
- [ ] The requirements listed in [Querying the Database Safely](https://transcom.github.io/mymove-docs/docs/backend/guides/golang-guide#querying-the-database-safely) have been satisfied.

### Database

#### Any new migrations/schema changes:

- [ ] Follows our guidelines for [Zero-Downtime Deploys](https://transcom.github.io/mymove-docs/docs/backend/setup/database-migrations#zero-downtime-migrations).
- [ ] Have been communicated to #g-database.
- [ ] Secure migrations have been tested following the instructions in our [docs](https://transcom.github.io/mymove-docs/docs/backend/setup/database-migrations#secure-migrations).

## Screenshots
How it appears in Postico:
![image](https://user-images.githubusercontent.com/111928238/236079460-65727abe-6c26-4536-b0e8-40ce1352d265.png)

