### PR TITLE
MB-15324 Payment requests should show up in their detail tab regardless of gbloc

### DIFF
--- a/pkg/handlers/ghcapi/payment_request.go
+++ b/pkg/handlers/ghcapi/payment_request.go
@@ -39,7 +39,6 @@ func (h GetPaymentRequestForMoveHandler) Handle(
 
 			paymentRequests, err := h.FetchPaymentRequestListByMove(
 				appCtx,
-				appCtx.Session().OfficeUserID,
 				locator,
 			)
 			if err != nil {

--- a/pkg/services/mocks/PaymentRequestListFetcher.go
+++ b/pkg/services/mocks/PaymentRequestListFetcher.go
@@ -51,25 +51,25 @@ func (_m *PaymentRequestListFetcher) FetchPaymentRequestList(appCtx appcontext.A
 	return r0, r1, r2
 }
 
-// FetchPaymentRequestListByMove provides a mock function with given fields: appCtx, officeUserID, locator
-func (_m *PaymentRequestListFetcher) FetchPaymentRequestListByMove(appCtx appcontext.AppContext, officeUserID uuid.UUID, locator string) (*models.PaymentRequests, error) {
-	ret := _m.Called(appCtx, officeUserID, locator)
+// FetchPaymentRequestListByMove provides a mock function with given fields: appCtx, locator
+func (_m *PaymentRequestListFetcher) FetchPaymentRequestListByMove(appCtx appcontext.AppContext, locator string) (*models.PaymentRequests, error) {
+	ret := _m.Called(appCtx, locator)
 
 	var r0 *models.PaymentRequests
 	var r1 error
-	if rf, ok := ret.Get(0).(func(appcontext.AppContext, uuid.UUID, string) (*models.PaymentRequests, error)); ok {
-		return rf(appCtx, officeUserID, locator)
+	if rf, ok := ret.Get(0).(func(appcontext.AppContext, string) (*models.PaymentRequests, error)); ok {
+		return rf(appCtx, locator)
 	}
-	if rf, ok := ret.Get(0).(func(appcontext.AppContext, uuid.UUID, string) *models.PaymentRequests); ok {
-		r0 = rf(appCtx, officeUserID, locator)
+	if rf, ok := ret.Get(0).(func(appcontext.AppContext, string) *models.PaymentRequests); ok {
+		r0 = rf(appCtx, locator)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*models.PaymentRequests)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(appcontext.AppContext, uuid.UUID, string) error); ok {
-		r1 = rf(appCtx, officeUserID, locator)
+	if rf, ok := ret.Get(1).(func(appcontext.AppContext, string) error); ok {
+		r1 = rf(appCtx, locator)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/pkg/services/payment_request.go
+++ b/pkg/services/payment_request.go
@@ -36,7 +36,7 @@ type PaymentRequestShipmentRecalculator interface {
 //go:generate mockery --name PaymentRequestListFetcher
 type PaymentRequestListFetcher interface {
 	FetchPaymentRequestList(appCtx appcontext.AppContext, officeUserID uuid.UUID, params *FetchPaymentRequestListParams) (*models.PaymentRequests, int, error)
-	FetchPaymentRequestListByMove(appCtx appcontext.AppContext, officeUserID uuid.UUID, locator string) (*models.PaymentRequests, error)
+	FetchPaymentRequestListByMove(appCtx appcontext.AppContext, locator string) (*models.PaymentRequests, error)
 }
 
 // PaymentRequestFetcher is the exported interface for fetching a payment request

--- a/pkg/services/payment_request/payment_request_list_fetcher.go
+++ b/pkg/services/payment_request/payment_request_list_fetcher.go
@@ -130,7 +130,7 @@ func (f *paymentRequestListFetcher) FetchPaymentRequestList(appCtx appcontext.Ap
 }
 
 // FetchPaymentRequestListByMove returns a payment request by move locator id
-func (f *paymentRequestListFetcher) FetchPaymentRequestListByMove(appCtx appcontext.AppContext, officeUserID uuid.UUID, locator string) (*models.PaymentRequests, error) {
+func (f *paymentRequestListFetcher) FetchPaymentRequestListByMove(appCtx appcontext.AppContext, locator string) (*models.PaymentRequests, error) {
 	paymentRequests := models.PaymentRequests{}
 
 	// Replaced EagerPreload due to nullable fka on Contractor

--- a/pkg/services/payment_request/payment_request_list_fetcher_test.go
+++ b/pkg/services/payment_request/payment_request_list_fetcher_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func (suite *PaymentRequestServiceSuite) TestFetchPaymentRequestListbyMove() {
-	suite.Run("Only returns visible (where Move.Show is not false) payment requests matching office user GBLOC", func() {
+	suite.Run("Only returns visible (where Move.Show is not false) payment requests", func() {
 		paymentRequestListFetcher := NewPaymentRequestListFetcher()
 
 		officeUser := factory.BuildOfficeUserWithRoles(suite.DB(), nil, []roles.RoleType{roles.RoleTypeTOO})
@@ -26,7 +26,7 @@ func (suite *PaymentRequestServiceSuite) TestFetchPaymentRequestListbyMove() {
 				},
 			},
 		}, nil)
-		// We need a payment request with a move that has a shipment that's within the GBLOC
+		// We need a payment request with a move that has a shipment
 		paymentRequest := factory.BuildPaymentRequest(suite.DB(), []factory.Customization{
 			{
 				Model:    expectedMove,

--- a/pkg/services/payment_request/payment_request_list_fetcher_test.go
+++ b/pkg/services/payment_request/payment_request_list_fetcher_test.go
@@ -17,8 +17,6 @@ func (suite *PaymentRequestServiceSuite) TestFetchPaymentRequestListbyMove() {
 	suite.Run("Only returns visible (where Move.Show is not false) payment requests", func() {
 		paymentRequestListFetcher := NewPaymentRequestListFetcher()
 
-		officeUser := factory.BuildOfficeUserWithRoles(suite.DB(), nil, []roles.RoleType{roles.RoleTypeTOO})
-
 		expectedMove := factory.BuildMoveWithShipment(suite.DB(), []factory.Customization{
 			{
 				Model: models.Move{
@@ -43,7 +41,7 @@ func (suite *PaymentRequestServiceSuite) TestFetchPaymentRequestListbyMove() {
 			},
 		}, nil)
 
-		expectedPaymentRequests, err := paymentRequestListFetcher.FetchPaymentRequestListByMove(suite.AppContextForTest(), officeUser.ID, "ABC123")
+		expectedPaymentRequests, err := paymentRequestListFetcher.FetchPaymentRequestListByMove(suite.AppContextForTest(), "ABC123")
 
 		suite.NoError(err)
 		suite.Equal(1, len(*expectedPaymentRequests))
@@ -412,7 +410,7 @@ func (suite *PaymentRequestServiceSuite) TestFetchPaymentRequestListUSMCGBLOC() 
 
 	suite.Run("returns USMC payment requests for move", func() {
 		paymentRequestListFetcher := NewPaymentRequestListFetcher()
-		expectedPaymentRequests, err := paymentRequestListFetcher.FetchPaymentRequestListByMove(suite.AppContextForTest(), officeUserUSMC.ID, paymentRequestUSMC.MoveTaskOrder.Locator)
+		expectedPaymentRequests, err := paymentRequestListFetcher.FetchPaymentRequestListByMove(suite.AppContextForTest(), paymentRequestUSMC.MoveTaskOrder.Locator)
 		paymentRequests := *expectedPaymentRequests
 
 		suite.NoError(err)


### PR DESCRIPTION
## [Jira ticket](https://dp3.atlassian.net/browse/MB-15324)

## Summary

This change removes the branch and gbloc filters from `FetchPaymentRequestListByMove`. Now it will just use the locator as its filter. Since we have QAE users searching for moves by locator and potentially viewing payment requests we need to make sure those populate in the detail view. 



## Verification Steps for the Author

These are to be checked by the author.

- [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
- [ ] Have the Jira acceptance criteria been met for this change?

## Verification Steps for Reviewers

These are to be checked by a reviewer.

### Setup to Run the Code

- [Instructions for starting storybook](https://transcom.github.io/mymove-docs/docs/frontend/setup/run-storybook)
- [Instructions for starting the MilMove application](https://transcom.github.io/mymove-docs/docs/about/application-setup/milmove-local-client/)
- [Instructions for running tests](https://transcom.github.io/mymove-docs/docs/about/development/testing)

### How to test

1. Access the office app and find a move in the default gbloc
2. Login to the admin app and change a user to be a different gbloc
3. Use the QAE search UI to find that move again and click on its payment request tab
4. There should be payment requests there on the page

### Frontend

- [ ] There are no aXe warnings for UI.
- [ ] This works in [Supported Browsers and their phone views](https://transcom.github.io/mymove-docs/docs/about/supported-browsers) (Chrome, Firefox, Edge).
- [ ] There are no new console errors in the browser devtools.
- [ ] There are no new console errors in the test output.
- [ ] If this PR adds a new component to Storybook, it ensures the component is fully responsive, OR if it is intentionally not, a wrapping div using the `officeApp` class or custom `min-width` styling is used to hide any states the would not be visible to the user.

### Backend

- [ ] Code follows the guidelines for [Logging](https://transcom.github.io/mymove-docs/docs/about/development/logging).
- [ ] The requirements listed in [Querying the Database Safely](https://transcom.github.io/mymove-docs/docs/backend/guides/golang-guide#querying-the-database-safely) have been satisfied.

### Database

#### Any new migrations/schema changes:

- [ ] Follows our guidelines for [Zero-Downtime Deploys](https://transcom.github.io/mymove-docs/docs/backend/setup/database-migrations#zero-downtime-migrations).
- [ ] Have been communicated to #g-database.
- [ ] Secure migrations have been tested following the instructions in our [docs](https://transcom.github.io/mymove-docs/docs/backend/setup/database-migrations#secure-migrations).

## Screenshots
<img width="2032" alt="image" src="https://github.com/transcom/mymove/assets/4325613/8b84cce1-c829-4c76-881f-32e95ab14d0a">
