### PR TITLE
[MB-16405] Preview and Post MTO Modal Display Domestic Linehaul on TOO Approval Bug

### DIFF
--- a/src/components/Office/ShipmentApprovalPreview/ShipmentApprovalPreview.jsx
+++ b/src/components/Office/ShipmentApprovalPreview/ShipmentApprovalPreview.jsx
@@ -89,7 +89,7 @@ const ShipmentApprovalPreview = ({
                         className={classNames(styles.shipmentServiceItems)}
                         shipmentType={shipment.shipmentType}
                         destinationZip3={shipment.destinationAddress?.postalCode.slice(0, 3)}
-                        pickupZip3={shipment.pickupAddress.postalCode.slice(0, 3)}
+                        pickupZip3={shipment.pickupAddress?.postalCode.slice(0, 3)}
                       />
                     </div>
                   </div>

--- a/src/components/Office/ShipmentApprovalPreview/ShipmentApprovalPreview.jsx
+++ b/src/components/Office/ShipmentApprovalPreview/ShipmentApprovalPreview.jsx
@@ -88,7 +88,7 @@ const ShipmentApprovalPreview = ({
                       <ShipmentServiceItemsTable
                         className={classNames(styles.shipmentServiceItems)}
                         shipmentType={shipment.shipmentType}
-                        destinationZip3={shipment.destinationAddress.postalCode.slice(0, 3)}
+                        destinationZip3={shipment.destinationAddress?.postalCode.slice(0, 3)}
                         pickupZip3={shipment.pickupAddress.postalCode.slice(0, 3)}
                       />
                     </div>

--- a/src/components/Office/ShipmentApprovalPreview/ShipmentApprovalPreview.jsx
+++ b/src/components/Office/ShipmentApprovalPreview/ShipmentApprovalPreview.jsx
@@ -88,6 +88,8 @@ const ShipmentApprovalPreview = ({
                       <ShipmentServiceItemsTable
                         className={classNames(styles.shipmentServiceItems)}
                         shipmentType={shipment.shipmentType}
+                        destinationZip3={shipment.destinationAddress.postalCode.slice(0, 3)}
+                        pickupZip3={shipment.pickupAddress.postalCode.slice(0, 3)}
                       />
                     </div>
                   </div>

--- a/src/components/Office/ShipmentApprovalPreview/ShipmentApprovalPreview.test.jsx
+++ b/src/components/Office/ShipmentApprovalPreview/ShipmentApprovalPreview.test.jsx
@@ -72,6 +72,65 @@ const shipments = [
   },
   {
     approvedDate: '0001-01-01',
+    createdAt: '2020-06-10T15:58:02.404029Z',
+    customerRemarks: 'please treat gently',
+    counselorRemarks: 'all good',
+    destinationAddress: {
+      city: 'Venice',
+      country: 'US',
+      eTag: 'MjAyMC0wNi0xMFQxNTo1ODowMi4zODk0MTJa',
+      id: '672ff379-f6e3-48b4-a87d-796713f8f997',
+      postalCode: '90292',
+      state: 'CA',
+      streetAddress1: '987 Any Avenue',
+      streetAddress2: 'P.O. Box 9876',
+      streetAddress3: 'c/o Some Person',
+    },
+    eTag: 'MjAyMC0wNi0xMFQxNTo1ODowMi40MDQwMzFa',
+    id: 'ce01a5b8-9b44-4511-8a8d-edb60f2a4aea',
+    moveTaskOrderID: '9c7b255c-2981-4bf8-839f-61c7458e2b4d',
+    pickupAddress: {
+      city: 'Beverly Hills',
+      country: 'US',
+      eTag: 'MjAyMC0wNi0xMFQxNTo1ODowMi4zODQ3Njla',
+      id: '1686751b-ab36-43cf-b3c9-c0f467d13c19',
+      postalCode: '90210',
+      state: 'CA',
+      streetAddress1: '123 Any Street',
+      streetAddress2: 'P.O. Box 12345',
+      streetAddress3: 'c/o Some Person',
+    },
+    rejectionReason: 'shipment not good enough',
+    requestedPickupDate: '2018-03-15',
+    scheduledPickupDate: '2018-03-16',
+    secondaryDeliveryAddress: {
+      city: 'Beverly Hills',
+      country: 'US',
+      eTag: 'MjAyMC0wNi0xMFQxNTo1ODowMi4zOTkzMlo=',
+      id: '15e8f6cc-e1d7-44b2-b1e0-fcb3d6442831',
+      postalCode: '90210',
+      state: 'CA',
+      streetAddress1: '123 Any Street',
+      streetAddress2: 'P.O. Box 12345',
+      streetAddress3: 'c/o Some Person',
+    },
+    secondaryPickupAddress: {
+      city: 'Beverly Hills',
+      country: 'US',
+      eTag: 'MjAyMC0wNi0xMFQxNTo1ODowMi4zOTM4OTZa',
+      id: '9b79e0c3-8ed5-4fb8-aa36-95845707d8ee',
+      postalCode: '90210',
+      state: 'CA',
+      streetAddress1: '123 Any Street',
+      streetAddress2: 'P.O. Box 12345',
+      streetAddress3: 'c/o Some Person',
+    },
+    shipmentType: SHIPMENT_OPTIONS.HHG,
+    status: 'SUBMITTED',
+    updatedAt: '2020-06-10T15:58:02.404031Z',
+  },
+  {
+    approvedDate: '0001-01-01',
     createdAt: '2020-06-10T15:58:02.431993Z',
     customerRemarks: 'please treat gently',
     counselorRemarks: 'all good',
@@ -227,7 +286,8 @@ describe('Shipment preview modal', () => {
     expect(wrapper.find(CustomerInfoList).exists()).toBe(true);
 
     expect(wrapper.find('h3').at(0).text()).toEqual('Household goods');
-    expect(wrapper.find('h3').at(1).text()).toEqual('Non-temp storage release');
+    expect(wrapper.find('h3').at(1).text()).toEqual('Household goods');
+    expect(wrapper.find('h3').at(2).text()).toEqual('Non-temp storage release');
   });
   it('renders the modal successfully with mtoAgents provided', () => {
     const wrapper = mount(
@@ -312,7 +372,7 @@ describe('Shipment preview modal', () => {
     expect(wrapper.find('[data-testid="destinationAddress"]').at(0).text()).toEqual(
       '987 Any Avenue, P.O. Box 9876, Fairfield, CA 94535',
     );
-    expect(wrapper.find('[data-testid="destinationAddress"]').at(1).text()).toEqual(
+    expect(wrapper.find('[data-testid="destinationAddress"]').at(2).text()).toEqual(
       ordersInfo.newDutyLocation.address.postalCode,
     );
   });

--- a/src/components/Office/ShipmentApprovalPreview/shipmentApprovalPreview.stories.jsx
+++ b/src/components/Office/ShipmentApprovalPreview/shipmentApprovalPreview.stories.jsx
@@ -191,11 +191,11 @@ const shipments = [
     createdAt: '2020-06-10T15:58:02.404029Z',
     customerRemarks: 'please treat gently',
     destinationAddress: {
-      city: 'Fairfield',
+      city: 'Venice',
       country: 'US',
       eTag: 'MjAyMC0wNi0xMFQxNTo1ODowMi4zODk0MTJa',
       id: '672ff379-f6e3-48b4-a87d-796713f8f997',
-      postalCode: '90245',
+      postalCode: '90292',
       state: 'CA',
       streetAddress1: '987 Any Avenue',
       streetAddress2: 'P.O. Box 9876',

--- a/src/components/Office/ShipmentApprovalPreview/shipmentApprovalPreview.stories.jsx
+++ b/src/components/Office/ShipmentApprovalPreview/shipmentApprovalPreview.stories.jsx
@@ -186,6 +186,65 @@ const shipments = [
     updatedAt: '2020-06-10T15:58:02.431995Z',
     mtoAgents: agents,
   },
+  {
+    approvedDate: '0001-01-01',
+    createdAt: '2020-06-10T15:58:02.404029Z',
+    customerRemarks: 'please treat gently',
+    destinationAddress: {
+      city: 'Fairfield',
+      country: 'US',
+      eTag: 'MjAyMC0wNi0xMFQxNTo1ODowMi4zODk0MTJa',
+      id: '672ff379-f6e3-48b4-a87d-796713f8f997',
+      postalCode: '90245',
+      state: 'CA',
+      streetAddress1: '987 Any Avenue',
+      streetAddress2: 'P.O. Box 9876',
+      streetAddress3: 'c/o Some Person',
+    },
+    eTag: 'MjAyMC0wNi0xMFQxNTo1ODowMi40MDQwMzFa',
+    id: 'ce01a5b8-9b44-4511-8a8d-edb60f2a4aea',
+    moveTaskOrderID: '9c7b255c-2981-4bf8-839f-61c7458e2b4d',
+    pickupAddress: {
+      city: 'Beverly Hills',
+      country: 'US',
+      eTag: 'MjAyMC0wNi0xMFQxNTo1ODowMi4zODQ3Njla',
+      id: '1686751b-ab36-43cf-b3c9-c0f467d13c19',
+      postalCode: '90210',
+      state: 'CA',
+      streetAddress1: '123 Any Street',
+      streetAddress2: 'P.O. Box 12345',
+      streetAddress3: 'c/o Some Person',
+    },
+    rejectionReason: 'shipment not good enough',
+    requestedPickupDate: '2018-03-15',
+    scheduledPickupDate: '2018-03-16',
+    secondaryDeliveryAddress: {
+      city: 'Beverly Hills',
+      country: 'US',
+      eTag: 'MjAyMC0wNi0xMFQxNTo1ODowMi4zOTkzMlo=',
+      id: '15e8f6cc-e1d7-44b2-b1e0-fcb3d6442831',
+      postalCode: '90210',
+      state: 'CA',
+      streetAddress1: '123 Any Street',
+      streetAddress2: 'P.O. Box 12345',
+      streetAddress3: 'c/o Some Person',
+    },
+    secondaryPickupAddress: {
+      city: 'Beverly Hills',
+      country: 'US',
+      eTag: 'MjAyMC0wNi0xMFQxNTo1ODowMi4zOTM4OTZa',
+      id: '9b79e0c3-8ed5-4fb8-aa36-95845707d8ee',
+      postalCode: '90210',
+      state: 'CA',
+      streetAddress1: '123 Any Street',
+      streetAddress2: 'P.O. Box 12345',
+      streetAddress3: 'c/o Some Person',
+    },
+    shipmentType: SHIPMENT_OPTIONS.HHG,
+    status: 'SUBMITTED',
+    updatedAt: '2020-06-10T15:58:02.404031Z',
+    mtoAgents: agents,
+  },
 ];
 
 const allowancesInfo = {
@@ -260,7 +319,7 @@ const ordersInfo = {
   sacSDN: '',
 };
 
-export const shipmentApprovalPreviewModal = () => (
+export const shipmentApprovalPreviewModalDLH = () => (
   <div style={{ minWidth: '1240px' }}>
     <ShipmentApprovalPreview
       customerInfo={customerInfo}
@@ -268,6 +327,23 @@ export const shipmentApprovalPreviewModal = () => (
         return true;
       }}
       mtoShipments={[shipments[0]]}
+      allowancesInfo={allowancesInfo}
+      counselingFee
+      shipmentManagementFee
+      onSubmit={action('submit shipment approval')}
+      ordersInfo={ordersInfo}
+    />
+  </div>
+);
+
+export const shipmentApprovalPreviewModalDSH = () => (
+  <div style={{ minWidth: '1240px' }}>
+    <ShipmentApprovalPreview
+      customerInfo={customerInfo}
+      setIsModalVisible={() => {
+        return true;
+      }}
+      mtoShipments={[shipments[3]]}
       allowancesInfo={allowancesInfo}
       counselingFee
       shipmentManagementFee

--- a/src/components/Office/ShipmentServiceItemsTable/ShipmentServiceItemsTable.jsx
+++ b/src/components/Office/ShipmentServiceItemsTable/ShipmentServiceItemsTable.jsx
@@ -36,13 +36,18 @@ const shipmentTypes = {
 
 const ShipmentServiceItemsTable = ({ shipmentType, destinationZip3, pickupZip3, className }) => {
   const shipmentServiceItems = shipmentTypes[`${shipmentType}`] || [];
-  const shortHaulServiceItems = shipmentServiceItems.filter((item) => {
-    return item !== 'Domestic linehaul';
-  });
-  const longHaulServiceItems = shipmentServiceItems.filter((item) => {
-    return item !== 'Domestic shorthaul';
-  });
   const sameZip3 = destinationZip3 === pickupZip3;
+  let filteredServiceItemsList;
+
+  if (sameZip3) {
+    filteredServiceItemsList = shipmentServiceItems.filter((item) => {
+      return item !== serviceItemCodes.DLH;
+    });
+  } else {
+    filteredServiceItemsList = shipmentServiceItems.filter((item) => {
+      return item !== serviceItemCodes.DSH;
+    });
+  }
   return (
     <div className={classNames('container', 'container--gray', className)}>
       <table className={classNames('table--stacked', styles.serviceItemsTable)}>
@@ -50,7 +55,7 @@ const ShipmentServiceItemsTable = ({ shipmentType, destinationZip3, pickupZip3, 
           <div className="stackedtable-header">
             <h4>
               Service items for this shipment <br />
-              {sameZip3 ? shortHaulServiceItems.length : longHaulServiceItems.length} items
+              {filteredServiceItemsList.length} items
             </h4>
           </div>
         </caption>
@@ -60,17 +65,11 @@ const ShipmentServiceItemsTable = ({ shipmentType, destinationZip3, pickupZip3, 
           </tr>
         </thead>
         <tbody>
-          {sameZip3
-            ? shortHaulServiceItems.map((serviceItem) => (
-                <tr key={serviceItem}>
-                  <td>{serviceItem}</td>
-                </tr>
-              ))
-            : longHaulServiceItems.map((serviceItem) => (
-                <tr key={serviceItem}>
-                  <td>{serviceItem}</td>
-                </tr>
-              ))}
+          {filteredServiceItemsList.map((serviceItem) => (
+            <tr key={serviceItem}>
+              <td>{serviceItem}</td>
+            </tr>
+          ))}
         </tbody>
       </table>
     </div>

--- a/src/components/Office/ShipmentServiceItemsTable/ShipmentServiceItemsTable.jsx
+++ b/src/components/Office/ShipmentServiceItemsTable/ShipmentServiceItemsTable.jsx
@@ -9,6 +9,7 @@ import { serviceItemCodes } from 'content/serviceItems';
 const shipmentTypes = {
   HHG: [
     serviceItemCodes.DLH,
+    serviceItemCodes.DSH,
     serviceItemCodes.FSC,
     serviceItemCodes.DOP,
     serviceItemCodes.DDP,
@@ -17,6 +18,7 @@ const shipmentTypes = {
   ],
   HHG_INTO_NTS_DOMESTIC: [
     serviceItemCodes.DLH,
+    serviceItemCodes.DSH,
     serviceItemCodes.FSC,
     serviceItemCodes.DOP,
     serviceItemCodes.DDP,
@@ -24,6 +26,7 @@ const shipmentTypes = {
   ],
   HHG_OUTOF_NTS_DOMESTIC: [
     serviceItemCodes.DLH,
+    serviceItemCodes.DSH,
     serviceItemCodes.FSC,
     serviceItemCodes.DOP,
     serviceItemCodes.DDP,
@@ -31,9 +34,15 @@ const shipmentTypes = {
   ],
 };
 
-const ShipmentServiceItemsTable = ({ shipmentType, className }) => {
+const ShipmentServiceItemsTable = ({ shipmentType, destinationZip3, pickupZip3, className }) => {
   const shipmentServiceItems = shipmentTypes[`${shipmentType}`] || [];
-
+  const shortHaulServiceItems = shipmentServiceItems.filter((item) => {
+    return item !== 'Domestic linehaul';
+  });
+  const lineHaulServiceItems = shipmentServiceItems.filter((item) => {
+    return item !== 'Domestic shorthaul';
+  });
+  const sameZip3 = destinationZip3 === pickupZip3;
   return (
     <div className={classNames('container', 'container--gray', className)}>
       <table className={classNames('table--stacked', styles.serviceItemsTable)}>
@@ -50,11 +59,17 @@ const ShipmentServiceItemsTable = ({ shipmentType, className }) => {
           </tr>
         </thead>
         <tbody>
-          {shipmentServiceItems.map((serviceItem) => (
-            <tr key={serviceItem}>
-              <td>{serviceItem}</td>
-            </tr>
-          ))}
+          {sameZip3
+            ? shortHaulServiceItems.map((serviceItem) => (
+                <tr key={serviceItem}>
+                  <td>{serviceItem}</td>
+                </tr>
+              ))
+            : lineHaulServiceItems.map((serviceItem) => (
+                <tr key={serviceItem}>
+                  <td>{serviceItem}</td>
+                </tr>
+              ))}
         </tbody>
       </table>
     </div>

--- a/src/components/Office/ShipmentServiceItemsTable/ShipmentServiceItemsTable.jsx
+++ b/src/components/Office/ShipmentServiceItemsTable/ShipmentServiceItemsTable.jsx
@@ -48,9 +48,7 @@ const ShipmentServiceItemsTable = ({ shipmentType, destinationZip3, pickupZip3, 
       <table className={classNames('table--stacked', styles.serviceItemsTable)}>
         <caption>
           <div className="stackedtable-header">
-            <h4>
-              Service items for this shipment <span>{shipmentServiceItems.length} items</span>
-            </h4>
+            <h4>Service items for this shipment {shipmentServiceItems.length} items</h4>
           </div>
         </caption>
         <thead className="table--small">

--- a/src/components/Office/ShipmentServiceItemsTable/ShipmentServiceItemsTable.jsx
+++ b/src/components/Office/ShipmentServiceItemsTable/ShipmentServiceItemsTable.jsx
@@ -39,7 +39,7 @@ const ShipmentServiceItemsTable = ({ shipmentType, destinationZip3, pickupZip3, 
   const shortHaulServiceItems = shipmentServiceItems.filter((item) => {
     return item !== 'Domestic linehaul';
   });
-  const lineHaulServiceItems = shipmentServiceItems.filter((item) => {
+  const longHaulServiceItems = shipmentServiceItems.filter((item) => {
     return item !== 'Domestic shorthaul';
   });
   const sameZip3 = destinationZip3 === pickupZip3;
@@ -48,7 +48,10 @@ const ShipmentServiceItemsTable = ({ shipmentType, destinationZip3, pickupZip3, 
       <table className={classNames('table--stacked', styles.serviceItemsTable)}>
         <caption>
           <div className="stackedtable-header">
-            <h4>Service items for this shipment {shipmentServiceItems.length} items</h4>
+            <h4>
+              Service items for this shipment <br />
+              {sameZip3 ? shortHaulServiceItems.length : longHaulServiceItems.length} items
+            </h4>
           </div>
         </caption>
         <thead className="table--small">
@@ -63,7 +66,7 @@ const ShipmentServiceItemsTable = ({ shipmentType, destinationZip3, pickupZip3, 
                   <td>{serviceItem}</td>
                 </tr>
               ))
-            : lineHaulServiceItems.map((serviceItem) => (
+            : longHaulServiceItems.map((serviceItem) => (
                 <tr key={serviceItem}>
                   <td>{serviceItem}</td>
                 </tr>

--- a/src/components/Office/ShipmentServiceItemsTable/ShipmentServiceItemsTable.test.jsx
+++ b/src/components/Office/ShipmentServiceItemsTable/ShipmentServiceItemsTable.test.jsx
@@ -29,9 +29,6 @@ describe('Shipment Service Items Table', () => {
       expect(
         await screen.findByRole('heading', { name: 'Service items for this shipment 6 items', level: 4 }),
       ).toBeInTheDocument();
-      // expect(await screen.findByRole('heading', { level: 4 })).toHaveTextContent(
-      //   /Service items for this shipment 6 items/,
-      // );
       expect(screen.getByText(serviceItem)).toBeInTheDocument();
     });
   });
@@ -52,9 +49,6 @@ describe('Shipment Service Items Table', () => {
           shipmentType={SHIPMENT_OPTIONS.HHG}
         />,
       );
-      // expect(await screen.findByRole('heading', { level: 4 })).toHaveTextContent(
-      //   /Service items for this shipment 6 items/,
-      // );
       expect(
         await screen.findByRole('heading', { name: 'Service items for this shipment 6 items', level: 4 }),
       ).toBeInTheDocument();

--- a/src/components/Office/ShipmentServiceItemsTable/ShipmentServiceItemsTable.test.jsx
+++ b/src/components/Office/ShipmentServiceItemsTable/ShipmentServiceItemsTable.test.jsx
@@ -26,10 +26,12 @@ describe('Shipment Service Items Table', () => {
           shipmentType={SHIPMENT_OPTIONS.HHG}
         />,
       );
-      // expect(
-      //   await screen.findByRole('heading', { name: 'Service items for this shipment 6 items', level: 4 }),
-      // ).toBeInTheDocument();
-      expect(await screen.findByText('Service items for this shipment 6 items')).toBeInTheDocument();
+      expect(
+        await screen.findByRole('heading', { name: 'Service items for this shipment 6 items', level: 4 }),
+      ).toBeInTheDocument();
+      // expect(await screen.findByRole('heading', { level: 4 })).toHaveTextContent(
+      //   /Service items for this shipment 6 items/,
+      // );
       expect(screen.getByText(serviceItem)).toBeInTheDocument();
     });
   });
@@ -50,6 +52,9 @@ describe('Shipment Service Items Table', () => {
           shipmentType={SHIPMENT_OPTIONS.HHG}
         />,
       );
+      // expect(await screen.findByRole('heading', { level: 4 })).toHaveTextContent(
+      //   /Service items for this shipment 6 items/,
+      // );
       expect(
         await screen.findByRole('heading', { name: 'Service items for this shipment 6 items', level: 4 }),
       ).toBeInTheDocument();
@@ -65,7 +70,13 @@ describe('Shipment Service Items Table', () => {
       ['Domestic destination price'],
       ['Domestic NTS packing'],
     ])('expects %s to be in the document', async (serviceItem) => {
-      render(<ShipmentServiceItemsTable shipmentType={SHIPMENT_OPTIONS.NTS} />);
+      render(
+        <ShipmentServiceItemsTable
+          destinationZip3={destZip3}
+          pickupZip3={pickupZip3}
+          shipmentType={SHIPMENT_OPTIONS.NTS}
+        />,
+      );
       expect(
         await screen.findByRole('heading', { name: 'Service items for this shipment 5 items', level: 4 }),
       ).toBeInTheDocument();
@@ -81,7 +92,13 @@ describe('Shipment Service Items Table', () => {
       ['Domestic destination price'],
       ['Domestic unpacking'],
     ])('expects %s to be in the document', async (serviceItem) => {
-      render(<ShipmentServiceItemsTable shipmentType={SHIPMENT_OPTIONS.NTSR} />);
+      render(
+        <ShipmentServiceItemsTable
+          destinationZip3={destZip3}
+          pickupZip3={pickupZip3}
+          shipmentType={SHIPMENT_OPTIONS.NTSR}
+        />,
+      );
       expect(
         await screen.findByRole('heading', { name: 'Service items for this shipment 5 items', level: 4 }),
       ).toBeInTheDocument();

--- a/src/components/Office/ShipmentServiceItemsTable/ShipmentServiceItemsTable.test.jsx
+++ b/src/components/Office/ShipmentServiceItemsTable/ShipmentServiceItemsTable.test.jsx
@@ -5,6 +5,10 @@ import ShipmentServiceItemsTable from './ShipmentServiceItemsTable';
 
 import { SHIPMENT_OPTIONS } from 'shared/constants';
 
+const destZip3 = '112';
+const sameDestZip3 = '902';
+const pickupZip3 = '902';
+
 describe('Shipment Service Items Table', () => {
   describe('renders the hhg longhaul shipment type with service items', () => {
     it.each([
@@ -15,7 +19,37 @@ describe('Shipment Service Items Table', () => {
       ['Domestic packing'],
       ['Domestic unpacking'],
     ])('expects %s to be in the document', async (serviceItem) => {
-      render(<ShipmentServiceItemsTable shipmentType={SHIPMENT_OPTIONS.HHG} />);
+      render(
+        <ShipmentServiceItemsTable
+          destinationZip3={destZip3}
+          pickupZip3={pickupZip3}
+          shipmentType={SHIPMENT_OPTIONS.HHG}
+        />,
+      );
+      // expect(
+      //   await screen.findByRole('heading', { name: 'Service items for this shipment 6 items', level: 4 }),
+      // ).toBeInTheDocument();
+      expect(await screen.findByText('Service items for this shipment 6 items')).toBeInTheDocument();
+      expect(screen.getByText(serviceItem)).toBeInTheDocument();
+    });
+  });
+
+  describe('renders the hhg shorthaul shipment type with service items', () => {
+    it.each([
+      ['Domestic shorthaul'],
+      ['Fuel surcharge'],
+      ['Domestic origin price'],
+      ['Domestic destination price'],
+      ['Domestic packing'],
+      ['Domestic unpacking'],
+    ])('expects %s to be in the document', async (serviceItem) => {
+      render(
+        <ShipmentServiceItemsTable
+          destinationZip3={sameDestZip3}
+          pickupZip3={pickupZip3}
+          shipmentType={SHIPMENT_OPTIONS.HHG}
+        />,
+      );
       expect(
         await screen.findByRole('heading', { name: 'Service items for this shipment 6 items', level: 4 }),
       ).toBeInTheDocument();

--- a/src/components/Office/ShipmentServiceItemsTable/shipmentServiceItemsTable.stories.jsx
+++ b/src/components/Office/ShipmentServiceItemsTable/shipmentServiceItemsTable.stories.jsx
@@ -25,6 +25,10 @@ export const HHGShorthaulServiceItems = () => (
   />
 );
 
-export const NTSServiceItems = () => <ShipmentServiceItemsTable shipmentType={SHIPMENT_OPTIONS.NTS} />;
+export const NTSServiceItems = () => (
+  <ShipmentServiceItemsTable destinationZip3={destZip3} pickupZip3={pickupZip3} shipmentType={SHIPMENT_OPTIONS.NTS} />
+);
 
-export const NTSRServiceItems = () => <ShipmentServiceItemsTable shipmentType={SHIPMENT_OPTIONS.NTSR} />;
+export const NTSRServiceItems = () => (
+  <ShipmentServiceItemsTable destinationZip3={destZip3} pickupZip3={pickupZip3} shipmentType={SHIPMENT_OPTIONS.NTSR} />
+);

--- a/src/components/Office/ShipmentServiceItemsTable/shipmentServiceItemsTable.stories.jsx
+++ b/src/components/Office/ShipmentServiceItemsTable/shipmentServiceItemsTable.stories.jsx
@@ -9,9 +9,21 @@ export default {
   component: ShipmentServiceItemsTable,
 };
 
-export const HHGLonghaulServiceItems = () => <ShipmentServiceItemsTable shipmentType={SHIPMENT_OPTIONS.HHG} />;
+const destZip3 = '112';
+const sameDestZip3 = '902';
+const pickupZip3 = '902';
 
-export const HHGShorthaulServiceItems = () => <ShipmentServiceItemsTable shipmentType={SHIPMENT_OPTIONS.HHG} />;
+export const HHGLonghaulServiceItems = () => (
+  <ShipmentServiceItemsTable destinationZip3={destZip3} pickupZip3={pickupZip3} shipmentType={SHIPMENT_OPTIONS.HHG} />
+);
+
+export const HHGShorthaulServiceItems = () => (
+  <ShipmentServiceItemsTable
+    destinationZip3={sameDestZip3}
+    pickupZip3={pickupZip3}
+    shipmentType={SHIPMENT_OPTIONS.HHG}
+  />
+);
 
 export const NTSServiceItems = () => <ShipmentServiceItemsTable shipmentType={SHIPMENT_OPTIONS.NTS} />;
 


### PR DESCRIPTION
## [MB-16405](https://dp3.atlassian.net/browse/MB-16405?atlOrigin=eyJpIjoiOTFjODRkMWYwOWM0NGQ5ZjlkYjMwZDUzZjRhY2MwMmMiLCJwIjoiaiJ9)

## Summary

-Added a fix in which if a shipment has the same destination zip3 and origin zip3, the service item list will include "domestic shorthaul". If a shipment has different zip3's for destination and origin, then the service item list will include "domestic linehaul". 

-Updated Storybook components for 
1) `ShipmentApprovalPreview` to include `shipmentApprovalPreviewModalDSH` and `shipmentApprovalPreviewModalDLH`.
2) `ShipmentServiceItemsTable`

-Updated tests for `ShipmentApprovalPreview.test.jsx` and 'ShipmentServiceItemsTable.test.jsx`

**PLEASE NOTE**
Storybook is not accurately showing the bolded text for "Service items for this shipment x items". This issue existed on Storybook staging prior to my changes. I am leaving this as is since I do not want to mistakenly change the styling on other Storybook components. The bold text is correctly showing on the actual app. 

Storybook staging - text is not bold (before my changes)
![storybook-staging-not-bold](https://github.com/transcom/mymove/assets/110994428/45d770c6-4670-44d3-ac08-8013dd7d1d2a)

Storybook local - text is not bold (after my changes)
![storybook-local-not-bold](https://github.com/transcom/mymove/assets/110994428/42bd1c7a-f50f-4134-8863-ff0f4c8400a7)

## Verification Steps for the Author

These are to be checked by the author.

- [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
- [ ] Have the Jira acceptance criteria been met for this change?

## Verification Steps for Reviewers

These are to be checked by a reviewer.

### Setup to Run the Code

- [Instructions for starting storybook](https://transcom.github.io/mymove-docs/docs/frontend/setup/run-storybook)
- [Instructions for starting the MilMove application](https://transcom.github.io/mymove-docs/docs/about/application-setup/milmove-local-client/)
- [Instructions for running tests](https://transcom.github.io/mymove-docs/docs/about/development/testing)

### How to test

1. Log into Office app as TOO (too_role@office.mil)
2. Select move "WTSTAT". On Move Details page, under "Requested Shipments", click on the checkbox next to each shipment. Note 1 HHG shipment has different zip3s for the destination and origin. The other HHG shipment has the same zip3s.   
3. Scroll down and click on "Approve Selected". The Preview and post MTO modal should pop up.
4. The shipment with the different zip3s will have "Domestic linehaul" as a service item. The shipment with the same zip3s will have "Domestic shorthaul".

### Frontend

- [ ] There are no aXe warnings for UI.
- [ ] This works in [Supported Browsers and their phone views](https://transcom.github.io/mymove-docs/docs/about/supported-browsers) (Chrome, Firefox, Edge).
- [ ] There are no new console errors in the browser devtools.
- [ ] There are no new console errors in the test output.
- [ ] If this PR adds a new component to Storybook, it ensures the component is fully responsive, OR if it is intentionally not, a wrapping div using the `officeApp` class or custom `min-width` styling is used to hide any states the would not be visible to the user.

## Screenshots
Shorthaul move with same zip3s
![actual-local-bold](https://github.com/transcom/mymove/assets/110994428/4d28d651-27c7-46dc-b07f-80aa6c647a2b)

Longhaul move with different zip3s
![Screenshot 2023-07-10 at 12 59 47 PM](https://github.com/transcom/mymove/assets/110994428/516a6040-5aa5-4271-af0e-4ad342e0240a)


[MB-16405]: https://dp3.atlassian.net/browse/MB-16405?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ