### PR TITLE
MB-16399 update SITDestinationFinalAddress with approved sit address update

### DIFF
--- a/pkg/handlers/primeapi/api.go
+++ b/pkg/handlers/primeapi/api.go
@@ -43,6 +43,7 @@ func NewPrimeAPI(handlerConfig handlers.HandlerConfig) *primeoperations.MymoveAP
 	shipmentFetcher := mtoshipment.NewMTOShipmentFetcher()
 	moveWeights := move.NewMoveWeights(mtoshipment.NewShipmentReweighRequester())
 	uploadCreator := upload.NewUploadCreator(handlerConfig.FileStorer())
+	serviceItemUpdater := mtoserviceitem.NewMTOServiceItemUpdater(queryBuilder, moveRouter, shipmentFetcher, addressCreator)
 
 	paymentRequestRecalculator := paymentrequest.NewPaymentRequestRecalculator(
 		paymentrequest.NewPaymentRequestCreator(
@@ -78,7 +79,7 @@ func NewPrimeAPI(handlerConfig handlers.HandlerConfig) *primeoperations.MymoveAP
 
 	primeAPI.MtoServiceItemUpdateMTOServiceItemHandler = UpdateMTOServiceItemHandler{
 		handlerConfig,
-		mtoserviceitem.NewMTOServiceItemUpdater(builder, moveRouter, shipmentFetcher, addressCreator),
+		serviceItemUpdater,
 	}
 
 	primeAPI.MtoServiceItemCreateServiceRequestDocumentUploadHandler = CreateServiceRequestDocumentUploadHandler{
@@ -180,7 +181,7 @@ func NewPrimeAPI(handlerConfig handlers.HandlerConfig) *primeoperations.MymoveAP
 
 	primeAPI.SitAddressUpdateCreateSITAddressUpdateRequestHandler = CreateSITAddressUpdateRequestHandler{
 		handlerConfig,
-		sitaddressupdate.NewSITAddressUpdateRequestCreator(handlerConfig.HHGPlanner(), addressCreator, moveRouter),
+		sitaddressupdate.NewSITAddressUpdateRequestCreator(handlerConfig.HHGPlanner(), addressCreator, serviceItemUpdater, moveRouter),
 	}
 	return primeAPI
 }

--- a/pkg/handlers/primeapi/sit_service_item_address_update_test.go
+++ b/pkg/handlers/primeapi/sit_service_item_address_update_test.go
@@ -14,6 +14,9 @@ import (
 	routemocks "github.com/transcom/mymove/pkg/route/mocks"
 	"github.com/transcom/mymove/pkg/services/address"
 	moverouter "github.com/transcom/mymove/pkg/services/move"
+	mtoserviceitem "github.com/transcom/mymove/pkg/services/mto_service_item"
+	mtoshipment "github.com/transcom/mymove/pkg/services/mto_shipment"
+	"github.com/transcom/mymove/pkg/services/query"
 	sitaddressupdate "github.com/transcom/mymove/pkg/services/sit_address_update"
 )
 
@@ -27,7 +30,9 @@ func (suite *HandlerSuite) TestCreateSITAddressUpdateRequest() {
 	).Return(mockedDistance, nil)
 
 	moveRouter := moverouter.NewMoveRouter()
-	sitAddressUpdateCreator := sitaddressupdate.NewSITAddressUpdateRequestCreator(mockPlanner, address.NewAddressCreator(), moveRouter)
+	addressCreator := address.NewAddressCreator()
+	serviceItemUpdater := mtoserviceitem.NewMTOServiceItemUpdater(query.NewQueryBuilder(), moveRouter, mtoshipment.NewMTOShipmentFetcher(), addressCreator)
+	sitAddressUpdateCreator := sitaddressupdate.NewSITAddressUpdateRequestCreator(mockPlanner, addressCreator, serviceItemUpdater, moveRouter)
 
 	suite.Run("Success 201 - Create SIT address update request", func() {
 		// Testcase:   sitExtension is created

--- a/pkg/services/sit_address_update/sit_address_update_request_creator.go
+++ b/pkg/services/sit_address_update/sit_address_update_request_creator.go
@@ -5,22 +5,25 @@ import (
 
 	"github.com/transcom/mymove/pkg/appcontext"
 	"github.com/transcom/mymove/pkg/apperror"
+	"github.com/transcom/mymove/pkg/etag"
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/route"
 	"github.com/transcom/mymove/pkg/services"
 )
 
 type sitAddressUpdateRequestCreator struct {
-	planner        route.Planner
-	addressCreator services.AddressCreator
-	checks         []sitAddressUpdateValidator
-	moveRouter     services.MoveRouter
+	planner            route.Planner
+	addressCreator     services.AddressCreator
+	serviceItemUpdater services.MTOServiceItemUpdater
+	checks             []sitAddressUpdateValidator
+	moveRouter         services.MoveRouter
 }
 
-func NewSITAddressUpdateRequestCreator(planner route.Planner, addressCreator services.AddressCreator, moveRouter services.MoveRouter) services.SITAddressUpdateRequestCreator {
+func NewSITAddressUpdateRequestCreator(planner route.Planner, addressCreator services.AddressCreator, serviceItemUpdater services.MTOServiceItemUpdater, moveRouter services.MoveRouter) services.SITAddressUpdateRequestCreator {
 	return &sitAddressUpdateRequestCreator{
-		planner:        planner,
-		addressCreator: addressCreator,
+		planner:            planner,
+		addressCreator:     addressCreator,
+		serviceItemUpdater: serviceItemUpdater,
 		checks: []sitAddressUpdateValidator{
 			checkAndValidateRequiredFields(),
 			checkPrimeRequiredFields(),
@@ -107,6 +110,22 @@ func (f *sitAddressUpdateRequestCreator) CreateSITAddressUpdateRequest(appCtx ap
 					return err
 				}
 			}
+		} else if sitAddressUpdateRequest.Status == models.SITAddressUpdateStatusApproved {
+			var serviceItem models.MTOServiceItem
+			err := txnAppCtx.DB().Find(&serviceItem, sitAddressUpdateRequest.MTOServiceItemID)
+			if err != nil {
+				return err
+			}
+
+			serviceItem.SITDestinationFinalAddressID = &newAddress.ID
+			serviceItem.SITDestinationFinalAddress = newAddress
+
+			updatedServiceItem, err := f.serviceItemUpdater.UpdateMTOServiceItemBasic(txnAppCtx, &serviceItem, etag.GenerateEtag(serviceItem.UpdatedAt))
+			if err != nil {
+				return err
+			}
+
+			sitAddressUpdateRequest.MTOServiceItem = *updatedServiceItem
 		}
 
 		return nil

--- a/pkg/services/sit_address_update/sit_address_update_request_creator_test.go
+++ b/pkg/services/sit_address_update/sit_address_update_request_creator_test.go
@@ -10,11 +10,15 @@ import (
 	"github.com/transcom/mymove/pkg/services/address"
 	moverouter "github.com/transcom/mymove/pkg/services/move"
 	movefetcher "github.com/transcom/mymove/pkg/services/move_task_order"
+	mtoserviceitem "github.com/transcom/mymove/pkg/services/mto_service_item"
+	mtoshipment "github.com/transcom/mymove/pkg/services/mto_shipment"
+	"github.com/transcom/mymove/pkg/services/query"
 )
 
 func (suite *SITAddressUpdateServiceSuite) TestCreateSITAddressUpdateRequest() {
 	moveRouter := moverouter.NewMoveRouter()
 	addressCreator := address.NewAddressCreator()
+	serviceItemUpdater := mtoserviceitem.NewMTOServiceItemUpdater(query.NewQueryBuilder(), moveRouter, mtoshipment.NewMTOShipmentFetcher(), addressCreator)
 	requestedMockedDistance := 55
 	approvedMockedDistance := 45
 
@@ -63,7 +67,7 @@ func (suite *SITAddressUpdateServiceSuite) TestCreateSITAddressUpdateRequest() {
 			},
 		}, []factory.Trait{factory.GetTraitSITAddressUpdateWithMoveSetUp})
 
-		creator := NewSITAddressUpdateRequestCreator(mockPlanner, addressCreator, moveRouter)
+		creator := NewSITAddressUpdateRequestCreator(mockPlanner, addressCreator, serviceItemUpdater, moveRouter)
 
 		createdAddressUpdateRequest, err := creator.CreateSITAddressUpdateRequest(suite.AppContextForTest(), &sitAddressUpdate)
 
@@ -142,7 +146,7 @@ func (suite *SITAddressUpdateServiceSuite) TestCreateSITAddressUpdateRequest() {
 			},
 		}, []factory.Trait{factory.GetTraitSITAddressUpdateWithMoveSetUp})
 
-		creator := NewSITAddressUpdateRequestCreator(mockPlanner, addressCreator, moveRouter)
+		creator := NewSITAddressUpdateRequestCreator(mockPlanner, addressCreator, serviceItemUpdater, moveRouter)
 
 		createdAddressUpdateRequest, err := creator.CreateSITAddressUpdateRequest(suite.AppContextForTest(), &sitAddressUpdate)
 
@@ -160,6 +164,9 @@ func (suite *SITAddressUpdateServiceSuite) TestCreateSITAddressUpdateRequest() {
 		suite.Equal(*serviceItem.SITDestinationFinalAddressID, createdAddressUpdateRequest.OldAddressID)
 		suite.Equal(serviceItem.SITDestinationFinalAddress.StreetAddress1, createdAddressUpdateRequest.OldAddress.StreetAddress1)
 		suite.Equal(serviceItem.SITDestinationFinalAddress.PostalCode, createdAddressUpdateRequest.OldAddress.PostalCode)
+		sitDestinationFinalAddress := *createdAddressUpdateRequest.MTOServiceItem.SITDestinationFinalAddress
+		suite.Equal(createdAddressUpdateRequest.NewAddress.StreetAddress1, sitDestinationFinalAddress.StreetAddress1)
+		suite.Equal(createdAddressUpdateRequest.NewAddress.PostalCode, sitDestinationFinalAddress.PostalCode)
 
 		// Contractor Remarks should match
 		suite.Equal(*sitAddressUpdate.ContractorRemarks, *createdAddressUpdateRequest.ContractorRemarks)
@@ -210,7 +217,7 @@ func (suite *SITAddressUpdateServiceSuite) TestCreateSITAddressUpdateRequest() {
 			},
 		}, []factory.Trait{factory.GetTraitSITAddressUpdateWithMoveSetUp})
 
-		creator := NewSITAddressUpdateRequestCreator(mockPlanner, addressCreator, moveRouter)
+		creator := NewSITAddressUpdateRequestCreator(mockPlanner, addressCreator, serviceItemUpdater, moveRouter)
 
 		createdAddressUpdateRequest, err := creator.CreateSITAddressUpdateRequest(suite.AppContextForTest(), &sitAddressUpdate)
 
@@ -259,7 +266,7 @@ func (suite *SITAddressUpdateServiceSuite) TestCreateSITAddressUpdateRequest() {
 			},
 		}, []factory.Trait{factory.GetTraitSITAddressUpdateWithMoveSetUp})
 
-		creator := NewSITAddressUpdateRequestCreator(mockPlanner, addressCreator, moveRouter)
+		creator := NewSITAddressUpdateRequestCreator(mockPlanner, addressCreator, serviceItemUpdater, moveRouter)
 
 		createdAddressUpdateRequest, err := creator.CreateSITAddressUpdateRequest(suite.AppContextForTest(), &sitAddressUpdate)
 


### PR DESCRIPTION
## [Jira ticket](https://dp3.atlassian.net/browse/MB-16399)

## Summary

This ticket updates the `SITDestinationFinalAddress` on the service item when the prime creates an auto-approved sit address update

## Verification Steps for the Author

These are to be checked by the author.

- [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
- [ ] Have the Jira acceptance criteria been met for this change?

## Verification Steps for Reviewers

These are to be checked by a reviewer.

### Setup to Run the Code

- [Instructions for starting storybook](https://transcom.github.io/mymove-docs/docs/frontend/setup/run-storybook)
- [Instructions for starting the MilMove application](https://transcom.github.io/mymove-docs/docs/about/application-setup/milmove-local-client/)
- [Instructions for running tests](https://transcom.github.io/mymove-docs/docs/about/development/testing)

### How to test

1. Run `make db_dev_e2e_populate`
2. Find the `DDDSIT` service item ID for move `SITUP1`
3. make a `POST` request to `https://primelocal:9443/prime/v1/sit-address-updates` with this body
```
{
  "newAddress": {
    "streetAddress1": "7 Q St",
    "city": "Beverly Hills",
    "state": "CA",
    "postalCode": "90210"
  },
  "contractorRemarks": "test remarks",
  "mtoServiceItemID": {service_item_id}
}
```
4. Look at move `SITUP1` again and verify that the `SITDestinationFinalAddress` matches `newAddress`

### Backend

- [ ] Code follows the guidelines for [Logging](https://transcom.github.io/mymove-docs/docs/about/development/logging).
- [ ] The requirements listed in [Querying the Database Safely](https://transcom.github.io/mymove-docs/docs/backend/guides/golang-guide#querying-the-database-safely) have been satisfied.

