### PR TITLE
MB-15521 Allow Services Counselors to delete their own support remarks

### DIFF
--- a/src/pages/Office/ServicesCounselorCustomerSupportRemarks/ServicesCounselorCustomerSupportRemarks.jsx
+++ b/src/pages/Office/ServicesCounselorCustomerSupportRemarks/ServicesCounselorCustomerSupportRemarks.jsx
@@ -1,13 +1,18 @@
-import React from 'react';
+import React, { useState } from 'react';
 import 'styles/office.scss';
 import { GridContainer, Grid } from '@trussworks/react-uswds';
 import { useParams } from 'react-router-dom';
 import classnames from 'classnames';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 
 import styles from '../TXOMoveInfo/TXOTab.module.scss';
+import Alert from '../../../shared/Alert';
 
 import customerSupportRemarkStyles from './ServicesCounselorCustomerSupportRemarks.module.scss';
 
+import { deleteCustomerSupportRemark } from 'services/ghcApi';
+import { CUSTOMER_SUPPORT_REMARKS } from 'constants/queryKeys';
+import ConnectedDeleteCustomerSupportRemarkConfirmationModal from 'components/ConfirmationModals/DeleteCustomerSupportRemarkConfirmationModal';
 import { useCustomerSupportRemarksQueries } from 'hooks/queries';
 import LoadingPlaceholder from 'shared/LoadingPlaceholder';
 import SomethingWentWrong from 'shared/SomethingWentWrong';
@@ -16,47 +21,71 @@ import CustomerSupportRemarkForm from 'components/Office/CustomerSupportRemarkFo
 
 const ServicesCounselorCustomerSupportRemarks = () => {
   const { moveCode } = useParams();
+  const [showDeletionSuccess, setShowDeletionSuccess] = useState(false);
+  const [customerSupportRemarkIDToDelete, setCustomerSupportRemarkIDToDelete] = useState(null);
   const { customerSupportRemarks, isLoading, isError } = useCustomerSupportRemarksQueries(moveCode);
+  const queryClient = useQueryClient();
+  const { mutate: deleteCustomerSupportRemarkMutation } = useMutation(deleteCustomerSupportRemark, {
+    onSuccess: async () => {
+      await queryClient.invalidateQueries([CUSTOMER_SUPPORT_REMARKS, moveCode]);
+      setCustomerSupportRemarkIDToDelete(null);
+      setShowDeletionSuccess(true);
+    },
+  });
+
+  const onDelete = (remarkID) => {
+    deleteCustomerSupportRemarkMutation({ customerSupportRemarkID: remarkID });
+  };
 
   if (isLoading) return <LoadingPlaceholder />;
   if (isError) return <SomethingWentWrong />;
 
   return (
-    <div className={classnames(styles.tabContent, customerSupportRemarkStyles.customerSupportRemarksContent)}>
-      <GridContainer className={customerSupportRemarkStyles.customerSupportRemarksTitle}>
-        <Grid row>
-          <Grid col desktop={{ col: 8, offset: 2 }}>
-            <h1>Customer support remarks</h1>
+    <>
+      <ConnectedDeleteCustomerSupportRemarkConfirmationModal
+        isOpen={customerSupportRemarkIDToDelete !== null}
+        customerSupportRemarkID={customerSupportRemarkIDToDelete}
+        onClose={() => setCustomerSupportRemarkIDToDelete(null)}
+        onSubmit={onDelete}
+      />
+      <div className={classnames(styles.tabContent, customerSupportRemarkStyles.customerSupportRemarksContent)}>
+        <GridContainer className={customerSupportRemarkStyles.customerSupportRemarksTitle}>
+          <Grid row>
+            <Grid col desktop={{ col: 8, offset: 2 }}>
+              {showDeletionSuccess && <Alert type="success">Your remark has been deleted.</Alert>}
+              <h1>Customer support remarks</h1>
+            </Grid>
           </Grid>
-        </Grid>
-      </GridContainer>
-      <GridContainer>
-        <Grid row>
-          <Grid
-            className={customerSupportRemarkStyles.customerSupportRemarksContainer}
-            col
-            desktop={{ col: 8, offset: 2 }}
-          >
-            <h2>Remarks</h2>
+        </GridContainer>
+        <GridContainer>
+          <Grid row>
+            <Grid
+              className={customerSupportRemarkStyles.customerSupportRemarksContainer}
+              col
+              desktop={{ col: 8, offset: 2 }}
+            >
+              <h2>Remarks</h2>
 
-            <CustomerSupportRemarkForm />
+              <CustomerSupportRemarkForm />
 
-            <h3>Past remarks</h3>
+              <h3>Past remarks</h3>
 
-            {customerSupportRemarks.length === 0 && <p>No remarks yet.</p>}
-            {customerSupportRemarks.length > 0 &&
-              customerSupportRemarks.map((customerSupportRemark) => {
-                return (
-                  <CustomerSupportRemarkText
-                    customerSupportRemark={customerSupportRemark}
-                    key={customerSupportRemark.id}
-                  />
-                );
-              })}
+              {customerSupportRemarks.length === 0 && <p>No remarks yet.</p>}
+              {customerSupportRemarks.length > 0 &&
+                customerSupportRemarks.map((customerSupportRemark) => {
+                  return (
+                    <CustomerSupportRemarkText
+                      customerSupportRemark={customerSupportRemark}
+                      key={customerSupportRemark.id}
+                      onDelete={setCustomerSupportRemarkIDToDelete}
+                    />
+                  );
+                })}
+            </Grid>
           </Grid>
-        </Grid>
-      </GridContainer>
-    </div>
+        </GridContainer>
+      </div>
+    </>
   );
 };
 export default ServicesCounselorCustomerSupportRemarks;


### PR DESCRIPTION
## [Jira ticket](https://dp3.atlassian.net/browse/MB-15521)

## Summary

Enables Services Counselors to be able to delete their own support remarks.

[this article](tbd) explains more about the approach used.

## Verification Steps for the Author

These are to be checked by the author.

- [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
- [ ] Have the Jira acceptance criteria been met for this change?

## Verification Steps for Reviewers

These are to be checked by a reviewer.

### Setup to Run the Code

- [Instructions for starting storybook](https://transcom.github.io/mymove-docs/docs/frontend/setup/run-storybook)
- [Instructions for starting the MilMove application](https://transcom.github.io/mymove-docs/docs/about/application-setup/milmove-local-client/)
- [Instructions for running tests](https://transcom.github.io/mymove-docs/docs/about/development/testing)

### How to test

1. Access the office app as a counselor role
2. Type up a support remark
3. Delete that remark.

### Frontend

- [ ] There are no aXe warnings for UI.
- [ ] This works in [Supported Browsers and their phone views](https://transcom.github.io/mymove-docs/docs/about/supported-browsers) (Chrome, Firefox, Edge).
- [ ] There are no new console errors in the browser devtools.
- [ ] There are no new console errors in the test output.
- [ ] If this PR adds a new component to Storybook, it ensures the component is fully responsive, OR if it is intentionally not, a wrapping div using the `officeApp` class or custom `min-width` styling is used to hide any states the would not be visible to the user.

### Backend

- [ ] Code follows the guidelines for [Logging](https://transcom.github.io/mymove-docs/docs/about/development/logging).
- [ ] The requirements listed in [Querying the Database Safely](https://transcom.github.io/mymove-docs/docs/backend/guides/golang-guide#querying-the-database-safely) have been satisfied.

### Database

#### Any new migrations/schema changes:

- [ ] Follows our guidelines for [Zero-Downtime Deploys](https://transcom.github.io/mymove-docs/docs/backend/setup/database-migrations#zero-downtime-migrations).
- [ ] Have been communicated to #g-database.
- [ ] Secure migrations have been tested following the instructions in our [docs](https://transcom.github.io/mymove-docs/docs/backend/setup/database-migrations#secure-migrations).

## Screenshots
![Jun-21-2023 15-41-41](https://github.com/transcom/mymove/assets/4325613/a8392019-e91e-4b04-a02a-aed26a292008)

