### PR TITLE
MB-15801 - Select element unclickable in playwright

### DIFF
--- a/playwright/tests/office/servicescounseling/servicesCounselingFlows.spec.js
+++ b/playwright/tests/office/servicescounseling/servicesCounselingFlows.spec.js
@@ -228,16 +228,19 @@ test.describe('Services counselor user', () => {
     await page.getByRole('button', { name: 'Review documents' }).click();
 
     await scPage.waitForPage.reviewWeightTicket();
-    await page.getByText('Accept').click();
+
+    await expect(page.getByLabel('Accept')).toBeVisible();
+    await page.getByLabel('Accept').dispatchEvent('click');
     await page.getByRole('button', { name: 'Continue' }).click();
 
     await scPage.waitForPage.reviewProGear();
-    await page.getByText('Accept').click();
+    await expect(page.getByLabel('Accept')).toBeVisible();
+    await page.getByLabel('Accept').dispatchEvent('click');
     await page.getByRole('button', { name: 'Continue' }).click();
 
     await scPage.waitForPage.reviewReceipt();
-    await expect(page.getByText('Accept')).toBeVisible();
-    await page.getByText('Accept').click();
+    await expect(page.getByLabel('Accept')).toBeVisible();
+    await page.getByLabel('Accept').dispatchEvent('click');
     await page.getByRole('button', { name: 'Continue' }).click();
 
     await scPage.waitForPage.reviewDocumentsConfirmation();


### PR DESCRIPTION
## [Jira ticket](https://dp3.atlassian.net/browse/MB-15801)

## Summary

This fixes an issue where using `getByLabel` on options in a React USWDS `Select` component failed to register. Playwright expects elements to be in (or scrollable to within) the viewport before clicking them, which isn't possible here. 

Calling `dispatchEvent('click')` bypasses this requirement. It also allows the elements to be selected by the label instead of by text, which is a better guarantee for accessibility, since we should be ensuring the existence of a label.

## Verification Steps for the Author

These are to be checked by the author.

- [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
- [ ] Have the Jira acceptance criteria been met for this change?

## Verification Steps for Reviewers

The test should pass individually and when the others are run.

`yarn playwright test playwright/tests/office/servicescounseling/servicesCounselingFlows.spec.js`
`make e2e_test`