### PR TITLE
MB-16074: Use latest github/webpack-bundlesize-compare-action, truncate comment

### DIFF
--- a/.github/workflows/analyze-bundle.yml
+++ b/.github/workflows/analyze-bundle.yml
@@ -108,7 +108,7 @@ jobs:
       pull-requests: write
     steps:
       - uses: actions/download-artifact@v3
-      - uses: github/webpack-bundlesize-compare-action@v1.5.0
+      - uses: github/webpack-bundlesize-compare-action@v1.7.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           current-stats-json-path: ./head-stats/bundle-stats.json


### PR DESCRIPTION
## [Jira ticket](https://dp3.atlassian.net/browse/MB-16074)

## Summary

Use latest version of the bundlesize-compare action that will truncate the comment if it's too large

