### PR TITLE
MB-16456 - Fix ShipmentDisplay styles to fit SIT display maximum width

### DIFF
--- a/src/components/Office/ShipmentDetails/ShipmentDetails.module.scss
+++ b/src/components/Office/ShipmentDetails/ShipmentDetails.module.scss
@@ -8,6 +8,7 @@
 
 .ShipmentDetailsMain {
   @include u-margin-right(4);
+  min-width: 633px; // minimum width to fit the widest shipment details row
 
   :global(.table--data-point-group),
   .shipmentSITSummary {

--- a/src/components/Office/ShipmentDetails/ShipmentDetailsSidebar.jsx
+++ b/src/components/Office/ShipmentDetails/ShipmentDetailsSidebar.jsx
@@ -103,7 +103,7 @@ const ShipmentDetailsSidebar = ({
             header={agent.agentType === 'RELEASING_AGENT' ? 'Releasing agent' : 'Receiving agent'}
             border
           >
-            <div>{formatAgent(agent)}</div>
+            <div className={styles.MtoAgentSection}>{formatAgent(agent)}</div>
           </SimpleSection>
         ))}
 

--- a/src/components/Office/ShipmentDetails/ShipmentDetailsSidebar.module.scss
+++ b/src/components/Office/ShipmentDetails/ShipmentDetailsSidebar.module.scss
@@ -6,3 +6,7 @@
     padding-right: 0;
   }
 }
+
+.MtoAgentSection {
+  word-break: break-all;
+}


### PR DESCRIPTION
## [Jira ticket](https://dp3.atlassian.net/browse/MB-16456)

## Summary

These small changes should set a minimum width for the shipment display to fit the maximum width of the SIT Display.
 

## Verification Steps for the Author

These are to be checked by the author.

- [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
- [ ] Have the Jira acceptance criteria been met for this change?

## Verification Steps for Reviewers

These are to be checked by a reviewer.

### Setup to Run the Code

- [Instructions for starting storybook](https://transcom.github.io/mymove-docs/docs/frontend/setup/run-storybook)
- [Instructions for starting the MilMove application](https://transcom.github.io/mymove-docs/docs/about/application-setup/milmove-local-client/)
- [Instructions for running tests](https://transcom.github.io/mymove-docs/docs/about/development/testing)

### How to test

1. Create a move with the test harness scenario _HHGMoveIn200DaysSITWithPendingExtension_
2. Access the office app as a TOO 
3. Navigate to the move MTO page
4. Verify that the pending extension tag is not split between two rows and that the mto agent information is word-wrapped.

### Frontend

- [ ] There are no aXe warnings for UI.
- [ ] This works in [Supported Browsers and their phone views](https://transcom.github.io/mymove-docs/docs/about/supported-browsers) (Chrome, Firefox, Edge).
- [ ] There are no new console errors in the browser devtools.
- [ ] There are no new console errors in the test output.
- [ ] If this PR adds a new component to Storybook, it ensures the component is fully responsive, OR if it is intentionally not, a wrapping div using the `officeApp` class or custom `min-width` styling is used to hide any states the would not be visible to the user.

### Backend

- [ ] Code follows the guidelines for [Logging](https://transcom.github.io/mymove-docs/docs/about/development/logging).
- [ ] The requirements listed in [Querying the Database Safely](https://transcom.github.io/mymove-docs/docs/backend/guides/golang-guide#querying-the-database-safely) have been satisfied.

### Database

#### Any new migrations/schema changes:

- [ ] Follows our guidelines for [Zero-Downtime Deploys](https://transcom.github.io/mymove-docs/docs/backend/setup/database-migrations#zero-downtime-migrations).
- [ ] Have been communicated to #g-database.
- [ ] Secure migrations have been tested following the instructions in our [docs](https://transcom.github.io/mymove-docs/docs/backend/setup/database-migrations#secure-migrations).

## Screenshots
