### PR TITLE
MB-16176: Test coverage checks are optional

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1344,27 +1344,6 @@ jobs:
           root: .
           paths:
             - tmp/test-results/gotest
-      # only save the cache on default branch builds because we only want to
-      # change the baseline of test results on main builds
-      - when:
-          condition:
-            equal: [main, << pipeline.git.branch >>]
-          steps:
-            - run:
-                name: 'Copy coverage to baseline'
-                command: |
-                  mkdir -p ~/transcom/mymove/tmp/baseline-go-coverage
-                  cp ~/transcom/mymove/tmp/test-results/gotest/app/go-coverage.txt \
-                        ~/transcom/mymove/tmp/baseline-go-coverage/go-coverage.txt
-            # ##### NOTE: Make sure this key prefix matches the one
-            # ##### below in the server_test_coverage restore_cache
-            #
-            # Use the BuildNum to update the cache key so that the
-            # coverage cache is always updated
-            - save_cache:
-                key: v6-server-tests-coverage-{{ .BuildNum }}
-                paths:
-                  - ~/transcom/mymove/tmp/baseline-go-coverage
       - announce_failure
 
   server_test_coverage:
@@ -1399,6 +1378,27 @@ jobs:
             ./scripts/ensure-go-test-coverage \
             tmp/baseline-go-coverage/go-coverage.txt \
             tmp/test-results/gotest/app/go-coverage.txt
+      # only save the cache on default branch builds because we only want to
+      # change the baseline of test results on main builds
+      - when:
+          condition:
+            equal: [main, << pipeline.git.branch >>]
+          steps:
+            - run:
+                name: 'Copy coverage to baseline'
+                command: |
+                  mkdir -p ~/transcom/mymove/tmp/baseline-go-coverage
+                  cp ~/transcom/mymove/tmp/test-results/gotest/app/go-coverage.txt \
+                        ~/transcom/mymove/tmp/baseline-go-coverage/go-coverage.txt
+            # ##### NOTE: Make sure this key prefix matches the one
+            # ##### below above
+            #
+            # Use the BuildNum to update the cache key so that the
+            # coverage cache is always updated
+            - save_cache:
+                key: v6-server-tests-coverage-{{ .BuildNum }}
+                paths:
+                  - ~/transcom/mymove/tmp/baseline-go-coverage
 
   # `client_test` runs the client side Javascript tests
   client_test:
@@ -1421,27 +1421,6 @@ jobs:
           root: .
           paths:
             - coverage
-      # only save the cache on default branch builds because we only want to
-      # change the baseline of test results on main builds
-      - when:
-          condition:
-            equal: [main, << pipeline.git.branch >>]
-          steps:
-            - run:
-                name: 'Copy coverage to baseline'
-                command: |
-                  mkdir -p ~/transcom/mymove/tmp/baseline-jest-coverage
-                  cp ~/transcom/mymove/coverage/clover.xml \
-                        ~/transcom/mymove/tmp/baseline-jest-coverage/clover.xml
-            # ##### NOTE: Make sure this key prefix matches the one
-            # ##### below in client_test_coverage in restore_cache
-            #
-            # Use the BuildNum to update the cache key so that the
-            # coverage cache is always updated
-            - save_cache:
-                key: v5-client-tests-coverage-{{ .BuildNum }}
-                paths:
-                  - ~/transcom/mymove/tmp/baseline-jest-coverage
       - announce_failure
 
   client_test_coverage:
@@ -1476,6 +1455,27 @@ jobs:
             ./scripts/ensure-js-test-coverage \
             tmp/baseline-jest-coverage/clover.xml \
             coverage/clover.xml
+      # only save the cache on default branch builds because we only want to
+      # change the baseline of test results on main builds
+      - when:
+          condition:
+            equal: [main, << pipeline.git.branch >>]
+          steps:
+            - run:
+                name: 'Copy coverage to baseline'
+                command: |
+                  mkdir -p ~/transcom/mymove/tmp/baseline-jest-coverage
+                  cp ~/transcom/mymove/coverage/clover.xml \
+                        ~/transcom/mymove/tmp/baseline-jest-coverage/clover.xml
+            # ##### NOTE: Make sure this key prefix matches the one
+            # ##### above
+            #
+            # Use the BuildNum to update the cache key so that the
+            # coverage cache is always updated
+            - save_cache:
+                key: v5-client-tests-coverage-{{ .BuildNum }}
+                paths:
+                  - ~/transcom/mymove/tmp/baseline-jest-coverage
 
 
   # Compile the server side of the app once and persist the relevant

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1380,9 +1380,16 @@ jobs:
             tmp/test-results/gotest/app/go-coverage.txt
       # only save the cache on default branch builds because we only want to
       # change the baseline of test results on main builds
+      #
+      # Save the new baseline regardless of if the coverage succeeds
+      # or fails as a merge to main means we have a new baseline. We
+      # will use other means to measure if our coverage is increasing
+      # or decreasing
       - when:
           condition:
-            equal: [main, << pipeline.git.branch >>]
+            and:
+              - equal: [main, << pipeline.git.branch >>]
+              - when: always
           steps:
             - run:
                 name: 'Copy coverage to baseline'
@@ -1399,6 +1406,17 @@ jobs:
                 key: v6-server-tests-coverage-{{ .BuildNum }}
                 paths:
                   - ~/transcom/mymove/tmp/baseline-go-coverage
+            - aws_vars_transcom_gov_dev
+            - run:
+                name: 'Record server coverage stats'
+                command: |
+                  timestamp=$(date +"%Y-%m-%dT%H:%M:%SZ")
+                  coverage=$(grep statements tmp/test-results/gotest/app/go-coverage.txt | grep -o '[0-9.]*')
+                  aws cloudwatch put-metric-data \
+                  --metric-name server_test_coverage \
+                  --namespace circleci \
+                  --value "${coverage}" \
+                  --timestamp "${timestamp}"
 
   # `client_test` runs the client side Javascript tests
   client_test:
@@ -1457,9 +1475,15 @@ jobs:
             coverage/clover.xml
       # only save the cache on default branch builds because we only want to
       # change the baseline of test results on main builds
+      # Save the new baseline regardless of if the coverage succeeds
+      # or fails as a merge to main means we have a new baseline. We
+      # will use other means to measure if our coverage is increasing
+      # or decreasing
       - when:
           condition:
-            equal: [main, << pipeline.git.branch >>]
+            and:
+              - equal: [main, << pipeline.git.branch >>]
+              - when: always
           steps:
             - run:
                 name: 'Copy coverage to baseline'
@@ -1476,6 +1500,19 @@ jobs:
                 key: v5-client-tests-coverage-{{ .BuildNum }}
                 paths:
                   - ~/transcom/mymove/tmp/baseline-jest-coverage
+            - aws_vars_transcom_gov_dev
+            - run:
+                name: 'Record client coverage stats'
+                command: |
+                  timestamp=$(date +"%Y-%m-%dT%H:%M:%SZ")
+                  coverage=$(grep -B 1 'span.*Statements' coverage/lcov-report/index.html | grep -o '[0-9.]*')
+                  aws cloudwatch put-metric-data \
+                  --metric-name client_test_coverage \
+                  --namespace circleci \
+                  --value "${coverage}" \
+                  --timestamp "${timestamp}"
+
+
 
 
   # Compile the server side of the app once and persist the relevant

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1332,7 +1332,7 @@ jobs:
             - go-mod-sources-v5-{{ checksum "go.sum" }}-{{ checksum ".go-version" }}
       - run: echo 'export PATH=${PATH}:${GOPATH}/bin:~/transcom/mymove/bin' >> $BASH_ENV
       # make -j 2 tells make to run 2 simultaneous builds
-      - run: make -j 2 bin/milmove bin/go-junit-report
+      - run: make -j 2 bin/milmove bin/gotestsum
       - server_tests_step:
           application: app
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1331,6 +1331,48 @@ jobs:
           keys:
             - go-mod-sources-v5-{{ checksum "go.sum" }}-{{ checksum ".go-version" }}
       - run: echo 'export PATH=${PATH}:${GOPATH}/bin:~/transcom/mymove/bin' >> $BASH_ENV
+      # make -j 2 tells make to run 2 simultaneous builds
+      - run: make -j 2 bin/milmove bin/go-junit-report
+      - server_tests_step:
+          application: app
+      - store_artifacts:
+          path: ~/transcom/mymove/tmp/test-results
+          destination: test-results
+      - store_test_results:
+          path: ~/transcom/mymove/tmp/test-results
+      - persist_to_workspace:
+          root: .
+          paths:
+            - tmp/test-results/gotest
+      # only save the cache on default branch builds because we only want to
+      # change the baseline of test results on main builds
+      - when:
+          condition:
+            equal: [main, << pipeline.git.branch >>]
+          steps:
+            - run:
+                name: 'Copy coverage to baseline'
+                command: |
+                  mkdir -p ~/transcom/mymove/tmp/baseline-go-coverage
+                  cp ~/transcom/mymove/tmp/test-results/gotest/app/go-coverage.txt \
+                        ~/transcom/mymove/tmp/baseline-go-coverage/go-coverage.txt
+            # ##### NOTE: Make sure this key prefix matches the one
+            # ##### below in the server_test_coverage restore_cache
+            #
+            # Use the BuildNum to update the cache key so that the
+            # coverage cache is always updated
+            - save_cache:
+                key: v6-server-tests-coverage-{{ .BuildNum }}
+                paths:
+                  - ~/transcom/mymove/tmp/baseline-go-coverage
+      - announce_failure
+
+  server_test_coverage:
+    executor: tls_small
+    steps:
+      - checkout
+      - attach_workspace:
+          at: .
       - restore_cache:
           keys:
             #
@@ -1350,50 +1392,13 @@ jobs:
             #
             # The trailing hyphen in restore_cache seems important
             # according to the page linked above
-            - v5-server-tests-coverage-
-      - run:
-          name: Save Baseline Test Coverage
-          command: |
-            [ -r ~/transcom/mymove/tmp/test-results/gotest/app/go-coverage.txt ] && cp ~/transcom/mymove/tmp/test-results/gotest/app/go-coverage.txt /tmp/coverage_baseline.txt || echo "Skipping saving baseline"
-            rm -rf ~/transcom/mymove/tmp/test-results
-      # make -j 2 tells make to run 2 simultaneous builds
-      - run: make -j 2 bin/milmove bin/go-junit-report
-      - server_tests_step:
-          application: app
-      - run:
-          name: Ensure we save both the coverage baseline & the go-coverage text files before checking test coverage status
-          command: |
-            if [ -r /tmp/coverage_baseline.txt ]; then
-              cp -v /tmp/coverage_baseline.txt ~/transcom/mymove/tmp/test-results/previous-coverage-baseline.txt
-            fi
-            if [ -r ~/transcom/mymove/tmp/test-results/gotest/app/go-coverage.txt ]; then
-              cp -v ~/transcom/mymove/tmp/test-results/gotest/app/go-coverage.txt ~/transcom/mymove/tmp/test-results/current-coverage.txt
-            fi
+            - v6-server-tests-coverage-
       - run:
           name: Ensure Test Coverage Increasing
           command: |
-            ./scripts/ensure-go-test-coverage /tmp/coverage_baseline.txt tmp/test-results/gotest/app/go-coverage.txt
-      - store_artifacts:
-          path: ~/transcom/mymove/tmp/test-results
-          destination: test-results
-      - store_test_results:
-          path: ~/transcom/mymove/tmp/test-results
-      # only save the cache on default branch builds because we only want to
-      # change the baseline of test results on main builds
-      - when:
-          condition:
-            equal: [main, << pipeline.git.branch >>]
-          steps:
-            # ##### NOTE: Make sure this key prefix matches the one
-            # ##### above in restore_cache
-            #
-            # Use the BuildNum to update the cache key so that the
-            # coverage cache is always updated
-            - save_cache:
-                key: v5-server-tests-coverage-{{ .BuildNum }}
-                paths:
-                  - ~/transcom/mymove/tmp/test-results
-      - announce_failure
+            ./scripts/ensure-go-test-coverage \
+            tmp/baseline-go-coverage/go-coverage.txt \
+            tmp/test-results/gotest/app/go-coverage.txt
 
   # `client_test` runs the client side Javascript tests
   client_test:
@@ -1403,6 +1408,48 @@ jobs:
       - restore_cache:
           keys:
             - v3-cache-yarn-v3-{{ checksum "yarn.lock" }}
+      - run:
+          name: Install Frozen YARN dependencies
+          command: yarn install --frozen-lockfile --cache-folder ~/.cache/yarn
+      - run: make client_test_coverage
+      - store_artifacts:
+          path: ~/transcom/mymove/coverage
+          destination: coverage
+      - store_test_results:
+          path: ~/transcom/mymove
+      - persist_to_workspace:
+          root: .
+          paths:
+            - coverage
+      # only save the cache on default branch builds because we only want to
+      # change the baseline of test results on main builds
+      - when:
+          condition:
+            equal: [main, << pipeline.git.branch >>]
+          steps:
+            - run:
+                name: 'Copy coverage to baseline'
+                command: |
+                  mkdir -p ~/transcom/mymove/tmp/baseline-jest-coverage
+                  cp ~/transcom/mymove/coverage/clover.xml \
+                        ~/transcom/mymove/tmp/baseline-jest-coverage/clover.xml
+            # ##### NOTE: Make sure this key prefix matches the one
+            # ##### below in client_test_coverage in restore_cache
+            #
+            # Use the BuildNum to update the cache key so that the
+            # coverage cache is always updated
+            - save_cache:
+                key: v5-client-tests-coverage-{{ .BuildNum }}
+                paths:
+                  - ~/transcom/mymove/tmp/baseline-jest-coverage
+      - announce_failure
+
+  client_test_coverage:
+    executor: tls_small
+    steps:
+      - checkout
+      - attach_workspace:
+          at: .
       - restore_cache:
           #
           # https://circleci.com/docs/caching/#restoring-cache
@@ -1422,41 +1469,14 @@ jobs:
           # The trailing hyphen in restore_cache seems important
           # according to the page linked above
           keys:
-            - v4-client-tests-coverage-
-      - run:
-          name: Save Baseline Test Coverage
-          command: |
-            [ -r ~/transcom/mymove/coverage/clover.xml ] && cp ~/transcom/mymove/coverage/clover.xml /tmp/clover_baseline.xml || echo "Skipping saving baseline"
-            rm -rf ~/transcom/mymove/coverage
-      - run:
-          name: Install Frozen YARN dependencies
-          command: yarn install --frozen-lockfile --cache-folder ~/.cache/yarn
-      - run: make client_test_coverage
+            - v5-client-tests-coverage-
       - run:
           name: Ensure Test Coverage Increasing
           command: |
-            ./scripts/ensure-js-test-coverage /tmp/clover_baseline.xml coverage/clover.xml
-      - store_artifacts:
-          path: ~/transcom/mymove/coverage
-          destination: coverage
-      - store_test_results:
-          path: ~/transcom/mymove
-      # only save the cache on default branch builds because we only want to
-      # change the baseline of test results on main builds
-      - when:
-          condition:
-            equal: [main, << pipeline.git.branch >>]
-          steps:
-            # ##### NOTE: Make sure this key prefix matches the one
-            # ##### above in restore_cache
-            #
-            # Use the BuildNum to update the cache key so that the
-            # coverage cache is always updated
-            - save_cache:
-                key: v4-client-tests-coverage-{{ .BuildNum }}
-                paths:
-                  - ~/transcom/mymove/coverage
-      - announce_failure
+            ./scripts/ensure-js-test-coverage \
+            tmp/baseline-jest-coverage/clover.xml \
+            coverage/clover.xml
+
 
   # Compile the server side of the app once and persist the relevant
   # build artifacts to the workspace.
@@ -2132,9 +2152,27 @@ workflows:
             branches:
               ignore: *client-ignore-branch
 
+      - client_test_coverage:
+          requires:
+            - client_test
+          # See comments at the top of this file for configuring/using
+          # this branch config
+          filters:
+            branches:
+              ignore: *client-ignore-branch
+
       - server_test:
           requires:
             - pre_deps_golang
+          # See comments at the top of this file for configuring/using
+          # this branch config
+          filters:
+            branches:
+              ignore: *server-ignore-branch
+
+      - server_test_coverage:
+          requires:
+            - server_test
           # See comments at the top of this file for configuring/using
           # this branch config
           filters:

--- a/pkg/tools/tools.go
+++ b/pkg/tools/tools.go
@@ -12,11 +12,9 @@ import (
 	_ "github.com/codegangsta/gin"
 	// Install for managing the database
 	_ "github.com/gobuffalo/pop/v6/soda"
-	// Install go-junit-report for CircleCI test result report generation
-	_ "github.com/jstemmer/go-junit-report"
 	// Install for autogenerating mocks
 	_ "github.com/vektra/mockery/v2"
-	// Possible replacement for go-junit-report
+	// Replacement for go-junit-report
 	_ "gotest.tools/gotestsum"
 	// Install for go-swagger code generation
 	_ "github.com/go-swagger/go-swagger/cmd/swagger"

--- a/scripts/ensure-go-test-coverage
+++ b/scripts/ensure-go-test-coverage
@@ -46,5 +46,4 @@ if new_percent < baseline_percent:
   print(f"\nBaseline test coverage: {baseline_percent}")
   print(f"New test coverage: {new_percent}")
   print("Test Coverage has decreased\n")
-  # ALWAYS PASS
-  sys.exit(0)
+  sys.exit(1)

--- a/scripts/ensure-js-test-coverage
+++ b/scripts/ensure-js-test-coverage
@@ -36,5 +36,4 @@ print(f"New test coverage: {new_percent}")
 if new_percent < baseline_percent:
   print("Test Coverage has decreased")
   print(f"Refer to the following to learn how resolve this: {HELP_URL}")
-  # ALWAYS PASS
-  sys.exit(0)
+  sys.exit(1)

--- a/scripts/run-server-test
+++ b/scripts/run-server-test
@@ -9,7 +9,6 @@
 # - COVERAGE: '1' will enable test coverage flags
 # - DRY_RUN: '1' will build the tests but not run them
 # - SERVER_REPORT: '1' will run go-junit-report and go coverage on output
-# - GO_JUNIT_REPORT: Use go-junit-report to generate the junit report
 # - LONG_TEST: '1' will remove the '-short' flag and run extended tests
 # - NO_RACE: disables the race detector, allowing the tests to run faster
 # - NO_DB: Will disable the db reset and migration steps
@@ -18,11 +17,6 @@
 # Disable test caching with `-count 1` - caching was masking local test failures
 
 set -eu -o pipefail
-
-# default to gotestsum if GO_JUNIT is not defined
-if [[ "${SERVER_REPORT:-}" == "1" && -z "${GO_JUNIT_REPORT:-}" ]]; then
-  GOTESTSUM=1
-fi
 
 # colors
 RED='\033[0;31m'
@@ -86,10 +80,6 @@ mkdir -p "${test_dir}"
 
 function server_report_cleanup()
 {
-  if [[ "${GOTESTSUM:-}" != "1" ]]; then
-    # generate the junit report
-    bin/go-junit-report < "${test_output_file}" > "${test_report_file}"
-  fi
   if [[ "${COVERAGE:-}" == "1" ]]; then
     go tool cover -func=coverage.out -o "${test_dir}/go-coverage.txt"
     go tool cover -html=coverage.out -o "${test_dir}/go-coverage.html"
@@ -114,17 +104,12 @@ function server_report_cleanup()
 
 # Set up junit report and ensure its run on exit
 if [[ "${SERVER_REPORT:-}" == "1" ]]; then
-  if [[ "${GOTESTSUM:-}" != "1" ]]; then
-    if [ ! -f bin/go-junit-report ]; then
-      make bin/go-junit-report
-    fi
-  fi
   # setup a trap incase the tests fail, we still want to generate the report
   trap server_report_cleanup EXIT
 fi
 
 gotest_args+=("-vet=off")
-if [[ "${GOTESTSUM:-}" == "1" ]]; then
+if [[ "${SERVER_REPORT:-}" == "1" ]]; then
   if [[ ! -f bin/gotestsum ]]; then
     make bin/gotestsum
   fi


### PR DESCRIPTION
## Summary

Make the test coverage separate steps so they can fail and not be required.

Persist the coverage information to the workspace so that the new coverage steps can access the coverage.

Always update the coverage baseline on `main`, record the stats to AWS so we can track changes over time

## Verification Steps for the Author

I tested by hardcoding the baseline coverage numbers to 80% and [confirmed that the steps failed](https://app.circleci.com/pipelines/github/transcom/mymove/54083/workflows/9f931128-17f2-44c6-a4dd-94fc29e21f38)

This is using a new cache for client and server tests because the cache location is changing, but I tested it by overriding the main branch check for one workflow run in CircleCI
