### PR TITLE
[MB-15973] Upgrades the query-string dependency to v8

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "path-to-regexp": "^6.2.1",
     "playwright": "^1.31.2",
     "prop-types": "^15.8.1",
-    "query-string": "7",
+    "query-string": "^8.1.0",
     "ra-language-english": "^4.9.2",
     "react": "^17.0.1",
     "react-admin": "^4.5.3",

--- a/src/scenes/SystemAdmin/shared/rest_provider.js
+++ b/src/scenes/SystemAdmin/shared/rest_provider.js
@@ -1,4 +1,4 @@
-import { stringify } from 'query-string';
+import qs from 'query-string';
 import { diff } from 'deep-object-diff';
 import { snakeCase } from 'lodash';
 import {
@@ -50,7 +50,7 @@ const restProvider = (apiUrl, httpClient = fetchUtils.fetchJson) => {
           perPage,
           filter: JSON.stringify(params.filter),
         };
-        url = `${apiUrl}/${resource}?${stringify(query)}`;
+        url = `${apiUrl}/${resource}?${qs.stringify(query)}`;
         break;
       }
       case GET_ONE:
@@ -62,7 +62,7 @@ const restProvider = (apiUrl, httpClient = fetchUtils.fetchJson) => {
             page: 1,
             perPage: 10000,
           };
-          url = `${apiUrl}/${resource}?${stringify(query)}`;
+          url = `${apiUrl}/${resource}?${qs.stringify(query)}`;
           break;
         }
         if (params.ids !== undefined) {
@@ -73,7 +73,7 @@ const restProvider = (apiUrl, httpClient = fetchUtils.fetchJson) => {
             id: params.id,
           }),
         };
-        url = `${apiUrl}/${resource}?${stringify(query)}`;
+        url = `${apiUrl}/${resource}?${qs.stringify(query)}`;
         break;
       }
       case GET_MANY_REFERENCE: {
@@ -89,7 +89,7 @@ const restProvider = (apiUrl, httpClient = fetchUtils.fetchJson) => {
             [params.target]: params.id,
           }),
         };
-        url = `${apiUrl}/${resource}?${stringify(query)}`;
+        url = `${apiUrl}/${resource}?${qs.stringify(query)}`;
         break;
       }
       case UPDATE: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -8570,6 +8570,11 @@ decode-uri-component@^0.2.0, decode-uri-component@^0.2.2:
   resolved "https://registry.yarnpkg.com/decode-uri-component/-/decode-uri-component-0.2.2.tgz#e69dbe25d37941171dd540e024c444cd5188e1e9"
   integrity sha512-FqUYQ+8o158GyGTrMFJms9qh3CqTKvAqgqsTnkLI8sKu0028orqBhxNMFkFen0zGyg6epACD32pjVk58ngIErQ==
 
+decode-uri-component@^0.4.1:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/decode-uri-component/-/decode-uri-component-0.4.1.tgz#2ac4859663c704be22bf7db760a1494a49ab2cc5"
+  integrity sha512-+8VxcR21HhTy8nOt6jf20w0c9CADrw1O8d+VZ/YzzCt4bJ3uBjw+D1q2osAB8RnpwwaeYBxy0HyKQxD5JBMuuQ==
+
 decompress-response@^3.3.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/decompress-response/-/decompress-response-3.3.0.tgz#80a4dd323748384bfa248083622aedec982adff3"
@@ -10082,6 +10087,11 @@ filter-obj@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/filter-obj/-/filter-obj-1.1.0.tgz#9b311112bc6c6127a16e016c6c5d7f19e0805c5b"
   integrity sha512-8rXg1ZnX7xzy2NGDVkBVaAy+lSlPNwad13BtgSlLuxfIslyt5Vg64U7tFcCt4WS1R0hvtnQybT/IyCkGZ3DpXQ==
+
+filter-obj@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/filter-obj/-/filter-obj-5.1.0.tgz#5bd89676000a713d7db2e197f660274428e524ed"
+  integrity sha512-qWeTREPoT7I0bifpPUXtxkZJ1XJzxWtfoWWkdVGqa+eCr3SHW/Ocp89o8vLvbUuQnadybJpjOKu4V+RwO6sGng==
 
 finalhandler@1.1.2:
   version "1.1.2"
@@ -15375,16 +15385,6 @@ qs@^6.11.1:
   dependencies:
     side-channel "^1.0.4"
 
-query-string@7, query-string@^7.1.1:
-  version "7.1.3"
-  resolved "https://registry.yarnpkg.com/query-string/-/query-string-7.1.3.tgz#a1cf90e994abb113a325804a972d98276fe02328"
-  integrity sha512-hh2WYhq4fi8+b+/2Kg9CEge4fDPvHS534aOOvOZeQ3+Vf2mCFsaFBYj0i+iXcAq6I9Vzp5fjMFBlONvayDC1qg==
-  dependencies:
-    decode-uri-component "^0.2.2"
-    filter-obj "^1.1.0"
-    split-on-first "^1.0.0"
-    strict-uri-encode "^2.0.0"
-
 query-string@^6.12.1:
   version "6.14.1"
   resolved "https://registry.yarnpkg.com/query-string/-/query-string-6.14.1.tgz#7ac2dca46da7f309449ba0f86b1fd28255b0c86a"
@@ -15394,6 +15394,25 @@ query-string@^6.12.1:
     filter-obj "^1.1.0"
     split-on-first "^1.0.0"
     strict-uri-encode "^2.0.0"
+
+query-string@^7.1.1:
+  version "7.1.3"
+  resolved "https://registry.yarnpkg.com/query-string/-/query-string-7.1.3.tgz#a1cf90e994abb113a325804a972d98276fe02328"
+  integrity sha512-hh2WYhq4fi8+b+/2Kg9CEge4fDPvHS534aOOvOZeQ3+Vf2mCFsaFBYj0i+iXcAq6I9Vzp5fjMFBlONvayDC1qg==
+  dependencies:
+    decode-uri-component "^0.2.2"
+    filter-obj "^1.1.0"
+    split-on-first "^1.0.0"
+    strict-uri-encode "^2.0.0"
+
+query-string@^8.1.0:
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/query-string/-/query-string-8.1.0.tgz#e7f95367737219544cd360a11a4f4ca03836e115"
+  integrity sha512-BFQeWxJOZxZGix7y+SByG3F36dA0AbTy9o6pSmKFcFz7DAj0re9Frkty3saBn3nHo3D0oZJ/+rx3r8H8r8Jbpw==
+  dependencies:
+    decode-uri-component "^0.4.1"
+    filter-obj "^5.1.0"
+    split-on-first "^3.0.0"
 
 querystring@0.2.0:
   version "0.2.0"
@@ -17185,6 +17204,11 @@ split-on-first@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/split-on-first/-/split-on-first-1.1.0.tgz#f610afeee3b12bce1d0c30425e76398b78249a5f"
   integrity sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw==
+
+split-on-first@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/split-on-first/-/split-on-first-3.0.0.tgz#f04959c9ea8101b9b0bbf35a61b9ebea784a23e7"
+  integrity sha512-qxQJTx2ryR0Dw0ITYyekNQWpz6f8dGd7vffGNflQQ3Iqj9NJ6qiZ7ELpZsJ/QBhIVAiDfXdag3+Gp8RvWa62AA==
 
 sprintf-js@~1.0.2:
   version "1.0.3"


### PR DESCRIPTION
## Summary

This pull request upgrades the `query-string` package to the next major version (v8). Since the new major version of the package is a pure ES module, it seems we can no longer `import `parts of it, and so one file was changed to import the entire package rather than just the necessary parts. (As the whole package is a relatively tiny set of string manipulation utilities, there should be no perceptible impact to performance or build time.)

There is no Jira ticket for this work, as it is a part of A-Team's [dependency maintenance chore](https://dp3.atlassian.net/browse/MB-15973) during this slice.