### PR TITLE
[MB-15875] Prime API update service item endpoint to validate against the 50 mile rule

### DIFF
--- a/pkg/gen/primeapi/embedded_spec.go
+++ b/pkg/gen/primeapi/embedded_spec.go
@@ -3616,6 +3616,9 @@ func init() {
             "sitDestinationFinalAddress": {
               "$ref": "#/definitions/Address"
             },
+            "sitDestinationUpdatedAddress": {
+              "$ref": "#/definitions/Address"
+            },
             "timeMilitary1": {
               "description": "Time of delivery corresponding to ` + "`" + `firstAvailableDeliveryDate1` + "`" + `, in military format.",
               "type": "string",
@@ -3629,6 +3632,13 @@ func init() {
               "pattern": "\\d{4}Z",
               "x-nullable": true,
               "example": "1400Z"
+            },
+            "updatedDistanceFromOriginalAddress": {
+              "description": "The distance between the orignal SIT delivery address and the sitDestinationUpdatedAddress. In order for the Prime to make this update the distance must be \u003c= 50 miles.",
+              "type": "integer",
+              "maximum": 50,
+              "x-nullable": true,
+              "example": 25
             }
           }
         }
@@ -8046,6 +8056,9 @@ func init() {
             "sitDestinationFinalAddress": {
               "$ref": "#/definitions/Address"
             },
+            "sitDestinationUpdatedAddress": {
+              "$ref": "#/definitions/Address"
+            },
             "timeMilitary1": {
               "description": "Time of delivery corresponding to ` + "`" + `firstAvailableDeliveryDate1` + "`" + `, in military format.",
               "type": "string",
@@ -8059,6 +8072,13 @@ func init() {
               "pattern": "\\d{4}Z",
               "x-nullable": true,
               "example": "1400Z"
+            },
+            "updatedDistanceFromOriginalAddress": {
+              "description": "The distance between the orignal SIT delivery address and the sitDestinationUpdatedAddress. In order for the Prime to make this update the distance must be \u003c= 50 miles.",
+              "type": "integer",
+              "maximum": 50,
+              "x-nullable": true,
+              "example": 25
             }
           }
         }

--- a/pkg/gen/primemessages/update_m_t_o_service_item_s_i_t.go
+++ b/pkg/gen/primemessages/update_m_t_o_service_item_s_i_t.go
@@ -41,6 +41,9 @@ type UpdateMTOServiceItemSIT struct {
 	// sit destination final address
 	SitDestinationFinalAddress *Address `json:"sitDestinationFinalAddress,omitempty"`
 
+	// sit destination updated address
+	SitDestinationUpdatedAddress *Address `json:"sitDestinationUpdatedAddress,omitempty"`
+
 	// Time of delivery corresponding to `firstAvailableDeliveryDate1`, in military format.
 	// Example: 1400Z
 	// Pattern: \d{4}Z
@@ -50,6 +53,11 @@ type UpdateMTOServiceItemSIT struct {
 	// Example: 1400Z
 	// Pattern: \d{4}Z
 	TimeMilitary2 *string `json:"timeMilitary2,omitempty"`
+
+	// The distance between the orignal SIT delivery address and the sitDestinationUpdatedAddress. In order for the Prime to make this update the distance must be <= 50 miles.
+	// Example: 25
+	// Maximum: 50
+	UpdatedDistanceFromOriginalAddress *int64 `json:"updatedDistanceFromOriginalAddress,omitempty"`
 }
 
 // ID gets the id of this subtype
@@ -94,6 +102,9 @@ func (m *UpdateMTOServiceItemSIT) UnmarshalJSON(raw []byte) error {
 		// sit destination final address
 		SitDestinationFinalAddress *Address `json:"sitDestinationFinalAddress,omitempty"`
 
+		// sit destination updated address
+		SitDestinationUpdatedAddress *Address `json:"sitDestinationUpdatedAddress,omitempty"`
+
 		// Time of delivery corresponding to `firstAvailableDeliveryDate1`, in military format.
 		// Example: 1400Z
 		// Pattern: \d{4}Z
@@ -103,6 +114,11 @@ func (m *UpdateMTOServiceItemSIT) UnmarshalJSON(raw []byte) error {
 		// Example: 1400Z
 		// Pattern: \d{4}Z
 		TimeMilitary2 *string `json:"timeMilitary2,omitempty"`
+
+		// The distance between the orignal SIT delivery address and the sitDestinationUpdatedAddress. In order for the Prime to make this update the distance must be <= 50 miles.
+		// Example: 25
+		// Maximum: 50
+		UpdatedDistanceFromOriginalAddress *int64 `json:"updatedDistanceFromOriginalAddress,omitempty"`
 	}
 	buf := bytes.NewBuffer(raw)
 	dec := json.NewDecoder(buf)
@@ -141,8 +157,10 @@ func (m *UpdateMTOServiceItemSIT) UnmarshalJSON(raw []byte) error {
 	result.ReServiceCode = data.ReServiceCode
 	result.SitDepartureDate = data.SitDepartureDate
 	result.SitDestinationFinalAddress = data.SitDestinationFinalAddress
+	result.SitDestinationUpdatedAddress = data.SitDestinationUpdatedAddress
 	result.TimeMilitary1 = data.TimeMilitary1
 	result.TimeMilitary2 = data.TimeMilitary2
+	result.UpdatedDistanceFromOriginalAddress = data.UpdatedDistanceFromOriginalAddress
 
 	*m = result
 
@@ -174,6 +192,9 @@ func (m UpdateMTOServiceItemSIT) MarshalJSON() ([]byte, error) {
 		// sit destination final address
 		SitDestinationFinalAddress *Address `json:"sitDestinationFinalAddress,omitempty"`
 
+		// sit destination updated address
+		SitDestinationUpdatedAddress *Address `json:"sitDestinationUpdatedAddress,omitempty"`
+
 		// Time of delivery corresponding to `firstAvailableDeliveryDate1`, in military format.
 		// Example: 1400Z
 		// Pattern: \d{4}Z
@@ -183,6 +204,11 @@ func (m UpdateMTOServiceItemSIT) MarshalJSON() ([]byte, error) {
 		// Example: 1400Z
 		// Pattern: \d{4}Z
 		TimeMilitary2 *string `json:"timeMilitary2,omitempty"`
+
+		// The distance between the orignal SIT delivery address and the sitDestinationUpdatedAddress. In order for the Prime to make this update the distance must be <= 50 miles.
+		// Example: 25
+		// Maximum: 50
+		UpdatedDistanceFromOriginalAddress *int64 `json:"updatedDistanceFromOriginalAddress,omitempty"`
 	}{
 
 		FirstAvailableDeliveryDate1: m.FirstAvailableDeliveryDate1,
@@ -195,9 +221,13 @@ func (m UpdateMTOServiceItemSIT) MarshalJSON() ([]byte, error) {
 
 		SitDestinationFinalAddress: m.SitDestinationFinalAddress,
 
+		SitDestinationUpdatedAddress: m.SitDestinationUpdatedAddress,
+
 		TimeMilitary1: m.TimeMilitary1,
 
 		TimeMilitary2: m.TimeMilitary2,
+
+		UpdatedDistanceFromOriginalAddress: m.UpdatedDistanceFromOriginalAddress,
 	})
 	if err != nil {
 		return nil, err
@@ -247,11 +277,19 @@ func (m *UpdateMTOServiceItemSIT) Validate(formats strfmt.Registry) error {
 		res = append(res, err)
 	}
 
+	if err := m.validateSitDestinationUpdatedAddress(formats); err != nil {
+		res = append(res, err)
+	}
+
 	if err := m.validateTimeMilitary1(formats); err != nil {
 		res = append(res, err)
 	}
 
 	if err := m.validateTimeMilitary2(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateUpdatedDistanceFromOriginalAddress(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -367,6 +405,26 @@ func (m *UpdateMTOServiceItemSIT) validateSitDestinationFinalAddress(formats str
 	return nil
 }
 
+func (m *UpdateMTOServiceItemSIT) validateSitDestinationUpdatedAddress(formats strfmt.Registry) error {
+
+	if swag.IsZero(m.SitDestinationUpdatedAddress) { // not required
+		return nil
+	}
+
+	if m.SitDestinationUpdatedAddress != nil {
+		if err := m.SitDestinationUpdatedAddress.Validate(formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("sitDestinationUpdatedAddress")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("sitDestinationUpdatedAddress")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
 func (m *UpdateMTOServiceItemSIT) validateTimeMilitary1(formats strfmt.Registry) error {
 
 	if swag.IsZero(m.TimeMilitary1) { // not required
@@ -393,11 +451,28 @@ func (m *UpdateMTOServiceItemSIT) validateTimeMilitary2(formats strfmt.Registry)
 	return nil
 }
 
+func (m *UpdateMTOServiceItemSIT) validateUpdatedDistanceFromOriginalAddress(formats strfmt.Registry) error {
+
+	if swag.IsZero(m.UpdatedDistanceFromOriginalAddress) { // not required
+		return nil
+	}
+
+	if err := validate.MaximumInt("updatedDistanceFromOriginalAddress", "body", *m.UpdatedDistanceFromOriginalAddress, 50, false); err != nil {
+		return err
+	}
+
+	return nil
+}
+
 // ContextValidate validate this update m t o service item s i t based on the context it is used
 func (m *UpdateMTOServiceItemSIT) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
 	var res []error
 
 	if err := m.contextValidateSitDestinationFinalAddress(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.contextValidateSitDestinationUpdatedAddress(ctx, formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -429,6 +504,22 @@ func (m *UpdateMTOServiceItemSIT) contextValidateSitDestinationFinalAddress(ctx 
 				return ve.ValidateName("sitDestinationFinalAddress")
 			} else if ce, ok := err.(*errors.CompositeError); ok {
 				return ce.ValidateName("sitDestinationFinalAddress")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (m *UpdateMTOServiceItemSIT) contextValidateSitDestinationUpdatedAddress(ctx context.Context, formats strfmt.Registry) error {
+
+	if m.SitDestinationUpdatedAddress != nil {
+		if err := m.SitDestinationUpdatedAddress.ContextValidate(ctx, formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("sitDestinationUpdatedAddress")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("sitDestinationUpdatedAddress")
 			}
 			return err
 		}

--- a/pkg/handlers/primeapi/payloads/payload_to_model.go
+++ b/pkg/handlers/primeapi/payloads/payload_to_model.go
@@ -509,9 +509,23 @@ func MTOServiceItemModelFromUpdate(mtoServiceItemID string, mtoServiceItem prime
 		sit := mtoServiceItem.(*primemessages.UpdateMTOServiceItemSIT)
 		model.SITDepartureDate = models.TimePointer(time.Time(sit.SitDepartureDate))
 		model.ReService.Code = models.ReServiceCode(sit.ReServiceCode)
-		model.SITDestinationFinalAddress = AddressModel(sit.SitDestinationFinalAddress)
-		if model.SITDestinationFinalAddress != nil {
-			model.SITDestinationFinalAddressID = &model.SITDestinationFinalAddress.ID
+
+		if sit.SitDestinationUpdatedAddress == nil && sit.UpdatedDistanceFromOriginalAddress == nil {
+			model.SITDestinationFinalAddress = AddressModel(sit.SitDestinationFinalAddress)
+			if model.SITDestinationFinalAddress != nil {
+				model.SITDestinationFinalAddressID = &model.SITDestinationFinalAddress.ID
+			}
+		}
+
+		if sit.SitDestinationUpdatedAddress != nil && sit.UpdatedDistanceFromOriginalAddress != nil {
+			if *sit.UpdatedDistanceFromOriginalAddress <= 50 {
+				model.SITDestinationFinalAddress = AddressModel(sit.SitDestinationUpdatedAddress)
+				if model.SITDestinationFinalAddress != nil {
+					model.SITDestinationFinalAddressID = &model.SITDestinationFinalAddress.ID
+				}
+			} else {
+				verrs.Add("Distance exceeds 50 miles", "please submit address change request using new endpoint")
+			}
 		}
 
 		if sit.ReServiceCode == string(models.ReServiceCodeDDDSIT) ||

--- a/swagger-def/prime.yaml
+++ b/swagger-def/prime.yaml
@@ -2629,6 +2629,16 @@ definitions:
             type: string
             description: Second available date that Prime can deliver SIT service item.
             x-nullable: true
+          sitDestinationUpdatedAddress:
+            $ref: '#/definitions/Address'
+          updatedDistanceFromOriginalAddress:
+            description: >-
+              The distance between the orignal SIT delivery address and the sitDestinationUpdatedAddress.
+              In order for the Prime to make this update the distance must be <= 50 miles.
+            type: integer
+            example: 25
+            maximum: 50
+            x-nullable: true
   UpdateMTOShipment:
     properties:
       scheduledPickupDate:

--- a/swagger/prime.yaml
+++ b/swagger/prime.yaml
@@ -2975,6 +2975,17 @@ definitions:
             type: string
             description: Second available date that Prime can deliver SIT service item.
             x-nullable: true
+          sitDestinationUpdatedAddress:
+            $ref: '#/definitions/Address'
+          updatedDistanceFromOriginalAddress:
+            description: >-
+              The distance between the orignal SIT delivery address and the
+              sitDestinationUpdatedAddress. In order for the Prime to make this
+              update the distance must be <= 50 miles.
+            type: integer
+            example: 25
+            maximum: 50
+            x-nullable: true
   UpdateMTOShipment:
     properties:
       scheduledPickupDate:


### PR DESCRIPTION
## [Jira ticket](https://dp3.atlassian.net/browse/MB-15875)

## Summary

WIP will probably trash

## Verification Steps for the Author

These are to be checked by the author.

- [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
- [ ] Have the Jira acceptance criteria been met for this change?

## Verification Steps for Reviewers

These are to be checked by a reviewer.

### Setup to Run the Code

- [Instructions for starting storybook](https://transcom.github.io/mymove-docs/docs/frontend/setup/run-storybook)
- [Instructions for starting the MilMove application](https://transcom.github.io/mymove-docs/docs/about/application-setup/milmove-local-client/)
- [Instructions for running tests](https://transcom.github.io/mymove-docs/docs/about/development/testing)

### How to test

1. Access the
2. Login as a
3.

### Frontend

- [ ] There are no aXe warnings for UI.
- [ ] This works in [Supported Browsers and their phone views](https://transcom.github.io/mymove-docs/docs/about/supported-browsers) (Chrome, Firefox, Edge).
- [ ] There are no new console errors in the browser devtools.
- [ ] There are no new console errors in the test output.
- [ ] If this PR adds a new component to Storybook, it ensures the component is fully responsive, OR if it is intentionally not, a wrapping div using the `officeApp` class or custom `min-width` styling is used to hide any states the would not be visible to the user.

### Backend

- [ ] Code follows the guidelines for [Logging](https://transcom.github.io/mymove-docs/docs/about/development/logging).
- [ ] The requirements listed in [Querying the Database Safely](https://transcom.github.io/mymove-docs/docs/backend/guides/golang-guide#querying-the-database-safely) have been satisfied.

### Database

#### Any new migrations/schema changes:

- [ ] Follows our guidelines for [Zero-Downtime Deploys](https://transcom.github.io/mymove-docs/docs/backend/setup/database-migrations#zero-downtime-migrations).
- [ ] Have been communicated to #g-database.
- [ ] Secure migrations have been tested following the instructions in our [docs](https://transcom.github.io/mymove-docs/docs/backend/setup/database-migrations#secure-migrations).

## Screenshots
