### PR TITLE
[MB-15962] Fix SITDisplayDetails storybook renderings

### DIFF
--- a/src/components/Office/ShipmentDetails/ShipmentDetails.stories.jsx
+++ b/src/components/Office/ShipmentDetails/ShipmentDetails.stories.jsx
@@ -20,7 +20,7 @@ export default {
       MockDate.set(mockedDate);
       addons.getChannel().on('storyRendered', MockDate.reset);
       return (
-        <div style={{ padding: '1em' }}>
+        <div>
           <Story />
         </div>
       );

--- a/src/components/Office/ShipmentDetails/ShipmentDetails.stories.jsx
+++ b/src/components/Office/ShipmentDetails/ShipmentDetails.stories.jsx
@@ -1,5 +1,7 @@
 import React from 'react';
 import { Route } from 'react-router';
+import MockDate from 'mockdate';
+import addons from '@storybook/addons';
 
 import { SITStatusOrigin } from '../ShipmentSITDisplay/ShipmentSITDisplayTestParams';
 
@@ -9,8 +11,21 @@ import { LOA_TYPE } from 'shared/constants';
 import { permissionTypes } from 'constants/permissions';
 import { MockProviders } from 'testUtils';
 
+// Based on SITStatusOrigin. The date is 15 days after the entry date.
+const mockedDate = '2021-08-28T15:41:59.373Z';
 export default {
   title: 'Office Components/Shipment Details',
+  decorators: [
+    (Story) => {
+      MockDate.set(mockedDate);
+      addons.getChannel().on('storyRendered', MockDate.reset);
+      return (
+        <div style={{ padding: '1em', backgroundColor: '#f9f9f9' }}>
+          <Story />
+        </div>
+      );
+    },
+  ],
 };
 
 const shipment = {

--- a/src/components/Office/ShipmentDetails/ShipmentDetails.stories.jsx
+++ b/src/components/Office/ShipmentDetails/ShipmentDetails.stories.jsx
@@ -20,7 +20,7 @@ export default {
       MockDate.set(mockedDate);
       addons.getChannel().on('storyRendered', MockDate.reset);
       return (
-        <div style={{ padding: '1em', backgroundColor: '#f9f9f9' }}>
+        <div style={{ padding: '1em' }}>
           <Story />
         </div>
       );

--- a/src/components/Office/SubmitSITExtensionModal/SubmitSITExtensionModal.stories.jsx
+++ b/src/components/Office/SubmitSITExtensionModal/SubmitSITExtensionModal.stories.jsx
@@ -1,10 +1,25 @@
 import React from 'react';
+import MockDate from 'mockdate';
+import addons from '@storybook/addons';
 
 import SubmitSITExtensionModal from './SubmitSITExtensionModal';
 
+// Based on sitStatus below. The date is 31 days after the entry date.
+const mockedDate = '2023-04-19T00:00:00.000Z';
 export default {
   title: 'Office Components/SubmitSITExtensionModal',
   component: SubmitSITExtensionModal,
+  decorators: [
+    (Story) => {
+      MockDate.set(mockedDate);
+      addons.getChannel().on('storyRendered', MockDate.reset);
+      return (
+        <div style={{ padding: '1em', backgroundColor: '#f9f9f9' }}>
+          <Story />
+        </div>
+      );
+    },
+  ],
 };
 
 const sitStatus = {


### PR DESCRIPTION
## [Jira ticket](https://dp3.atlassian.net/browse/MB-15962)

## Summary

Add Mock Date to keep dates from changing in Storybook renderings of the ShipmentSITDisplay component.

## Verification Steps for the Author

These are to be checked by the author.

- [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
- [ ] Have the Jira acceptance criteria been met for this change?

## Verification Steps for Reviewers

These are to be checked by a reviewer.

### Setup to Run the Code

- [Instructions for starting storybook](https://transcom.github.io/mymove-docs/docs/frontend/setup/run-storybook)
- [Instructions for starting the MilMove application](https://transcom.github.io/mymove-docs/docs/about/application-setup/milmove-local-client/)
- [Instructions for running tests](https://transcom.github.io/mymove-docs/docs/about/development/testing)

### How to test

1. Access Storybook
2. Look `ShipmentDetails` and `SubmitSITExtension` components
3. Renders as expected

### Frontend

- [ ] There are no aXe warnings for UI.
- [ ] This works in [Supported Browsers and their phone views](https://transcom.github.io/mymove-docs/docs/about/supported-browsers) (Chrome, Firefox, Edge).
- [ ] There are no new console errors in the browser devtools.
- [ ] There are no new console errors in the test output.
- [ ] If this PR adds a new component to Storybook, it ensures the component is fully responsive, OR if it is intentionally not, a wrapping div using the `officeApp` class or custom `min-width` styling is used to hide any states the would not be visible to the user.

