### PR TITLE
[MB-14677] Adjusts colors after a11y audit

### DIFF
--- a/src/components/Customer/MtoShipmentForm/MtoShipmentForm.jsx
+++ b/src/components/Customer/MtoShipmentForm/MtoShipmentForm.jsx
@@ -474,7 +474,7 @@ class MtoShipmentForm extends Component {
                         </Fieldset>
                       </SectionWrapper>
 
-                      <Hint>
+                      <Hint darkText>
                         <p>You can change details about your move by talking with your counselor or your movers</p>
                       </Hint>
 

--- a/src/components/Customer/Review/ShipmentCard/ShipmentCard.module.scss
+++ b/src/components/Customer/Review/ShipmentCard/ShipmentCard.module.scss
@@ -32,7 +32,7 @@
       }
 
       p {
-        color: #92979b;
+        color: $base-darker;
         margin: 0;
       }
     }

--- a/src/components/Hint/Hint.stories.jsx
+++ b/src/components/Hint/Hint.stories.jsx
@@ -19,3 +19,9 @@ export const MultipleParagraphs = () => (
     <p>Here is another paragraph hint text.</p>
   </Hint>
 );
+
+export const DarkerText = () => (
+  <Hint darkerText>
+    <p>Here is some hint text.</p>
+  </Hint>
+);

--- a/src/components/Hint/index.jsx
+++ b/src/components/Hint/index.jsx
@@ -1,11 +1,11 @@
 import React from 'react';
-import { string, node } from 'prop-types';
+import { string, node, bool } from 'prop-types';
 
 import styles from './index.module.scss';
 
-const Hint = ({ className, children, ...props }) => (
+const Hint = ({ className, children, darkText, ...props }) => (
   // eslint-disable-next-line react/jsx-props-no-spreading
-  <div {...props} className={`${styles.Hint} ${className}`}>
+  <div {...props} className={`${styles.Hint} ${className} ${darkText ? styles.DarkText : ''}`}>
     {children}
   </div>
 );
@@ -13,10 +13,12 @@ const Hint = ({ className, children, ...props }) => (
 Hint.propTypes = {
   className: string,
   children: node.isRequired,
+  darkText: bool,
 };
 
 Hint.defaultProps = {
   className: '',
+  darkText: false,
 };
 
 export default Hint;

--- a/src/components/Hint/index.module.scss
+++ b/src/components/Hint/index.module.scss
@@ -20,6 +20,10 @@
   p + p {
     @include u-margin-top('105');
   }
+
+  &.DarkText p {
+    color: $base-darkest;
+  }
 }
 
 :global(.grid-row) + .Hint {

--- a/src/pages/MyMove/SelectShipmentType.module.scss
+++ b/src/pages/MyMove/SelectShipmentType.module.scss
@@ -4,7 +4,7 @@
 @import '../../shared/styles/_variables';
 
 .footer {
-  color: $base;
+  color: $base-darkest;
   @include u-margin-top(3);
   @include u-margin-bottom(3);
 }


### PR DESCRIPTION
## Jira ticket: [MB-14677](https://dp3.atlassian.net/browse/MB-14677)

Completes subtasks [MB-15234](https://dp3.atlassian.net/browse/MB-15234), [MB-15426](https://dp3.atlassian.net/browse/MB-15426), [MB-15427](https://dp3.atlassian.net/browse/MB-15427), and [MB-15428](https://dp3.atlassian.net/browse/MB-15428).

## Summary

This pull request address some concerns that came up during recent accessibility audits, specifically around insufficient text/background color contrast. As part of this work, a `darkText` prop is added to the `Hint` component which instructs the component to display contents with a darker font color.

## Verification Steps for the Author

These are to be checked by the author.

- [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
- [ ] Have the Jira acceptance criteria been met for this change?

## Verification Steps for Reviewers

These are to be checked by a reviewer.

### Setup to Run the Code

- [Instructions for starting storybook](https://transcom.github.io/mymove-docs/docs/frontend/setup/run-storybook)

### How to test

As the only changes are to the color of text elements, this pull request is explicitly best reviewed by looking at the Happo diffs, but if you want to run it locally these changes can also be seen in their components' Storybook entires.

### Frontend

- [ ] There are no aXe warnings for UI.
- [ ] This works in [Supported Browsers and their phone views](https://transcom.github.io/mymove-docs/docs/about/supported-browsers) (Chrome, Firefox, Edge).
- [ ] There are no new console errors in the browser devtools.
- [ ] There are no new console errors in the test output.
- [ ] If this PR adds a new component to Storybook, it ensures the component is fully responsive, OR if it is intentionally not, a wrapping div using the `officeApp` class or custom `min-width` styling is used to hide any states the would not be visible to the user.

[MB-14677]: https://dp3.atlassian.net/browse/MB-14677?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MB-15234]: https://dp3.atlassian.net/browse/MB-15234?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MB-15426]: https://dp3.atlassian.net/browse/MB-15426?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MB-15427]: https://dp3.atlassian.net/browse/MB-15427?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MB-15428]: https://dp3.atlassian.net/browse/MB-15428?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ