### PR TITLE
[MB-15544] Add migrations to repair failing `run_<env>_migrations` targets

### DIFF
--- a/cmd/milmove/gen_certs_migration.go
+++ b/cmd/milmove/gen_certs_migration.go
@@ -27,11 +27,6 @@ const (
 	UpdateFlag string = "update"
 	// ClientCertIDFlag is the ID flag for Client Cert
 	ClientCertIDFlag string = "certid"
-	// UserIDFlag is the User ID associated for Client Certificates flag
-	UserIDFlag string = "userid"
-
-	// The default UserID if a value for `userid` is not passed in
-	UserIDFlagDefault string = "Replace me with a User.ID (UUID) for a User from the Users table. This User.ID will be different across environments."
 
 	// template for adding client certificates
 	createCertsMigration string = `
@@ -41,44 +36,68 @@ const (
 -- Using a person's CAC as the certificate is a convenient way to permit a
 -- single trusted individual to interact with the Orders API and the Prime API. Eventually
 -- this CAC certificate should be removed.
-INSERT INTO public.client_certs (
-	id,
-	sha256_digest,
-	subject,
-	user_id,
-	allow_orders_api,
-	allow_prime,
-	created_at,
-	updated_at,
-	allow_air_force_orders_read,
-	allow_air_force_orders_write,
-	allow_army_orders_read,
-	allow_army_orders_write,
-	allow_coast_guard_orders_read,
-	allow_coast_guard_orders_write,
-	allow_marine_corps_orders_read,
-	allow_marine_corps_orders_write,
-	allow_navy_orders_read,
-	allow_navy_orders_write)
+INSERT INTO users (
+    id,
+    login_gov_email,
+    created_at,
+    updated_at)
 VALUES (
-	'{{.ID}}',
-	'{{.Fingerprint}}',
-	'{{.Subject}}',
-	'{{.UserID}}',
-	true,
-	true,
-	now(),
-	now(),
-	true,
-	true,
-	true,
-	true,
-	true,
-	true,
-	true,
-	true,
-	true,
-	true);
+    '{{.UserID}}',
+    '{{.Fingerprint}}' || '@api.move.mil',
+    now(),
+    now());
+
+INSERT INTO users_roles (
+    id,
+    role_id,
+    user_id,
+    created_at,
+    updated_at)
+VALUES (
+    uuid_generate_v4(),
+    (SELECT id FROM roles WHERE role_type = 'prime'),
+    '{{.UserID}}',
+    now(),
+    now());
+
+INSERT INTO public.client_certs (
+    id,
+    sha256_digest,
+    subject,
+    user_id,
+    allow_orders_api,
+    allow_prime,
+    created_at,
+    updated_at,
+    allow_air_force_orders_read,
+    allow_air_force_orders_write,
+    allow_army_orders_read,
+    allow_army_orders_write,
+    allow_coast_guard_orders_read,
+    allow_coast_guard_orders_write,
+    allow_marine_corps_orders_read,
+    allow_marine_corps_orders_write,
+    allow_navy_orders_read,
+    allow_navy_orders_write)
+VALUES (
+    '{{.ID}}',
+    '{{.Fingerprint}}',
+    '{{.Subject}}',
+    '{{.UserID}}',
+    true,
+    true,
+    now(),
+    now(),
+    true,
+    true,
+    true,
+    true,
+    true,
+    true,
+    true,
+    true,
+    true,
+    true);
 `
 	// template for updating client certificates
 	updateCertsMigration string = `
@@ -109,10 +128,8 @@ type CertsTemplate struct {
 func InitCertsMigrationFlags(flag *pflag.FlagSet) {
 	flag.StringP(FingerprintFlag, "f", "", "Certificate fingerprint in SHA 256 form")
 	flag.StringP(SubjectFlag, "s", "", "Certificate subject")
-	flag.StringP(UserIDFlag, "u", UserIDFlagDefault, "User ID to associate with the Certificate")
 	flag.Bool(UpdateFlag, false, "Create an update migration")
 	flag.String(ClientCertIDFlag, "", "Previous ID of client cert entry")
-
 }
 
 // CheckCertsMigration validates command line flags
@@ -144,24 +161,6 @@ func CheckCertsMigration(v *viper.Viper) error {
 		if len(subject) == 0 {
 			return errors.Errorf("%s is missing", SubjectFlag)
 		}
-	}
-
-	// Check if the User ID was passed in as a flag & validate if it's a valid
-	// UUID. Ultimately, the responsibility for this to be correct falls on the
-	// operator of the CLI without having this CLI check values from the RDS
-	// instance that this migration will be running on.
-	if v.GetString(UserIDFlag) != UserIDFlagDefault {
-		userID := v.GetString(UserIDFlag)
-
-		// Check if userID is a valid GUID
-		if uuid.FromStringOrNil(userID) == uuid.Nil {
-			return errors.Errorf(
-				"%s is not a valid UUID (value given: %s). Please copy the User ID from the Admin UI to ensure the User ID is a valid UUID",
-				UserIDFlag,
-				userID,
-			)
-		}
-
 	}
 
 	if v.GetBool(UpdateFlag) {
@@ -250,12 +249,9 @@ func genCertsMigration(cmd *cobra.Command, args []string) error {
 		subject = v.GetString(SubjectFlag)
 	}
 
-	userID := v.GetString(UserIDFlag)
-
 	certsTemplate := CertsTemplate{
 		Fingerprint: fingerprint,
 		Subject:     subject,
-		UserID:      userID,
 	}
 
 	var t1 *template.Template
@@ -266,6 +262,7 @@ func genCertsMigration(cmd *cobra.Command, args []string) error {
 		t1 = template.Must(template.New("certs_migration").Parse(updateCertsMigration))
 	} else {
 		certsTemplate.ID = uuid.Must(uuid.NewV4()).String()
+		certsTemplate.UserID = uuid.Must(uuid.NewV4()).String()
 		t1 = template.Must(template.New("certs_migration").Parse(createCertsMigration))
 	}
 

--- a/migrations/app/migrations_manifest.txt
+++ b/migrations/app/migrations_manifest.txt
@@ -783,6 +783,7 @@
 20230106211757_app_exp_cert_migration.up.sql
 20230117191419_rkoch_cac.up.sql
 20230120165432_update_camp_lejeune_closeout_value.up.sql
+20230201132843_create_referenced_users.up.sql
 20230201162639_rogeruiz_cac.up.sql
 20230202193449_add_daycos_and_movehq_certs.up.sql
 20230214161337_add_mmayo-truss_certs.up.sql
@@ -810,3 +811,4 @@
 20230504204015_creating_SIT_destination_address_update_table.up.sql
 20230509180256_fix_demo_certificate.up.sql
 20230510153921_all_dutylocations_government_counseling_true.up.sql
+20230510170842_repair_client_certs_records.up.sql

--- a/migrations/app/secure/20230201132843_create_referenced_users.up.sql
+++ b/migrations/app/secure/20230201132843_create_referenced_users.up.sql
@@ -1,0 +1,6 @@
+-- Local test migration.
+-- This will be run on development environments.
+-- It should mirror what you intend to apply on loadtest/demo/exp/stg/prd
+-- DO NOT include any sensitive data.
+
+-- do nothing

--- a/migrations/app/secure/20230510170842_repair_client_certs_records.up.sql
+++ b/migrations/app/secure/20230510170842_repair_client_certs_records.up.sql
@@ -1,0 +1,6 @@
+-- Local test migration.
+-- This will be run on development environments.
+-- It should mirror what you intend to apply on loadtest/demo/exp/stg/prd
+-- DO NOT include any sensitive data.
+
+-- do nothing


### PR DESCRIPTION
## [Jira ticket](https://dp3.atlassian.net/browse/MB-15544)

## Summary

As doing the work to import pricing data, we realized that several of the `run_<env>_migration` targets in the Makefile were failing when run locally.  It turns out that there were some migrations to add `client_certs` that were referencing user IDs that only existed in the deployed environment (i.e., they were created outside of a migration).  Therefore, when you ran the migrations (like `make run_stg_migrations`, for instance) on your local dev environment to test and review the deployed migrations, it would fail due to a foreign key error.  This PR attempts to fix this through some new secure migrations.

To get context on the problem, first run `make run_stg_migrations` on `main`.  You should see the FK constraint failure I mentioned above.  You also will get failures when doing the similar commands for `exp` and `demo`.

Next, download these secure migrations from all the deployed environments:
```
download-secure-migration 20230201162639_rogeruiz_cac.up.sql
download-secure-migration 20230214161337_add_mmayo-truss_certs.up.sql
download-secure-migration 20230404195728_katyc_cac_access.up.sql
download-secure-migration 20230420144546_ronak_cac.up.sql
```

In them, you will see that an ID for a `users` record is referenced that doesn't appear anywhere else in our migrations, leading to the failure.

Next, grab the two new secure migrations in this PR from all the deployed environments:
```
download-secure-migration 20230201132843_create_referenced_users.up.sql
download-secure-migration 20230510170842_repair_client_certs_records.up.sql
```

 I first created the `20230201132843_create_referenced_users.up.sql` migration backdated to just before the first CAC migration above so it would first before the above ones when rebuilding the migrations from scratch.  In it, I create temporary users so the migrations will pass locally.  Of course, on the deployed system where migrations have already been applied, we have to be careful to make it a no-op there (hence the use of the `ON CONFLICT` clause).

Next, I created a migration to run now that does two things: 1) for each CAC user above, creates a new user/role and updates the `client_certs` record to point to that new user (see #8707 for when this pattern was first introduced), and 2) deletes the temporary user from the first migration (and makes sure it was the temporary user and not an existing user on the deployed system).

Finally, I also adjusted the `certs-migration` subcommand of `milmove` to use a new template that hopefully will do something similar to the above and prevent future cert migrations with the same issue. 

## Verification Steps for the Author

These are to be checked by the author.

- [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
- [ ] Have the Jira acceptance criteria been met for this change?

## Verification Steps for Reviewers

These are to be checked by a reviewer.

### Setup to Run the Code

- [Instructions for starting storybook](https://transcom.github.io/mymove-docs/docs/frontend/setup/run-storybook)
- [Instructions for starting the MilMove application](https://transcom.github.io/mymove-docs/docs/about/application-setup/milmove-local-client/)
- [Instructions for running tests](https://transcom.github.io/mymove-docs/docs/about/development/testing)

### How to test

- Make sure all the deployed environments migrations can be run locally:
  - `make run_demo_migrations`
  - `make run_exp_migrations`
  - `make run_loadtest_migrations`
  - `make run_prd_migrations`
  - `make run_stg_migrations`
- Try creating a new certs migration and review and/or apply it locally:
  - `milmove gen certs-migration --name my_test_migration --cac
  - Note that you will need your CAC inserted into your reader when you do this.
  - More details can be found in [this documentation](https://dp3.atlassian.net/wiki/spaces/MT/pages/1751089156/How+to+Create+CAC+Access+for+using+Prime+API+and+uploading+Electronic+Orders).


### Frontend

- [ ] There are no aXe warnings for UI.
- [ ] This works in [Supported Browsers and their phone views](https://transcom.github.io/mymove-docs/docs/about/supported-browsers) (Chrome, Firefox, Edge).
- [ ] There are no new console errors in the browser devtools.
- [ ] There are no new console errors in the test output.
- [ ] If this PR adds a new component to Storybook, it ensures the component is fully responsive, OR if it is intentionally not, a wrapping div using the `officeApp` class or custom `min-width` styling is used to hide any states the would not be visible to the user.

### Backend

- [ ] Code follows the guidelines for [Logging](https://transcom.github.io/mymove-docs/docs/about/development/logging).
- [ ] The requirements listed in [Querying the Database Safely](https://transcom.github.io/mymove-docs/docs/backend/guides/golang-guide#querying-the-database-safely) have been satisfied.

### Database

#### Any new migrations/schema changes:

- [ ] Follows our guidelines for [Zero-Downtime Deploys](https://transcom.github.io/mymove-docs/docs/backend/setup/database-migrations#zero-downtime-migrations).
- [ ] Have been communicated to #g-database.
- [ ] Secure migrations have been tested following the instructions in our [docs](https://transcom.github.io/mymove-docs/docs/backend/setup/database-migrations#secure-migrations).

## Screenshots
