### PR TITLE
Fix modal scrolling in admin app

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,30 +39,30 @@ references:
 
   # In addition, it's common practice to disable acceptance tests and
   # ignore tests for dp3 deploys. See the branch settings below.
-  dp3-branch: &dp3-branch MB-15839-fix-modal-cutoff
+  dp3-branch: &dp3-branch placeholder_branch_name
   # MUST BE ONE OF: loadtest, demo, exp.
   # These are used to pull in env vars so the spelling matters!
-  dp3-env: &dp3-env exp
+  dp3-env: &dp3-env placeholder_env
 
   # set integration-ignore-branch to the branch if you want to IGNORE
   # integration tests, or `placeholder_branch_name` if you do want to
   # run them
-  integration-ignore-branch: &integration-ignore-branch MB-15839-fix-modal-cutoff
+  integration-ignore-branch: &integration-ignore-branch placeholder_branch_name
 
   # set integration-mtls-ignore-branch to the branch if you want to
   # IGNORE mtls integration tests, or `placeholder_branch_name` if you
   # do want to run them
-  integration-mtls-ignore-branch: &integration-mtls-ignore-branch MB-15839-fix-modal-cutoff
+  integration-mtls-ignore-branch: &integration-mtls-ignore-branch placeholder_branch_name
 
   # set client-ignore-branch to the branch if you want to IGNORE
   # client tests, or `placeholder_branch_name` if you do want to run
   # them
-  client-ignore-branch: &client-ignore-branch MB-15839-fix-modal-cutoff
+  client-ignore-branch: &client-ignore-branch placeholder_branch_name
 
   # set server-ignore-branch to the branch if you want to IGNORE
   # server tests, or `placeholder_branch_name` if you do want to run
   # them
-  server-ignore-branch: &server-ignore-branch MB-15839-fix-modal-cutoff
+  server-ignore-branch: &server-ignore-branch placeholder_branch_name
 
 executors:
   base_small:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,7 +39,7 @@ references:
 
   # In addition, it's common practice to disable acceptance tests and
   # ignore tests for dp3 deploys. See the branch settings below.
-  dp3-branch: &dp3-branch placeholder_branch_name
+  dp3-branch: &dp3-branch MB-15839-fix-modal-cutoff
   # MUST BE ONE OF: loadtest, demo, exp.
   # These are used to pull in env vars so the spelling matters!
   dp3-env: &dp3-env placeholder_env
@@ -47,22 +47,22 @@ references:
   # set integration-ignore-branch to the branch if you want to IGNORE
   # integration tests, or `placeholder_branch_name` if you do want to
   # run them
-  integration-ignore-branch: &integration-ignore-branch placeholder_branch_name
+  integration-ignore-branch: &integration-ignore-branch MB-15839-fix-modal-cutoff
 
   # set integration-mtls-ignore-branch to the branch if you want to
   # IGNORE mtls integration tests, or `placeholder_branch_name` if you
   # do want to run them
-  integration-mtls-ignore-branch: &integration-mtls-ignore-branch placeholder_branch_name
+  integration-mtls-ignore-branch: &integration-mtls-ignore-branch MB-15839-fix-modal-cutoff
 
   # set client-ignore-branch to the branch if you want to IGNORE
   # client tests, or `placeholder_branch_name` if you do want to run
   # them
-  client-ignore-branch: &client-ignore-branch placeholder_branch_name
+  client-ignore-branch: &client-ignore-branch MB-15839-fix-modal-cutoff
 
   # set server-ignore-branch to the branch if you want to IGNORE
   # server tests, or `placeholder_branch_name` if you do want to run
   # them
-  server-ignore-branch: &server-ignore-branch placeholder_branch_name
+  server-ignore-branch: &server-ignore-branch MB-15839-fix-modal-cutoff
 
 executors:
   base_small:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,7 +42,7 @@ references:
   dp3-branch: &dp3-branch MB-15839-fix-modal-cutoff
   # MUST BE ONE OF: loadtest, demo, exp.
   # These are used to pull in env vars so the spelling matters!
-  dp3-env: &dp3-env placeholder_env
+  dp3-env: &dp3-env exp
 
   # set integration-ignore-branch to the branch if you want to IGNORE
   # integration tests, or `placeholder_branch_name` if you do want to

--- a/src/scenes/SystemAdmin/index.jsx
+++ b/src/scenes/SystemAdmin/index.jsx
@@ -38,9 +38,9 @@ class AdminWrapper extends Component {
             <Route path="/system/*" element={this.state.isLoggedIn ? <Home /> : <SignIn />} />)
             <Route path="*" element={<Navigate to="/system" />} />
           </Routes>
-       </div>
-       <div id="modal-root" />
-    </>
+        </div>
+        <div id="modal-root" />
+      </>
     );
   }
 }

--- a/src/scenes/SystemAdmin/index.jsx
+++ b/src/scenes/SystemAdmin/index.jsx
@@ -27,17 +27,20 @@ class AdminWrapper extends Component {
 
   render() {
     return (
-      <div id="app-root">
-        <CUIHeader />
-        <Routes>
-          {/* no auth */}
-          <Route path="/sign-in" element={<SignIn />} />
-          <Route path="/invalid-permissions" element={<InvalidPermissions />} />
-          {/* system is basename of admin app, see https://marmelab.com/react-admin/Routing.html#using-react-admin-inside-a-route */}
-          <Route path="/system/*" element={this.state.isLoggedIn ? <Home /> : <SignIn />} />)
-          <Route path="*" element={<Navigate to="/system" />} />
-        </Routes>
-      </div>
+      <>
+        <div id="app-root">
+          <CUIHeader />
+          <Routes>
+            {/* no auth */}
+            <Route path="/sign-in" element={<SignIn />} />
+            <Route path="/invalid-permissions" element={<InvalidPermissions />} />
+            {/* system is basename of admin app, see https://marmelab.com/react-admin/Routing.html#using-react-admin-inside-a-route */}
+            <Route path="/system/*" element={this.state.isLoggedIn ? <Home /> : <SignIn />} />)
+            <Route path="*" element={<Navigate to="/system" />} />
+          </Routes>
+       </div>
+       <div id="modal-root" />
+    </>
     );
   }
 }


### PR DESCRIPTION
## [Jira ticket](https://dp3.atlassian.net/browse/MB-15839)

## Summary

The consent modal that appears after clicking `Sign in` would not allow for scrolling in the admin app, on smaller screens. This prevented users from accepting the consent terms. In the office and milmove applications, the modal worked as expected and users could scroll down to accept.

This PR makes a minor change to the HTML in the admin app to separate the modal into its own `div`, similar to the office and milmove applications. Now admin users using smaller screens can scroll down to accept the terms.

## Verification Steps for the Author

These are to be checked by the author.

- [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
- [ ] Have the Jira acceptance criteria been met for this change?

### How to test

1. Use a small screen; either a) resize your browser window so full modal is not visible, b) use mobile emulator, if you have access to one. Note: I didn't find the device selector in the browser (checked in Brave and Firefox) was able to recreate the initial issue.
2. Go to the admin application sign in screen
3. Click `Sign In`
4. When the modal pops up, you should not see the buttons at the bottom
5. Scroll down within the modal and you will be able to `Accept terms` or 'Cancel'