### PR TITLE
Mock the story rendered date.

### DIFF
--- a/src/components/Office/ReviewSITExtensionModal/ReviewSITExtensionModal.stories.jsx
+++ b/src/components/Office/ReviewSITExtensionModal/ReviewSITExtensionModal.stories.jsx
@@ -1,10 +1,25 @@
 import React from 'react';
+import MockDate from 'mockdate';
+import addons from '@storybook/addons';
 
 import ReviewSITExtensionModal from './ReviewSITExtensionModal';
+
+const mockedDate = '2023-09-06T15:41:59.373Z';
 
 export default {
   title: 'Office Components/ReviewSITExtensionModal',
   component: ReviewSITExtensionModal,
+  decorators: [
+    (Story) => {
+      MockDate.set(mockedDate);
+      addons.getChannel().on('storyRendered', MockDate.reset);
+      return (
+        <div>
+          <Story />
+        </div>
+      );
+    },
+  ],
 };
 
 const sitExtension = {


### PR DESCRIPTION
## Summary

This PR adds a decorator to the ReviewSITExtensionModal that mocks the date on which the story was rendered. In the ShipmentSITDisplay component, the SIT authorized end date can be based on the current date; the rendered date will therefore change on subsequent renders. This forces that date to be deterministic.

This approach is borrowed wholesale from the implementation in the ShipmentDetails story.

## Verification Steps for the Author

These are to be checked by the author.

- [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
- [ ] Have the Jira acceptance criteria been met for this change?

## Verification Steps for Reviewers

Note that the SIT End Date on the ReviewSITExtensionModal story does not change. 

## Screenshots

![Screenshot 2023-05-09 at 10 15 12 AM](https://github.com/transcom/mymove/assets/1245800/51078bf0-0889-4ea5-a6e9-be9027d073b0)
