### PR TITLE
[MB-15719] Change the logic behind validation of prime-provided estimated weight

### DIFF
--- a/pkg/handlers/primeapi/mto_shipment_test.go
+++ b/pkg/handlers/primeapi/mto_shipment_test.go
@@ -1613,7 +1613,6 @@ func (suite *HandlerSuite) TestUpdateMTOShipmentDateLogic() {
 	suite.Run("Successful case if estimated weight added on scheduled pickup date", func() {
 		handler, move := setupTestData()
 
-		twoMinutesAgo := now.Add(time.Duration(time.Duration.Minutes(2)))
 		oldShipment := factory.BuildMTOShipment(suite.DB(), []factory.Customization{
 			{
 				Model:    move,
@@ -1622,7 +1621,7 @@ func (suite *HandlerSuite) TestUpdateMTOShipmentDateLogic() {
 			{
 				Model: models.MTOShipment{
 					Status:              models.MTOShipmentStatusApproved,
-					ScheduledPickupDate: &twoMinutesAgo,
+					ScheduledPickupDate: &now,
 				},
 			},
 		}, nil)
@@ -1677,7 +1676,7 @@ func (suite *HandlerSuite) TestUpdateMTOShipmentDateLogic() {
 		payload := primemessages.UpdateMTOShipment{
 			PrimeEstimatedWeight: handlers.FmtPoundPtr(&primeEstimatedWeight),
 		}
-		req := httptest.NewRequest("PATCH", fmt.Sprintf("/mto_shipments/%s", oldShipment.ID.String()), nil)
+		req := httptest.NewRequest("PATCH", fmt.Sprintf("/mto-shipments/%s", oldShipment.ID.String()), nil)
 		params := mtoshipmentops.UpdateMTOShipmentParams{
 			HTTPRequest:   req,
 			MtoShipmentID: *handlers.FmtUUID(oldShipment.ID),


### PR DESCRIPTION
## [Jira ticket](https://dp3.atlassian.net/browse/MB-15719)

## Summary

This pull request updates the handler code for the update MTO shipment endpoint that's exposed to the Prime, by removing the existing validation code around estimated weights, approval dates, and scheduled pickup dates, and replacing it with a check that the estimated weight can only be added **on or before** the scheduled pickup date. (If there scheduled pickup date is not present, the estimated weight can still be added.)

Quite a few tests are updated to reflect the existing functionality.
