### PR TITLE
MB-16168: fix crud auth failure by implementing driver.DriverContext

### DIFF
--- a/pkg/cli/dbconn.go
+++ b/pkg/cli/dbconn.go
@@ -332,6 +332,11 @@ func InitDatabase(v *viper.Viper, creds *credentials.Credentials, logger *zap.Lo
 		// Set a bogus password holder. It will be replaced with an RDS auth token as the password.
 		passHolder := "*****"
 
+		// The AWS docs say the authentication tokens have a lifetime
+		// of 15 minutes, but testing in AWS shows, for some reasons,
+		// we start getting failures after 5 minutes
+		refreshInterval := 1 * time.Minute
+
 		err := iampg.EnableIAM(dbConnectionDetails.Host,
 			dbConnectionDetails.Port,
 			v.GetString(DbRegionFlag),
@@ -339,7 +344,7 @@ func InitDatabase(v *viper.Viper, creds *credentials.Credentials, logger *zap.Lo
 			passHolder,
 			creds,
 			iampg.RDSU{},
-			10*time.Minute, // Refresh every 10 minutes
+			refreshInterval,
 			logger,
 			make(chan bool))
 		if err != nil {

--- a/pkg/iampostgres/iampostgres.go
+++ b/pkg/iampostgres/iampostgres.go
@@ -165,6 +165,9 @@ func EnableIAM(host string, port string, region string, user string, passTemplat
 		shouldQuitChan:   shouldQuitChan,
 	}
 
+	// ensure at least one token has been generated
+	iamPostgres.generateNewIamPassword()
+
 	// GoRoutine to continually refresh the RDS IAM auth on the given interval.
 	go iamPostgres.refreshRDSIAM()
 	return nil

--- a/pkg/iampostgres/iampostgres_test.go
+++ b/pkg/iampostgres/iampostgres_test.go
@@ -303,19 +303,3 @@ func (fd FakeDriver) Close() error {
 func (fd FakeDriver) ResetSession(ctx context.Context) error {
 	return errors.New("FakeResetSession Error")
 }
-
-func TestDriverConnWrapper(t *testing.T) {
-	assert := assert.New(t)
-
-	fakeDriver := FakeDriver{}
-	wrapper := DriverConnWrapper{
-		Pinger:          fakeDriver,
-		Conn:            fakeDriver,
-		SessionResetter: fakeDriver,
-	}
-
-	ctx := context.Background()
-	assert.Error(wrapper.Ping(ctx))
-	assert.Error(wrapper.Close())
-	assert.Error(wrapper.ResetSession(ctx))
-}

--- a/pkg/iampostgres/iampostgres_test.go
+++ b/pkg/iampostgres/iampostgres_test.go
@@ -83,8 +83,9 @@ func TestGetCurrentPassword(t *testing.T) {
 	assert.NotNil(iamPostgres)
 
 	// this should block once and then continue
-	currentPass := iamPostgres.getCurrentPass()
+	currentPass, currentPassTime := iamPostgres.getCurrentPass()
 	assert.Equal(currentPass, "abc")
+	assert.NotNil(currentPassTime)
 	shouldQuitChan <- true
 
 	// This test wants to ensure that getCurrentPass does not return
@@ -155,8 +156,9 @@ func TestGetCurrentPasswordFail(t *testing.T) {
 	assert.NotNil(iamPostgres)
 
 	// this should block until maxRetries, then return empty string
-	currentPass := iamPostgres.getCurrentPass()
+	currentPass, currentPassTime := iamPostgres.getCurrentPass()
 	assert.Equal(currentPass, "")
+	assert.NotNil(currentPassTime)
 	shouldQuitChan <- true
 	assert.Equal(int(iamPostgres.maxRetries), pauseCounter)
 }
@@ -227,8 +229,9 @@ func TestEnableIAMNormal(t *testing.T) {
 
 	// Confirm that the password has changed (it's no longer the initial
 	// password) to the 1 password being cycled through.
-	pass := iamPostgres.getCurrentPass()
+	pass, passTime := iamPostgres.getCurrentPass()
 	assert.Equal("abc", pass)
+	assert.NotNil(passTime)
 
 	shouldQuitChan <- true
 
@@ -271,8 +274,9 @@ func TestUpdateDSN(t *testing.T) {
 			currentPassMutex: sync.Mutex{},
 			logger:           zaptest.NewLogger(t),
 		}
-		dsn, err := localIamPostgresConfig.updateDSN(tt.dsn)
+		dsn, dsnTime, err := localIamPostgresConfig.updateDSN(tt.dsn)
 		assert.Equal(dsn, tt.expectedDSN)
+		assert.Equal(localIamPostgresConfig.currentIamTime, dsnTime)
 		assert.Nil(err)
 	}
 }

--- a/pkg/testingsuite/pop_suite.go
+++ b/pkg/testingsuite/pop_suite.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/transcom/mymove/pkg/appcontext"
 	"github.com/transcom/mymove/pkg/auth"
+	"github.com/transcom/mymove/pkg/iampostgres"
 	"github.com/transcom/mymove/pkg/random"
 )
 
@@ -296,7 +297,7 @@ func (suite *PopTestSuite) getDbConnectionDetails() {
 	// from cloning
 	suite.pgConnDetails = &pop.ConnectionDetails{
 		Dialect:  dbDialect,
-		Driver:   "postgres",
+		Driver:   iampostgres.CustomPostgres,
 		Database: "postgres",
 		Host:     dbHost,
 		Port:     dbPortTest,
@@ -314,7 +315,7 @@ func (suite *PopTestSuite) getDbConnectionDetails() {
 	// than the role that runs database migrations.
 	suite.lowPrivConnDetails = &pop.ConnectionDetails{
 		Dialect:  dbDialect,
-		Driver:   "postgres",
+		Driver:   iampostgres.CustomPostgres,
 		Database: dbNamePackage,
 		Host:     dbHost,
 		Port:     dbPortTest,
@@ -328,7 +329,7 @@ func (suite *PopTestSuite) getDbConnectionDetails() {
 	// higher than the role that runs application.
 	suite.highPrivConnDetails = &pop.ConnectionDetails{
 		Dialect:  dbDialect,
-		Driver:   "postgres",
+		Driver:   iampostgres.CustomPostgres,
 		Database: dbNamePackage,
 		Host:     dbHost,
 		Port:     dbPortTest,

--- a/pkg/testingsuite/pop_suite_txn.go
+++ b/pkg/testingsuite/pop_suite_txn.go
@@ -10,6 +10,8 @@ import (
 
 	"github.com/DATA-DOG/go-txdb"
 	"github.com/gobuffalo/pop/v6"
+
+	"github.com/transcom/mymove/pkg/iampostgres"
 )
 
 // per process tracking of which dbNum is used
@@ -321,7 +323,7 @@ func (suite *PopTestSuite) findOrCreatePerTestTransactionDb() {
 		suite.lowPrivConnDetails.Database, pid)
 	// Register will panic if the same driver is registered more than
 	// once in the same process, so we've checked for that up above
-	txdb.Register(fakePopSqlxDriverName, "postgres", dataSourceName)
+	txdb.Register(fakePopSqlxDriverName, iampostgres.CustomPostgres, dataSourceName)
 }
 
 // tearDownTxnTest closes the db connection established for this test


### PR DESCRIPTION
## [Jira ticket](https://dp3.atlassian.net/browse/MB-16168)

## Summary

Hopefully fixes the `pq: PAM authentication failed for user "crud"` error. Our custom driver now implements the [DriverContext](https://pkg.go.dev/database/sql/driver#DriverContext) interface which allows us to have a custom [Connector](https://pkg.go.dev/database/sql/driver#Connector). That ensures we can update the IAM authentication token on every database connection.

While it's very hard to prove this fixes the bug, I can no longer reliably reproduce it. I've only seen one error in testing.

## Verification Steps for the Author

These are to be checked by the author.

- [ ] Tested in the Loadtest environment (for changes to containers, app startup, or connection to data stores)
- [ ] Have the Jira acceptance criteria been met for this change?

## Verification Steps for Reviewers

These are to be checked by a reviewer.

### Setup to Run the Code

Since these errors only occur in our deployed environments, local testing isn't really useful.

