### PR TITLE
[ DEMO Prep ] Adding reason field to the Prime UI for destination SIT service items

### DIFF
--- a/src/components/PrimeUI/CreateShipmentServiceItemForm/DestinationSITServiceItemForm.jsx
+++ b/src/components/PrimeUI/CreateShipmentServiceItemForm/DestinationSITServiceItemForm.jsx
@@ -12,8 +12,10 @@ import { formatDateForSwagger } from 'shared/dates';
 import { formatAddressForPrimeAPI } from 'utils/formatters';
 import { DatePickerInput } from 'components/form/fields';
 import { ShipmentShape } from 'types/shipment';
+import TextField from 'components/form/fields/TextField/TextField';
 
 const destinationSITValidationSchema = Yup.object().shape({
+  reason: Yup.string().required('Required'),
   firstAvailableDeliveryDate1: Yup.date().typeError('Enter a complete date in DD MMM YYYY format (day, month, year).'),
   timeMilitary1: Yup.string().matches(/^(\d{4}Z)$/, 'Must be a valid military time (e.g. 1400Z)'),
   firstAvailableDeliveryDate2: Yup.date().typeError('Enter a complete date in DD MMM YYYY format (day, month, year).'),
@@ -31,6 +33,7 @@ const DestinationSITServiceItemForm = ({ shipment, submission }) => {
     mtoShipmentID: shipment.id,
     modelType: 'MTOServiceItemDestSIT',
     reServiceCode: 'DDFSIT',
+    reason: '',
     firstAvailableDeliveryDate1: '',
     timeMilitary1: '',
     firstAvailableDeliveryDate2: '',
@@ -73,6 +76,7 @@ const DestinationSITServiceItemForm = ({ shipment, submission }) => {
         <input type="hidden" name="mtoShipmentID" />
         <input type="hidden" name="modelType" />
         <input type="hidden" name="reServiceCode" />
+        <TextField label="Reason" name="reason" />
         <DatePickerInput label="First available delivery date" name="firstAvailableDeliveryDate1" />
         <MaskedTextField
           id="timeMilitary1"
@@ -91,7 +95,7 @@ const DestinationSITServiceItemForm = ({ shipment, submission }) => {
         />
         <DatePickerInput label="SIT entry date" name="sitEntryDate" />
         <DatePickerInput label="SIT departure date" name="sitDepartureDate" />
-        <AddressFields legend="SIT destination final address" name="sitHHGActualOrigin" />
+        <AddressFields legend="SIT destination final address" name="sitDestinationFinalAddress" />
         <Button type="submit">Create service item</Button>
       </Form>
     </Formik>


### PR DESCRIPTION
## [Jira ticket](tbd)

## Summary

[This PR](https://github.com/transcom/mymove/pull/10789) has changes that fix the issue in the Prime Simulator where the newly required reason field is not being passed to the createMTOServiceItem endpoint. 

I am bringing this in now to allow the upcoming demo presenters to use the Prime simulator.

## Verification Steps for the Author

These are to be checked by the author.

- [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
- [ ] Have the Jira acceptance criteria been met for this change?

## Verification Steps for Reviewers

These are to be checked by a reviewer.

### Setup to Run the Code

- [Instructions for starting storybook](https://transcom.github.io/mymove-docs/docs/frontend/setup/run-storybook)
- [Instructions for starting the MilMove application](https://transcom.github.io/mymove-docs/docs/about/application-setup/milmove-local-client/)
- [Instructions for running tests](https://transcom.github.io/mymove-docs/docs/about/development/testing)

### How to test

1. Access the
2. Login as a
3.

### Frontend

- [ ] There are no aXe warnings for UI.
- [ ] This works in [Supported Browsers and their phone views](https://transcom.github.io/mymove-docs/docs/about/supported-browsers) (Chrome, Firefox, Edge).
- [ ] There are no new console errors in the browser devtools.
- [ ] There are no new console errors in the test output.
- [ ] If this PR adds a new component to Storybook, it ensures the component is fully responsive, OR if it is intentionally not, a wrapping div using the `officeApp` class or custom `min-width` styling is used to hide any states the would not be visible to the user.


