### PR TITLE
MB-16114: Revert "Enable open telemetry and container health check in staging"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1909,8 +1909,6 @@ jobs:
     executor: mymove_pusher
     environment:
       - APP_ENVIRONMENT: 'stg'
-      - OPEN_TELEMETRY_SIDECAR: 'true'
-      - HEALTH_CHECK: 'true'
     steps:
       - checkout
       - aws_vars_stg
@@ -1924,8 +1922,6 @@ jobs:
     executor: mymove_pusher
     environment:
       - APP_ENVIRONMENT: 'stg'
-      - OPEN_TELEMETRY_SIDECAR: 'true'
-      - HEALTH_CHECK: 'true'
     steps:
       - checkout
       - aws_vars_stg


### PR DESCRIPTION
This reverts commit dc0849f9240b9fb8416e5c27a1a4f49137fe79b9.

Staging is not able to pull from the aws repo

