### PR TITLE
Mb 15179 reason required sit nt

### DIFF
--- a/pkg/gen/primeapi/embedded_spec.go
+++ b/pkg/gen/primeapi/embedded_spec.go
@@ -1966,7 +1966,7 @@ func init() {
       "required": [
         "modelType",
         "moveTaskOrderID",
-        "rejectionReason"
+        "reason"
       ],
       "properties": {
         "eTag": {
@@ -2001,6 +2001,13 @@ func init() {
           "type": "string",
           "readOnly": true
         },
+        "reason": {
+          "description": "A reason why this particular service item is justified.",
+          "type": "string",
+          "x-nullable": false,
+          "x-omitempty": false,
+          "readOnly": true
+        },
         "rejectionReason": {
           "description": "The reason why this service item was rejected by the TOO.",
           "type": "string",
@@ -2023,8 +2030,7 @@ func init() {
         {
           "type": "object",
           "required": [
-            "reServiceCode",
-            "rejectionReason"
+            "reServiceCode"
           ],
           "properties": {
             "reServiceCode": {
@@ -2176,13 +2182,6 @@ func init() {
                 "DCRT",
                 "DUCRT"
               ]
-            },
-            "reason": {
-              "description": "The contractor's explanation for why an item needed to be crated or uncrated. Used by the TOO while deciding to approve or reject the service item.\n",
-              "type": "string",
-              "x-nullable": true,
-              "x-omitempty": false,
-              "example": "Storage items need to be picked up"
             }
           }
         }
@@ -2221,11 +2220,6 @@ func init() {
                 "DOFSIT",
                 "DOASIT"
               ]
-            },
-            "reason": {
-              "description": "Explanation of why Prime is picking up SIT item.",
-              "type": "string",
-              "example": "Storage items need to be picked up"
             },
             "sitDepartureDate": {
               "description": "Departure date for SIT. This is the end date of the SIT at either origin or destination. This is optional as it can be updated using the UpdateMTOServiceItemSIT modelType at a later date.",
@@ -2285,11 +2279,6 @@ func init() {
                 "DOSHUT",
                 "DDSHUT"
               ]
-            },
-            "reason": {
-              "description": "The contractor's explanation for why a shuttle service is requested. Used by the TOO while deciding to approve or reject the service item.\n",
-              "type": "string",
-              "example": "Storage items need to be picked up."
             }
           }
         }
@@ -6395,7 +6384,7 @@ func init() {
       "required": [
         "modelType",
         "moveTaskOrderID",
-        "rejectionReason"
+        "reason"
       ],
       "properties": {
         "eTag": {
@@ -6430,6 +6419,13 @@ func init() {
           "type": "string",
           "readOnly": true
         },
+        "reason": {
+          "description": "A reason why this particular service item is justified.",
+          "type": "string",
+          "x-nullable": false,
+          "x-omitempty": false,
+          "readOnly": true
+        },
         "rejectionReason": {
           "description": "The reason why this service item was rejected by the TOO.",
           "type": "string",
@@ -6452,8 +6448,7 @@ func init() {
         {
           "type": "object",
           "required": [
-            "reServiceCode",
-            "rejectionReason"
+            "reServiceCode"
           ],
           "properties": {
             "reServiceCode": {
@@ -6605,13 +6600,6 @@ func init() {
                 "DCRT",
                 "DUCRT"
               ]
-            },
-            "reason": {
-              "description": "The contractor's explanation for why an item needed to be crated or uncrated. Used by the TOO while deciding to approve or reject the service item.\n",
-              "type": "string",
-              "x-nullable": true,
-              "x-omitempty": false,
-              "example": "Storage items need to be picked up"
             }
           }
         }
@@ -6650,11 +6638,6 @@ func init() {
                 "DOFSIT",
                 "DOASIT"
               ]
-            },
-            "reason": {
-              "description": "Explanation of why Prime is picking up SIT item.",
-              "type": "string",
-              "example": "Storage items need to be picked up"
             },
             "sitDepartureDate": {
               "description": "Departure date for SIT. This is the end date of the SIT at either origin or destination. This is optional as it can be updated using the UpdateMTOServiceItemSIT modelType at a later date.",
@@ -6714,11 +6697,6 @@ func init() {
                 "DOSHUT",
                 "DDSHUT"
               ]
-            },
-            "reason": {
-              "description": "The contractor's explanation for why a shuttle service is requested. Used by the TOO while deciding to approve or reject the service item.\n",
-              "type": "string",
-              "example": "Storage items need to be picked up."
             }
           }
         }

--- a/pkg/gen/primeapi/embedded_spec.go
+++ b/pkg/gen/primeapi/embedded_spec.go
@@ -1965,7 +1965,8 @@ func init() {
       "type": "object",
       "required": [
         "modelType",
-        "moveTaskOrderID"
+        "moveTaskOrderID",
+        "rejectionReason"
       ],
       "properties": {
         "eTag": {
@@ -2022,7 +2023,8 @@ func init() {
         {
           "type": "object",
           "required": [
-            "reServiceCode"
+            "reServiceCode",
+            "rejectionReason"
           ],
           "properties": {
             "reServiceCode": {
@@ -6392,7 +6394,8 @@ func init() {
       "type": "object",
       "required": [
         "modelType",
-        "moveTaskOrderID"
+        "moveTaskOrderID",
+        "rejectionReason"
       ],
       "properties": {
         "eTag": {
@@ -6449,7 +6452,8 @@ func init() {
         {
           "type": "object",
           "required": [
-            "reServiceCode"
+            "reServiceCode",
+            "rejectionReason"
           ],
           "properties": {
             "reServiceCode": {

--- a/pkg/gen/primemessages/m_t_o_service_item.go
+++ b/pkg/gen/primemessages/m_t_o_service_item.go
@@ -62,6 +62,7 @@ type MTOServiceItem interface {
 
 	// The reason why this service item was rejected by the TOO.
 	// Example: item was too heavy
+	// Required: true
 	// Read Only: true
 	RejectionReason() *string
 	SetRejectionReason(*string)
@@ -273,6 +274,10 @@ func (m *mTOServiceItem) Validate(formats strfmt.Registry) error {
 		res = append(res, err)
 	}
 
+	if err := m.validateRejectionReason(formats); err != nil {
+		res = append(res, err)
+	}
+
 	if err := m.validateStatus(formats); err != nil {
 		res = append(res, err)
 	}
@@ -314,6 +319,15 @@ func (m *mTOServiceItem) validateMtoShipmentID(formats strfmt.Registry) error {
 	}
 
 	if err := validate.FormatOf("mtoShipmentID", "body", "uuid", m.MtoShipmentID().String(), formats); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (m *mTOServiceItem) validateRejectionReason(formats strfmt.Registry) error {
+
+	if err := validate.Required("rejectionReason", "body", m.RejectionReason()); err != nil {
 		return err
 	}
 

--- a/pkg/gen/primemessages/m_t_o_service_item.go
+++ b/pkg/gen/primemessages/m_t_o_service_item.go
@@ -60,9 +60,14 @@ type MTOServiceItem interface {
 	ReServiceName() string
 	SetReServiceName(string)
 
+	// A reason why this particular service item is justified.
+	// Required: true
+	// Read Only: true
+	Reason() string
+	SetReason(string)
+
 	// The reason why this service item was rejected by the TOO.
 	// Example: item was too heavy
-	// Required: true
 	// Read Only: true
 	RejectionReason() *string
 	SetRejectionReason(*string)
@@ -87,6 +92,8 @@ type mTOServiceItem struct {
 	mtoShipmentIdField strfmt.UUID
 
 	reServiceNameField string
+
+	reasonField string
 
 	rejectionReasonField *string
 
@@ -150,6 +157,16 @@ func (m *mTOServiceItem) ReServiceName() string {
 // SetReServiceName sets the re service name of this polymorphic type
 func (m *mTOServiceItem) SetReServiceName(val string) {
 	m.reServiceNameField = val
+}
+
+// Reason gets the reason of this polymorphic type
+func (m *mTOServiceItem) Reason() string {
+	return m.reasonField
+}
+
+// SetReason sets the reason of this polymorphic type
+func (m *mTOServiceItem) SetReason(val string) {
+	m.reasonField = val
 }
 
 // RejectionReason gets the rejection reason of this polymorphic type
@@ -274,7 +291,7 @@ func (m *mTOServiceItem) Validate(formats strfmt.Registry) error {
 		res = append(res, err)
 	}
 
-	if err := m.validateRejectionReason(formats); err != nil {
+	if err := m.validateReason(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -325,9 +342,9 @@ func (m *mTOServiceItem) validateMtoShipmentID(formats strfmt.Registry) error {
 	return nil
 }
 
-func (m *mTOServiceItem) validateRejectionReason(formats strfmt.Registry) error {
+func (m *mTOServiceItem) validateReason(formats strfmt.Registry) error {
 
-	if err := validate.Required("rejectionReason", "body", m.RejectionReason()); err != nil {
+	if err := validate.RequiredString("reason", "body", m.Reason()); err != nil {
 		return err
 	}
 
@@ -368,6 +385,10 @@ func (m *mTOServiceItem) ContextValidate(ctx context.Context, formats strfmt.Reg
 	}
 
 	if err := m.contextValidateReServiceName(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.contextValidateReason(ctx, formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -420,6 +441,15 @@ func (m *mTOServiceItem) contextValidateModelType(ctx context.Context, formats s
 func (m *mTOServiceItem) contextValidateReServiceName(ctx context.Context, formats strfmt.Registry) error {
 
 	if err := validate.ReadOnly(ctx, "reServiceName", "body", string(m.ReServiceName())); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (m *mTOServiceItem) contextValidateReason(ctx context.Context, formats strfmt.Registry) error {
+
+	if err := validate.ReadOnly(ctx, "reason", "body", string(m.Reason())); err != nil {
 		return err
 	}
 

--- a/pkg/gen/primemessages/m_t_o_service_item_basic.go
+++ b/pkg/gen/primemessages/m_t_o_service_item_basic.go
@@ -149,7 +149,7 @@ func (m *MTOServiceItemBasic) UnmarshalJSON(raw []byte) error {
 
 		ReServiceName string `json:"reServiceName,omitempty"`
 
-		RejectionReason *string `json:"rejectionReason,omitempty"`
+		RejectionReason *string `json:"rejectionReason"`
 
 		Status MTOServiceItemStatus `json:"status,omitempty"`
 	}
@@ -217,7 +217,7 @@ func (m MTOServiceItemBasic) MarshalJSON() ([]byte, error) {
 
 		ReServiceName string `json:"reServiceName,omitempty"`
 
-		RejectionReason *string `json:"rejectionReason,omitempty"`
+		RejectionReason *string `json:"rejectionReason"`
 
 		Status MTOServiceItemStatus `json:"status,omitempty"`
 	}{
@@ -258,6 +258,10 @@ func (m *MTOServiceItemBasic) Validate(formats strfmt.Registry) error {
 	}
 
 	if err := m.validateMtoShipmentID(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateRejectionReason(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -308,6 +312,15 @@ func (m *MTOServiceItemBasic) validateMtoShipmentID(formats strfmt.Registry) err
 	}
 
 	if err := validate.FormatOf("mtoShipmentID", "body", "uuid", m.MtoShipmentID().String(), formats); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (m *MTOServiceItemBasic) validateRejectionReason(formats strfmt.Registry) error {
+
+	if err := validate.Required("rejectionReason", "body", m.RejectionReason()); err != nil {
 		return err
 	}
 

--- a/pkg/gen/primemessages/m_t_o_service_item_basic.go
+++ b/pkg/gen/primemessages/m_t_o_service_item_basic.go
@@ -30,6 +30,8 @@ type MTOServiceItemBasic struct {
 
 	reServiceNameField string
 
+	reasonField string
+
 	rejectionReasonField *string
 
 	statusField MTOServiceItemStatus
@@ -98,6 +100,16 @@ func (m *MTOServiceItemBasic) SetReServiceName(val string) {
 	m.reServiceNameField = val
 }
 
+// Reason gets the reason of this subtype
+func (m *MTOServiceItemBasic) Reason() string {
+	return m.reasonField
+}
+
+// SetReason sets the reason of this subtype
+func (m *MTOServiceItemBasic) SetReason(val string) {
+	m.reasonField = val
+}
+
 // RejectionReason gets the rejection reason of this subtype
 func (m *MTOServiceItemBasic) RejectionReason() *string {
 	return m.rejectionReasonField
@@ -149,7 +161,9 @@ func (m *MTOServiceItemBasic) UnmarshalJSON(raw []byte) error {
 
 		ReServiceName string `json:"reServiceName,omitempty"`
 
-		RejectionReason *string `json:"rejectionReason"`
+		Reason string `json:"reason"`
+
+		RejectionReason *string `json:"rejectionReason,omitempty"`
 
 		Status MTOServiceItemStatus `json:"status,omitempty"`
 	}
@@ -176,6 +190,8 @@ func (m *MTOServiceItemBasic) UnmarshalJSON(raw []byte) error {
 	result.mtoShipmentIdField = base.MtoShipmentID
 
 	result.reServiceNameField = base.ReServiceName
+
+	result.reasonField = base.Reason
 
 	result.rejectionReasonField = base.RejectionReason
 
@@ -217,7 +233,9 @@ func (m MTOServiceItemBasic) MarshalJSON() ([]byte, error) {
 
 		ReServiceName string `json:"reServiceName,omitempty"`
 
-		RejectionReason *string `json:"rejectionReason"`
+		Reason string `json:"reason"`
+
+		RejectionReason *string `json:"rejectionReason,omitempty"`
 
 		Status MTOServiceItemStatus `json:"status,omitempty"`
 	}{
@@ -233,6 +251,8 @@ func (m MTOServiceItemBasic) MarshalJSON() ([]byte, error) {
 		MtoShipmentID: m.MtoShipmentID(),
 
 		ReServiceName: m.ReServiceName(),
+
+		Reason: m.Reason(),
 
 		RejectionReason: m.RejectionReason(),
 
@@ -261,7 +281,7 @@ func (m *MTOServiceItemBasic) Validate(formats strfmt.Registry) error {
 		res = append(res, err)
 	}
 
-	if err := m.validateRejectionReason(formats); err != nil {
+	if err := m.validateReason(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -318,9 +338,9 @@ func (m *MTOServiceItemBasic) validateMtoShipmentID(formats strfmt.Registry) err
 	return nil
 }
 
-func (m *MTOServiceItemBasic) validateRejectionReason(formats strfmt.Registry) error {
+func (m *MTOServiceItemBasic) validateReason(formats strfmt.Registry) error {
 
-	if err := validate.Required("rejectionReason", "body", m.RejectionReason()); err != nil {
+	if err := validate.RequiredString("reason", "body", m.Reason()); err != nil {
 		return err
 	}
 
@@ -385,6 +405,10 @@ func (m *MTOServiceItemBasic) ContextValidate(ctx context.Context, formats strfm
 		res = append(res, err)
 	}
 
+	if err := m.contextValidateReason(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
 	if err := m.contextValidateRejectionReason(ctx, formats); err != nil {
 		res = append(res, err)
 	}
@@ -438,6 +462,15 @@ func (m *MTOServiceItemBasic) contextValidateModelType(ctx context.Context, form
 func (m *MTOServiceItemBasic) contextValidateReServiceName(ctx context.Context, formats strfmt.Registry) error {
 
 	if err := validate.ReadOnly(ctx, "reServiceName", "body", string(m.ReServiceName())); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (m *MTOServiceItemBasic) contextValidateReason(ctx context.Context, formats strfmt.Registry) error {
+
+	if err := validate.ReadOnly(ctx, "reason", "body", string(m.Reason())); err != nil {
 		return err
 	}
 

--- a/pkg/gen/primemessages/m_t_o_service_item_dest_s_i_t.go
+++ b/pkg/gen/primemessages/m_t_o_service_item_dest_s_i_t.go
@@ -30,6 +30,8 @@ type MTOServiceItemDestSIT struct {
 
 	reServiceNameField string
 
+	reasonField string
+
 	rejectionReasonField *string
 
 	statusField MTOServiceItemStatus
@@ -129,6 +131,16 @@ func (m *MTOServiceItemDestSIT) SetReServiceName(val string) {
 	m.reServiceNameField = val
 }
 
+// Reason gets the reason of this subtype
+func (m *MTOServiceItemDestSIT) Reason() string {
+	return m.reasonField
+}
+
+// SetReason sets the reason of this subtype
+func (m *MTOServiceItemDestSIT) SetReason(val string) {
+	m.reasonField = val
+}
+
 // RejectionReason gets the rejection reason of this subtype
 func (m *MTOServiceItemDestSIT) RejectionReason() *string {
 	return m.rejectionReasonField
@@ -211,7 +223,9 @@ func (m *MTOServiceItemDestSIT) UnmarshalJSON(raw []byte) error {
 
 		ReServiceName string `json:"reServiceName,omitempty"`
 
-		RejectionReason *string `json:"rejectionReason"`
+		Reason string `json:"reason"`
+
+		RejectionReason *string `json:"rejectionReason,omitempty"`
 
 		Status MTOServiceItemStatus `json:"status,omitempty"`
 	}
@@ -238,6 +252,8 @@ func (m *MTOServiceItemDestSIT) UnmarshalJSON(raw []byte) error {
 	result.mtoShipmentIdField = base.MtoShipmentID
 
 	result.reServiceNameField = base.ReServiceName
+
+	result.reasonField = base.Reason
 
 	result.rejectionReasonField = base.RejectionReason
 
@@ -331,7 +347,9 @@ func (m MTOServiceItemDestSIT) MarshalJSON() ([]byte, error) {
 
 		ReServiceName string `json:"reServiceName,omitempty"`
 
-		RejectionReason *string `json:"rejectionReason"`
+		Reason string `json:"reason"`
+
+		RejectionReason *string `json:"rejectionReason,omitempty"`
 
 		Status MTOServiceItemStatus `json:"status,omitempty"`
 	}{
@@ -347,6 +365,8 @@ func (m MTOServiceItemDestSIT) MarshalJSON() ([]byte, error) {
 		MtoShipmentID: m.MtoShipmentID(),
 
 		ReServiceName: m.ReServiceName(),
+
+		Reason: m.Reason(),
 
 		RejectionReason: m.RejectionReason(),
 
@@ -375,7 +395,7 @@ func (m *MTOServiceItemDestSIT) Validate(formats strfmt.Registry) error {
 		res = append(res, err)
 	}
 
-	if err := m.validateRejectionReason(formats); err != nil {
+	if err := m.validateReason(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -460,9 +480,9 @@ func (m *MTOServiceItemDestSIT) validateMtoShipmentID(formats strfmt.Registry) e
 	return nil
 }
 
-func (m *MTOServiceItemDestSIT) validateRejectionReason(formats strfmt.Registry) error {
+func (m *MTOServiceItemDestSIT) validateReason(formats strfmt.Registry) error {
 
-	if err := validate.Required("rejectionReason", "body", m.RejectionReason()); err != nil {
+	if err := validate.RequiredString("reason", "body", m.Reason()); err != nil {
 		return err
 	}
 
@@ -635,6 +655,10 @@ func (m *MTOServiceItemDestSIT) ContextValidate(ctx context.Context, formats str
 		res = append(res, err)
 	}
 
+	if err := m.contextValidateReason(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
 	if err := m.contextValidateRejectionReason(ctx, formats); err != nil {
 		res = append(res, err)
 	}
@@ -688,6 +712,15 @@ func (m *MTOServiceItemDestSIT) contextValidateModelType(ctx context.Context, fo
 func (m *MTOServiceItemDestSIT) contextValidateReServiceName(ctx context.Context, formats strfmt.Registry) error {
 
 	if err := validate.ReadOnly(ctx, "reServiceName", "body", string(m.ReServiceName())); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (m *MTOServiceItemDestSIT) contextValidateReason(ctx context.Context, formats strfmt.Registry) error {
+
+	if err := validate.ReadOnly(ctx, "reason", "body", string(m.Reason())); err != nil {
 		return err
 	}
 

--- a/pkg/gen/primemessages/m_t_o_service_item_dest_s_i_t.go
+++ b/pkg/gen/primemessages/m_t_o_service_item_dest_s_i_t.go
@@ -211,7 +211,7 @@ func (m *MTOServiceItemDestSIT) UnmarshalJSON(raw []byte) error {
 
 		ReServiceName string `json:"reServiceName,omitempty"`
 
-		RejectionReason *string `json:"rejectionReason,omitempty"`
+		RejectionReason *string `json:"rejectionReason"`
 
 		Status MTOServiceItemStatus `json:"status,omitempty"`
 	}
@@ -331,7 +331,7 @@ func (m MTOServiceItemDestSIT) MarshalJSON() ([]byte, error) {
 
 		ReServiceName string `json:"reServiceName,omitempty"`
 
-		RejectionReason *string `json:"rejectionReason,omitempty"`
+		RejectionReason *string `json:"rejectionReason"`
 
 		Status MTOServiceItemStatus `json:"status,omitempty"`
 	}{
@@ -372,6 +372,10 @@ func (m *MTOServiceItemDestSIT) Validate(formats strfmt.Registry) error {
 	}
 
 	if err := m.validateMtoShipmentID(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateRejectionReason(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -450,6 +454,15 @@ func (m *MTOServiceItemDestSIT) validateMtoShipmentID(formats strfmt.Registry) e
 	}
 
 	if err := validate.FormatOf("mtoShipmentID", "body", "uuid", m.MtoShipmentID().String(), formats); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (m *MTOServiceItemDestSIT) validateRejectionReason(formats strfmt.Registry) error {
+
+	if err := validate.Required("rejectionReason", "body", m.RejectionReason()); err != nil {
 		return err
 	}
 

--- a/pkg/gen/primemessages/m_t_o_service_item_domestic_crating.go
+++ b/pkg/gen/primemessages/m_t_o_service_item_domestic_crating.go
@@ -30,6 +30,8 @@ type MTOServiceItemDomesticCrating struct {
 
 	reServiceNameField string
 
+	reasonField string
+
 	rejectionReasonField *string
 
 	statusField MTOServiceItemStatus
@@ -55,11 +57,6 @@ type MTOServiceItemDomesticCrating struct {
 	// Required: true
 	// Enum: [DCRT DUCRT]
 	ReServiceCode *string `json:"reServiceCode"`
-
-	// The contractor's explanation for why an item needed to be crated or uncrated. Used by the TOO while deciding to approve or reject the service item.
-	//
-	// Example: Storage items need to be picked up
-	Reason *string `json:"reason"`
 }
 
 // ETag gets the e tag of this subtype
@@ -121,6 +118,16 @@ func (m *MTOServiceItemDomesticCrating) SetReServiceName(val string) {
 	m.reServiceNameField = val
 }
 
+// Reason gets the reason of this subtype
+func (m *MTOServiceItemDomesticCrating) Reason() string {
+	return m.reasonField
+}
+
+// SetReason sets the reason of this subtype
+func (m *MTOServiceItemDomesticCrating) SetReason(val string) {
+	m.reasonField = val
+}
+
 // RejectionReason gets the rejection reason of this subtype
 func (m *MTOServiceItemDomesticCrating) RejectionReason() *string {
 	return m.rejectionReasonField
@@ -166,11 +173,6 @@ func (m *MTOServiceItemDomesticCrating) UnmarshalJSON(raw []byte) error {
 		// Required: true
 		// Enum: [DCRT DUCRT]
 		ReServiceCode *string `json:"reServiceCode"`
-
-		// The contractor's explanation for why an item needed to be crated or uncrated. Used by the TOO while deciding to approve or reject the service item.
-		//
-		// Example: Storage items need to be picked up
-		Reason *string `json:"reason"`
 	}
 	buf := bytes.NewBuffer(raw)
 	dec := json.NewDecoder(buf)
@@ -195,7 +197,9 @@ func (m *MTOServiceItemDomesticCrating) UnmarshalJSON(raw []byte) error {
 
 		ReServiceName string `json:"reServiceName,omitempty"`
 
-		RejectionReason *string `json:"rejectionReason"`
+		Reason string `json:"reason"`
+
+		RejectionReason *string `json:"rejectionReason,omitempty"`
 
 		Status MTOServiceItemStatus `json:"status,omitempty"`
 	}
@@ -223,6 +227,8 @@ func (m *MTOServiceItemDomesticCrating) UnmarshalJSON(raw []byte) error {
 
 	result.reServiceNameField = base.ReServiceName
 
+	result.reasonField = base.Reason
+
 	result.rejectionReasonField = base.RejectionReason
 
 	result.statusField = base.Status
@@ -231,7 +237,6 @@ func (m *MTOServiceItemDomesticCrating) UnmarshalJSON(raw []byte) error {
 	result.Description = data.Description
 	result.Item = data.Item
 	result.ReServiceCode = data.ReServiceCode
-	result.Reason = data.Reason
 
 	*m = result
 
@@ -265,11 +270,6 @@ func (m MTOServiceItemDomesticCrating) MarshalJSON() ([]byte, error) {
 		// Required: true
 		// Enum: [DCRT DUCRT]
 		ReServiceCode *string `json:"reServiceCode"`
-
-		// The contractor's explanation for why an item needed to be crated or uncrated. Used by the TOO while deciding to approve or reject the service item.
-		//
-		// Example: Storage items need to be picked up
-		Reason *string `json:"reason"`
 	}{
 
 		Crate: m.Crate,
@@ -279,8 +279,6 @@ func (m MTOServiceItemDomesticCrating) MarshalJSON() ([]byte, error) {
 		Item: m.Item,
 
 		ReServiceCode: m.ReServiceCode,
-
-		Reason: m.Reason,
 	})
 	if err != nil {
 		return nil, err
@@ -298,7 +296,9 @@ func (m MTOServiceItemDomesticCrating) MarshalJSON() ([]byte, error) {
 
 		ReServiceName string `json:"reServiceName,omitempty"`
 
-		RejectionReason *string `json:"rejectionReason"`
+		Reason string `json:"reason"`
+
+		RejectionReason *string `json:"rejectionReason,omitempty"`
 
 		Status MTOServiceItemStatus `json:"status,omitempty"`
 	}{
@@ -314,6 +314,8 @@ func (m MTOServiceItemDomesticCrating) MarshalJSON() ([]byte, error) {
 		MtoShipmentID: m.MtoShipmentID(),
 
 		ReServiceName: m.ReServiceName(),
+
+		Reason: m.Reason(),
 
 		RejectionReason: m.RejectionReason(),
 
@@ -342,7 +344,7 @@ func (m *MTOServiceItemDomesticCrating) Validate(formats strfmt.Registry) error 
 		res = append(res, err)
 	}
 
-	if err := m.validateRejectionReason(formats); err != nil {
+	if err := m.validateReason(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -411,9 +413,9 @@ func (m *MTOServiceItemDomesticCrating) validateMtoShipmentID(formats strfmt.Reg
 	return nil
 }
 
-func (m *MTOServiceItemDomesticCrating) validateRejectionReason(formats strfmt.Registry) error {
+func (m *MTOServiceItemDomesticCrating) validateReason(formats strfmt.Registry) error {
 
-	if err := validate.Required("rejectionReason", "body", m.RejectionReason()); err != nil {
+	if err := validate.RequiredString("reason", "body", m.Reason()); err != nil {
 		return err
 	}
 
@@ -507,6 +509,10 @@ func (m *MTOServiceItemDomesticCrating) ContextValidate(ctx context.Context, for
 		res = append(res, err)
 	}
 
+	if err := m.contextValidateReason(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
 	if err := m.contextValidateRejectionReason(ctx, formats); err != nil {
 		res = append(res, err)
 	}
@@ -564,6 +570,15 @@ func (m *MTOServiceItemDomesticCrating) contextValidateModelType(ctx context.Con
 func (m *MTOServiceItemDomesticCrating) contextValidateReServiceName(ctx context.Context, formats strfmt.Registry) error {
 
 	if err := validate.ReadOnly(ctx, "reServiceName", "body", string(m.ReServiceName())); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (m *MTOServiceItemDomesticCrating) contextValidateReason(ctx context.Context, formats strfmt.Registry) error {
+
+	if err := validate.ReadOnly(ctx, "reason", "body", string(m.Reason())); err != nil {
 		return err
 	}
 

--- a/pkg/gen/primemessages/m_t_o_service_item_domestic_crating.go
+++ b/pkg/gen/primemessages/m_t_o_service_item_domestic_crating.go
@@ -195,7 +195,7 @@ func (m *MTOServiceItemDomesticCrating) UnmarshalJSON(raw []byte) error {
 
 		ReServiceName string `json:"reServiceName,omitempty"`
 
-		RejectionReason *string `json:"rejectionReason,omitempty"`
+		RejectionReason *string `json:"rejectionReason"`
 
 		Status MTOServiceItemStatus `json:"status,omitempty"`
 	}
@@ -298,7 +298,7 @@ func (m MTOServiceItemDomesticCrating) MarshalJSON() ([]byte, error) {
 
 		ReServiceName string `json:"reServiceName,omitempty"`
 
-		RejectionReason *string `json:"rejectionReason,omitempty"`
+		RejectionReason *string `json:"rejectionReason"`
 
 		Status MTOServiceItemStatus `json:"status,omitempty"`
 	}{
@@ -339,6 +339,10 @@ func (m *MTOServiceItemDomesticCrating) Validate(formats strfmt.Registry) error 
 	}
 
 	if err := m.validateMtoShipmentID(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateRejectionReason(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -401,6 +405,15 @@ func (m *MTOServiceItemDomesticCrating) validateMtoShipmentID(formats strfmt.Reg
 	}
 
 	if err := validate.FormatOf("mtoShipmentID", "body", "uuid", m.MtoShipmentID().String(), formats); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (m *MTOServiceItemDomesticCrating) validateRejectionReason(formats strfmt.Registry) error {
+
+	if err := validate.Required("rejectionReason", "body", m.RejectionReason()); err != nil {
 		return err
 	}
 

--- a/pkg/gen/primemessages/m_t_o_service_item_origin_s_i_t.go
+++ b/pkg/gen/primemessages/m_t_o_service_item_origin_s_i_t.go
@@ -30,6 +30,8 @@ type MTOServiceItemOriginSIT struct {
 
 	reServiceNameField string
 
+	reasonField string
+
 	rejectionReasonField *string
 
 	statusField MTOServiceItemStatus
@@ -38,11 +40,6 @@ type MTOServiceItemOriginSIT struct {
 	// Required: true
 	// Enum: [DOFSIT DOASIT]
 	ReServiceCode *string `json:"reServiceCode"`
-
-	// Explanation of why Prime is picking up SIT item.
-	// Example: Storage items need to be picked up
-	// Required: true
-	Reason *string `json:"reason"`
 
 	// Departure date for SIT. This is the end date of the SIT at either origin or destination. This is optional as it can be updated using the UpdateMTOServiceItemSIT modelType at a later date.
 	// Format: date
@@ -122,6 +119,16 @@ func (m *MTOServiceItemOriginSIT) SetReServiceName(val string) {
 	m.reServiceNameField = val
 }
 
+// Reason gets the reason of this subtype
+func (m *MTOServiceItemOriginSIT) Reason() string {
+	return m.reasonField
+}
+
+// SetReason sets the reason of this subtype
+func (m *MTOServiceItemOriginSIT) SetReason(val string) {
+	m.reasonField = val
+}
+
 // RejectionReason gets the rejection reason of this subtype
 func (m *MTOServiceItemOriginSIT) RejectionReason() *string {
 	return m.rejectionReasonField
@@ -150,11 +157,6 @@ func (m *MTOServiceItemOriginSIT) UnmarshalJSON(raw []byte) error {
 		// Required: true
 		// Enum: [DOFSIT DOASIT]
 		ReServiceCode *string `json:"reServiceCode"`
-
-		// Explanation of why Prime is picking up SIT item.
-		// Example: Storage items need to be picked up
-		// Required: true
-		Reason *string `json:"reason"`
 
 		// Departure date for SIT. This is the end date of the SIT at either origin or destination. This is optional as it can be updated using the UpdateMTOServiceItemSIT modelType at a later date.
 		// Format: date
@@ -197,7 +199,9 @@ func (m *MTOServiceItemOriginSIT) UnmarshalJSON(raw []byte) error {
 
 		ReServiceName string `json:"reServiceName,omitempty"`
 
-		RejectionReason *string `json:"rejectionReason"`
+		Reason string `json:"reason"`
+
+		RejectionReason *string `json:"rejectionReason,omitempty"`
 
 		Status MTOServiceItemStatus `json:"status,omitempty"`
 	}
@@ -225,12 +229,13 @@ func (m *MTOServiceItemOriginSIT) UnmarshalJSON(raw []byte) error {
 
 	result.reServiceNameField = base.ReServiceName
 
+	result.reasonField = base.Reason
+
 	result.rejectionReasonField = base.RejectionReason
 
 	result.statusField = base.Status
 
 	result.ReServiceCode = data.ReServiceCode
-	result.Reason = data.Reason
 	result.SitDepartureDate = data.SitDepartureDate
 	result.SitEntryDate = data.SitEntryDate
 	result.SitHHGActualOrigin = data.SitHHGActualOrigin
@@ -252,11 +257,6 @@ func (m MTOServiceItemOriginSIT) MarshalJSON() ([]byte, error) {
 		// Enum: [DOFSIT DOASIT]
 		ReServiceCode *string `json:"reServiceCode"`
 
-		// Explanation of why Prime is picking up SIT item.
-		// Example: Storage items need to be picked up
-		// Required: true
-		Reason *string `json:"reason"`
-
 		// Departure date for SIT. This is the end date of the SIT at either origin or destination. This is optional as it can be updated using the UpdateMTOServiceItemSIT modelType at a later date.
 		// Format: date
 		SitDepartureDate *strfmt.Date `json:"sitDepartureDate,omitempty"`
@@ -277,8 +277,6 @@ func (m MTOServiceItemOriginSIT) MarshalJSON() ([]byte, error) {
 	}{
 
 		ReServiceCode: m.ReServiceCode,
-
-		Reason: m.Reason,
 
 		SitDepartureDate: m.SitDepartureDate,
 
@@ -304,7 +302,9 @@ func (m MTOServiceItemOriginSIT) MarshalJSON() ([]byte, error) {
 
 		ReServiceName string `json:"reServiceName,omitempty"`
 
-		RejectionReason *string `json:"rejectionReason"`
+		Reason string `json:"reason"`
+
+		RejectionReason *string `json:"rejectionReason,omitempty"`
 
 		Status MTOServiceItemStatus `json:"status,omitempty"`
 	}{
@@ -320,6 +320,8 @@ func (m MTOServiceItemOriginSIT) MarshalJSON() ([]byte, error) {
 		MtoShipmentID: m.MtoShipmentID(),
 
 		ReServiceName: m.ReServiceName(),
+
+		Reason: m.Reason(),
 
 		RejectionReason: m.RejectionReason(),
 
@@ -348,7 +350,7 @@ func (m *MTOServiceItemOriginSIT) Validate(formats strfmt.Registry) error {
 		res = append(res, err)
 	}
 
-	if err := m.validateRejectionReason(formats); err != nil {
+	if err := m.validateReason(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -357,10 +359,6 @@ func (m *MTOServiceItemOriginSIT) Validate(formats strfmt.Registry) error {
 	}
 
 	if err := m.validateReServiceCode(formats); err != nil {
-		res = append(res, err)
-	}
-
-	if err := m.validateReason(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -425,9 +423,9 @@ func (m *MTOServiceItemOriginSIT) validateMtoShipmentID(formats strfmt.Registry)
 	return nil
 }
 
-func (m *MTOServiceItemOriginSIT) validateRejectionReason(formats strfmt.Registry) error {
+func (m *MTOServiceItemOriginSIT) validateReason(formats strfmt.Registry) error {
 
-	if err := validate.Required("rejectionReason", "body", m.RejectionReason()); err != nil {
+	if err := validate.RequiredString("reason", "body", m.Reason()); err != nil {
 		return err
 	}
 
@@ -480,15 +478,6 @@ func (m *MTOServiceItemOriginSIT) validateReServiceCode(formats strfmt.Registry)
 
 	// value enum
 	if err := m.validateReServiceCodeEnum("reServiceCode", "body", *m.ReServiceCode); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func (m *MTOServiceItemOriginSIT) validateReason(formats strfmt.Registry) error {
-
-	if err := validate.Required("reason", "body", m.Reason); err != nil {
 		return err
 	}
 
@@ -570,6 +559,10 @@ func (m *MTOServiceItemOriginSIT) ContextValidate(ctx context.Context, formats s
 		res = append(res, err)
 	}
 
+	if err := m.contextValidateReason(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
 	if err := m.contextValidateRejectionReason(ctx, formats); err != nil {
 		res = append(res, err)
 	}
@@ -623,6 +616,15 @@ func (m *MTOServiceItemOriginSIT) contextValidateModelType(ctx context.Context, 
 func (m *MTOServiceItemOriginSIT) contextValidateReServiceName(ctx context.Context, formats strfmt.Registry) error {
 
 	if err := validate.ReadOnly(ctx, "reServiceName", "body", string(m.ReServiceName())); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (m *MTOServiceItemOriginSIT) contextValidateReason(ctx context.Context, formats strfmt.Registry) error {
+
+	if err := validate.ReadOnly(ctx, "reason", "body", string(m.Reason())); err != nil {
 		return err
 	}
 

--- a/pkg/gen/primemessages/m_t_o_service_item_origin_s_i_t.go
+++ b/pkg/gen/primemessages/m_t_o_service_item_origin_s_i_t.go
@@ -197,7 +197,7 @@ func (m *MTOServiceItemOriginSIT) UnmarshalJSON(raw []byte) error {
 
 		ReServiceName string `json:"reServiceName,omitempty"`
 
-		RejectionReason *string `json:"rejectionReason,omitempty"`
+		RejectionReason *string `json:"rejectionReason"`
 
 		Status MTOServiceItemStatus `json:"status,omitempty"`
 	}
@@ -304,7 +304,7 @@ func (m MTOServiceItemOriginSIT) MarshalJSON() ([]byte, error) {
 
 		ReServiceName string `json:"reServiceName,omitempty"`
 
-		RejectionReason *string `json:"rejectionReason,omitempty"`
+		RejectionReason *string `json:"rejectionReason"`
 
 		Status MTOServiceItemStatus `json:"status,omitempty"`
 	}{
@@ -345,6 +345,10 @@ func (m *MTOServiceItemOriginSIT) Validate(formats strfmt.Registry) error {
 	}
 
 	if err := m.validateMtoShipmentID(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateRejectionReason(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -415,6 +419,15 @@ func (m *MTOServiceItemOriginSIT) validateMtoShipmentID(formats strfmt.Registry)
 	}
 
 	if err := validate.FormatOf("mtoShipmentID", "body", "uuid", m.MtoShipmentID().String(), formats); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (m *MTOServiceItemOriginSIT) validateRejectionReason(formats strfmt.Registry) error {
+
+	if err := validate.Required("rejectionReason", "body", m.RejectionReason()); err != nil {
 		return err
 	}
 

--- a/pkg/gen/primemessages/m_t_o_service_item_shuttle.go
+++ b/pkg/gen/primemessages/m_t_o_service_item_shuttle.go
@@ -181,7 +181,7 @@ func (m *MTOServiceItemShuttle) UnmarshalJSON(raw []byte) error {
 
 		ReServiceName string `json:"reServiceName,omitempty"`
 
-		RejectionReason *string `json:"rejectionReason,omitempty"`
+		RejectionReason *string `json:"rejectionReason"`
 
 		Status MTOServiceItemStatus `json:"status,omitempty"`
 	}
@@ -274,7 +274,7 @@ func (m MTOServiceItemShuttle) MarshalJSON() ([]byte, error) {
 
 		ReServiceName string `json:"reServiceName,omitempty"`
 
-		RejectionReason *string `json:"rejectionReason,omitempty"`
+		RejectionReason *string `json:"rejectionReason"`
 
 		Status MTOServiceItemStatus `json:"status,omitempty"`
 	}{
@@ -315,6 +315,10 @@ func (m *MTOServiceItemShuttle) Validate(formats strfmt.Registry) error {
 	}
 
 	if err := m.validateMtoShipmentID(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateRejectionReason(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -369,6 +373,15 @@ func (m *MTOServiceItemShuttle) validateMtoShipmentID(formats strfmt.Registry) e
 	}
 
 	if err := validate.FormatOf("mtoShipmentID", "body", "uuid", m.MtoShipmentID().String(), formats); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (m *MTOServiceItemShuttle) validateRejectionReason(formats strfmt.Registry) error {
+
+	if err := validate.Required("rejectionReason", "body", m.RejectionReason()); err != nil {
 		return err
 	}
 

--- a/pkg/gen/primemessages/m_t_o_service_item_shuttle.go
+++ b/pkg/gen/primemessages/m_t_o_service_item_shuttle.go
@@ -30,6 +30,8 @@ type MTOServiceItemShuttle struct {
 
 	reServiceNameField string
 
+	reasonField string
+
 	rejectionReasonField *string
 
 	statusField MTOServiceItemStatus
@@ -47,12 +49,6 @@ type MTOServiceItemShuttle struct {
 	// Required: true
 	// Enum: [DOSHUT DDSHUT]
 	ReServiceCode *string `json:"reServiceCode"`
-
-	// The contractor's explanation for why a shuttle service is requested. Used by the TOO while deciding to approve or reject the service item.
-	//
-	// Example: Storage items need to be picked up.
-	// Required: true
-	Reason *string `json:"reason"`
 }
 
 // ETag gets the e tag of this subtype
@@ -114,6 +110,16 @@ func (m *MTOServiceItemShuttle) SetReServiceName(val string) {
 	m.reServiceNameField = val
 }
 
+// Reason gets the reason of this subtype
+func (m *MTOServiceItemShuttle) Reason() string {
+	return m.reasonField
+}
+
+// SetReason sets the reason of this subtype
+func (m *MTOServiceItemShuttle) SetReason(val string) {
+	m.reasonField = val
+}
+
 // RejectionReason gets the rejection reason of this subtype
 func (m *MTOServiceItemShuttle) RejectionReason() *string {
 	return m.rejectionReasonField
@@ -151,12 +157,6 @@ func (m *MTOServiceItemShuttle) UnmarshalJSON(raw []byte) error {
 		// Required: true
 		// Enum: [DOSHUT DDSHUT]
 		ReServiceCode *string `json:"reServiceCode"`
-
-		// The contractor's explanation for why a shuttle service is requested. Used by the TOO while deciding to approve or reject the service item.
-		//
-		// Example: Storage items need to be picked up.
-		// Required: true
-		Reason *string `json:"reason"`
 	}
 	buf := bytes.NewBuffer(raw)
 	dec := json.NewDecoder(buf)
@@ -181,7 +181,9 @@ func (m *MTOServiceItemShuttle) UnmarshalJSON(raw []byte) error {
 
 		ReServiceName string `json:"reServiceName,omitempty"`
 
-		RejectionReason *string `json:"rejectionReason"`
+		Reason string `json:"reason"`
+
+		RejectionReason *string `json:"rejectionReason,omitempty"`
 
 		Status MTOServiceItemStatus `json:"status,omitempty"`
 	}
@@ -209,6 +211,8 @@ func (m *MTOServiceItemShuttle) UnmarshalJSON(raw []byte) error {
 
 	result.reServiceNameField = base.ReServiceName
 
+	result.reasonField = base.Reason
+
 	result.rejectionReasonField = base.RejectionReason
 
 	result.statusField = base.Status
@@ -216,7 +220,6 @@ func (m *MTOServiceItemShuttle) UnmarshalJSON(raw []byte) error {
 	result.ActualWeight = data.ActualWeight
 	result.EstimatedWeight = data.EstimatedWeight
 	result.ReServiceCode = data.ReServiceCode
-	result.Reason = data.Reason
 
 	*m = result
 
@@ -242,12 +245,6 @@ func (m MTOServiceItemShuttle) MarshalJSON() ([]byte, error) {
 		// Required: true
 		// Enum: [DOSHUT DDSHUT]
 		ReServiceCode *string `json:"reServiceCode"`
-
-		// The contractor's explanation for why a shuttle service is requested. Used by the TOO while deciding to approve or reject the service item.
-		//
-		// Example: Storage items need to be picked up.
-		// Required: true
-		Reason *string `json:"reason"`
 	}{
 
 		ActualWeight: m.ActualWeight,
@@ -255,8 +252,6 @@ func (m MTOServiceItemShuttle) MarshalJSON() ([]byte, error) {
 		EstimatedWeight: m.EstimatedWeight,
 
 		ReServiceCode: m.ReServiceCode,
-
-		Reason: m.Reason,
 	})
 	if err != nil {
 		return nil, err
@@ -274,7 +269,9 @@ func (m MTOServiceItemShuttle) MarshalJSON() ([]byte, error) {
 
 		ReServiceName string `json:"reServiceName,omitempty"`
 
-		RejectionReason *string `json:"rejectionReason"`
+		Reason string `json:"reason"`
+
+		RejectionReason *string `json:"rejectionReason,omitempty"`
 
 		Status MTOServiceItemStatus `json:"status,omitempty"`
 	}{
@@ -290,6 +287,8 @@ func (m MTOServiceItemShuttle) MarshalJSON() ([]byte, error) {
 		MtoShipmentID: m.MtoShipmentID(),
 
 		ReServiceName: m.ReServiceName(),
+
+		Reason: m.Reason(),
 
 		RejectionReason: m.RejectionReason(),
 
@@ -318,7 +317,7 @@ func (m *MTOServiceItemShuttle) Validate(formats strfmt.Registry) error {
 		res = append(res, err)
 	}
 
-	if err := m.validateRejectionReason(formats); err != nil {
+	if err := m.validateReason(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -327,10 +326,6 @@ func (m *MTOServiceItemShuttle) Validate(formats strfmt.Registry) error {
 	}
 
 	if err := m.validateReServiceCode(formats); err != nil {
-		res = append(res, err)
-	}
-
-	if err := m.validateReason(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -379,9 +374,9 @@ func (m *MTOServiceItemShuttle) validateMtoShipmentID(formats strfmt.Registry) e
 	return nil
 }
 
-func (m *MTOServiceItemShuttle) validateRejectionReason(formats strfmt.Registry) error {
+func (m *MTOServiceItemShuttle) validateReason(formats strfmt.Registry) error {
 
-	if err := validate.Required("rejectionReason", "body", m.RejectionReason()); err != nil {
+	if err := validate.RequiredString("reason", "body", m.Reason()); err != nil {
 		return err
 	}
 
@@ -440,15 +435,6 @@ func (m *MTOServiceItemShuttle) validateReServiceCode(formats strfmt.Registry) e
 	return nil
 }
 
-func (m *MTOServiceItemShuttle) validateReason(formats strfmt.Registry) error {
-
-	if err := validate.Required("reason", "body", m.Reason); err != nil {
-		return err
-	}
-
-	return nil
-}
-
 // ContextValidate validate this m t o service item shuttle based on the context it is used
 func (m *MTOServiceItemShuttle) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
 	var res []error
@@ -462,6 +448,10 @@ func (m *MTOServiceItemShuttle) ContextValidate(ctx context.Context, formats str
 	}
 
 	if err := m.contextValidateReServiceName(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.contextValidateReason(ctx, formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -514,6 +504,15 @@ func (m *MTOServiceItemShuttle) contextValidateModelType(ctx context.Context, fo
 func (m *MTOServiceItemShuttle) contextValidateReServiceName(ctx context.Context, formats strfmt.Registry) error {
 
 	if err := validate.ReadOnly(ctx, "reServiceName", "body", string(m.ReServiceName())); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (m *MTOServiceItemShuttle) contextValidateReason(ctx context.Context, formats strfmt.Registry) error {
+
+	if err := validate.ReadOnly(ctx, "reason", "body", string(m.Reason())); err != nil {
 		return err
 	}
 

--- a/pkg/handlers/primeapi/payloads/model_to_payload.go
+++ b/pkg/handlers/primeapi/payloads/model_to_payload.go
@@ -532,7 +532,6 @@ func MTOServiceItem(mtoServiceItem *models.MTOServiceItem) primemessages.MTOServ
 		}
 		payload = &primemessages.MTOServiceItemOriginSIT{
 			ReServiceCode:      handlers.FmtString(string(mtoServiceItem.ReService.Code)),
-			Reason:             mtoServiceItem.Reason,
 			SitDepartureDate:   handlers.FmtDate(sitDepartureDate),
 			SitEntryDate:       handlers.FmtDatePtr(mtoServiceItem.SITEntryDate),
 			SitPostalCode:      mtoServiceItem.SITPostalCode,
@@ -576,7 +575,6 @@ func MTOServiceItem(mtoServiceItem *models.MTOServiceItem) primemessages.MTOServ
 		cratingSI := primemessages.MTOServiceItemDomesticCrating{
 			ReServiceCode: handlers.FmtString(string(mtoServiceItem.ReService.Code)),
 			Description:   mtoServiceItem.Description,
-			Reason:        mtoServiceItem.Reason,
 		}
 		cratingSI.Item.MTOServiceItemDimension = primemessages.MTOServiceItemDimension{
 			ID:     strfmt.UUID(item.ID.String()),
@@ -594,7 +592,6 @@ func MTOServiceItem(mtoServiceItem *models.MTOServiceItem) primemessages.MTOServ
 	case models.ReServiceCodeDDSHUT, models.ReServiceCodeDOSHUT:
 		payload = &primemessages.MTOServiceItemShuttle{
 			ReServiceCode:   handlers.FmtString(string(mtoServiceItem.ReService.Code)),
-			Reason:          mtoServiceItem.Reason,
 			EstimatedWeight: handlers.FmtPoundPtr(mtoServiceItem.EstimatedWeight),
 			ActualWeight:    handlers.FmtPoundPtr(mtoServiceItem.ActualWeight),
 		}

--- a/pkg/handlers/primeapi/payloads/payload_to_model.go
+++ b/pkg/handlers/primeapi/payloads/payload_to_model.go
@@ -356,6 +356,8 @@ func MTOServiceItemModel(mtoServiceItem primemessages.MTOServiceItem) (*models.M
 		return nil, nil
 	}
 
+	reason := models.MTOServiceItem{}.Reason
+
 	shipmentID := uuid.FromStringOrNil(mtoServiceItem.MtoShipmentID().String())
 
 	// basic service item
@@ -363,6 +365,7 @@ func MTOServiceItemModel(mtoServiceItem primemessages.MTOServiceItem) (*models.M
 		ID:              uuid.FromStringOrNil(mtoServiceItem.ID().String()),
 		MoveTaskOrderID: uuid.FromStringOrNil(mtoServiceItem.MoveTaskOrderID().String()),
 		MTOShipmentID:   &shipmentID,
+		Reason:          reason,
 		CreatedAt:       time.Now(),
 		UpdatedAt:       time.Now(),
 	}
@@ -377,7 +380,7 @@ func MTOServiceItemModel(mtoServiceItem primemessages.MTOServiceItem) (*models.M
 			model.ReService.Code = models.ReServiceCode(*originsit.ReServiceCode)
 		}
 
-		model.Reason = originsit.Reason
+		//model.Reason = originsit.Reason
 		sitEntryDate := handlers.FmtDatePtrToPopPtr(originsit.SitEntryDate)
 
 		if sitEntryDate != nil {
@@ -440,7 +443,7 @@ func MTOServiceItemModel(mtoServiceItem primemessages.MTOServiceItem) (*models.M
 		shuttleService := mtoServiceItem.(*primemessages.MTOServiceItemShuttle)
 		// values to get from payload
 		model.ReService.Code = models.ReServiceCode(*shuttleService.ReServiceCode)
-		model.Reason = shuttleService.Reason
+		//model.Reason = shuttleService.Reason
 		model.EstimatedWeight = handlers.PoundPtrFromInt64Ptr(shuttleService.EstimatedWeight)
 		model.ActualWeight = handlers.PoundPtrFromInt64Ptr(shuttleService.ActualWeight)
 
@@ -456,7 +459,7 @@ func MTOServiceItemModel(mtoServiceItem primemessages.MTOServiceItem) (*models.M
 		// have to get code from payload
 		model.ReService.Code = models.ReServiceCode(*domesticCrating.ReServiceCode)
 		model.Description = domesticCrating.Description
-		model.Reason = domesticCrating.Reason
+		//model.Reason = domesticCrating.Reason
 		model.Dimensions = models.MTOServiceItemDimensions{
 			models.MTOServiceItemDimension{
 				Type:   models.DimensionTypeItem,

--- a/pkg/handlers/primeapi/payloads/payload_to_model_test.go
+++ b/pkg/handlers/primeapi/payloads/payload_to_model_test.go
@@ -30,7 +30,7 @@ func (suite *PayloadsSuite) TestMTOServiceItemModel() {
 	itemMeasurement := int32(1100)
 	crateMeasurement := int32(1200)
 	dcrtCode := models.ReServiceCodeDCRT.String()
-	reason := "Reason"
+	//reason := "Reason"
 	description := "Description"
 
 	item := &primemessages.MTOServiceItemDimension{
@@ -47,8 +47,8 @@ func (suite *PayloadsSuite) TestMTOServiceItemModel() {
 
 	DCRTServiceItem := &primemessages.MTOServiceItemDomesticCrating{
 		ReServiceCode: &dcrtCode,
-		Reason:        &reason,
-		Description:   &description,
+		//Reason:        &reason,
+		Description: &description,
 	}
 	DCRTServiceItem.Item.MTOServiceItemDimension = *item
 	DCRTServiceItem.Crate.MTOServiceItemDimension = *crate
@@ -121,8 +121,8 @@ func (suite *PayloadsSuite) TestMTOServiceItemModel() {
 
 		badDCRTServiceItem := &primemessages.MTOServiceItemDomesticCrating{
 			ReServiceCode: &dcrtCode,
-			Reason:        &reason,
-			Description:   &description,
+			//Reason:        &reason,
+			Description: &description,
 		}
 		badDCRTServiceItem.Item.MTOServiceItemDimension = *item
 		badDCRTServiceItem.Crate.MTOServiceItemDimension = *badCrate

--- a/pkg/services/event/notification_test.go
+++ b/pkg/services/event/notification_test.go
@@ -201,7 +201,7 @@ func (suite *EventServiceSuite) Test_MTOServiceItemPayload() {
 		suite.Equal(mtoServiceItemDOSHUT.ID.String(), data.ID().String())
 		suite.Equal(mtoServiceItemDOSHUT.MTOShipmentID.String(), data.MtoShipmentID().String())
 		suite.Equal(string(mtoServiceItemDOSHUT.ReService.Code), *data.ReServiceCode)
-		suite.Equal(*mtoServiceItemDOSHUT.Reason, *data.Reason)
+		//suite.Equal(*mtoServiceItemDOSHUT.Reason, *data.Reason)
 	})
 
 }

--- a/swagger-def/prime.yaml
+++ b/swagger-def/prime.yaml
@@ -1592,6 +1592,7 @@ definitions:
     required:
       - modelType
       - moveTaskOrderID
+      - rejectionReason
   MTOServiceItemBasic: # spectral oas2-unused-definition is OK here due to polymorphism
     description: Describes a basic service item subtype of a MTOServiceItem.
     allOf:
@@ -1602,6 +1603,7 @@ definitions:
             $ref: 'definitions/ReServiceCode.yaml'
         required:
           - reServiceCode
+          - rejectionReason
   MTOServiceItemDestSIT: # spectral oas2-unused-definition is OK here due to polymorphism
     description: Describes a domestic destination SIT service item. Subtype of a MTOServiceItem.
     allOf:

--- a/swagger-def/prime.yaml
+++ b/swagger-def/prime.yaml
@@ -1575,6 +1575,12 @@ definitions:
         type: string
         readOnly: true
         description: The full descriptive name of the service.
+      reason:
+        type: string
+        readOnly: true
+        description: A reason why this particular service item is justified.
+        x-nullable: false
+        x-omitempty: false
       status:
         $ref: '#/definitions/MTOServiceItemStatus'
       rejectionReason:
@@ -1592,7 +1598,7 @@ definitions:
     required:
       - modelType
       - moveTaskOrderID
-      - rejectionReason
+      - reason
   MTOServiceItemBasic: # spectral oas2-unused-definition is OK here due to polymorphism
     description: Describes a basic service item subtype of a MTOServiceItem.
     allOf:
@@ -1603,7 +1609,6 @@ definitions:
             $ref: 'definitions/ReServiceCode.yaml'
         required:
           - reServiceCode
-          - rejectionReason
   MTOServiceItemDestSIT: # spectral oas2-unused-definition is OK here due to polymorphism
     description: Describes a domestic destination SIT service item. Subtype of a MTOServiceItem.
     allOf:
@@ -1703,14 +1708,6 @@ definitions:
             type: string
             example: Decorated horse head to be crated.
             description: A description of the item being crated.
-          reason:
-            type: string
-            example: Storage items need to be picked up
-            description: >
-              The contractor's explanation for why an item needed to be crated or uncrated. Used by the TOO while
-              deciding to approve or reject the service item.
-            x-nullable: true
-            x-omitempty: false
         required:
           - reServiceCode
           - item
@@ -1747,10 +1744,6 @@ definitions:
             enum:
               - DOFSIT # Domestic Origin First Day SIT
               - DOASIT # Domestic Origin Additional SIT
-          reason:
-            type: string
-            example: Storage items need to be picked up
-            description: Explanation of why Prime is picking up SIT item.
           sitPostalCode:
             type: string
             format: zip
@@ -1786,12 +1779,6 @@ definitions:
             enum:
               - DOSHUT # Domestic Origin Shuttle Service
               - DDSHUT # Domestic Destination Shuttle Service
-          reason:
-            type: string
-            example: Storage items need to be picked up.
-            description: >
-              The contractor's explanation for why a shuttle service is requested. Used by the TOO while deciding to
-              approve or reject the service item.
           estimatedWeight:
             type: integer
             example: 4200

--- a/swagger/prime.yaml
+++ b/swagger/prime.yaml
@@ -1794,6 +1794,12 @@ definitions:
         type: string
         readOnly: true
         description: The full descriptive name of the service.
+      reason:
+        type: string
+        readOnly: true
+        description: A reason why this particular service item is justified.
+        x-nullable: false
+        x-omitempty: false
       status:
         $ref: '#/definitions/MTOServiceItemStatus'
       rejectionReason:
@@ -1813,7 +1819,7 @@ definitions:
     required:
       - modelType
       - moveTaskOrderID
-      - rejectionReason
+      - reason
   MTOServiceItemBasic:
     description: Describes a basic service item subtype of a MTOServiceItem.
     allOf:
@@ -1824,7 +1830,6 @@ definitions:
             $ref: '#/definitions/ReServiceCode'
         required:
           - reServiceCode
-          - rejectionReason
   MTOServiceItemDestSIT:
     description: >-
       Describes a domestic destination SIT service item. Subtype of a
@@ -1939,15 +1944,6 @@ definitions:
             type: string
             example: Decorated horse head to be crated.
             description: A description of the item being crated.
-          reason:
-            type: string
-            example: Storage items need to be picked up
-            description: >
-              The contractor's explanation for why an item needed to be crated
-              or uncrated. Used by the TOO while deciding to approve or reject
-              the service item.
-            x-nullable: true
-            x-omitempty: false
         required:
           - reServiceCode
           - item
@@ -1985,10 +1981,6 @@ definitions:
             enum:
               - DOFSIT
               - DOASIT
-          reason:
-            type: string
-            example: Storage items need to be picked up
-            description: Explanation of why Prime is picking up SIT item.
           sitPostalCode:
             type: string
             format: zip
@@ -2028,13 +2020,6 @@ definitions:
             enum:
               - DOSHUT
               - DDSHUT
-          reason:
-            type: string
-            example: Storage items need to be picked up.
-            description: >
-              The contractor's explanation for why a shuttle service is
-              requested. Used by the TOO while deciding to approve or reject the
-              service item.
           estimatedWeight:
             type: integer
             example: 4200

--- a/swagger/prime.yaml
+++ b/swagger/prime.yaml
@@ -1813,6 +1813,7 @@ definitions:
     required:
       - modelType
       - moveTaskOrderID
+      - rejectionReason
   MTOServiceItemBasic:
     description: Describes a basic service item subtype of a MTOServiceItem.
     allOf:
@@ -1823,6 +1824,7 @@ definitions:
             $ref: '#/definitions/ReServiceCode'
         required:
           - reServiceCode
+          - rejectionReason
   MTOServiceItemDestSIT:
     description: >-
       Describes a domestic destination SIT service item. Subtype of a


### PR DESCRIPTION
## [Jira ticket](https://dp3.atlassian.net/browse/MB-15947)

## Summary

Is there anything you would like reviewers to give additional scrutiny?

[this article](tbd) explains more about the approach used.

## Verification Steps for the Author

These are to be checked by the author.

- [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
- [ ] Have the Jira acceptance criteria been met for this change?

## Verification Steps for Reviewers

These are to be checked by a reviewer.

### Setup to Run the Code

- [Instructions for starting storybook](https://transcom.github.io/mymove-docs/docs/frontend/setup/run-storybook)
- [Instructions for starting the MilMove application](https://transcom.github.io/mymove-docs/docs/about/application-setup/milmove-local-client/)
- [Instructions for running tests](https://transcom.github.io/mymove-docs/docs/about/development/testing)

### How to test

1. Access the
2. Login as a
3.

### Frontend

- [ ] There are no aXe warnings for UI.
- [ ] This works in [Supported Browsers and their phone views](https://transcom.github.io/mymove-docs/docs/about/supported-browsers) (Chrome, Firefox, Edge).
- [ ] There are no new console errors in the browser devtools.
- [ ] There are no new console errors in the test output.
- [ ] If this PR adds a new component to Storybook, it ensures the component is fully responsive, OR if it is intentionally not, a wrapping div using the `officeApp` class or custom `min-width` styling is used to hide any states the would not be visible to the user.

### Backend

- [ ] Code follows the guidelines for [Logging](https://transcom.github.io/mymove-docs/docs/about/development/logging).
- [ ] The requirements listed in [Querying the Database Safely](https://transcom.github.io/mymove-docs/docs/backend/guides/golang-guide#querying-the-database-safely) have been satisfied.

### Database

#### Any new migrations/schema changes:

- [ ] Follows our guidelines for [Zero-Downtime Deploys](https://transcom.github.io/mymove-docs/docs/backend/setup/database-migrations#zero-downtime-migrations).
- [ ] Have been communicated to #g-database.
- [ ] Secure migrations have been tested following the instructions in our [docs](https://transcom.github.io/mymove-docs/docs/backend/setup/database-migrations#secure-migrations).

## Screenshots
