### PR TITLE
[MB-16086] Make PrimeEstimatedWeight Optional for Creating a Shuttle Service Item

### DIFF
--- a/pkg/services/mto_service_item/mto_service_item_creator.go
+++ b/pkg/services/mto_service_item/mto_service_item_creator.go
@@ -123,12 +123,6 @@ func (o *mtoServiceItemCreator) CreateMTOServiceItem(appCtx appcontext.AppContex
 		}
 	}
 
-	if serviceItem.ReService.Code == models.ReServiceCodeDOSHUT || serviceItem.ReService.Code == models.ReServiceCodeDDSHUT {
-		if mtoShipment.PrimeEstimatedWeight == nil {
-			return nil, verrs, apperror.NewConflictError(mtoShipmentID, fmt.Sprintf("The associated MTOShipment (%s) must have a valid PrimeEstimatedWeight to create this service item.", mtoShipmentID))
-		}
-	}
-
 	if serviceItem.ReService.Code == models.ReServiceCodeDOASIT {
 		// DOASIT must be associated with shipment that has DOFSIT
 		serviceItem, err = o.validateSITStandaloneServiceItem(appCtx, serviceItem, models.ReServiceCodeDOFSIT)

--- a/pkg/services/mto_service_item/mto_service_item_creator_test.go
+++ b/pkg/services/mto_service_item/mto_service_item_creator_test.go
@@ -445,7 +445,7 @@ func (suite *MTOServiceItemServiceSuite) TestCreateMTOServiceItem() {
 	})
 
 	// If the service item we're trying to create is shuttle service and there is no estimated weight, it fails.
-	suite.Run("MTOServiceItemShuttle no prime weight", func() {
+	suite.Run("MTOServiceItemShuttle no prime weight is okay", func() {
 		// TESTCASE SCENARIO
 		// Under test: CreateMTOServiceItem function
 		// Set up:     Create DDSHUT service item on a shipment without estimated weight
@@ -472,9 +472,8 @@ func (suite *MTOServiceItemServiceSuite) TestCreateMTOServiceItem() {
 		}
 
 		createdServiceItems, _, err := creator.CreateMTOServiceItem(suite.AppContextForTest(), &serviceItemNoWeight)
-		suite.Nil(createdServiceItems)
-		suite.Error(err)
-		suite.IsType(apperror.ConflictError{}, err)
+		suite.NotNil(createdServiceItems)
+		suite.NoError(err)
 	})
 
 	setupDDFSITData := func() (models.MTOServiceItemCustomerContact, models.MTOServiceItemCustomerContact, models.MTOServiceItem) {

--- a/pkg/services/mto_shipment/mto_shipment_creator.go
+++ b/pkg/services/mto_shipment/mto_shipment_creator.go
@@ -106,15 +106,6 @@ func (f mtoShipmentCreator) CreateMTOShipment(appCtx appcontext.AppContext, ship
 			serviceItem.ReServiceID = reService.ID
 			serviceItem.Status = models.MTOServiceItemStatusSubmitted
 
-			if serviceItem.ReService.Code == models.ReServiceCodeDOSHUT || serviceItem.ReService.Code == models.ReServiceCodeDDSHUT {
-				if shipment.PrimeEstimatedWeight == nil {
-					return nil, apperror.NewConflictError(
-						serviceItem.ReService.ID,
-						"for creating a service item. MTOShipment associated with this service item must have a valid PrimeEstimatedWeight.",
-					)
-				}
-			}
-
 			serviceItemsList = append(serviceItemsList, serviceItem)
 		}
 		shipment.MTOServiceItems = serviceItemsList

--- a/pkg/services/mto_shipment/mto_shipment_creator_test.go
+++ b/pkg/services/mto_shipment/mto_shipment_creator_test.go
@@ -330,16 +330,10 @@ func (suite *MTOShipmentServiceSuite) TestCreateMTOShipment() {
 			},
 		}
 
-		weight := unit.Pound(2) // for DDSHUT service item type
 		mtoShipment := factory.BuildMTOShipment(nil, []factory.Customization{
 			{
 				Model:    subtestData.move,
 				LinkOnly: true,
-			},
-			{
-				Model: models.MTOShipment{
-					PrimeEstimatedWeight: &weight,
-				},
 			},
 		}, nil)
 


### PR DESCRIPTION
## [Jira ticket](https://dp3.atlassian.net/browse/MB-16086)

## Summary

This PR allows the prime to create a shuttling service item without the PrimeEstimatedWeight being set on the shipment

## Verification Steps for the Author

These are to be checked by the author.

- [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
- [x] Have the Jira acceptance criteria been met for this change?

## Verification Steps for Reviewers

These are to be checked by a reviewer.

### Setup to Run the Code

- [Instructions for starting storybook](https://transcom.github.io/mymove-docs/docs/frontend/setup/run-storybook)
- [Instructions for starting the MilMove application](https://transcom.github.io/mymove-docs/docs/about/application-setup/milmove-local-client/)
- [Instructions for running tests](https://transcom.github.io/mymove-docs/docs/about/development/testing)

### How to test

1. Access the office app
2. Login as a prime simulated user
3. Choose a move and choose to create a shipment (it's important to create a new shipment given that a lot of the existing shipments have their estimated weight field populated)
4. Don't provide an estimated weight for the shipment. Submit to create the shipment
5. Create a shuttling service item for the previously created shipment (by clicking Add Service Item)
6. You should not receive an error and the service item should successfully be created

