### PR TITLE
Refactor RoutingConfig to store CSRFMiddleware

### DIFF
--- a/cmd/milmove/serve.go
+++ b/cmd/milmove/serve.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"crypto/tls"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"log"
@@ -440,10 +441,14 @@ func initializeRouteOptions(v *viper.Viper, routingConfig *routing.Config) {
 		routingConfig.GHCSwaggerPath = v.GetString(cli.GHCSwaggerFlag)
 	}
 	routingConfig.ServeDevlocalAuth = v.GetBool(cli.DevlocalAuthFlag)
-	routingConfig.CSRFAuthKey = v.GetString(cli.CSRFAuthKeyFlag)
 
 	routingConfig.GitBranch = gitBranch
 	routingConfig.GitCommit = gitCommit
+
+	csrfAuthKey, err := hex.DecodeString(v.GetString(cli.CSRFAuthKeyFlag))
+	if err == nil {
+		routingConfig.CSRFMiddleware = routing.InitCSRFMiddlware(csrfAuthKey, routingConfig.HandlerConfig.UseSecureCookie(), "/", auth.GorillaCSRFToken)
+	}
 }
 
 func buildRoutingConfig(appCtx appcontext.AppContext, v *viper.Viper, redisPool *redis.Pool, awsSession *awssession.Session, isDevOrTest bool, tlsConfig *tls.Config) *routing.Config {

--- a/pkg/handlers/routing/base_routing_suite.go
+++ b/pkg/handlers/routing/base_routing_suite.go
@@ -9,6 +9,7 @@ import (
 	"path"
 	"time"
 
+	"github.com/gorilla/csrf"
 	"github.com/spf13/afero"
 
 	"github.com/transcom/mymove/pkg/auth"
@@ -70,6 +71,10 @@ func (suite *BaseRoutingSuite) RoutingConfig() *Config {
 	_, err = f.Write([]byte(suite.indexContent))
 	suite.FatalNoError(err)
 
+	// make a fake csrf auth key that would be completely insecure for
+	// real world usage
+	fakeCsrfAuthKey := make([]byte, 32)
+
 	suite.routingConfig = &Config{
 		FileSystem:    fakeFs,
 		HandlerConfig: handlerConfig,
@@ -87,6 +92,8 @@ func (suite *BaseRoutingSuite) RoutingConfig() *Config {
 		ServeGHC:            true,
 		ServeDevlocalAuth:   true,
 		ServeOrders:         true,
+
+		CSRFMiddleware: InitCSRFMiddlware(fakeCsrfAuthKey, false, "/", auth.GorillaCSRFToken),
 
 		// note that enabling devlocal auth also enables accessing the
 		// Prime API without requiring mTLS. See
@@ -147,8 +154,20 @@ func (suite *BaseRoutingSuite) setupRequestSession(req *http.Request, user model
 	}
 	cookie.Expires = time.Unix(1, 0)
 	cookie.MaxAge = -1
+	req.AddCookie(cookie)
 
-	req.Header.Add("cookie", cookie.String())
+	// set up CSRF cookie and headers
+	maskedToken := ""
+	tokenHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		maskedToken = csrf.Token(r)
+	})
+	fakeReq := httptest.NewRequest("GET", "/", nil)
+	rr := httptest.NewRecorder()
+	suite.routingConfig.CSRFMiddleware(tokenHandler).ServeHTTP(rr, fakeReq)
+	for _, cookie := range rr.Result().Cookies() {
+		req.AddCookie(cookie)
+	}
+	req.Header.Set("X-CSRF-Token", maskedToken)
 }
 
 func (suite *BaseRoutingSuite) SetupAdminRequestSession(req *http.Request, adminUser models.AdminUser) {

--- a/pkg/handlers/routing/routing_init.go
+++ b/pkg/handlers/routing/routing_init.go
@@ -1,7 +1,8 @@
 package routing
 
 import (
-	"encoding/hex"
+	"errors"
+	"fmt"
 	"net/http"
 	"net/http/pprof"
 	"path"
@@ -25,6 +26,7 @@ import (
 	"github.com/transcom/mymove/pkg/handlers/primeapi"
 	"github.com/transcom/mymove/pkg/handlers/supportapi"
 	"github.com/transcom/mymove/pkg/handlers/testharnessapi"
+	"github.com/transcom/mymove/pkg/logging"
 	"github.com/transcom/mymove/pkg/middleware"
 	"github.com/transcom/mymove/pkg/storage"
 	"github.com/transcom/mymove/pkg/telemetry"
@@ -52,9 +54,6 @@ type Config struct {
 
 	// What is the maximum body size that should be accepted?
 	MaxBodySize int64
-
-	// To prevent CSRF, configure a authentication key
-	CSRFAuthKey string
 
 	// Should the swagger ui be served? Generally only enabled in development
 	ServeSwaggerUI bool
@@ -104,6 +103,27 @@ type Config struct {
 	// The git branch and commit used when building this server
 	GitBranch string
 	GitCommit string
+
+	// To prevent CSRF, configure a CSRF Middlware
+	// Configuring it here lets us re-use it / override it effectively
+	// in tests
+	CSRFMiddleware func(http.Handler) http.Handler
+}
+
+func InitCSRFMiddlware(csrfAuthKey []byte, secure bool, path string, cookieName string) func(http.Handler) http.Handler {
+	return csrf.Protect(csrfAuthKey,
+		csrf.Secure(secure),
+		csrf.Path(path),
+		csrf.CookieName(cookieName),
+		csrf.ErrorHandler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			reason := csrf.FailureReason(r)
+			logger := logging.FromContext(r.Context())
+			logger.Info("Request forbidden by CSRF Middleware", zap.String("reason", reason.Error()))
+			http.Error(w, fmt.Sprintf("%s - %s",
+				http.StatusText(http.StatusForbidden), reason),
+				http.StatusForbidden)
+		})),
+	)
 }
 
 // InitRouting sets up the routing
@@ -301,13 +321,11 @@ func InitRouting(appCtx appcontext.AppContext, redisPool *redis.Pool,
 		debug.HandleFunc("/", http.NotFound).Methods("GET")
 	}
 
-	// CSRF path is set specifically at the root to avoid duplicate tokens from different paths
-	csrfAuthKey, err := hex.DecodeString(routingConfig.CSRFAuthKey)
-	if err != nil {
-		appCtx.Logger().Fatal("Failed to decode csrf auth key", zap.Error(err))
+	if routingConfig.CSRFMiddleware == nil {
+		return nil, errors.New("Missing CSRF Middleware")
 	}
 	appCtx.Logger().Info("Enabling CSRF protection")
-	root.Use(csrf.Protect(csrfAuthKey, csrf.Secure(routingConfig.HandlerConfig.UseSecureCookie()), csrf.Path("/"), csrf.CookieName(auth.GorillaCSRFToken)))
+	root.Use(routingConfig.CSRFMiddleware)
 	root.Use(maskedCSRFMiddleware)
 
 	site.Host(routingConfig.HandlerConfig.AppNames().MilServername).PathPrefix("/").


### PR DESCRIPTION
* This allows the base routing suite of tests to re-use the csrf middleware cookie store for faking requests
* Override the default CSRF unauthorized handler to log if the request is forbidden.
* Update the UploadAmendedOrders test to use these new features
