### PR TITLE
[MB-16191] create table and model for service request documents and uploads

### DIFF
--- a/migrations/app/migrations_manifest.txt
+++ b/migrations/app/migrations_manifest.txt
@@ -821,3 +821,4 @@
 20230515145532_fix_searchable_full_name.up.sql
 20230516170511_create_service_items_customer_contacts_join_table.up.sql
 20230522153040_add_local_move_orders_type_comment.up.sql
+20230601203817_creating_service_request_documents_table.up.sql

--- a/migrations/app/migrations_manifest.txt
+++ b/migrations/app/migrations_manifest.txt
@@ -822,3 +822,4 @@
 20230516170511_create_service_items_customer_contacts_join_table.up.sql
 20230522153040_add_local_move_orders_type_comment.up.sql
 20230601203817_creating_service_request_documents_table.up.sql
+20230602140622_creating_service_request_uploads_table.up.sql

--- a/migrations/app/schema/20230601203817_creating_service_request_documents_table.up.sql
+++ b/migrations/app/schema/20230601203817_creating_service_request_documents_table.up.sql
@@ -2,15 +2,12 @@ CREATE TABLE service_request_documents
 (
 	id uuid PRIMARY KEY,
 	mto_service_item_id uuid NOT NULL CONSTRAINT service_request_documents_mto_service_item_id_fkey REFERENCES mto_service_items (id),
-	upload_id uuid NOT NULL
-        constraint service_request_documents_upload_id_fkey references uploads,
     created_at timestamp without time zone NOT NULL,
     updated_at timestamp without time zone NOT NULL,
-    constraint service_request_documents_unique_key unique (mto_service_item_id, upload_id)
+    constraint service_request_documents_unique_key unique (mto_service_item_id)
 );
 
 -- Column Comments
-COMMENT on TABLE service_request_documents IS 'Stores uploads from the Prime that represent proof of a service item request';
+COMMENT on TABLE service_request_documents IS 'Associates uploads from the Prime that represent proof of a service item request';
 COMMENT on COLUMN service_request_documents.id IS 'uuid that represents this entity';
 COMMENT on COLUMN service_request_documents.mto_service_item_id IS 'Foreign key of the mto_service_items table';
-COMMENT on COLUMN service_request_documents.upload_id IS 'Foreign key of the uploads table';

--- a/migrations/app/schema/20230601203817_creating_service_request_documents_table.up.sql
+++ b/migrations/app/schema/20230601203817_creating_service_request_documents_table.up.sql
@@ -1,0 +1,16 @@
+CREATE TABLE service_request_documents
+(
+	id uuid PRIMARY KEY,
+	mto_service_item_id uuid NOT NULL CONSTRAINT service_request_documents_mto_service_item_id_fkey REFERENCES mto_service_items (id),
+	upload_id uuid NOT NULL
+        constraint service_request_documents_upload_id_fkey references uploads,
+    created_at timestamp without time zone NOT NULL,
+    updated_at timestamp without time zone NOT NULL,
+    constraint service_request_documents_unique_key unique (mto_service_item_id, upload_id)
+);
+
+-- Column Comments
+COMMENT on TABLE service_request_documents IS 'Stores uploads from the Prime that represent proof of a service item request';
+COMMENT on COLUMN service_request_documents.id IS 'uuid that represents this entity';
+COMMENT on COLUMN service_request_documents.mto_service_item_id IS 'Foreign key of the mto_service_items table';
+COMMENT on COLUMN service_request_documents.upload_id IS 'Foreign key of the uploads table';

--- a/migrations/app/schema/20230602140622_creating_service_request_uploads_table.up.sql
+++ b/migrations/app/schema/20230602140622_creating_service_request_uploads_table.up.sql
@@ -1,7 +1,6 @@
 create table service_request_document_uploads
 (
-    id uuid not null
-        primary key,
+    id uuid primary key,
     service_request_documents_id uuid
         constraint service_request_documents_service_request_documents_id_fkey
             references service_request_documents not null,
@@ -16,4 +15,6 @@ create table service_request_document_uploads
 -- Column Comments
 COMMENT on TABLE service_request_document_uploads IS 'Stores uploads from the Prime that represent proof of a service item request';
 COMMENT on COLUMN service_request_document_uploads.id IS 'uuid that represents this entity';
+COMMENT on COLUMN service_request_document_uploads.contractor_id IS 'uuid that represents the contractor who provided the upload';
+COMMENT on COLUMN service_request_document_uploads.service_request_documents_id IS 'uuid that represents the associated service request document';
 COMMENT on COLUMN service_request_document_uploads.upload_id IS 'Foreign key of the uploads table';

--- a/migrations/app/schema/20230602140622_creating_service_request_uploads_table.up.sql
+++ b/migrations/app/schema/20230602140622_creating_service_request_uploads_table.up.sql
@@ -1,0 +1,19 @@
+create table service_request_document_uploads
+(
+    id uuid not null
+        primary key,
+    service_request_documents_id uuid
+        constraint service_request_documents_service_request_documents_id_fkey
+            references service_request_documents not null,
+    contractor_id uuid not null constraint service_request_documents_contractor_id_fkey references contractors,
+    upload_id uuid not null constraint service_request_documents_uploads_id_fkey references upload,
+    created_at timestamp not null,
+    updated_at timestamp not null,
+    deleted_at timestamp with time zone
+
+);
+
+-- Column Comments
+COMMENT on TABLE service_request_document_uploads IS 'Stores uploads from the Prime that represent proof of a service item request';
+COMMENT on COLUMN service_request_document_uploads.id IS 'uuid that represents this entity';
+COMMENT on COLUMN service_request_document_uploads.upload_id IS 'Foreign key of the uploads table';

--- a/migrations/app/schema/20230602140622_creating_service_request_uploads_table.up.sql
+++ b/migrations/app/schema/20230602140622_creating_service_request_uploads_table.up.sql
@@ -6,7 +6,7 @@ create table service_request_document_uploads
         constraint service_request_documents_service_request_documents_id_fkey
             references service_request_documents not null,
     contractor_id uuid not null constraint service_request_documents_contractor_id_fkey references contractors,
-    upload_id uuid not null constraint service_request_documents_uploads_id_fkey references upload,
+    upload_id uuid not null constraint service_request_documents_uploads_id_fkey references uploads,
     created_at timestamp not null,
     updated_at timestamp not null,
     deleted_at timestamp with time zone

--- a/pkg/models/service_request_document.go
+++ b/pkg/models/service_request_document.go
@@ -1,0 +1,36 @@
+package models
+
+import (
+	"time"
+
+	"github.com/gobuffalo/pop/v6"
+	"github.com/gobuffalo/validate/v3"
+	"github.com/gobuffalo/validate/v3/validators"
+	"github.com/gofrs/uuid"
+)
+
+// ServiceRequestDocument represents a document for a service item requst by the Prime
+type ServiceRequestDocument struct {
+	ID               uuid.UUID `json:"id" db:"id"`
+	MTOServiceItemID uuid.UUID `json:"mto_service_item_id" db:"mto_service_item_id"`
+	CreatedAt        time.Time `db:"created_at"`
+	UpdatedAt        time.Time `db:"updated_at"`
+
+	//Associations
+	MTOServiceItem                MTOServiceItem                `belongs_to:"mto_service_item" fk_id:"mto_service_item_id"`
+	ServiceRequestDocumentUploads ServiceRequestDocumentUploads `has_many:"service_request_document_uploads" fk_id:"service_request_documents_id" order_by:"created_at asc"`
+}
+
+// TableName overrides the table name used by Pop.
+func (s ServiceRequestDocument) TableName() string {
+	return "service_request_documents"
+}
+
+type ServiceRequestDocuments []ServiceRequestDocument
+
+// Validate gets run every time you call a "pop.Validate*" (pop.ValidateAndSave, pop.ValidateAndCreate, pop.ValidateAndUpdate) method.
+func (s *ServiceRequestDocument) Validate(tx *pop.Connection) (*validate.Errors, error) {
+	return validate.Validate(
+		&validators.UUIDIsPresent{Field: s.MTOServiceItemID, Name: "MTOServiceItemID"},
+	), nil
+}

--- a/pkg/models/service_request_document_test.go
+++ b/pkg/models/service_request_document_test.go
@@ -1,0 +1,27 @@
+package models_test
+
+import (
+	"github.com/gofrs/uuid"
+
+	"github.com/transcom/mymove/pkg/models"
+)
+
+func (suite *ModelSuite) TestServiceRequestDocumentValidation() {
+	suite.Run("test valid ServiceRequestDocument", func() {
+		validServiceRequestDocument := models.ServiceRequestDocument{
+			MTOServiceItemID: uuid.Must(uuid.NewV4()),
+		}
+		expErrors := map[string][]string{}
+		suite.verifyValidationErrors(&validServiceRequestDocument, expErrors)
+	})
+
+	suite.Run("test empty ServiceRequestDocument", func() {
+		invalidServiceRequestDocument := models.ServiceRequestDocument{}
+
+		expErrors := map[string][]string{
+			"mtoservice_item_id": {"MTOServiceItemID can not be blank."},
+		}
+
+		suite.verifyValidationErrors(&invalidServiceRequestDocument, expErrors)
+	})
+}

--- a/pkg/models/service_request_document_upload.go
+++ b/pkg/models/service_request_document_upload.go
@@ -1,0 +1,39 @@
+package models
+
+import (
+	"time"
+
+	"github.com/gobuffalo/pop/v6"
+	"github.com/gobuffalo/validate/v3"
+	"github.com/gobuffalo/validate/v3/validators"
+	"github.com/gofrs/uuid"
+)
+
+// A ServiceRequestDocumentUpload represents an user uploaded file, such as an image or PDF.
+type ServiceRequestDocumentUpload struct {
+	ID                       uuid.UUID              `db:"id"`
+	ServiceRequestDocumentID uuid.UUID              `db:"service_request_documents_id"`
+	ServiceRequestDocument   ServiceRequestDocument `belongs_to:"service_request_documents" fk_id:"service_request_documents_id"`
+	ContractorID             uuid.UUID              `db:"contractor_id"`
+	Contractor               Contractor             `belongs_to:"contractors" fk_id:"contractor_id"`
+	UploadID                 uuid.UUID              `db:"upload_id"`
+	Upload                   Upload                 `belongs_to:"uploads" fk_id:"upload_id"`
+	CreatedAt                time.Time              `db:"created_at"`
+	UpdatedAt                time.Time              `db:"updated_at"`
+	DeletedAt                *time.Time             `db:"deleted_at"`
+}
+
+// TableName overrides the table name used by Pop.
+func (u ServiceRequestDocumentUpload) TableName() string {
+	return "service_request_document_uploads"
+}
+
+type ServiceRequestDocumentUploads []ServiceRequestDocumentUpload
+
+// Validate gets run every time you call a "pop.Validate*" (pop.ValidateAndSave, pop.ValidateAndCreate, pop.ValidateAndUpdate) method.
+func (u *ServiceRequestDocumentUpload) Validate(tx *pop.Connection) (*validate.Errors, error) {
+	return validate.Validate(
+		&validators.UUIDIsPresent{Field: u.ContractorID, Name: "ContractorID"},
+		&validators.UUIDIsPresent{Field: u.ServiceRequestDocumentID, Name: "ServiceRequestDocumentID"},
+	), nil
+}

--- a/pkg/models/service_request_document_upload_test.go
+++ b/pkg/models/service_request_document_upload_test.go
@@ -1,0 +1,29 @@
+package models_test
+
+import (
+	"github.com/gofrs/uuid"
+
+	"github.com/transcom/mymove/pkg/models"
+)
+
+func (suite *ModelSuite) TestServiceRequestDocumentUploadValidation() {
+	suite.Run("test valid ServiceRequestDocumentUpload", func() {
+		validServiceRequestDocumentUpload := models.ServiceRequestDocumentUpload{
+			ContractorID:             uuid.Must(uuid.NewV4()),
+			ServiceRequestDocumentID: uuid.Must(uuid.NewV4()),
+		}
+		expErrors := map[string][]string{}
+		suite.verifyValidationErrors(&validServiceRequestDocumentUpload, expErrors)
+	})
+
+	suite.Run("test empty ServiceRequestDocumentUpload", func() {
+		invalidServiceRequestDocumentUpload := models.ServiceRequestDocumentUpload{}
+
+		expErrors := map[string][]string{
+			"contractor_id":               {"ContractorID can not be blank."},
+			"service_request_document_id": {"ServiceRequestDocumentID can not be blank."},
+		}
+
+		suite.verifyValidationErrors(&invalidServiceRequestDocumentUpload, expErrors)
+	})
+}


### PR DESCRIPTION
## [Jira ticket](https://dp3.atlassian.net/browse/MB-16191)

## Summary

This PR creates 2 new database tables and their corresponding models

Note: In addition to the service request documents, I also created the table necessary for storing the documents associated uploads that isn't tied to proof of service docs. 

These changes were modeled after `proof_of_service_docs` and `prime_uploads` tables

## Verification Steps for the Author

These are to be checked by the author.

- [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
- [x] Have the Jira acceptance criteria been met for this change?

## Verification Steps for Reviewers

#### Any new migrations/schema changes:

- [x] Follows our guidelines for [Zero-Downtime Deploys](https://transcom.github.io/mymove-docs/docs/backend/setup/database-migrations#zero-downtime-migrations).
- [x] Have been communicated to #g-database.
- [x] Secure migrations have been tested following the instructions in our [docs](https://transcom.github.io/mymove-docs/docs/backend/setup/database-migrations#secure-migrations).

