### PR TITLE
MB-16114: Enable open telemetry and container health check in staging

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1909,6 +1909,8 @@ jobs:
     executor: mymove_pusher
     environment:
       - APP_ENVIRONMENT: 'stg'
+      - OPEN_TELEMETRY_SIDECAR: 'true'
+      - HEALTH_CHECK: 'true'
     steps:
       - checkout
       - aws_vars_stg
@@ -1922,6 +1924,8 @@ jobs:
     executor: mymove_pusher
     environment:
       - APP_ENVIRONMENT: 'stg'
+      - OPEN_TELEMETRY_SIDECAR: 'true'
+      - HEALTH_CHECK: 'true'
     steps:
       - checkout
       - aws_vars_stg


### PR DESCRIPTION
## [Jira ticket](https://dp3.atlassian.net/browse/MB-16114)

## Summary

We've had good success running the open telemetry sidecar in the loadtest environment, and now it would be good to run it in staging. Also enable the service health checks

## Verification Steps for the Author

These are to be checked by the author.

- [ ] Tested in the Loadtest environment (for changes to containers, app startup, or connection to data stores)
- [ ] Have the Jira acceptance criteria been met for this change?

