### PR TITLE
MB-16075: Try FE Bundle cancel in progress per job

### DIFF
--- a/.github/workflows/analyze-bundle.yml
+++ b/.github/workflows/analyze-bundle.yml
@@ -21,9 +21,6 @@ on:
     branches:
       - main
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
 
 jobs:
   changes:
@@ -40,6 +37,9 @@ jobs:
               - 'yarn.lock'
 
   build-head:
+    concurrency:
+      group: bundle-build-head-${{ github.event.pull_request.number || github.ref }}
+      cancel-in-progress: true
     needs: changes
     if: ${{ needs.changes.outputs.frontend == 'true' }}
     name: 'Build head'
@@ -69,6 +69,9 @@ jobs:
           path: ./build/bundle-stats.json
 
   build-base:
+    concurrency:
+      group: bundle-build-base-${{ github.event.pull_request.number || github.ref }}
+      cancel-in-progress: true
     needs: changes
     if: ${{ needs.changes.outputs.frontend == 'true' }}
     name: 'Build base'
@@ -101,6 +104,10 @@ jobs:
 
   # run the action against the stats.json files
   compare:
+    if: ${{ needs.changes.outputs.frontend == 'true' }}
+    concurrency:
+      group: bundle-compare-${{ github.event.pull_request.number || github.ref }}
+      cancel-in-progress: true
     name: 'Compare base & head bundle sizes'
     runs-on: ubuntu-latest
     needs: [build-base, build-head]
@@ -113,3 +120,9 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           current-stats-json-path: ./head-stats/bundle-stats.json
           base-stats-json-path: ./base-stats/bundle-stats.json
+
+  noop:
+    name: 'Noop job to prevent notification'
+    runs-on: ubuntu-latest
+    steps:
+      - run: 'echo "No build required" '


### PR DESCRIPTION
## [Jira ticket](https://dp3.atlassian.net/browse/MB-16075)

## Summary

Try to eliminate spurious cancelled notifications

If you look at the github checks, the FE bundle compare will no longer show as cancelled, but as skipped

