### PR TITLE
fix: send psql `stdout`/`stderr` to `/dev/null` when checking the db connection

### DIFF
--- a/scripts/wait-for-db
+++ b/scripts/wait-for-db
@@ -12,7 +12,7 @@ db_name="${DB_NAME:-postgres}"
 db_port="${DB_PORT:-5432}"
 retries=0
 timeout="${DB_TIMEOUT:-20}"
-db_check_command="psql postgres://${db_user}:${db_password}@${db_host}:${db_port}/${db_name} -c 'select 1;'"
+db_check_command="psql postgres://${db_user}:${db_password}@${db_host}:${db_port}/${db_name} -c 'select 1;' > /dev/null 2>&1"
 
 echo "> ${db_check_command}"
 echo -n "Checking for database connectivity.."


### PR DESCRIPTION
## Summary

We previously sent all `stdout`/`stderr` from this command to `/dev/null` until it got changed unintentionally. For some reason, not sending this to `/dev/null` can break `Goland` `Makefile` run configurations that run targets that use the `wait-for-db` script (the run configuration will just hang after it prints the output from the command). I didn't see anything that stood out as a way to fix that, so for now we'll go with the easier/faster route of reverting this change. If we do want to change how much info we get back in this script, we can dedicate more time to figuring out why the run configurations won't work.

Does anyone see any issue with this change? It can be helpful to see more info for debugging, but in terms of what the script itself needs, it only needs to know if it succeeded or failed.

## Screenshots

Run configuration:
![image](https://github.com/transcom/mymove/assets/35938642/6e1efbab-4b66-47c9-b64a-4e60beb5d632)

Run hanging:
![image](https://github.com/transcom/mymove/assets/35938642/f06f02cd-f7a9-48a9-8916-d2779a61669d)

Note the red stop square is lit up and available, and the green dot on the `Start DBs - Dev` tab indicating that the process is going, even though it should be done.

With this fix:
![image](https://github.com/transcom/mymove/assets/35938642/9e14e06d-6de6-4292-8661-69db6df4e572)

The process finishes and moves on to the next one, `Generate - Server`. 