### PR TITLE
[ MB-16408 ] Show correct remarks from Office

### DIFF
--- a/pkg/handlers/primeapi/payloads/model_to_payload.go
+++ b/pkg/handlers/primeapi/payloads/model_to_payload.go
@@ -841,7 +841,7 @@ func SITAddressUpdate(sitAddressUpdate *models.SITAddressUpdate) *primemessages.
 		NewAddressID:      strfmt.UUID(sitAddressUpdate.NewAddressID.String()),
 		NewAddress:        Address(&sitAddressUpdate.NewAddress),
 		ContractorRemarks: handlers.FmtStringPtr(sitAddressUpdate.ContractorRemarks),
-		OfficeRemarks:     handlers.FmtStringPtr(sitAddressUpdate.ContractorRemarks),
+		OfficeRemarks:     handlers.FmtStringPtr(sitAddressUpdate.OfficeRemarks),
 		OldAddressID:      strfmt.UUID(sitAddressUpdate.OldAddressID.String()),
 		OldAddress:        Address(&sitAddressUpdate.OldAddress),
 		Status:            primemessages.SitAddressUpdateStatus(sitAddressUpdate.Status),

--- a/pkg/handlers/primeapi/payloads/model_to_payload_test.go
+++ b/pkg/handlers/primeapi/payloads/model_to_payload_test.go
@@ -264,6 +264,7 @@ func (suite *PayloadsSuite) TestSitExtension() {
 func (suite *PayloadsSuite) TestSITAddressUpdate() {
 	newAddress := factory.BuildAddress(nil, nil, []factory.Trait{factory.GetTraitAddress3})
 	contractorRemark := "I must update the final address please"
+	officeRemark := ""
 
 	suite.Run("Success - Returns a SITAddressUpdate payload as expected", func() {
 		sitAddressUpdate := models.SITAddressUpdate{
@@ -272,6 +273,7 @@ func (suite *PayloadsSuite) TestSITAddressUpdate() {
 			NewAddressID:      newAddress.ID,
 			NewAddress:        newAddress,
 			ContractorRemarks: &contractorRemark,
+			OfficeRemarks:     &officeRemark,
 			Status:            models.SITAddressUpdateStatusRequested,
 			UpdatedAt:         time.Now(),
 			CreatedAt:         time.Now(),
@@ -289,6 +291,7 @@ func (suite *PayloadsSuite) TestSITAddressUpdate() {
 		suite.Equal(*payload.NewAddress.Country, *sitAddressUpdate.NewAddress.Country)
 		suite.Equal(*payload.NewAddress.StreetAddress1, sitAddressUpdate.NewAddress.StreetAddress1)
 		suite.Equal(payload.ContractorRemarks, sitAddressUpdate.ContractorRemarks)
+		suite.Equal(payload.OfficeRemarks, sitAddressUpdate.OfficeRemarks)
 		suite.Equal(payload.Status, sitAddressUpdate.Status)
 		suite.Equal(strfmt.DateTime(payload.UpdatedAt).String(), strfmt.DateTime(sitAddressUpdate.UpdatedAt).String())
 		suite.Equal(strfmt.DateTime(payload.CreatedAt).String(), strfmt.DateTime(sitAddressUpdate.CreatedAt).String())


### PR DESCRIPTION
## [Jira ticket](https://dp3.atlassian.net/browse/MB-16408)

## Summary

This is a bug fix for a bug caught in UAT acceptance. The issue was that
`OfficeRemarks` was being mapped to `ContractorRemarks`. This fixes the issue
and now allows the Prime to be able to see the `OfficeRemarks` in the
`SitAddressUpdates` field from the `prime/v1/move-task-order/{MOVEID}` endpoint
as expected.

## Verification Steps for Reviewers

These are to be checked by a reviewer.

### Setup to Run the Code

- [Instructions for starting storybook](https://transcom.github.io/mymove-docs/docs/frontend/setup/run-storybook)
- [Instructions for starting the MilMove application](https://transcom.github.io/mymove-docs/docs/about/application-setup/milmove-local-client/)
- [Instructions for running tests](https://transcom.github.io/mymove-docs/docs/about/development/testing)

### How to test

1. Navigate to `/testharness/list`.
1. Create a `HHGMoveInSITWithAddressChangeRequestOver50Miles`
1. As the Prime, get the payload from the `prime/v1/move-task-order/{ID}`
   endpoint.
1. Check the response for `mtoServiceItems` with a `modelType` of
   `MTOServiceItemDestSIT` and check the `sitAddressUpdates` list for the
   `officeRemarks` to be set to `null` when the `status` is `REQUESTED`.
1. Then as the TOO, reject or approve the SIT address update with remarks.
1. Check the response as the Prime again and see that the `officeRemarks` are
   what you entered in the Office app as the TOO.
