### PR TITLE
[MB-16412] Add orders nil checks in EDI 858 generation and additional logging fo…

### DIFF
--- a/pkg/services/invoice/ghc_payment_request_invoice_generator.go
+++ b/pkg/services/invoice/ghc_payment_request_invoice_generator.go
@@ -498,6 +498,14 @@ func (g ghcPaymentRequestInvoiceGenerator) createOriginAndDestinationSegments(ap
 		return apperror.NewConflictError(orders.ID, "Invalid Order, must have OriginDutyLocation")
 	}
 
+	if orders.ServiceMember.Affiliation == nil {
+		return apperror.NewInvalidInputError(orders.ID, fmt.Errorf("service member is missing an affiliation"), nil, "service member affiliation is required")
+	}
+
+	if orders.OriginDutyLocationGBLOC == nil {
+		return apperror.NewInvalidInputError(orders.ID, fmt.Errorf("origin duty location GBLOC value is missing"), nil, "origin duty location GBLOC is required")
+	}
+
 	header.OriginName = edisegment.N1{
 		EntityIdentifierCode:        "SF",
 		Name:                        originDutyLocation.Name,

--- a/pkg/services/payment_request/payment_request_reviewed_processor.go
+++ b/pkg/services/payment_request/payment_request_reviewed_processor.go
@@ -91,6 +91,10 @@ func (p *paymentRequestReviewedProcessor) ProcessAndLockReviewedPR(appCtx appcon
 			return fmt.Errorf("failure retrieving payment request with ID: %s. Err: %w", pr.ID, err)
 		}
 
+		appCtx.Logger().Info("processing locked payment request",
+			zap.String("paymentRequestID", pr.ID.String()),
+			zap.String("moveTaskOrderID", pr.MoveTaskOrderID.String()))
+
 		// generate EDI file
 		var edi858c ediinvoice.Invoice858C
 		edi858c, err = p.ediGenerator.Generate(txnAppCtx, lockedPR, false)
@@ -218,6 +222,7 @@ func (p *paymentRequestReviewedProcessor) ProcessReviewedPaymentRequest(appCtx a
 		return
 	}
 
+	logger.Info("preparing to process reviewed payment requests for send to Syncada", zap.Int("reviewedPaymentRequestCount", len(reviewedPaymentRequests)))
 	// Send all reviewed payment request to Syncada
 	for _, pr := range reviewedPaymentRequests {
 		err := p.ProcessAndLockReviewedPR(appCtx, pr)


### PR DESCRIPTION
…r PRs being processeed

## [Jira ticket](https://dp3.atlassian.net/browse/MB-16412)

## Summary

We were being told that our EDI 858 invoices were not making it to US Bank for recently reviewed payment requests.  Upon research the last successful submission I could find was from June 7th in our staging logs.  Eventually I came across a nil pointer panic around including orders data.  It's likely a move got into a bad state or was a very old move on staging that a payment request was created for and it was missing what is required data.

It was too difficult to identify the exact payment request because a panic was preventing the whole EDI processing task from logging informational logs and errors.

This PR adds some nil checks and logging so we can better understand which payment request might be blocking in the future as well as know how large our reviewed payment request queue is if it backs up.

https://ustcdp3.slack.com/archives/C04PL9ZLHFD/p1687379579150089

## Verification Steps for the Author

These are to be checked by the author.

- [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
- [ ] Have the Jira acceptance criteria been met for this change?

## Verification Steps for Reviewers

These are to be checked by a reviewer.

### Setup to Run the Code

- [Instructions for starting storybook](https://transcom.github.io/mymove-docs/docs/frontend/setup/run-storybook)
- [Instructions for starting the MilMove application](https://transcom.github.io/mymove-docs/docs/about/application-setup/milmove-local-client/)
- [Instructions for running tests](https://transcom.github.io/mymove-docs/docs/about/development/testing)

### How to test

1. Access the
2. Login as a
3.

### Frontend

- [ ] There are no aXe warnings for UI.
- [ ] This works in [Supported Browsers and their phone views](https://transcom.github.io/mymove-docs/docs/about/supported-browsers) (Chrome, Firefox, Edge).
- [ ] There are no new console errors in the browser devtools.
- [ ] There are no new console errors in the test output.
- [ ] If this PR adds a new component to Storybook, it ensures the component is fully responsive, OR if it is intentionally not, a wrapping div using the `officeApp` class or custom `min-width` styling is used to hide any states the would not be visible to the user.

### Backend

- [ ] Code follows the guidelines for [Logging](https://transcom.github.io/mymove-docs/docs/about/development/logging).
- [ ] The requirements listed in [Querying the Database Safely](https://transcom.github.io/mymove-docs/docs/backend/guides/golang-guide#querying-the-database-safely) have been satisfied.

### Database

#### Any new migrations/schema changes:

- [ ] Follows our guidelines for [Zero-Downtime Deploys](https://transcom.github.io/mymove-docs/docs/backend/setup/database-migrations#zero-downtime-migrations).
- [ ] Have been communicated to #g-database.
- [ ] Secure migrations have been tested following the instructions in our [docs](https://transcom.github.io/mymove-docs/docs/backend/setup/database-migrations#secure-migrations).

## Screenshots

![Screenshot 2023-06-22 at 4 19 19 PM](https://github.com/transcom/mymove/assets/52669884/ab7375ec-34e1-4b37-b1f5-17f9dba4267c)