### PR TITLE
MB-16142: Update version of python used by load integration test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,7 @@ references:
 
   # the image to use for running load tests
   # see milmove_load_testing for the right config
-  load_tester: &load_tester cimg/python:3.10.11
+  load_tester: &load_tester cimg/python:3.11.3
 
   postgres: &postgres cimg/postgres:12.11
 


### PR DESCRIPTION
## [Jira ticket](https://dp3.atlassian.net/browse/MB-16142)

## Summary

Update python version used by integration load tests in CircleCI

