### PR TITLE
[MB-16412] hoist nil check to cover multiple edi sections where orders GBLOC omi…

### DIFF
--- a/pkg/services/invoice/ghc_payment_request_invoice_generator.go
+++ b/pkg/services/invoice/ghc_payment_request_invoice_generator.go
@@ -240,6 +240,10 @@ func (g ghcPaymentRequestInvoiceGenerator) Generate(appCtx appcontext.AppContext
 		}
 	}
 
+	if moveTaskOrder.Orders.OriginDutyLocationGBLOC == nil {
+		return ediinvoice.Invoice858C{}, apperror.NewInvalidInputError(moveTaskOrder.OrdersID, fmt.Errorf("origin duty location GBLOC value is missing"), nil, "origin duty location GBLOC is required")
+	}
+
 	// Add buyer and seller organization names
 	err = g.createBuyerAndSellerOrganizationNamesSegments(appCtx, paymentRequest.ID, moveTaskOrder.Orders, &edi858.Header)
 	if err != nil {
@@ -496,14 +500,6 @@ func (g ghcPaymentRequestInvoiceGenerator) createOriginAndDestinationSegments(ap
 		}
 	} else {
 		return apperror.NewConflictError(orders.ID, "Invalid Order, must have OriginDutyLocation")
-	}
-
-	if orders.ServiceMember.Affiliation == nil {
-		return apperror.NewInvalidInputError(orders.ID, fmt.Errorf("service member is missing an affiliation"), nil, "service member affiliation is required")
-	}
-
-	if orders.OriginDutyLocationGBLOC == nil {
-		return apperror.NewInvalidInputError(orders.ID, fmt.Errorf("origin duty location GBLOC value is missing"), nil, "origin duty location GBLOC is required")
 	}
 
 	header.OriginName = edisegment.N1{

--- a/pkg/services/invoice/ghc_payment_request_invoice_generator_test.go
+++ b/pkg/services/invoice/ghc_payment_request_invoice_generator_test.go
@@ -1144,6 +1144,17 @@ func (suite *GHCInvoiceSuite) TestNilValues() {
 		nilPaymentRequest.MoveTaskOrder.Orders.TAC = oldTAC
 	})
 
+	suite.Run("nil originDutyLocationGBLOC returns error", func() {
+		setupTestData()
+		oldGBLOC := nilPaymentRequest.MoveTaskOrder.Orders.OriginDutyLocationGBLOC
+		nilPaymentRequest.MoveTaskOrder.Orders.OriginDutyLocationGBLOC = nil
+		_, err := generator.Generate(suite.AppContextForTest(), nilPaymentRequest, false)
+		suite.Error(err)
+		suite.IsType(apperror.InvalidInputError{}, err)
+		suite.Equal("origin duty location GBLOC is required", err.Error())
+		nilPaymentRequest.MoveTaskOrder.Orders.OriginDutyLocationGBLOC = oldGBLOC
+	})
+
 	suite.Run("nil country for NewDutyLocation does not cause panic", func() {
 		setupTestData()
 		oldCountry := nilPaymentRequest.MoveTaskOrder.Orders.NewDutyLocation.Address.Country


### PR DESCRIPTION
…ssion would result in panic

## [Jira ticket](https://dp3.atlassian.net/browse/MB-16412)

## Summary

Successor to prior change to checking for a nil origin duty location GBLOC, we needed to move the check above multiple sections in the EDI generator file https://github.com/transcom/mymove/pull/10950.  I removed the affiliation nil check because it looks like that already is happening elsewhere up the chain.

Also now there is a test to confirm an error is returned instead of a panic.

## Verification Steps for the Author

These are to be checked by the author.

- [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
- [ ] Have the Jira acceptance criteria been met for this change?

## Verification Steps for Reviewers

These are to be checked by a reviewer.

### Setup to Run the Code

- [Instructions for starting storybook](https://transcom.github.io/mymove-docs/docs/frontend/setup/run-storybook)
- [Instructions for starting the MilMove application](https://transcom.github.io/mymove-docs/docs/about/application-setup/milmove-local-client/)
- [Instructions for running tests](https://transcom.github.io/mymove-docs/docs/about/development/testing)

### How to test

1. From the Prime support API we can trigger the process edis task to process all reviewed payment requests waiting to be sent to Syncada.

```
//reviewed_payment_requests.json
{
     "body": {
         "deleteFromSyncada": true,
         "readFromSyncada": false,
         "sendToSyncada": true,
     }
}
```

```prime-api-client --cac --hostname api.stg.move.mil --port 443 support-reviewed-payment-requests --filename reviewed_payment_requests.json```

### Frontend

- [ ] There are no aXe warnings for UI.
- [ ] This works in [Supported Browsers and their phone views](https://transcom.github.io/mymove-docs/docs/about/supported-browsers) (Chrome, Firefox, Edge).
- [ ] There are no new console errors in the browser devtools.
- [ ] There are no new console errors in the test output.
- [ ] If this PR adds a new component to Storybook, it ensures the component is fully responsive, OR if it is intentionally not, a wrapping div using the `officeApp` class or custom `min-width` styling is used to hide any states the would not be visible to the user.

### Backend

- [ ] Code follows the guidelines for [Logging](https://transcom.github.io/mymove-docs/docs/about/development/logging).
- [ ] The requirements listed in [Querying the Database Safely](https://transcom.github.io/mymove-docs/docs/backend/guides/golang-guide#querying-the-database-safely) have been satisfied.

### Database

#### Any new migrations/schema changes:

- [ ] Follows our guidelines for [Zero-Downtime Deploys](https://transcom.github.io/mymove-docs/docs/backend/setup/database-migrations#zero-downtime-migrations).
- [ ] Have been communicated to #g-database.
- [ ] Secure migrations have been tested following the instructions in our [docs](https://transcom.github.io/mymove-docs/docs/backend/setup/database-migrations#secure-migrations).

## Screenshots

![Screenshot 2023-06-23 at 12 59 02 PM](https://github.com/transcom/mymove/assets/52669884/dc810ddf-b51b-4c56-a9e9-5424ad89d2fe)