### PR TITLE
Fix approve icon for Service Item Table

### DIFF
--- a/src/components/Office/ServiceItemsTable/ServiceItemsTable.jsx
+++ b/src/components/Office/ServiceItemsTable/ServiceItemsTable.jsx
@@ -170,7 +170,7 @@ const ServiceItemsTable = ({
                     onClick={() => handleUpdateMTOServiceItemStatus(id, mtoShipmentID, SERVICE_ITEM_STATUS.APPROVED)}
                   >
                     <span className="icon">
-                      <FontAwesomeIcon icon="times" />
+                      <FontAwesomeIcon icon="check" />
                     </span>{' '}
                     Approve
                   </Button>

--- a/src/components/Office/ServiceItemsTable/ServiceItemsTable.test.jsx
+++ b/src/components/Office/ServiceItemsTable/ServiceItemsTable.test.jsx
@@ -631,6 +631,7 @@ describe('ServiceItemsTable', () => {
 
     expect(approveTextButton.length).toBeTruthy();
 
+    expect(approveTextButton.at(0).find('svg[data-icon="check"]').length).toBe(1);
     expect(approveTextButton.at(0).contains('Approve')).toBe(true);
   });
 


### PR DESCRIPTION
## Summary

While the team was working through backlog, @afoon helpfully pointed out that
the `Approve` button text under **Rejected service items** contained a `x`
rather than `√`. This PR adds the appropriate icon name and also adds a small
test to ensure that the `Approve` button has check mark rather than an `x` mark.

- [x] Fixing Approve icon for Service Items Table;
- [x] Adding a test to ensure there's a check mark; ✅

## Verification Steps for the Author

Navigate to an MTO page with SIT service items that either has rejected items or
reject them to see the icon. I'm also going to be including screenshots to show
the before and after.

## Screenshots

| Time | Image |
| ---- | ----- |
| Before | <img width="700" alt="Captura de pantalla 2023-06-21 a la(s) 1 17 37 p m" src="https://github.com/transcom/mymove/assets/706004/6cbe71ef-6c26-44e3-b3c2-71c91d9a5840"> |
| After | <img width="700" alt="Captura de pantalla 2023-06-21 a la(s) 1 32 22 p m" src="https://github.com/transcom/mymove/assets/706004/e7b0d418-f2f7-4f8d-b4e3-6a95ee52a1ef"> |


