### PR TITLE
MB-15953-Remove authorized weight from the office orders

### DIFF
--- a/pkg/gen/ghcapi/embedded_spec.go
+++ b/pkg/gen/ghcapi/embedded_spec.go
@@ -8492,14 +8492,6 @@ func init() {
         "agency": {
           "$ref": "#/definitions/Affiliation"
         },
-        "authorizedWeight": {
-          "description": "unit is in lbs",
-          "type": "integer",
-          "minimum": 1,
-          "x-formatting": "weight",
-          "x-nullable": true,
-          "example": 2000
-        },
         "dependentsAuthorized": {
           "type": "boolean",
           "x-nullable": true
@@ -19087,14 +19079,6 @@ func init() {
       "properties": {
         "agency": {
           "$ref": "#/definitions/Affiliation"
-        },
-        "authorizedWeight": {
-          "description": "unit is in lbs",
-          "type": "integer",
-          "minimum": 1,
-          "x-formatting": "weight",
-          "x-nullable": true,
-          "example": 2000
         },
         "dependentsAuthorized": {
           "type": "boolean",

--- a/pkg/gen/ghcmessages/update_allowance_payload.go
+++ b/pkg/gen/ghcmessages/update_allowance_payload.go
@@ -22,11 +22,6 @@ type UpdateAllowancePayload struct {
 	// agency
 	Agency *Affiliation `json:"agency,omitempty"`
 
-	// unit is in lbs
-	// Example: 2000
-	// Minimum: 1
-	AuthorizedWeight *int64 `json:"authorizedWeight,omitempty"`
-
 	// dependents authorized
 	DependentsAuthorized *bool `json:"dependentsAuthorized,omitempty"`
 
@@ -63,10 +58,6 @@ func (m *UpdateAllowancePayload) Validate(formats strfmt.Registry) error {
 	var res []error
 
 	if err := m.validateAgency(formats); err != nil {
-		res = append(res, err)
-	}
-
-	if err := m.validateAuthorizedWeight(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -110,18 +101,6 @@ func (m *UpdateAllowancePayload) validateAgency(formats strfmt.Registry) error {
 			}
 			return err
 		}
-	}
-
-	return nil
-}
-
-func (m *UpdateAllowancePayload) validateAuthorizedWeight(formats strfmt.Registry) error {
-	if swag.IsZero(m.AuthorizedWeight) { // not required
-		return nil
-	}
-
-	if err := validate.MinimumInt("authorizedWeight", "body", *m.AuthorizedWeight, 1, false); err != nil {
-		return err
 	}
 
 	return nil

--- a/pkg/handlers/ghcapi/orders_test.go
+++ b/pkg/handlers/ghcapi/orders_test.go
@@ -995,7 +995,6 @@ func (suite *HandlerSuite) makeUpdateAllowanceHandlerSubtestData() (subtestData 
 	subtestData.move = factory.BuildServiceCounselingCompletedMove(suite.DB(), nil, nil)
 	subtestData.order = subtestData.move.Orders
 
-	newAuthorizedWeight := int64(10000)
 	grade := ghcmessages.GradeO5
 	affiliation := ghcmessages.AffiliationAIRFORCE
 	ocie := false
@@ -1005,7 +1004,6 @@ func (suite *HandlerSuite) makeUpdateAllowanceHandlerSubtestData() (subtestData 
 
 	subtestData.body = &ghcmessages.UpdateAllowancePayload{
 		Agency:               &affiliation,
-		AuthorizedWeight:     &newAuthorizedWeight,
 		DependentsAuthorized: models.BoolPointer(true),
 		Grade:                &grade,
 		OrganizationalClothingAndIndividualEquipment: &ocie,
@@ -1098,7 +1096,6 @@ func (suite *HandlerSuite) TestUpdateAllowanceHandler() {
 		suite.NoError(ordersPayload.Validate(strfmt.Default))
 
 		suite.Equal(order.ID.String(), ordersPayload.ID.String())
-		suite.Equal(body.AuthorizedWeight, ordersPayload.Entitlement.AuthorizedWeight)
 		suite.Equal(body.Grade, ordersPayload.Grade)
 		suite.Equal(body.Agency, ordersPayload.Agency)
 		suite.Equal(body.DependentsAuthorized, ordersPayload.Entitlement.DependentsAuthorized)

--- a/pkg/services/order/order_updater.go
+++ b/pkg/services/order/order_updater.go
@@ -375,11 +375,6 @@ func allowanceFromTOOPayload(existingOrder models.Order, payload ghcmessages.Upd
 		order.Entitlement.OrganizationalClothingAndIndividualEquipment = *payload.OrganizationalClothingAndIndividualEquipment
 	}
 
-	if payload.AuthorizedWeight != nil {
-		dbAuthorizedWeight := models.IntPointer(int(*payload.AuthorizedWeight))
-		order.Entitlement.DBAuthorizedWeight = dbAuthorizedWeight
-	}
-
 	if payload.DependentsAuthorized != nil {
 		order.Entitlement.DependentsAuthorized = payload.DependentsAuthorized
 	}

--- a/pkg/services/order/order_updater_test.go
+++ b/pkg/services/order/order_updater_test.go
@@ -541,7 +541,6 @@ func (suite *OrderServiceSuite) TestUpdateAllowanceAsTOO() {
 		orderUpdater := NewOrderUpdater(moveRouter)
 		order := factory.BuildServiceCounselingCompletedMove(suite.DB(), nil, nil).Orders
 
-		newAuthorizedWeight := int64(10000)
 		grade := ghcmessages.GradeO5
 		affiliation := ghcmessages.AffiliationAIRFORCE
 		ocie := false
@@ -552,7 +551,6 @@ func (suite *OrderServiceSuite) TestUpdateAllowanceAsTOO() {
 
 		payload := ghcmessages.UpdateAllowancePayload{
 			Agency:               &affiliation,
-			AuthorizedWeight:     &newAuthorizedWeight,
 			DependentsAuthorized: models.BoolPointer(true),
 			Grade:                &grade,
 			OrganizationalClothingAndIndividualEquipment: &ocie,
@@ -569,7 +567,6 @@ func (suite *OrderServiceSuite) TestUpdateAllowanceAsTOO() {
 
 		suite.NoError(err)
 		suite.Equal(order.ID.String(), updatedOrder.ID.String())
-		suite.Equal(*payload.AuthorizedWeight, int64(*updatedOrder.Entitlement.DBAuthorizedWeight))
 		suite.Equal(payload.DependentsAuthorized, updatedOrder.Entitlement.DependentsAuthorized)
 		suite.Equal(*payload.ProGearWeight, int64(updatedOrder.Entitlement.ProGearWeight))
 		suite.Equal(*payload.ProGearWeightSpouse, int64(updatedOrder.Entitlement.ProGearWeightSpouse))

--- a/playwright/tests/office/qaecsr/csrFlows.spec.js
+++ b/playwright/tests/office/qaecsr/csrFlows.spec.js
@@ -162,7 +162,6 @@ test.describe('Customer Support User Flows', () => {
       await expect(page.locator('select[name=agency]')).toBeDisabled();
       await expect(page.locator('select[name="grade"]')).toBeDisabled();
       await expect(page.locator('select[name="grade"]')).toBeDisabled();
-      await expect(page.locator('input[name="authorizedWeight"]')).toBeDisabled();
       await expect(page.locator('input[name="dependentsAuthorized"]')).toBeDisabled();
 
       // no save button should exist

--- a/src/components/Office/AllowancesDetailForm/AllowancesDetailForm.jsx
+++ b/src/components/Office/AllowancesDetailForm/AllowancesDetailForm.jsx
@@ -10,14 +10,7 @@ import { EntitlementShape } from 'types/order';
 import { formatWeight } from 'utils/formatters';
 import Hint from 'components/Hint';
 
-const AllowancesDetailForm = ({
-  header,
-  entitlements,
-  rankOptions,
-  branchOptions,
-  editableAuthorizedWeight,
-  formIsDisabled,
-}) => {
+const AllowancesDetailForm = ({ header, entitlements, rankOptions, branchOptions, formIsDisabled }) => {
   return (
     <div className={styles.AllowancesDetailForm}>
       {header && <h3 data-testid="header">{header}</h3>}
@@ -108,30 +101,7 @@ const AllowancesDetailForm = ({
           isDisabled={formIsDisabled}
         />
       </div>
-
-      {editableAuthorizedWeight && (
-        <MaskedTextField
-          data-testid="authorizedWeightInput"
-          defaultValue="0"
-          name="authorizedWeight"
-          label="Authorized weight (lbs)"
-          id="authorizedWeightInput"
-          mask={Number}
-          scale={0} // digits after point, 0 for integers
-          signed={false} // disallow negative
-          thousandsSeparator=","
-          lazy={false} // immediate masking evaluation
-          isDisabled={formIsDisabled}
-        />
-      )}
-
       <dl>
-        {!editableAuthorizedWeight && (
-          <>
-            <dt>Authorized weight</dt>
-            <dd data-testid="authorizedWeight">{formatWeight(entitlements.authorizedWeight)}</dd>
-          </>
-        )}
         <dt>Weight allowance</dt>
         <dd data-testid="weightAllowance">{formatWeight(entitlements.totalWeight)}</dd>
       </dl>
@@ -153,13 +123,11 @@ AllowancesDetailForm.propTypes = {
   rankOptions: DropdownArrayOf.isRequired,
   branchOptions: DropdownArrayOf.isRequired,
   header: PropTypes.string,
-  editableAuthorizedWeight: PropTypes.bool,
   formIsDisabled: PropTypes.bool,
 };
 
 AllowancesDetailForm.defaultProps = {
   header: null,
-  editableAuthorizedWeight: false,
   formIsDisabled: false,
 };
 

--- a/src/components/Office/DefinitionLists/AllowancesList.jsx
+++ b/src/components/Office/DefinitionLists/AllowancesList.jsx
@@ -25,10 +25,6 @@ const AllowancesList = ({ info, showVisualCues }) => {
           <dd data-testid="weightAllowance">{formatWeight(info.weightAllowance)}</dd>
         </div>
         <div className={descriptionListStyles.row}>
-          <dt>Authorized weight</dt>
-          <dd data-testid="authorizedWeight">{formatWeight(info.authorizedWeight)}</dd>
-        </div>
-        <div className={descriptionListStyles.row}>
           <dt>Storage in transit (SIT)</dt>
           <dd data-testid="storageInTransit">{info.storageInTransit} days</dd>
         </div>

--- a/src/components/Office/DefinitionLists/AllowancesList.test.jsx
+++ b/src/components/Office/DefinitionLists/AllowancesList.test.jsx
@@ -27,11 +27,6 @@ describe('AllowancesList', () => {
     expect(screen.getByText('12,000 lbs')).toBeInTheDocument();
   });
 
-  it('renders formatted authorized weight', () => {
-    render(<AllowancesList info={info} />);
-    expect(screen.getByText('11,000 lbs')).toBeInTheDocument();
-  });
-
   it('renders storage in transit', () => {
     render(<AllowancesList info={info} />);
     expect(screen.getByText('90 days')).toBeInTheDocument();

--- a/src/pages/Office/MoveAllowances/MoveAllowances.jsx
+++ b/src/pages/Office/MoveAllowances/MoveAllowances.jsx
@@ -177,7 +177,6 @@ const MoveAllowances = () => {
                     entitlements={order.entitlement}
                     rankOptions={rankDropdownOptions}
                     branchOptions={branchDropdownOption}
-                    editableAuthorizedWeight
                   />
                 </Restricted>
               </div>

--- a/src/pages/Office/MoveAllowances/MoveAllowances.jsx
+++ b/src/pages/Office/MoveAllowances/MoveAllowances.jsx
@@ -26,7 +26,6 @@ const rankDropdownOptions = dropdownInputOptions(ORDERS_RANK_OPTIONS);
 const branchDropdownOption = dropdownInputOptions(ORDERS_BRANCH_OPTIONS);
 
 const validationSchema = Yup.object({
-  authorizedWeight: Yup.number().min(1, 'Authorized weight must be greater than or equal to 1').required('Required'),
   proGearWeight: Yup.number()
     .min(0, 'Pro-gear weight must be greater than or equal to 0')
     .max(2000, "Enter a weight that does not go over the customer's maximum allowance")
@@ -83,7 +82,6 @@ const MoveAllowances = () => {
   const onSubmit = (values) => {
     const {
       grade,
-      authorizedWeight,
       agency,
       dependentsAuthorized,
       proGearWeight,
@@ -100,7 +98,6 @@ const MoveAllowances = () => {
       originDutyLocationId: order.originDutyLocation.id,
       reportByDate: order.report_by_date,
       grade,
-      authorizedWeight: Number(authorizedWeight),
       agency,
       dependentsAuthorized,
       proGearWeight: Number(proGearWeight),
@@ -114,7 +111,6 @@ const MoveAllowances = () => {
 
   const { entitlement, grade, agency } = order;
   const {
-    authorizedWeight,
     dependentsAuthorized,
     proGearWeight,
     proGearWeightSpouse,
@@ -124,7 +120,6 @@ const MoveAllowances = () => {
   } = entitlement;
 
   const initialValues = {
-    authorizedWeight: `${authorizedWeight}`,
     grade,
     agency,
     dependentsAuthorized,

--- a/swagger-def/ghc.yaml
+++ b/swagger-def/ghc.yaml
@@ -3757,13 +3757,6 @@ definitions:
   UpdateAllowancePayload:
     type: object
     properties:
-      authorizedWeight:
-        description: unit is in lbs
-        example: 2000
-        minimum: 1
-        type: integer
-        x-formatting: weight
-        x-nullable: true
       grade:
         $ref: '#/definitions/Grade'
       dependentsAuthorized:

--- a/swagger/ghc.yaml
+++ b/swagger/ghc.yaml
@@ -3885,13 +3885,6 @@ definitions:
   UpdateAllowancePayload:
     type: object
     properties:
-      authorizedWeight:
-        description: unit is in lbs
-        example: 2000
-        minimum: 1
-        type: integer
-        x-formatting: weight
-        x-nullable: true
       grade:
         $ref: '#/definitions/Grade'
       dependentsAuthorized:


### PR DESCRIPTION
## [Jira ticket](https://dp3.atlassian.net/browse/MB-15953)

## Summary

This ticket removes `Authorized weight` field from the Allowance document viewer and Allowances section on the move details page. 

**Reason for the removal:** 
- We don’t need authorized weight until international moves are implemented
- During the user exercises TOOs added an ‘authorized weight (lbs)’ when reviewing Allowances without knowing this update the max billable weight

## Verification Steps for the Author and Reviewer

- Login to the office app as TOO
- Find any move that's been approved or approvals requested
- Click on Move details tab
- Verify that authorized weight is not in the Allowances section
-  Edit Allowances
- Verify that authorized weight is not in the Allowance document viewer


## Screenshots
Shows authorized weight is not in the UI anymore.

https://user-images.githubusercontent.com/111006369/236873427-fcae0b8b-fc31-4985-ae24-e2bf1fd04ad0.mov

