### PR TITLE
MB-16062: Install yarn outside of nix to use installed node

### DIFF
--- a/nix/default.nix
+++ b/nix/default.nix
@@ -33,16 +33,6 @@ buildEnv {
     (import
       (builtins.fetchGit {
         # Descriptive name to make the store path easier to identify
-        name = "yarn-1.22.11";
-        url = "https://github.com/NixOS/nixpkgs/";
-        ref = "refs/heads/nixpkgs-unstable";
-        rev = "253aecf69ed7595aaefabde779aa6449195bebb7";
-      })
-      { }).yarn
-
-    (import
-      (builtins.fetchGit {
-        # Descriptive name to make the store path easier to identify
         name = "go-1.20.3";
         url = "https://github.com/NixOS/nixpkgs/";
         ref = "refs/heads/nixpkgs-unstable";

--- a/nix/update.sh
+++ b/nix/update.sh
@@ -16,6 +16,10 @@ export NIXPKGS_ALLOW_UNSUPPORTED_SYSTEM=1
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 # install packages
 nix-env -f "${DIR}" -i
+
+# install yarn using the node that was just installed
+npm install -g yarn
+
 # Store a hash of this file to the hash of the nix profile
 # This way if the config changes, we can warn about it via direnv
 # See the nix config in .envrc


### PR DESCRIPTION
## [Jira ticket](https://dp3.atlassian.net/browse/MB-16062)

## Summary

Installing yarn via nix means yarn uses the node bundled with yarn instead of the version explicitly specified. Switch to installing via `npm install -g yarn`.

## Verification Steps for Reviewers

```
./nix/update.sh
# See that yarn uses what is in the path
head -n 1 $NPM_CONFIG_PREFIX/bin/yarn
```