### PR TITLE
MB-16114: enable health check and otel in staging

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1907,8 +1907,13 @@ jobs:
   # `deploy_stg_app` updates the server-TLS app service in stg environment
   deploy_stg_app:
     executor: mymove_pusher
+    # use dockerhub otel collector image as govcloud does not have the
+    # right certs for pulling from public.ecr.aws
     environment:
       - APP_ENVIRONMENT: 'stg'
+      - OPEN_TELEMETRY_SIDECAR: 'true'
+      - OTEL_COLLECTOR_IMAGE: 'amazon/aws-otel-collector:v0.29.0'
+      - HEALTH_CHECK: 'true'
     steps:
       - checkout
       - aws_vars_stg
@@ -1920,8 +1925,13 @@ jobs:
   # `deploy_stg_app_client_tls` updates the mutual-TLS service in the stg environment
   deploy_stg_app_client_tls:
     executor: mymove_pusher
+    # use dockerhub otel collector image as govcloud does not have the
+    # right certs for pulling from public.ecr.aws
     environment:
       - APP_ENVIRONMENT: 'stg'
+      - OPEN_TELEMETRY_SIDECAR: 'true'
+      - OTEL_COLLECTOR_IMAGE: 'amazon/aws-otel-collector:v0.29.0'
+      - HEALTH_CHECK: 'true'
     steps:
       - checkout
       - aws_vars_stg

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1834,6 +1834,7 @@ jobs:
       - APP_ENVIRONMENT: *dp3-env
       - OPEN_TELEMETRY_SIDECAR: 'true'
       - HEALTH_CHECK: 'true'
+      - OTEL_COLLECTOR_IMAGE: 'amazon/aws-otel-collector:v0.29.0'
     steps:
       - checkout
       - aws_vars_dp3
@@ -1853,6 +1854,7 @@ jobs:
       - APP_ENVIRONMENT: *dp3-env
       - OPEN_TELEMETRY_SIDECAR: 'true'
       - HEALTH_CHECK: 'true'
+      - OTEL_COLLECTOR_IMAGE: 'amazon/aws-otel-collector:v0.29.0'
     steps:
       - checkout
       - aws_vars_dp3

--- a/cmd/ecs-deploy/task_def.go
+++ b/cmd/ecs-deploy/task_def.go
@@ -119,6 +119,7 @@ const (
 	memFlag                  string = "memory"
 	registerFlag             string = "register"
 	openTelemetrySidecarFlag string = "open-telemetry-sidecar"
+	otelCollectorImageFlag   string = "otel-collector-image"
 	healthCheckFlag          string = "health-check"
 )
 
@@ -231,6 +232,10 @@ func initTaskDefFlags(flag *pflag.FlagSet) {
 
 	// Open Telemetry SideCar
 	flag.Bool(openTelemetrySidecarFlag, false, "Include open telemetry sidecar container")
+	const defaultOtelImage = "public.ecr.aws/aws-observability/aws-otel-collector:v0.29.0"
+	flag.String(otelCollectorImageFlag, defaultOtelImage,
+		"Image to use for open telemetry sidecar")
+
 	// Health Check
 	flag.Bool(healthCheckFlag, false, "Include health check in the task definition")
 
@@ -874,10 +879,12 @@ service:
 
   extensions: [health_check]
 `
+
+		otelCollectorImage := v.GetString(otelCollectorImageFlag)
 		containerDefinitions = append(containerDefinitions,
 			&ecs.ContainerDefinition{
 				Name:      aws.String("otel-" + containerDefName),
-				Image:     aws.String("public.ecr.aws/aws-observability/aws-otel-collector:v0.29.0"),
+				Image:     aws.String(otelCollectorImage),
 				Essential: aws.Bool(true),
 				Environment: []*ecs.KeyValuePair{
 					{


### PR DESCRIPTION
## [Jira ticket](https://dp3.atlassian.net/browse/MB-16114)

## Summary

Try again enabling open telemetry sidecar in staging, but this time use the dockerhub image.

I tested this out in [loadtest](https://github.com/transcom/mymove/commit/b3d4615eb12c8ed8568ddae9a7c44929b1b4fca3)

## Verification Steps for the Author

These are to be checked by the author.

- [ ] Tested in the Loadtest environment (for changes to containers, app startup, or connection to data stores)
- [ ] Have the Jira acceptance criteria been met for this change?

