### PR TITLE
MB-15513 Fix prime shipment type and add to existing test

### DIFF
--- a/src/pages/PrimeUI/Shipment/PrimeUIShipmentCreateForm.jsx
+++ b/src/pages/PrimeUI/Shipment/PrimeUIShipmentCreateForm.jsx
@@ -29,7 +29,7 @@ const PrimeUIShipmentCreateForm = () => {
       <DropdownInput
         label="Shipment type"
         name="shipmentType"
-        options={dropdownInputOptions(SHIPMENT_OPTIONS)}
+        options={Object.values(SHIPMENT_OPTIONS).map((value) => ({ key: value, value }))}
         id="shipmentType"
       />
 

--- a/src/pages/PrimeUI/Shipment/PrimeUIShipmentCreateForm.test.jsx
+++ b/src/pages/PrimeUI/Shipment/PrimeUIShipmentCreateForm.test.jsx
@@ -120,14 +120,20 @@ describe('PrimeUIShipmentCreateForm', () => {
     );
   });
 
-  it('renders the initial form, selecting HHG', async () => {
+  it.each([
+    'HHG',
+    'HHG_SHORTHAUL_DOMESTIC',
+    'HHG_LONGHAUL_DOMESTIC',
+    'HHG_INTO_NTS_DOMESTIC',
+    'HHG_OUTOF_NTS_DOMESTIC',
+  ])('renders the initial form, selecting %s', async (shipmentType) => {
     renderShipmentCreateForm();
 
     const shipmentTypeInput = await screen.findByLabelText('Shipment type');
     expect(shipmentTypeInput).toBeInTheDocument();
 
-    // Make it an HHG.
-    await userEvent.selectOptions(shipmentTypeInput, ['HHG']);
+    // Select the shipment type
+    await userEvent.selectOptions(shipmentTypeInput, [shipmentType]);
 
     // Make sure than a PPM-specific field is not visible.
     expect(await screen.queryByLabelText('Expected Departure Date')).not.toBeInTheDocument();


### PR DESCRIPTION
## [Jira ticket](https://dp3.atlassian.net/browse/MB-15513)

## Summary

This PR fixes the invalid shipment type values that were present in the prime simulator create shipment form shipment type dropdown. It also parameterized the shipment create test to test all shipment types. 

### Setup to Run the Code

- [Instructions for starting the MilMove application](https://transcom.github.io/mymove-docs/docs/about/application-setup/milmove-local-client/)
- [Instructions for running tests](https://transcom.github.io/mymove-docs/docs/about/development/testing)

### How to test

1. Access the prime simulator
2. Select any move
3. Click 'Create Shipment'
4. Select either 'HHG_INTO_NTS_DOMESTIC' or 'HHG_OUTOF_NTS_DOMESTIC' as the shipment type
5. Complete the shipment form
6. Submit the form and ensure there are no errors related to the shipment type being invalid