### PR TITLE
[MB-16360] Resolve issue with non-deterministic Happo diffs in ReviewSITExtensionModal

### DIFF
--- a/src/components/Office/ReviewSITExtensionModal/ReviewSITExtensionModal.jsx
+++ b/src/components/Office/ReviewSITExtensionModal/ReviewSITExtensionModal.jsx
@@ -55,7 +55,7 @@ const SITHistoryItemHeader = ({ title, value }) => {
   }
 
   return (
-    <div className={styles.sitHistoryItemHeader}>
+    <div data-happo-hide className={styles.sitHistoryItemHeader}>
       {title}
       <span className={styles.hintText}>
         {action} + Requested = {value}


### PR DESCRIPTION
## [Jira ticket](https://dp3.atlassian.net/browse/MB-16360)

## Summary

This pull request resolves an issue where part of the `ReviewSITExtensionModal` component in Storybook was triggering Happo diffs whenever unrelated code was changed. This was due to the offending portion displaying a date that is 75 days in the future, which changes whenever the current date changes.

The div which contains the variable text had the `data-happo-hide` attribute added to it, which instructs Happo to ignore that portion when checking for diffs. (You can see the difference in the Happo run for this pull request, where two lines of text are now missing: https://happo.io/a/488/p/603/compare/ed3ce638271eedd0c47f7a0b5c15920cd5785549/81f5032869d5603fa4774b99567d7dc784d8d8b0)