### PR TITLE
[MB-16184] Updates service item autogeneration for HHGs with same ZIP3

### DIFF
--- a/pkg/services/mto_shipment/mto_shipment_updater.go
+++ b/pkg/services/mto_shipment/mto_shipment_updater.go
@@ -786,6 +786,21 @@ func reServiceCodesForShipment(shipment models.MTOShipment) []models.ReServiceCo
 
 	switch shipment.ShipmentType {
 	case models.MTOShipmentTypeHHG:
+
+		originZIP3 := shipment.PickupAddress.PostalCode[0:3]
+		destinationZIP3 := shipment.DestinationAddress.PostalCode[0:3]
+
+		if originZIP3 == destinationZIP3 {
+			return []models.ReServiceCode{
+				models.ReServiceCodeDSH,
+				models.ReServiceCodeFSC,
+				models.ReServiceCodeDOP,
+				models.ReServiceCodeDDP,
+				models.ReServiceCodeDPK,
+				models.ReServiceCodeDUPK,
+			}
+		}
+
 		// Need to create: Dom Linehaul, Fuel Surcharge, Dom Origin Price, Dom Destination Price, Dom Packing, and Dom Unpacking.
 		return []models.ReServiceCode{
 			models.ReServiceCodeDLH,


### PR DESCRIPTION
## [Jira ticket](https://dp3.atlassian.net/browse/MB-16184)

## Summary

This pull request updates the service item auto-generation code for HHG shipments. It compares the first three characters of the origin and destination postal codes, and as part of the set of service items it generates a different service code (`DSH`, or domestic shorthaul, instead of `DLH`, or domestic linehaul) based on whether those ZIP3s match.

## Verification Steps for the Author

These are to be checked by the author.

- [ ] Have the Jira acceptance criteria been met for this change?

## Verification Steps for Reviewers

These are to be checked by a reviewer.

### Setup to Run the Code

- [Instructions for starting the MilMove application](https://transcom.github.io/mymove-docs/docs/about/application-setup/milmove-local-client/)
- [Instructions for running tests](https://transcom.github.io/mymove-docs/docs/about/development/testing)

### How to test

1. Verify that server tests pass. Additionally,
2. As a customer, create a move with an HHG shipment that has an identical origin and destination ZIP3.
3. As a TXO, approve the move.
4. Verify that the Domestic Shorthaul service item is auto-generated, and not the Domestic Linehaul service item.

### Backend

- [ ] Code follows the guidelines for [Logging](https://transcom.github.io/mymove-docs/docs/about/development/logging).
- [ ] The requirements listed in [Querying the Database Safely](https://transcom.github.io/mymove-docs/docs/backend/guides/golang-guide#querying-the-database-safely) have been satisfied.