### PR TITLE
Mv/mb 13693/revisiting sit display

### DIFF
--- a/pkg/gen/ghcapi/embedded_spec.go
+++ b/pkg/gen/ghcapi/embedded_spec.go
@@ -8383,32 +8383,37 @@ func init() {
     },
     "SITStatus": {
       "properties": {
-        "daysInSIT": {
-          "type": "integer"
-        },
-        "location": {
-          "enum": [
-            "ORIGIN",
-            "DESTINATION"
-          ]
+        "currentSIT": {
+          "type": "object",
+          "properties": {
+            "daysInSIT": {
+              "type": "integer"
+            },
+            "location": {
+              "enum": [
+                "ORIGIN",
+                "DESTINATION"
+              ]
+            },
+            "sitAllowanceEndDate": {
+              "type": "string",
+              "format": "date",
+              "x-nullable": true
+            },
+            "sitDepartureDate": {
+              "type": "string",
+              "format": "date",
+              "x-nullable": true
+            },
+            "sitEntryDate": {
+              "type": "string",
+              "format": "date",
+              "x-nullable": true
+            }
+          }
         },
         "pastSITServiceItems": {
           "$ref": "#/definitions/MTOServiceItems"
-        },
-        "sitAllowanceEndDate": {
-          "type": "string",
-          "format": "date",
-          "x-nullable": true
-        },
-        "sitDepartureDate": {
-          "type": "string",
-          "format": "date",
-          "x-nullable": true
-        },
-        "sitEntryDate": {
-          "type": "string",
-          "format": "date",
-          "x-nullable": true
         },
         "totalDaysRemaining": {
           "type": "integer"
@@ -19389,6 +19394,52 @@ func init() {
     },
     "SITStatus": {
       "properties": {
+        "currentSIT": {
+          "type": "object",
+          "properties": {
+            "daysInSIT": {
+              "type": "integer",
+              "minimum": 0
+            },
+            "location": {
+              "enum": [
+                "ORIGIN",
+                "DESTINATION"
+              ]
+            },
+            "sitAllowanceEndDate": {
+              "type": "string",
+              "format": "date",
+              "x-nullable": true
+            },
+            "sitDepartureDate": {
+              "type": "string",
+              "format": "date",
+              "x-nullable": true
+            },
+            "sitEntryDate": {
+              "type": "string",
+              "format": "date",
+              "x-nullable": true
+            }
+          }
+        },
+        "pastSITServiceItems": {
+          "$ref": "#/definitions/MTOServiceItems"
+        },
+        "totalDaysRemaining": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "totalSITDaysUsed": {
+          "type": "integer",
+          "minimum": 0
+        }
+      }
+    },
+    "SITStatusCurrentSIT": {
+      "type": "object",
+      "properties": {
         "daysInSIT": {
           "type": "integer",
           "minimum": 0
@@ -19398,9 +19449,6 @@ func init() {
             "ORIGIN",
             "DESTINATION"
           ]
-        },
-        "pastSITServiceItems": {
-          "$ref": "#/definitions/MTOServiceItems"
         },
         "sitAllowanceEndDate": {
           "type": "string",
@@ -19416,14 +19464,6 @@ func init() {
           "type": "string",
           "format": "date",
           "x-nullable": true
-        },
-        "totalDaysRemaining": {
-          "type": "integer",
-          "minimum": 0
-        },
-        "totalSITDaysUsed": {
-          "type": "integer",
-          "minimum": 0
         }
       }
     },

--- a/pkg/gen/ghcmessages/s_i_t_status.go
+++ b/pkg/gen/ghcmessages/s_i_t_status.go
@@ -19,28 +19,11 @@ import (
 // swagger:model SITStatus
 type SITStatus struct {
 
-	// days in s i t
-	// Minimum: 0
-	DaysInSIT *int64 `json:"daysInSIT,omitempty"`
-
-	// location
-	// Enum: [ORIGIN DESTINATION]
-	Location interface{} `json:"location,omitempty"`
+	// current s i t
+	CurrentSIT *SITStatusCurrentSIT `json:"currentSIT,omitempty"`
 
 	// past s i t service items
 	PastSITServiceItems MTOServiceItems `json:"pastSITServiceItems,omitempty"`
-
-	// sit allowance end date
-	// Format: date
-	SitAllowanceEndDate *strfmt.Date `json:"sitAllowanceEndDate,omitempty"`
-
-	// sit departure date
-	// Format: date
-	SitDepartureDate *strfmt.Date `json:"sitDepartureDate,omitempty"`
-
-	// sit entry date
-	// Format: date
-	SitEntryDate *strfmt.Date `json:"sitEntryDate,omitempty"`
 
 	// total days remaining
 	// Minimum: 0
@@ -55,23 +38,11 @@ type SITStatus struct {
 func (m *SITStatus) Validate(formats strfmt.Registry) error {
 	var res []error
 
-	if err := m.validateDaysInSIT(formats); err != nil {
+	if err := m.validateCurrentSIT(formats); err != nil {
 		res = append(res, err)
 	}
 
 	if err := m.validatePastSITServiceItems(formats); err != nil {
-		res = append(res, err)
-	}
-
-	if err := m.validateSitAllowanceEndDate(formats); err != nil {
-		res = append(res, err)
-	}
-
-	if err := m.validateSitDepartureDate(formats); err != nil {
-		res = append(res, err)
-	}
-
-	if err := m.validateSitEntryDate(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -89,13 +60,20 @@ func (m *SITStatus) Validate(formats strfmt.Registry) error {
 	return nil
 }
 
-func (m *SITStatus) validateDaysInSIT(formats strfmt.Registry) error {
-	if swag.IsZero(m.DaysInSIT) { // not required
+func (m *SITStatus) validateCurrentSIT(formats strfmt.Registry) error {
+	if swag.IsZero(m.CurrentSIT) { // not required
 		return nil
 	}
 
-	if err := validate.MinimumInt("daysInSIT", "body", *m.DaysInSIT, 0, false); err != nil {
-		return err
+	if m.CurrentSIT != nil {
+		if err := m.CurrentSIT.Validate(formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("currentSIT")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("currentSIT")
+			}
+			return err
+		}
 	}
 
 	return nil
@@ -112,42 +90,6 @@ func (m *SITStatus) validatePastSITServiceItems(formats strfmt.Registry) error {
 		} else if ce, ok := err.(*errors.CompositeError); ok {
 			return ce.ValidateName("pastSITServiceItems")
 		}
-		return err
-	}
-
-	return nil
-}
-
-func (m *SITStatus) validateSitAllowanceEndDate(formats strfmt.Registry) error {
-	if swag.IsZero(m.SitAllowanceEndDate) { // not required
-		return nil
-	}
-
-	if err := validate.FormatOf("sitAllowanceEndDate", "body", "date", m.SitAllowanceEndDate.String(), formats); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func (m *SITStatus) validateSitDepartureDate(formats strfmt.Registry) error {
-	if swag.IsZero(m.SitDepartureDate) { // not required
-		return nil
-	}
-
-	if err := validate.FormatOf("sitDepartureDate", "body", "date", m.SitDepartureDate.String(), formats); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func (m *SITStatus) validateSitEntryDate(formats strfmt.Registry) error {
-	if swag.IsZero(m.SitEntryDate) { // not required
-		return nil
-	}
-
-	if err := validate.FormatOf("sitEntryDate", "body", "date", m.SitEntryDate.String(), formats); err != nil {
 		return err
 	}
 
@@ -182,6 +124,10 @@ func (m *SITStatus) validateTotalSITDaysUsed(formats strfmt.Registry) error {
 func (m *SITStatus) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
 	var res []error
 
+	if err := m.contextValidateCurrentSIT(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
 	if err := m.contextValidatePastSITServiceItems(ctx, formats); err != nil {
 		res = append(res, err)
 	}
@@ -189,6 +135,27 @@ func (m *SITStatus) ContextValidate(ctx context.Context, formats strfmt.Registry
 	if len(res) > 0 {
 		return errors.CompositeValidationError(res...)
 	}
+	return nil
+}
+
+func (m *SITStatus) contextValidateCurrentSIT(ctx context.Context, formats strfmt.Registry) error {
+
+	if m.CurrentSIT != nil {
+
+		if swag.IsZero(m.CurrentSIT) { // not required
+			return nil
+		}
+
+		if err := m.CurrentSIT.ContextValidate(ctx, formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("currentSIT")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("currentSIT")
+			}
+			return err
+		}
+	}
+
 	return nil
 }
 
@@ -217,6 +184,129 @@ func (m *SITStatus) MarshalBinary() ([]byte, error) {
 // UnmarshalBinary interface implementation
 func (m *SITStatus) UnmarshalBinary(b []byte) error {
 	var res SITStatus
+	if err := swag.ReadJSON(b, &res); err != nil {
+		return err
+	}
+	*m = res
+	return nil
+}
+
+// SITStatusCurrentSIT s i t status current s i t
+//
+// swagger:model SITStatusCurrentSIT
+type SITStatusCurrentSIT struct {
+
+	// days in s i t
+	// Minimum: 0
+	DaysInSIT *int64 `json:"daysInSIT,omitempty"`
+
+	// location
+	// Enum: [ORIGIN DESTINATION]
+	Location interface{} `json:"location,omitempty"`
+
+	// sit allowance end date
+	// Format: date
+	SitAllowanceEndDate *strfmt.Date `json:"sitAllowanceEndDate,omitempty"`
+
+	// sit departure date
+	// Format: date
+	SitDepartureDate *strfmt.Date `json:"sitDepartureDate,omitempty"`
+
+	// sit entry date
+	// Format: date
+	SitEntryDate *strfmt.Date `json:"sitEntryDate,omitempty"`
+}
+
+// Validate validates this s i t status current s i t
+func (m *SITStatusCurrentSIT) Validate(formats strfmt.Registry) error {
+	var res []error
+
+	if err := m.validateDaysInSIT(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateSitAllowanceEndDate(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateSitDepartureDate(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateSitEntryDate(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if len(res) > 0 {
+		return errors.CompositeValidationError(res...)
+	}
+	return nil
+}
+
+func (m *SITStatusCurrentSIT) validateDaysInSIT(formats strfmt.Registry) error {
+	if swag.IsZero(m.DaysInSIT) { // not required
+		return nil
+	}
+
+	if err := validate.MinimumInt("currentSIT"+"."+"daysInSIT", "body", *m.DaysInSIT, 0, false); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (m *SITStatusCurrentSIT) validateSitAllowanceEndDate(formats strfmt.Registry) error {
+	if swag.IsZero(m.SitAllowanceEndDate) { // not required
+		return nil
+	}
+
+	if err := validate.FormatOf("currentSIT"+"."+"sitAllowanceEndDate", "body", "date", m.SitAllowanceEndDate.String(), formats); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (m *SITStatusCurrentSIT) validateSitDepartureDate(formats strfmt.Registry) error {
+	if swag.IsZero(m.SitDepartureDate) { // not required
+		return nil
+	}
+
+	if err := validate.FormatOf("currentSIT"+"."+"sitDepartureDate", "body", "date", m.SitDepartureDate.String(), formats); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (m *SITStatusCurrentSIT) validateSitEntryDate(formats strfmt.Registry) error {
+	if swag.IsZero(m.SitEntryDate) { // not required
+		return nil
+	}
+
+	if err := validate.FormatOf("currentSIT"+"."+"sitEntryDate", "body", "date", m.SitEntryDate.String(), formats); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// ContextValidate validates this s i t status current s i t based on context it is used
+func (m *SITStatusCurrentSIT) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
+	return nil
+}
+
+// MarshalBinary interface implementation
+func (m *SITStatusCurrentSIT) MarshalBinary() ([]byte, error) {
+	if m == nil {
+		return nil, nil
+	}
+	return swag.WriteJSON(m)
+}
+
+// UnmarshalBinary interface implementation
+func (m *SITStatusCurrentSIT) UnmarshalBinary(b []byte) error {
+	var res SITStatusCurrentSIT
 	if err := swag.ReadJSON(b, &res); err != nil {
 		return err
 	}

--- a/pkg/handlers/ghcapi/internal/payloads/model_to_payload.go
+++ b/pkg/handlers/ghcapi/internal/payloads/model_to_payload.go
@@ -670,14 +670,16 @@ func SITStatus(shipmentSITStatuses *services.SITStatus, storer storage.FileStore
 		return nil
 	}
 	payload := &ghcmessages.SITStatus{
-		DaysInSIT:           handlers.FmtIntPtrToInt64(&shipmentSITStatuses.DaysInSIT),
-		TotalDaysRemaining:  handlers.FmtIntPtrToInt64(&shipmentSITStatuses.TotalDaysRemaining),
-		Location:            shipmentSITStatuses.Location,
 		PastSITServiceItems: MTOServiceItemModels(shipmentSITStatuses.PastSITs, storer),
-		SitDepartureDate:    handlers.FmtDatePtr(shipmentSITStatuses.SITDepartureDate),
-		SitAllowanceEndDate: handlers.FmtDate(shipmentSITStatuses.SITAllowanceEndDate),
-		SitEntryDate:        handlers.FmtDate(shipmentSITStatuses.SITEntryDate),
 		TotalSITDaysUsed:    handlers.FmtIntPtrToInt64(&shipmentSITStatuses.TotalSITDaysUsed),
+		TotalDaysRemaining:  handlers.FmtIntPtrToInt64(&shipmentSITStatuses.TotalDaysRemaining),
+		CurrentSIT: &ghcmessages.SITStatusCurrentSIT{
+			Location:            shipmentSITStatuses.CurrentSIT.Location,
+			DaysInSIT:           handlers.FmtIntPtrToInt64(&shipmentSITStatuses.CurrentSIT.DaysInSIT),
+			SitEntryDate:        handlers.FmtDate(shipmentSITStatuses.CurrentSIT.SITEntryDate),
+			SitDepartureDate:    handlers.FmtDatePtr(shipmentSITStatuses.CurrentSIT.SITDepartureDate),
+			SitAllowanceEndDate: handlers.FmtDate(shipmentSITStatuses.CurrentSIT.SITAllowanceEndDate),
+		},
 	}
 
 	return payload

--- a/pkg/handlers/ghcapi/mto_shipment_test.go
+++ b/pkg/handlers/ghcapi/mto_shipment_test.go
@@ -237,12 +237,12 @@ func (suite *HandlerSuite) TestListMTOShipmentsHandler() {
 		suite.Nil(payloadShipment2.StorageFacility)
 
 		suite.Equal(int64(190), *payloadShipment.SitDaysAllowance)
-		suite.Equal(mtoshipment.OriginSITLocation, payloadShipment.SitStatus.Location)
-		suite.Equal(int64(7), *payloadShipment.SitStatus.DaysInSIT)
+		suite.Equal(mtoshipment.OriginSITLocation, payloadShipment.SitStatus.CurrentSIT.Location)
+		suite.Equal(int64(7), *payloadShipment.SitStatus.CurrentSIT.DaysInSIT)
 		suite.Equal(int64(176), *payloadShipment.SitStatus.TotalDaysRemaining)
 		suite.Equal(int64(14), *payloadShipment.SitStatus.TotalSITDaysUsed) // 7 from the previous SIT and 7 from the current
-		suite.Equal(subtestData.sit.SITEntryDate.Format("2006-01-02"), payloadShipment.SitStatus.SitEntryDate.String())
-		suite.Equal(subtestData.sit.SITDepartureDate.Format("2006-01-02"), payloadShipment.SitStatus.SitDepartureDate.String())
+		suite.Equal(subtestData.sit.SITEntryDate.Format("2006-01-02"), payloadShipment.SitStatus.CurrentSIT.SitEntryDate.String())
+		suite.Equal(subtestData.sit.SITDepartureDate.Format("2006-01-02"), payloadShipment.SitStatus.CurrentSIT.SitDepartureDate.String())
 
 		suite.Len(payloadShipment.SitStatus.PastSITServiceItems, 1)
 		year, month, day := time.Now().Date()

--- a/pkg/services/mto_shipment.go
+++ b/pkg/services/mto_shipment.go
@@ -124,15 +124,19 @@ type ShipmentRouter interface {
 
 // SITStatus is the summary of the current SIT service item days in storage remaining balance and dates
 type SITStatus struct {
-	ShipmentID          uuid.UUID
+	ShipmentID         uuid.UUID
+	TotalSITDaysUsed   int
+	TotalDaysRemaining int
+	CurrentSIT         CurrentSIT
+	PastSITs           []models.MTOServiceItem
+}
+
+type CurrentSIT struct {
 	Location            string
-	TotalSITDaysUsed    int
-	TotalDaysRemaining  int
 	DaysInSIT           int
 	SITEntryDate        time.Time
-	SITAllowanceEndDate time.Time
 	SITDepartureDate    *time.Time
-	PastSITs            []models.MTOServiceItem
+	SITAllowanceEndDate time.Time
 }
 
 // ShipmentSITStatus is the interface for calculating SIT service item summary balances of shipments

--- a/pkg/services/mto_shipment/shipment_sit_status_test.go
+++ b/pkg/services/mto_shipment/shipment_sit_status_test.go
@@ -112,7 +112,7 @@ func (suite *MTOShipmentServiceSuite) TestShipmentSITStatus() {
 
 		suite.Equal(15, sitStatus.TotalSITDaysUsed)
 		suite.Equal(75, sitStatus.TotalDaysRemaining)
-		suite.Equal("", sitStatus.Location) // No current SIT so it will receive the zero value of empty
+		suite.Equal("", sitStatus.CurrentSIT.Location) // No current SIT so it will receive the zero value of empty
 	})
 
 	suite.Run("calculates status for a shipment currently in SIT", func() {
@@ -152,12 +152,12 @@ func (suite *MTOShipmentServiceSuite) TestShipmentSITStatus() {
 		suite.NoError(err)
 		suite.NotNil(sitStatus)
 
-		suite.Equal(OriginSITLocation, sitStatus.Location)
+		suite.Equal(OriginSITLocation, sitStatus.CurrentSIT.Location)
 		suite.Equal(30, sitStatus.TotalSITDaysUsed)
 		suite.Equal(60, sitStatus.TotalDaysRemaining)
-		suite.Equal(30, sitStatus.DaysInSIT)
-		suite.Equal(aMonthAgo.String(), sitStatus.SITEntryDate.String())
-		suite.Nil(sitStatus.SITDepartureDate)
+		suite.Equal(30, sitStatus.CurrentSIT.DaysInSIT)
+		suite.Equal(aMonthAgo.String(), sitStatus.CurrentSIT.SITEntryDate.String())
+		suite.Nil(sitStatus.CurrentSIT.SITDepartureDate)
 		suite.Equal(approvedShipment.ID.String(), sitStatus.ShipmentID.String())
 		suite.Len(sitStatus.PastSITs, 0)
 	})
@@ -222,12 +222,12 @@ func (suite *MTOShipmentServiceSuite) TestShipmentSITStatus() {
 
 		suite.NotNil(sitStatus)
 
-		suite.Equal(OriginSITLocation, sitStatus.Location)
+		suite.Equal(OriginSITLocation, sitStatus.CurrentSIT.Location)
 		suite.Equal(22, sitStatus.TotalSITDaysUsed) // 15 days from previous SIT, 7 days from the current
 		suite.Equal(68, sitStatus.TotalDaysRemaining)
-		suite.Equal(7, sitStatus.DaysInSIT)
-		suite.Equal(aWeekAgo.String(), sitStatus.SITEntryDate.String())
-		suite.Nil(sitStatus.SITDepartureDate)
+		suite.Equal(7, sitStatus.CurrentSIT.DaysInSIT)
+		suite.Equal(aWeekAgo.String(), sitStatus.CurrentSIT.SITEntryDate.String())
+		suite.Nil(sitStatus.CurrentSIT.SITDepartureDate)
 		suite.Equal(approvedShipment.ID.String(), sitStatus.ShipmentID.String())
 
 		suite.Len(sitStatus.PastSITs, 1)
@@ -294,12 +294,12 @@ func (suite *MTOShipmentServiceSuite) TestShipmentSITStatus() {
 
 		suite.NotNil(sitStatus)
 
-		suite.Equal(DestinationSITLocation, sitStatus.Location)
+		suite.Equal(DestinationSITLocation, sitStatus.CurrentSIT.Location)
 		suite.Equal(22, sitStatus.TotalSITDaysUsed) // 15 days from previous SIT, 7 days from the current
 		suite.Equal(68, sitStatus.TotalDaysRemaining)
-		suite.Equal(7, sitStatus.DaysInSIT)
-		suite.Equal(aWeekAgo.String(), sitStatus.SITEntryDate.String())
-		suite.Nil(sitStatus.SITDepartureDate)
+		suite.Equal(7, sitStatus.CurrentSIT.DaysInSIT)
+		suite.Equal(aWeekAgo.String(), sitStatus.CurrentSIT.SITEntryDate.String())
+		suite.Nil(sitStatus.CurrentSIT.SITDepartureDate)
 		suite.Equal(approvedShipment.ID.String(), sitStatus.ShipmentID.String())
 
 		suite.Len(sitStatus.PastSITs, 1)
@@ -366,12 +366,12 @@ func (suite *MTOShipmentServiceSuite) TestShipmentSITStatus() {
 
 		suite.NotNil(sitStatus)
 
-		suite.Equal(DestinationSITLocation, sitStatus.Location)
+		suite.Equal(DestinationSITLocation, sitStatus.CurrentSIT.Location)
 		suite.Equal(97, sitStatus.TotalSITDaysUsed) // 15 days from previous SIT, 7 days from the current
 		suite.Equal(-7, sitStatus.TotalDaysRemaining)
-		suite.Equal(7, sitStatus.DaysInSIT)
-		suite.Equal(aWeekAgo.String(), sitStatus.SITEntryDate.String())
-		suite.Nil(sitStatus.SITDepartureDate)
+		suite.Equal(7, sitStatus.CurrentSIT.DaysInSIT)
+		suite.Equal(aWeekAgo.String(), sitStatus.CurrentSIT.SITEntryDate.String())
+		suite.Nil(sitStatus.CurrentSIT.SITDepartureDate)
 		suite.Equal(approvedShipment.ID.String(), sitStatus.ShipmentID.String())
 
 		suite.Len(sitStatus.PastSITs, 1)

--- a/src/components/Office/ReviewSITExtensionModal/ReviewSITExtensionModal.jsx
+++ b/src/components/Office/ReviewSITExtensionModal/ReviewSITExtensionModal.jsx
@@ -66,7 +66,7 @@ const SITHistoryItemHeader = ({ title, value }) => {
 
 const SitStatusTables = ({ sitStatus, sitExtension, shipment }) => {
   const { totalSITDaysUsed, daysInSIT, location } = sitStatus;
-  const sitEntryDate = moment(sitStatus.sitEntryDate, swaggerDateFormat);
+  const sitEntryDate = moment(sitStatus.currentSIT.sitEntryDate, swaggerDateFormat);
   const daysInPreviousSIT = totalSITDaysUsed - daysInSIT;
 
   /**
@@ -211,10 +211,10 @@ const ReviewSITExtensionsModal = ({ onClose, onSubmit, sitExtension, shipment, s
     daysApproved: String(shipment.sitDaysAllowance),
     requestReason: sitExtension.requestReason,
     officeRemarks: '',
-    sitEndDate: formatDateForDatePicker(moment(sitStatus.sitAllowanceEndDate, swaggerDateFormat)),
+    sitEndDate: formatDateForDatePicker(moment(sitStatus.currentSIT.sitAllowanceEndDate, swaggerDateFormat)),
   };
   const minimumDaysAllowed = shipment.sitDaysAllowance + 1;
-  const sitEntryDate = moment(sitStatus.sitEntryDate, swaggerDateFormat);
+  const sitEntryDate = moment(sitStatus.currentSIT.sitEntryDate, swaggerDateFormat);
   const reviewSITExtensionSchema = Yup.object().shape({
     acceptExtension: Yup.mixed().oneOf(['yes', 'no']).required('Required'),
     requestReason: Yup.string().required('Required'),

--- a/src/components/Office/ShipmentSITDisplay/ShipmentSITDisplay.jsx
+++ b/src/components/Office/ShipmentSITDisplay/ShipmentSITDisplay.jsx
@@ -70,11 +70,10 @@ const SitHistoryList = ({ sitHistory, dayAllowance }) => {
 };
 
 const SitStatusTables = ({ shipment, sitExtensions, sitStatus, openModalButton }) => {
-  // const currentOrUpcomingSIT = !!sitStatus?.location;
   const pendingSITExtension = sitExtensions.find((se) => se.status === SIT_EXTENSION_STATUS.PENDING);
-  const currentDaysInSIT = sitStatus?.daysInSIT || 0;
+  const currentDaysInSIT = sitStatus?.currentSIT?.daysInSIT || 0;
   const currentDaysInSITElement = <p>{currentDaysInSIT}</p>;
-  let sitEntryDate = sitStatus?.sitEntryDate;
+  let sitEntryDate = sitStatus?.currentSIT?.sitEntryDate;
   if (!sitEntryDate) {
     sitEntryDate = shipment.mtoServiceItems?.reduce((item, acc) => {
       // Check if the current
@@ -87,7 +86,7 @@ const SitStatusTables = ({ shipment, sitExtensions, sitStatus, openModalButton }
 
   sitEntryDate = moment(sitEntryDate, swaggerDateFormat);
   const sitStartDateElement = <p>{formatDate(sitEntryDate, swaggerDateFormat, 'DD MMM YYYY')}</p>;
-  const sitEndDate = moment(sitStatus?.sitAllowanceEndDate, swaggerDateFormat);
+  const sitEndDate = moment(sitStatus?.currentSIT?.sitAllowanceEndDate, swaggerDateFormat);
   const sitEndDateString = sitEndDate.isValid() ? formatDateForDatePicker(sitEndDate) : '-';
 
   // Previous SIT calculations and date ranges
@@ -103,7 +102,8 @@ const SitStatusTables = ({ shipment, sitExtensions, sitStatus, openModalButton }
   });
 
   // Currently active SIT
-  const currentLocation = sitStatus?.location === LOCATION_TYPES.DESTINATION ? 'destination SIT' : 'origin SIT';
+  const currentLocation =
+    sitStatus?.currentSIT?.location === LOCATION_TYPES.DESTINATION ? 'destination SIT' : 'origin SIT';
 
   const totalSITDaysUsed = sitStatus?.totalSITDaysUsed || 0;
   const totalDaysRemaining = () => {
@@ -118,7 +118,7 @@ const SitStatusTables = ({ shipment, sitExtensions, sitStatus, openModalButton }
     <>
       <div className={styles.title}>
         <p>SIT (STORAGE IN TRANSIT){pendingSITExtension && <Tag>Additional Days Requested</Tag>}</p>
-        {/* currentOrUpcomingSIT && */ openModalButton}
+        {sitStatus.currentSIT && openModalButton}
       </div>
       <div className={styles.tableContainer} data-testid="sitStatusTable">
         {/* Sit Total days table */}
@@ -129,8 +129,8 @@ const SitStatusTables = ({ shipment, sitExtensions, sitStatus, openModalButton }
       </div>
 
       {/* Current SIT Info Section */}
-      {
-        /* currentOrUpcomingSIT &&  */ <>
+      {sitStatus.currentSIT && (
+        <>
           <div className={styles.tableContainer} data-testid="sitStartAndEndTable">
             {/* Sit Start and End table */}
             {currentDaysInSIT > 0 && <p className={styles.sitHeader}>Current location: {currentLocation}</p>}
@@ -145,7 +145,7 @@ const SitStatusTables = ({ shipment, sitExtensions, sitStatus, openModalButton }
             <DataTable columnHeaders={[`Total days in ${currentLocation}`]} dataRow={[currentDaysInSITElement]} />
           </div>
         </>
-      }
+      )}
 
       {/* Service Items */}
       {sitStatus?.pastSITServiceItems && (

--- a/src/components/Office/SubmitSITExtensionModal/SubmitSITExtensionModal.jsx
+++ b/src/components/Office/SubmitSITExtensionModal/SubmitSITExtensionModal.jsx
@@ -42,13 +42,13 @@ const SitEndDateForm = ({ onChange }) => (
 
 const SitStatusTables = ({ sitStatus, shipment }) => {
   const { totalSITDaysUsed, daysInSIT } = sitStatus;
-  const sitEntryDate = moment(sitStatus.sitEntryDate, swaggerDateFormat);
+  const sitEntryDate = moment(sitStatus.currentSIT.sitEntryDate, swaggerDateFormat);
   const daysInPreviousSIT = totalSITDaysUsed - daysInSIT;
 
   const sitAllowanceHelper = useField({ name: 'daysApproved', id: 'daysApproved' })[2];
   const endDateHelper = useField({ name: 'sitEndDate', id: 'sitEndDate' })[2];
   // Currently active SIT
-  const currentLocation = sitStatus.location === LOCATION_TYPES.ORIGIN ? 'origin SIT' : 'destination SIT';
+  const currentLocation = sitStatus.currentSIT.location === LOCATION_TYPES.ORIGIN ? 'origin SIT' : 'destination SIT';
 
   const currentDaysInSit = <p>{daysInSIT}</p>;
   const currentDateEnteredSit = <p>{formatDateForDatePicker(sitEntryDate)}</p>;
@@ -155,10 +155,10 @@ const SubmitSITExtensionModal = ({ shipment, sitStatus, onClose, onSubmit }) => 
     requestReason: '',
     officeRemarks: '',
     daysApproved: String(shipment.sitDaysAllowance),
-    sitEndDate: formatDateForDatePicker(moment(sitStatus.sitAllowanceEndDate, swaggerDateFormat)),
+    sitEndDate: formatDateForDatePicker(moment(sitStatus.currentSIT.sitAllowanceEndDate, swaggerDateFormat)),
   };
-  const minimumDaysAllowed = sitStatus.totalSITDaysUsed - sitStatus.daysInSIT + 1;
-  const sitEntryDate = moment(sitStatus.sitEntryDate, swaggerDateFormat);
+  const minimumDaysAllowed = sitStatus.totalSITDaysUsed - sitStatus.currentSIT.daysInSIT + 1;
+  const sitEntryDate = moment(sitStatus.currentSIT.sitEntryDate, swaggerDateFormat);
   const reviewSITExtensionSchema = Yup.object().shape({
     requestReason: Yup.string().required('Required'),
     officeRemarks: Yup.string().nullable(),

--- a/src/types/sitStatusShape.js
+++ b/src/types/sitStatusShape.js
@@ -65,12 +65,14 @@ const PastServiceItemsShape = PropTypes.shape({
 });
 
 export const SitStatusShape = PropTypes.shape({
-  location: LOCATION_TYPES_ONE_OF,
   totalSITDaysUsed: PropTypes.number.isRequired,
   totalDaysRemaining: PropTypes.number.isRequired,
-  daysInSIT: PropTypes.number,
-  sitEntryDate: PropTypes.string,
-  sitDepartureDate: PropTypes.string,
-  sitAllowanceEndDate: PropTypes.string,
+  currentSIT: PropTypes.shape({
+    location: LOCATION_TYPES_ONE_OF,
+    daysInSIT: PropTypes.number,
+    sitEntryDate: PropTypes.string,
+    sitDepartureDate: PropTypes.string,
+    sitAllowanceEndDate: PropTypes.string,
+  }),
   pastSITServiceItems: PropTypes.arrayOf(PastServiceItemsShape),
 });

--- a/swagger-def/definitions/SITStatus.yaml
+++ b/swagger-def/definitions/SITStatus.yaml
@@ -1,28 +1,31 @@
 properties:
-  location:
-    enum:
-      - 'ORIGIN'
-      - 'DESTINATION'
   totalSITDaysUsed:
     type: integer
     minimum: 0
   totalDaysRemaining:
     type: integer
     minimum: 0
-  daysInSIT:
-    type: integer
-    minimum: 0
-  sitEntryDate:
-    type: string
-    format: date
-    x-nullable: true
-  sitDepartureDate:
-    type: string
-    format: date
-    x-nullable: true
-  sitAllowanceEndDate:
-    type: string
-    format: date
-    x-nullable: true
+  currentSIT:
+    type: object
+    properties:
+      location:
+        enum:
+          - 'ORIGIN'
+          - 'DESTINATION'
+      daysInSIT:
+        type: integer
+        minimum: 0
+      sitEntryDate:
+        type: string
+        format: date
+        x-nullable: true
+      sitDepartureDate:
+        type: string
+        format: date
+        x-nullable: true
+      sitAllowanceEndDate:
+        type: string
+        format: date
+        x-nullable: true
   pastSITServiceItems:
     $ref: 'MTOServiceItems.yaml'

--- a/swagger/ghc.yaml
+++ b/swagger/ghc.yaml
@@ -6222,31 +6222,34 @@ definitions:
       $ref: '#/definitions/SITExtension'
   SITStatus:
     properties:
-      location:
-        enum:
-          - ORIGIN
-          - DESTINATION
       totalSITDaysUsed:
         type: integer
         minimum: 0
       totalDaysRemaining:
         type: integer
         minimum: 0
-      daysInSIT:
-        type: integer
-        minimum: 0
-      sitEntryDate:
-        type: string
-        format: date
-        x-nullable: true
-      sitDepartureDate:
-        type: string
-        format: date
-        x-nullable: true
-      sitAllowanceEndDate:
-        type: string
-        format: date
-        x-nullable: true
+      currentSIT:
+        type: object
+        properties:
+          location:
+            enum:
+              - ORIGIN
+              - DESTINATION
+          daysInSIT:
+            type: integer
+            minimum: 0
+          sitEntryDate:
+            type: string
+            format: date
+            x-nullable: true
+          sitDepartureDate:
+            type: string
+            format: date
+            x-nullable: true
+          sitAllowanceEndDate:
+            type: string
+            format: date
+            x-nullable: true
       pastSITServiceItems:
         $ref: '#/definitions/MTOServiceItems'
   PPMShipmentStatus:


### PR DESCRIPTION
## [Jira ticket](https://dp3.atlassian.net/browse/MB-13693)

## Summary

Is there anything you would like reviewers to give additional scrutiny?

[this article](tbd) explains more about the approach used.

## Verification Steps for the Author

These are to be checked by the author.

- [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
- [ ] Have the Jira acceptance criteria been met for this change?

## Verification Steps for Reviewers

These are to be checked by a reviewer.

### Setup to Run the Code

- [Instructions for starting storybook](https://transcom.github.io/mymove-docs/docs/frontend/setup/run-storybook)
- [Instructions for starting the MilMove application](https://transcom.github.io/mymove-docs/docs/about/application-setup/milmove-local-client/)
- [Instructions for running tests](https://transcom.github.io/mymove-docs/docs/about/development/testing)

### How to test

1. Access the
2. Login as a
3.

### Frontend

- [ ] There are no aXe warnings for UI.
- [ ] This works in [Supported Browsers and their phone views](https://transcom.github.io/mymove-docs/docs/about/supported-browsers) (Chrome, Firefox, Edge).
- [ ] There are no new console errors in the browser devtools.
- [ ] There are no new console errors in the test output.
- [ ] If this PR adds a new component to Storybook, it ensures the component is fully responsive, OR if it is intentionally not, a wrapping div using the `officeApp` class or custom `min-width` styling is used to hide any states the would not be visible to the user.

### Backend

- [ ] Code follows the guidelines for [Logging](https://transcom.github.io/mymove-docs/docs/about/development/logging).
- [ ] The requirements listed in [Querying the Database Safely](https://transcom.github.io/mymove-docs/docs/backend/guides/golang-guide#querying-the-database-safely) have been satisfied.

### Database

#### Any new migrations/schema changes:

- [ ] Follows our guidelines for [Zero-Downtime Deploys](https://transcom.github.io/mymove-docs/docs/backend/setup/database-migrations#zero-downtime-migrations).
- [ ] Have been communicated to #g-database.
- [ ] Secure migrations have been tested following the instructions in our [docs](https://transcom.github.io/mymove-docs/docs/backend/setup/database-migrations#secure-migrations).

## Screenshots
