### PR TITLE
Correct typo for clarity

### DIFF
--- a/pkg/gen/primeapi/embedded_spec.go
+++ b/pkg/gen/primeapi/embedded_spec.go
@@ -4237,7 +4237,7 @@ func init() {
       "name": "paymentRequest"
     },
     {
-      "description": "A **sitAddressUpdate** is submitted when the prime or office user wishes to update the final address for an\napproved service item. sitAddressUpdates with a distance greater than 50 miles will be automatically approved while\na distance greater than 50 miles will typically require office user approval.\n",
+      "description": "A **sitAddressUpdate** is submitted when the prime or office user wishes to update the final address for an\napproved service item. sitAddressUpdates with a distance less than or equal to 50 miles will be automatically\napproved while a distance greater than 50 miles will typically require office user approval.\n",
       "name": "sitAddressUpdate"
     }
   ],
@@ -8850,7 +8850,7 @@ func init() {
       "name": "paymentRequest"
     },
     {
-      "description": "A **sitAddressUpdate** is submitted when the prime or office user wishes to update the final address for an\napproved service item. sitAddressUpdates with a distance greater than 50 miles will be automatically approved while\na distance greater than 50 miles will typically require office user approval.\n",
+      "description": "A **sitAddressUpdate** is submitted when the prime or office user wishes to update the final address for an\napproved service item. sitAddressUpdates with a distance less than or equal to 50 miles will be automatically\napproved while a distance greater than 50 miles will typically require office user approval.\n",
       "name": "sitAddressUpdate"
     }
   ],

--- a/swagger-def/prime.yaml
+++ b/swagger-def/prime.yaml
@@ -33,8 +33,8 @@ tags:
   - name: sitAddressUpdate
     description: |
       A **sitAddressUpdate** is submitted when the prime or office user wishes to update the final address for an
-      approved service item. sitAddressUpdates with a distance greater than 50 miles will be automatically approved while
-      a distance greater than 50 miles will typically require office user approval.
+      approved service item. sitAddressUpdates with a distance less than or equal to 50 miles will be automatically
+      approved while a distance greater than 50 miles will typically require office user approval.
 
 x-tagGroups:
   - name: Endpoints

--- a/swagger/prime.yaml
+++ b/swagger/prime.yaml
@@ -79,11 +79,11 @@ tags:
       A **sitAddressUpdate** is submitted when the prime or office user wishes
       to update the final address for an
 
-      approved service item. sitAddressUpdates with a distance greater than 50
-      miles will be automatically approved while
+      approved service item. sitAddressUpdates with a distance less than or
+      equal to 50 miles will be automatically
 
-      a distance greater than 50 miles will typically require office user
-      approval.
+      approved while a distance greater than 50 miles will typically require
+      office user approval.
 x-tagGroups:
   - name: Endpoints
     tags:


### PR DESCRIPTION
## Summary

This fixes a typo in the prime.yaml that clarifies when an address update is auto approved and when it isn't.