### PR TITLE
MB-14729 - Remove validation of the "Current duty location" and the "New duty location" being the same location

### DIFF
--- a/playwright/tests/my/mymove/orders.spec.js
+++ b/playwright/tests/my/mymove/orders.spec.js
@@ -29,14 +29,7 @@ test('Users can upload orders', async ({ page, customerPage }) => {
   //
   await page.locator('div:has(label:has-text("Are dependents")) >> div.usa-radio').getByText('No').click();
 
-  // Verify that a user can't use the same duty location
   await customerPage.selectDutyLocation('Yuma AFB', 'new_duty_location');
-  await expect(
-    page.getByText('You entered the same duty location for your origin and destination. Please change one of them.'),
-  ).toBeVisible();
-
-  // Change to a different destination duty location, then proceed to next page
-  await customerPage.selectDutyLocation('NAS Fort Worth JRB', 'new_duty_location');
   await customerPage.navigateForward();
   await customerPage.waitForPage.ordersUpload();
 

--- a/src/components/Customer/CurrentDutyLocationForm/CurrentDutyLocationForm.jsx
+++ b/src/components/Customer/CurrentDutyLocationForm/CurrentDutyLocationForm.jsx
@@ -10,15 +10,9 @@ import WizardNavigation from 'components/Customer/WizardNavigation/WizardNavigat
 import formStyles from 'styles/form.module.scss';
 import { DutyLocationShape } from 'types/dutyLocation';
 
-const CurrentDutyLocationForm = ({ initialValues, onBack, onSubmit, newDutyLocation }) => {
+const CurrentDutyLocationForm = ({ initialValues, onBack, onSubmit }) => {
   const validationSchema = Yup.object().shape({
-    current_location: Yup.object()
-      .required('Required')
-      .test(
-        'existing and new duty location should not match',
-        'You entered the same duty location for your origin and destination. Please change one of them.',
-        (value) => value?.id !== newDutyLocation?.id,
-      ),
+    current_location: Yup.object().required('Required'),
   });
 
   return (
@@ -55,11 +49,6 @@ CurrentDutyLocationForm.propTypes = {
   }).isRequired,
   onBack: func.isRequired,
   onSubmit: func.isRequired,
-  newDutyLocation: DutyLocationShape,
-};
-
-CurrentDutyLocationForm.defaultProps = {
-  newDutyLocation: {},
 };
 
 export default CurrentDutyLocationForm;

--- a/src/components/Customer/CurrentDutyLocationForm/CurrentDutyLocationForm.stories.jsx
+++ b/src/components/Customer/CurrentDutyLocationForm/CurrentDutyLocationForm.stories.jsx
@@ -32,29 +32,3 @@ export const InitialValues = (argTypes) => (
     onBack={argTypes.onBack}
   />
 );
-
-export const Error = (argTypes) => (
-  <CurrentDutyLocationForm
-    initialValues={{
-      current_location: {
-        address: {
-          city: 'Los Angeles',
-          state: 'CA',
-          postalCode: '90245',
-        },
-        name: 'Los Angeles AFB',
-        id: 'testId',
-      },
-    }}
-    newDutyLocation={{
-      address: {
-        city: 'Los Angeles',
-        state: 'CA',
-        postalCode: '90245',
-      },
-      id: 'testId',
-    }}
-    onSubmit={argTypes.onSubmit}
-    onBack={argTypes.onBack}
-  />
-);

--- a/src/components/Customer/CurrentDutyLocationForm/CurrentDutyLocationForm.test.jsx
+++ b/src/components/Customer/CurrentDutyLocationForm/CurrentDutyLocationForm.test.jsx
@@ -29,7 +29,7 @@ describe('CurrentDutyLocationForm component', () => {
       <CurrentDutyLocationForm
         onSubmit={jest.fn()}
         onBack={jest.fn()}
-        initialValues={{ current_location: {} }}
+        initialValues={{ current_location: null }}
         newDutyLocation={{}}
       />,
     );
@@ -40,9 +40,9 @@ describe('CurrentDutyLocationForm component', () => {
     });
   });
 
-  it('shows an error message if trying to submit an invalid form', async () => {
+  it('does not disable submit if current and new duty locations are the same', async () => {
     const onSubmit = jest.fn();
-    const { getByRole, getAllByText } = render(
+    const { getByRole } = render(
       <CurrentDutyLocationForm
         onSubmit={onSubmit}
         onBack={jest.fn()}
@@ -55,11 +55,7 @@ describe('CurrentDutyLocationForm component', () => {
     const submitBtn = getByRole('button', { name: 'Next' });
 
     await waitFor(() => {
-      expect(submitBtn).toHaveAttribute('disabled');
-      expect(
-        getAllByText('You entered the same duty location for your origin and destination. Please change one of them.')
-          .length,
-      ).toBe(1);
+      expect(submitBtn).not.toHaveAttribute('disabled');
     });
   });
 

--- a/src/components/Customer/EditOrdersForm/EditOrdersForm.jsx
+++ b/src/components/Customer/EditOrdersForm/EditOrdersForm.jsx
@@ -15,7 +15,6 @@ import profileImage from 'scenes/Review/images/profile.png';
 import Hint from 'components/Hint/index';
 import { DropdownArrayOf } from 'types';
 import { ExistingUploadsShape } from 'types/uploads';
-import { DutyLocationShape } from 'types/dutyLocation';
 import { DropdownInput, DatePickerInput, DutyLocationInput } from 'components/form/fields';
 import WizardNavigation from 'components/Customer/WizardNavigation/WizardNavigation';
 import Callout from 'components/Callout';
@@ -30,7 +29,6 @@ const EditOrdersForm = ({
   filePondEl,
   onSubmit,
   ordersTypeOptions,
-  currentDutyLocation,
   onCancel,
 }) => {
   const validationSchema = Yup.object().shape({
@@ -44,15 +42,7 @@ const EditOrdersForm = ({
       .typeError('Enter a complete date in DD MMM YYYY format (day, month, year).')
       .required('Required'),
     has_dependents: Yup.mixed().oneOf(['yes', 'no']).required('Required'),
-    new_duty_location: Yup.object()
-      .shape({
-        name: Yup.string().notOneOf(
-          [currentDutyLocation?.name],
-          'You entered the same duty location for your origin and destination. Please change one of them.',
-        ),
-      })
-      .nullable()
-      .required('Required'),
+    new_duty_location: Yup.object().nullable().required('Required'),
     uploaded_orders: Yup.array()
       .of(
         Yup.object().shape({
@@ -205,7 +195,6 @@ EditOrdersForm.propTypes = {
     }),
     uploaded_orders: ExistingUploadsShape,
   }).isRequired,
-  currentDutyLocation: DutyLocationShape.isRequired,
   onCancel: PropTypes.func.isRequired,
 };
 

--- a/src/components/Customer/EditOrdersForm/EditOrdersForm.test.jsx
+++ b/src/components/Customer/EditOrdersForm/EditOrdersForm.test.jsx
@@ -230,7 +230,7 @@ describe('EditOrdersForm component', () => {
     });
   });
 
-  it('validates the new duty location against the current duty location', async () => {
+  it('allows new and current duty location to be the same', async () => {
     // Not testing the upload interaction, so give uploaded orders to the props.
     render(
       <EditOrdersForm
@@ -272,13 +272,7 @@ describe('EditOrdersForm component', () => {
       });
     });
 
-    expect(submitButton).toBeDisabled();
-
-    expect(
-      screen.getByText(
-        'You entered the same duty location for your origin and destination. Please change one of them.',
-      ),
-    ).toBeInTheDocument();
+    expect(submitButton).not.toHaveAttribute('disabled');
   });
 
   it('shows an error message if the form is invalid', async () => {

--- a/src/components/Customer/OrdersInfoForm/OrdersInfoForm.jsx
+++ b/src/components/Customer/OrdersInfoForm/OrdersInfoForm.jsx
@@ -11,13 +11,12 @@ import Hint from 'components/Hint/index';
 import { Form } from 'components/form/Form';
 import { DropdownArrayOf } from 'types';
 import formStyles from 'styles/form.module.scss';
-import { DutyLocationShape } from 'types/dutyLocation';
 import SectionWrapper from 'components/Customer/SectionWrapper';
 import WizardNavigation from 'components/Customer/WizardNavigation/WizardNavigation';
 import Callout from 'components/Callout';
 import { formatLabelReportByDate } from 'utils/formatters';
 
-const OrdersInfoForm = ({ currentDutyLocation, ordersTypeOptions, initialValues, onSubmit, onBack }) => {
+const OrdersInfoForm = ({ ordersTypeOptions, initialValues, onSubmit, onBack }) => {
   const validationSchema = Yup.object().shape({
     orders_type: Yup.mixed()
       .oneOf(ordersTypeOptions.map((i) => i.key))
@@ -29,15 +28,7 @@ const OrdersInfoForm = ({ currentDutyLocation, ordersTypeOptions, initialValues,
       .typeError('Enter a complete date in DD MMM YYYY format (day, month, year).')
       .required('Required'),
     has_dependents: Yup.mixed().oneOf(['yes', 'no']).required('Required'),
-    new_duty_location: Yup.object()
-      .shape({
-        name: Yup.string().notOneOf(
-          [currentDutyLocation?.name],
-          'You entered the same duty location for your origin and destination. Please change one of them.',
-        ),
-      })
-      .nullable()
-      .required('Required'),
+    new_duty_location: Yup.object().nullable().required('Required'),
   });
 
   return (
@@ -149,7 +140,6 @@ OrdersInfoForm.propTypes = {
   }).isRequired,
   onSubmit: PropTypes.func.isRequired,
   onBack: PropTypes.func.isRequired,
-  currentDutyLocation: DutyLocationShape.isRequired,
 };
 
 export default OrdersInfoForm;

--- a/src/components/Customer/OrdersInfoForm/OrdersInfoForm.test.jsx
+++ b/src/components/Customer/OrdersInfoForm/OrdersInfoForm.test.jsx
@@ -172,7 +172,7 @@ describe('OrdersInfoForm component', () => {
     expect(ordersTypeDropdown).toHaveValue('SEPARATION');
   });
 
-  it('validates the new duty location against the current duty location', async () => {
+  it('allows new and current duty location to be the same', async () => {
     render(<OrdersInfoForm {...testProps} currentDutyLocation={{ name: 'Luke AFB' }} />);
 
     await userEvent.selectOptions(screen.getByLabelText('Orders type'), 'PERMANENT_CHANGE_OF_STATION');
@@ -191,12 +191,7 @@ describe('OrdersInfoForm component', () => {
       });
     });
 
-    expect(screen.getByRole('button', { name: 'Next' })).toHaveAttribute('disabled');
-    expect(
-      screen.getByText(
-        'You entered the same duty location for your origin and destination. Please change one of them.',
-      ),
-    ).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Next' })).not.toHaveAttribute('disabled');
   });
 
   it('shows an error message if trying to submit an invalid form', async () => {

--- a/src/components/Customer/ServiceInfoForm/ServiceInfoForm.jsx
+++ b/src/components/Customer/ServiceInfoForm/ServiceInfoForm.jsx
@@ -16,7 +16,7 @@ import { dropdownInputOptions } from 'utils/formatters';
 import formStyles from 'styles/form.module.scss';
 import { DutyLocationShape } from 'types/dutyLocation';
 
-const ServiceInfoForm = ({ initialValues, onSubmit, onCancel, newDutyLocation }) => {
+const ServiceInfoForm = ({ initialValues, onSubmit, onCancel }) => {
   const branchOptions = dropdownInputOptions(SERVICE_MEMBER_AGENCY_LABELS);
   const rankOptions = dropdownInputOptions(ORDERS_RANK_OPTIONS);
 
@@ -30,13 +30,7 @@ const ServiceInfoForm = ({ initialValues, onSubmit, onCancel, newDutyLocation })
       .matches(/[0-9]{10}/, 'Enter a 10-digit DOD ID number')
       .required('Required'),
     rank: Yup.mixed().oneOf(Object.keys(ORDERS_RANK_OPTIONS)).required('Required'),
-    current_location: Yup.object()
-      .required('Required')
-      .test(
-        'existing and new duty location should not match',
-        'You entered the same duty location for your origin and destination. Please change one of them.',
-        (value) => value?.id !== newDutyLocation?.id,
-      ),
+    current_location: Yup.object().required('Required'),
   });
 
   return (
@@ -120,11 +114,6 @@ ServiceInfoForm.propTypes = {
   }).isRequired,
   onCancel: PropTypes.func.isRequired,
   onSubmit: PropTypes.func.isRequired,
-  newDutyLocation: DutyLocationShape,
-};
-
-ServiceInfoForm.defaultProps = {
-  newDutyLocation: {},
 };
 
 export default ServiceInfoForm;

--- a/src/components/Customer/ServiceInfoForm/ServiceInfoForm.test.jsx
+++ b/src/components/Customer/ServiceInfoForm/ServiceInfoForm.test.jsx
@@ -185,31 +185,6 @@ describe('ServiceInfoForm', () => {
     expect(await screen.findByText('Enter a 10-digit DOD ID number')).toBeInTheDocument();
   });
 
-  it('validates the new duty location against the current duty location', async () => {
-    render(
-      <ServiceInfoForm
-        {...testProps}
-        newDutyLocation={{ name: 'Luke AFB', id: 'a8d6b33c-8370-4e92-8df2-356b8c9d0c1a' }}
-      />,
-    );
-
-    // Test Duty Location Search Box interaction
-    const dutyLocationInput = await screen.getByLabelText('Current duty location');
-    fireEvent.change(dutyLocationInput, { target: { value: 'AFB' } });
-    await act(() => selectEvent.select(dutyLocationInput, /Luke/));
-
-    expect(await screen.findByRole('form')).toHaveFormValues({
-      current_location: 'Luke AFB',
-    });
-
-    expect(await screen.findByRole('button', { name: 'Save' })).toHaveAttribute('disabled');
-    expect(
-      await screen.findByText(
-        'You entered the same duty location for your origin and destination. Please change one of them.',
-      ),
-    ).toBeInTheDocument();
-  });
-
   it('shows an error message if trying to submit an invalid form', async () => {
     render(<ServiceInfoForm {...testProps} />);
 
@@ -230,7 +205,12 @@ describe('ServiceInfoForm', () => {
   });
 
   it('submits the form when its valid', async () => {
-    render(<ServiceInfoForm {...testProps} />);
+    render(
+      <ServiceInfoForm
+        {...testProps}
+        newDutyLocation={{ name: 'Luke AFB', id: 'a8d6b33c-8370-4e92-8df2-356b8c9d0c1a' }}
+      />,
+    );
     const submitBtn = screen.getByRole('button', { name: 'Save' });
 
     await userEvent.type(screen.getByLabelText('First name'), 'Leo');


### PR DESCRIPTION
## [Jira ticket](https://dp3.atlassian.net/browse/MB-14729)

## Summary

This removes all form validations that prohibited new and current duty locations from being the same during move setup. It updates tests to check explicitly that this is allowed.

## Verification Steps for the Author

These are to be checked by the author.

- [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
- [ ] Have the Jira acceptance criteria been met for this change?

## Verification Steps for Reviewers

These are to be checked by a reviewer.

### Setup to Run the Code

- [Instructions for starting storybook](https://transcom.github.io/mymove-docs/docs/frontend/setup/run-storybook)
- [Instructions for starting the MilMove application](https://transcom.github.io/mymove-docs/docs/about/application-setup/milmove-local-client/)
- [Instructions for running tests](https://transcom.github.io/mymove-docs/docs/about/development/testing)

### How to test

1. In the customer app, create a new user and follow the flow to create a move.
2. When prompted for the Current Duty Location, enter one above (I used Scott AFB 🎉 ), noting that no validation prevents it. (This is the `CurrentDutyLocationForm`, though it's not clear how it would have ever failed this validation. The test takes care of it anyway.)
3. Complete the move flow.
4. From the dashboard, add an order, setting the New Duty Location to the current location. Notice no validation failure. Save. (`OrdersInfoForm`)
5. From the dashboard, click Edit Orders, then update the New Duty Location to something other than the current location, then back to the current location. Notice no validation failure. Save. (`EditOrdersForm`)
6. Click the profile link top-left, then edit the service info. Change the current duty location, then change it back, noting no validation failure. Save. (`ServiceInfoForm`)

### Frontend

- [ ] There are no aXe warnings for UI.
- [ ] This works in [Supported Browsers and their phone views](https://transcom.github.io/mymove-docs/docs/about/supported-browsers) (Chrome, Firefox, Edge).
- [ ] There are no new console errors in the browser devtools.
- [ ] There are no new console errors in the test output.
- [ ] If this PR adds a new component to Storybook, it ensures the component is fully responsive, OR if it is intentionally not, a wrapping div using the `officeApp` class or custom `min-width` styling is used to hide any states the would not be visible to the user.


## Screenshots
<img width="687" alt="CurrentDutyLocation" src="https://github.com/transcom/mymove/assets/1245800/4c0ce4d2-d16a-43e4-95d4-3e0034d910e6">
<img width="880" alt="OrdersInfoForm" src="https://github.com/transcom/mymove/assets/1245800/4a021b76-099f-4102-825b-ddd919320d20">
<img width="1005" alt="EditOrdersForm" src="https://github.com/transcom/mymove/assets/1245800/d923ff31-f550-4c6a-a238-412ea85de26e">
<img width="986" alt="ServiceInfoForm" src="https://github.com/transcom/mymove/assets/1245800/fefef6af-b3e8-4ccd-a4c6-1ea12cb6ccd8">
