### PR TITLE
MB-16198 - Restrict sit address updates to DDDSIT

### DIFF
--- a/pkg/services/sit_address_update/approved_sit_address_update_creator.go
+++ b/pkg/services/sit_address_update/approved_sit_address_update_creator.go
@@ -26,6 +26,7 @@ func NewApprovedOfficeSITAddressUpdateCreator(planner route.Planner, addressCrea
 		checks: []sitAddressUpdateValidator{
 			checkAndValidateRequiredFields(),
 			checkTOORequiredFields(),
+			checkServiceItem(),
 		},
 	}
 }

--- a/pkg/services/sit_address_update/rules.go
+++ b/pkg/services/sit_address_update/rules.go
@@ -73,7 +73,7 @@ func checkServiceItem() sitAddressUpdateValidator {
 		verrs := validate.NewErrors()
 
 		var serviceItem models.MTOServiceItem
-		err := appCtx.DB().Where("id = ?", sitAddressUpdate.MTOServiceItemID).First(&serviceItem)
+		err := appCtx.DB().Eager("ReService", "SITDestinationOriginalAddress").Where("id = ?", sitAddressUpdate.MTOServiceItemID).First(&serviceItem)
 		if err != nil {
 			verrs.Add("MTOServiceItem", "MTOServiceItem was not found")
 		}
@@ -86,7 +86,7 @@ func checkServiceItem() sitAddressUpdateValidator {
 			verrs.Add("SITDestinationFinalAddressID", "SITDestinationFinalAddressID is required")
 		}
 
-		if sitAddressUpdate.MTOServiceItem.ReService.Code != models.ReServiceCodeDDDSIT {
+		if serviceItem.ReService.Code != models.ReServiceCodeDDDSIT {
 			verrs.Add("MTOServiceItem", "A SIT address update request may only be created for a DDDSIT service item")
 		}
 

--- a/pkg/services/sit_address_update/rules_test.go
+++ b/pkg/services/sit_address_update/rules_test.go
@@ -55,83 +55,8 @@ func (suite *SITAddressUpdateServiceSuite) TestCheckRequiredFields() {
 			suite.IsType(&validate.Errors{}, err)
 			suite.Contains(err.Error(), "NewAddress is required")
 			suite.Contains(err.Error(), "MTOServiceItem is required")
-			suite.Contains(err.Error(), "MTOServiceItem was not found")
-			suite.Contains(err.Error(), "SITDestinationFinalAddressID is required")
 		})
 
-		suite.Run("Create SITAddressUpdate with rejected service item", func() {
-			mtoServiceItem := factory.BuildMTOServiceItem(suite.DB(), []factory.Customization{
-				{
-					Model: models.MTOServiceItem{
-						Status: models.MTOServiceItemStatusRejected,
-					},
-				},
-			}, nil)
-			sitAddressUpdate := factory.BuildSITAddressUpdate(nil, []factory.Customization{
-				{
-					Model:    mtoServiceItem,
-					LinkOnly: true,
-				},
-			}, nil)
-
-			err := checkAndValidateRequiredFields().Validate(
-				suite.AppContextForTest(),
-				&sitAddressUpdate,
-			)
-
-			suite.Error(err)
-			suite.IsType(&validate.Errors{}, err)
-			suite.Contains(err.Error(), "MTOServiceItem must be approved")
-		})
-
-		suite.Run("Create SITAddressUpdate with no service item", func() {
-			sitAddressUpdate := factory.BuildSITAddressUpdate(nil, []factory.Customization{
-				{
-					Model: models.SITAddressUpdate{
-						OfficeRemarks: models.StringPointer("office remarks"),
-					},
-				},
-			}, nil)
-
-			err := checkAndValidateRequiredFields().Validate(
-				suite.AppContextForTest(),
-				&sitAddressUpdate,
-			)
-
-			suite.Error(err)
-			suite.IsType(&validate.Errors{}, err)
-			suite.Contains(err.Error(), "MTOServiceItem was not found")
-		})
-
-		suite.Run("Create SITAddressUpdate with missing SITDestinationFinalAddressID", func() {
-			oldAddress := factory.BuildAddress(suite.DB(), nil, nil)
-			mtoServiceItem := factory.BuildMTOServiceItem(suite.DB(), []factory.Customization{
-				{
-					Model: models.MTOServiceItem{
-						Status: models.MTOServiceItemStatusApproved,
-					},
-				}}, nil)
-			sitAddressUpdate := factory.BuildSITAddressUpdate(nil, []factory.Customization{
-				{
-					Model:    oldAddress,
-					LinkOnly: true,
-					Type:     &factory.Addresses.SITAddressUpdateOldAddress,
-				},
-				{
-					Model:    mtoServiceItem,
-					LinkOnly: true,
-				},
-			}, nil)
-
-			err := checkAndValidateRequiredFields().Validate(
-				suite.AppContextForTest(),
-				&sitAddressUpdate,
-			)
-
-			suite.Error(err)
-			suite.IsType(&validate.Errors{}, err)
-			suite.Contains(err.Error(), "SITDestinationFinalAddressID is required")
-		})
 	})
 }
 
@@ -185,5 +110,167 @@ func (suite *SITAddressUpdateServiceSuite) TestCheckTOORequiredFields() {
 			suite.IsType(&validate.Errors{}, err)
 			suite.Contains(err.Error(), "are required")
 		})
+	})
+}
+
+func (suite *SITAddressUpdateServiceSuite) TestCheckServiceItem() {
+	suite.Run("Success", func() {
+		suite.Run("Create SITAddressUpdate", func() {
+			oldAddress := factory.BuildAddress(suite.DB(), nil, nil)
+			mtoServiceItem := factory.BuildMTOServiceItem(suite.DB(), []factory.Customization{
+				{
+					Model: models.MTOServiceItem{
+						Status: models.MTOServiceItemStatusApproved,
+					},
+				},
+			}, nil)
+			sitAddressUpdate := factory.BuildSITAddressUpdate(nil, []factory.Customization{
+				{
+					Model:    oldAddress,
+					LinkOnly: true,
+					Type:     &factory.Addresses.SITAddressUpdateOldAddress,
+				},
+				{
+					Model:    mtoServiceItem,
+					LinkOnly: true,
+				},
+				{
+					Model: models.SITAddressUpdate{
+						OfficeRemarks: models.StringPointer("office remarks"),
+					},
+				},
+			}, nil)
+
+			err := checkTOORequiredFields().Validate(
+				suite.AppContextForTest(),
+				&sitAddressUpdate,
+			)
+
+			suite.NilOrNoVerrs(err)
+		})
+	})
+
+	suite.Run("Failure", func() {
+		suite.Run("Create SITAddressUpdate with no MTOServiceItem", func() {
+			sitAddressUpdate := models.SITAddressUpdate{}
+
+			err := checkServiceItem().Validate(
+				suite.AppContextForTest(),
+				&sitAddressUpdate,
+			)
+
+			suite.Error(err)
+			suite.IsType(&validate.Errors{}, err)
+			suite.Contains(err.Error(), "MTOServiceItem was not found")
+		})
+	})
+
+	suite.Run("Create SITAddressUpdate with rejected service item", func() {
+		mtoServiceItem := factory.BuildMTOServiceItem(suite.DB(), []factory.Customization{
+			{
+				Model: models.MTOServiceItem{
+					Status: models.MTOServiceItemStatusRejected,
+				},
+			},
+		}, nil)
+		sitAddressUpdate := factory.BuildSITAddressUpdate(nil, []factory.Customization{
+			{
+				Model:    mtoServiceItem,
+				LinkOnly: true,
+			},
+		}, nil)
+
+		err := checkServiceItem().Validate(
+			suite.AppContextForTest(),
+			&sitAddressUpdate,
+		)
+
+		suite.Error(err)
+		suite.IsType(&validate.Errors{}, err)
+		suite.Contains(err.Error(), "MTOServiceItem must be approved")
+	})
+
+	suite.Run("Create SITAddressUpdate with no service item", func() {
+		sitAddressUpdate := factory.BuildSITAddressUpdate(nil, []factory.Customization{
+			{
+				Model: models.SITAddressUpdate{
+					OfficeRemarks: models.StringPointer("office remarks"),
+				},
+			},
+		}, nil)
+
+		err := checkServiceItem().Validate(
+			suite.AppContextForTest(),
+			&sitAddressUpdate,
+		)
+
+		suite.Error(err)
+		suite.IsType(&validate.Errors{}, err)
+		suite.Contains(err.Error(), "MTOServiceItem was not found")
+	})
+
+	suite.Run("Create SITAddressUpdate with missing SITDestinationFinalAddressID", func() {
+		oldAddress := factory.BuildAddress(suite.DB(), nil, nil)
+		mtoServiceItem := factory.BuildMTOServiceItem(suite.DB(), []factory.Customization{
+			{
+				Model: models.MTOServiceItem{
+					Status: models.MTOServiceItemStatusApproved,
+				},
+			}}, nil)
+		sitAddressUpdate := factory.BuildSITAddressUpdate(nil, []factory.Customization{
+			{
+				Model:    oldAddress,
+				LinkOnly: true,
+				Type:     &factory.Addresses.SITAddressUpdateOldAddress,
+			},
+			{
+				Model:    mtoServiceItem,
+				LinkOnly: true,
+			},
+		}, nil)
+
+		err := checkServiceItem().Validate(
+			suite.AppContextForTest(),
+			&sitAddressUpdate,
+		)
+
+		suite.Error(err)
+		suite.IsType(&validate.Errors{}, err)
+		suite.Contains(err.Error(), "SITDestinationFinalAddressID is required")
+	})
+
+	suite.Run("Create SITAddressUpdate with service item of incorrect type", func() {
+		oldAddress := factory.BuildAddress(suite.DB(), nil, nil)
+		mtoServiceItem := factory.BuildMTOServiceItem(suite.DB(), []factory.Customization{
+			{
+				Model: models.MTOServiceItem{
+					Status: models.MTOServiceItemStatusApproved,
+				},
+			},
+			{
+				Model: models.ReService{
+					Code: models.ReServiceCodeDDSHUT,
+				},
+			}}, nil)
+		sitAddressUpdate := factory.BuildSITAddressUpdate(nil, []factory.Customization{
+			{
+				Model:    oldAddress,
+				LinkOnly: true,
+				Type:     &factory.Addresses.SITAddressUpdateOldAddress,
+			},
+			{
+				Model:    mtoServiceItem,
+				LinkOnly: true,
+			},
+		}, nil)
+
+		err := checkServiceItem().Validate(
+			suite.AppContextForTest(),
+			&sitAddressUpdate,
+		)
+
+		suite.Error(err)
+		suite.IsType(&validate.Errors{}, err)
+		suite.Contains(err.Error(), "A SIT address update request may only be created for a DDDSIT service item")
 	})
 }

--- a/pkg/services/sit_address_update/sit_address_update_request_creator.go
+++ b/pkg/services/sit_address_update/sit_address_update_request_creator.go
@@ -25,6 +25,7 @@ func NewSITAddressUpdateRequestCreator(planner route.Planner, addressCreator ser
 			checkAndValidateRequiredFields(),
 			checkPrimeRequiredFields(),
 			checkForExistingSITAddressUpdate(),
+			checkServiceItem(),
 		},
 		moveRouter: moveRouter,
 	}


### PR DESCRIPTION
## [Jira ticket](https://dp3.atlassian.net/browse/MB-16198)

## Summary
The PR should add a validation to new address updates which checks to see if the associated service item is a DDDSIT.
I also slightly reorganized the address updates validations so that they would be categorized a little more specifically.

## Verification Steps for the Author

These are to be checked by the author.

- [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
- [ ] Have the Jira acceptance criteria been met for this change?

## Verification Steps for Reviewers

These are to be checked by a reviewer.

### Setup to Run the Code

- [Instructions for starting storybook](https://transcom.github.io/mymove-docs/docs/frontend/setup/run-storybook)
- [Instructions for starting the MilMove application](https://transcom.github.io/mymove-docs/docs/about/application-setup/milmove-local-client/)
- [Instructions for running tests](https://transcom.github.io/mymove-docs/docs/about/development/testing)

### How to test

1. Ensure the new and reorganized server tests pass
2. Submit an address update request via the local prime api to a service item that isn't DDDSIT and validate that the request returns an error

### Backend

- [ ] Code follows the guidelines for [Logging](https://transcom.github.io/mymove-docs/docs/about/development/logging).
- [ ] The requirements listed in [Querying the Database Safely](https://transcom.github.io/mymove-docs/docs/backend/guides/golang-guide#querying-the-database-safely) have been satisfied.

### Database
