### PR TITLE
Fix coverage saving on main

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -298,6 +298,11 @@ commands:
             echo "export TLS_CA=$PRD_MOVE_MIL_DOD_TLS_CA" >> $BASH_ENV
             source $BASH_ENV
   aws_vars_transcom_gov_dev:
+    parameters:
+      when:
+        description: when to run
+        type: string
+        default: on_success
     steps:
       - run:
           name: 'Setting up AWS environment variables for gov-dev env'
@@ -307,6 +312,7 @@ commands:
             echo "export AWS_ACCESS_KEY_ID=$GOV_DEV_ACCESS_KEY_ID" >> $BASH_ENV
             echo "export AWS_SECRET_ACCESS_KEY=$GOV_DEV_SECRET_KEY" >> $BASH_ENV
             source $BASH_ENV
+          when: << parameters.when >>
   tls_vars_gov_dev:
     steps:
       - run:
@@ -1397,6 +1403,8 @@ jobs:
                   mkdir -p ~/transcom/mymove/tmp/baseline-go-coverage
                   cp ~/transcom/mymove/tmp/test-results/gotest/app/go-coverage.txt \
                         ~/transcom/mymove/tmp/baseline-go-coverage/go-coverage.txt
+
+                when: always
             # ##### NOTE: Make sure this key prefix matches the one
             # ##### below above
             #
@@ -1406,7 +1414,9 @@ jobs:
                 key: v6-server-tests-coverage-{{ .BuildNum }}
                 paths:
                   - ~/transcom/mymove/tmp/baseline-go-coverage
-            - aws_vars_transcom_gov_dev
+                when: always
+            - aws_vars_transcom_gov_dev:
+                when: always
             - run:
                 name: 'Record server coverage stats'
                 command: |
@@ -1417,6 +1427,7 @@ jobs:
                   --namespace circleci \
                   --value "${coverage}" \
                   --timestamp "${timestamp}"
+                when: always
 
   # `client_test` runs the client side Javascript tests
   client_test:
@@ -1483,7 +1494,6 @@ jobs:
           condition:
             and:
               - equal: [main, << pipeline.git.branch >>]
-              - when: always
           steps:
             - run:
                 name: 'Copy coverage to baseline'
@@ -1491,6 +1501,7 @@ jobs:
                   mkdir -p ~/transcom/mymove/tmp/baseline-jest-coverage
                   cp ~/transcom/mymove/coverage/clover.xml \
                         ~/transcom/mymove/tmp/baseline-jest-coverage/clover.xml
+                when: always
             # ##### NOTE: Make sure this key prefix matches the one
             # ##### above
             #
@@ -1500,7 +1511,9 @@ jobs:
                 key: v5-client-tests-coverage-{{ .BuildNum }}
                 paths:
                   - ~/transcom/mymove/tmp/baseline-jest-coverage
-            - aws_vars_transcom_gov_dev
+                when: always
+            - aws_vars_transcom_gov_dev:
+                when: always
             - run:
                 name: 'Record client coverage stats'
                 command: |
@@ -1511,9 +1524,7 @@ jobs:
                   --namespace circleci \
                   --value "${coverage}" \
                   --timestamp "${timestamp}"
-
-
-
+                when: always
 
   # Compile the server side of the app once and persist the relevant
   # build artifacts to the workspace.


### PR DESCRIPTION
## Summary

Update the CircleCI config to always save the coverage cache on main

## Verification Steps for the Author

* This was tested on this [branch first](https://app.circleci.com/pipelines/github/transcom/mymove/54567/workflows/733ca4f3-267e-4268-9eba-df6f6b39f603/jobs/923465)

### How to test

This change is entirely in CircleCI

