### PR TITLE
MB-16219 Allow address customization in shipment_address_update

### DIFF
--- a/pkg/factory/shared.go
+++ b/pkg/factory/shared.go
@@ -164,6 +164,8 @@ type addressGroup struct {
 	SITDestinationFinalAddress    CustomType
 	SITDestinationOriginalAddress CustomType
 	W2Address                     CustomType
+	OriginalAddress               CustomType
+	NewAddress                    CustomType
 }
 
 // Addresses is the struct to access the various fields externally
@@ -183,6 +185,8 @@ var Addresses = addressGroup{
 	SITDestinationFinalAddress:    "SITDestinationFinalAddress",
 	SITDestinationOriginalAddress: "SITDestinationOriginalAddress",
 	W2Address:                     "W2Address",
+	OriginalAddress:               "OriginalAddress",
+	NewAddress:                    "NewAddress",
 }
 
 // dimensionGroup is a grouping of all the Dimension related fields

--- a/pkg/factory/shipment_address_update_factory.go
+++ b/pkg/factory/shipment_address_update_factory.go
@@ -26,9 +26,23 @@ func BuildShipmentAddressUpdate(db *pop.Connection, customs []Customization, tra
 		}
 	}
 
-	// Create orig/new addresses
-	originalAddress := BuildAddress(db, customs, traits)
-	newAddress := BuildAddress(db, customs, traits)
+	// Find Original Address Customizations
+	tempOrigAddressCustoms := customs
+	validOrigCustoms := findValidCustomization(customs, Addresses.OriginalAddress)
+	if validOrigCustoms != nil {
+		tempOrigAddressCustoms = convertCustomizationInList(tempOrigAddressCustoms, Addresses.OriginalAddress, Address)
+	}
+	// Create Original Address
+	originalAddress := BuildAddress(db, tempOrigAddressCustoms, traits)
+
+	// Find New Address Customizations
+	tempNewAddressCustoms := customs
+	validNewCustoms := findValidCustomization(customs, Addresses.NewAddress)
+	if validNewCustoms != nil {
+		tempNewAddressCustoms = convertCustomizationInList(tempNewAddressCustoms, Addresses.NewAddress, Address)
+	}
+	// Create New Address
+	newAddress := BuildAddress(db, tempNewAddressCustoms, traits)
 
 	shipmentAddressUpdate := models.ShipmentAddressUpdate{
 		ID:                uuid.Must(uuid.NewV4()),
@@ -76,6 +90,15 @@ func GetTraitShipmentAddressUpdateRequested() []Customization {
 				Status: models.MTOShipmentStatusApproved,
 			},
 		},
+		{
+			Model: models.Address{
+				StreetAddress1: "1234 Any Avenue",
+				City:           "Des Moines",
+				State:          "IA",
+				PostalCode:     "50309",
+			},
+			Type: &Addresses.NewAddress,
+		},
 	}
 }
 
@@ -97,6 +120,15 @@ func GetTraitShipmentAddressUpdateApproved() []Customization {
 				Status: models.MTOShipmentStatusApproved,
 			},
 		},
+		{
+			Model: models.Address{
+				StreetAddress1: "5678 Some Avenue",
+				City:           "Des Moines",
+				State:          "IA",
+				PostalCode:     "50309",
+			},
+			Type: &Addresses.NewAddress,
+		},
 	}
 }
 
@@ -117,6 +149,15 @@ func GetTraitShipmentAddressUpdateRejected() []Customization {
 			Model: models.MTOShipment{
 				Status: models.MTOShipmentStatusApproved,
 			},
+		},
+		{
+			Model: models.Address{
+				StreetAddress1: "9012 Some Avenue",
+				City:           "Des Moines",
+				State:          "IA",
+				PostalCode:     "50309",
+			},
+			Type: &Addresses.NewAddress,
 		},
 	}
 }


### PR DESCRIPTION
## [Jira ticket](https://dp3.atlassian.net/browse/MB-16219)

## Summary
This brief PR adds the ability to customize the two addresses associated with a shipment_address_update. It also makes use of this functionality to ensure the original and new addresses differ from one another in the shipment_address_updates created by the factory (devseed). 

## To Validate

1. Run `make db_dev_fresh` and ensure there are no errors
2. Look in the database to ensure the new and original addresses assiocated with a shipment_address_update are different from one another. You can use the below query to ensure the postal_codes differ:

```SQL
SELECT oa.postal_code, na.postal_code FROM shipment_address_updates sau
	Left Join addresses na on sau.new_address_id = na.id
	Left Join addresses oa on sau.original_address_id = oa.id
```
<img width="918" alt="Screenshot 2023-06-26 at 9 34 04 AM" src="https://github.com/transcom/mymove/assets/62263329/30daf54f-9934-4553-b103-ef348056c964">
