### PR TITLE
MB-16351 add sit fsc details on TOO view

### DIFF
--- a/src/components/Office/ServiceItemDetails/ServiceItemDetails.jsx
+++ b/src/components/Office/ServiceItemDetails/ServiceItemDetails.jsx
@@ -27,7 +27,8 @@ const ServiceItemDetails = ({ id, code, details, serviceRequestDocs }) => {
   switch (code) {
     case 'DOFSIT':
     case 'DOASIT':
-    case 'DOPSIT': {
+    case 'DOPSIT':
+    case 'DOSFSC': {
       detailSection = (
         <div>
           <dl>
@@ -59,7 +60,8 @@ const ServiceItemDetails = ({ id, code, details, serviceRequestDocs }) => {
     }
     case 'DDFSIT':
     case 'DDASIT':
-    case 'DDDSIT': {
+    case 'DDDSIT':
+    case 'DDSFSC': {
       const { customerContacts } = details;
       // Below we are using the sortBy func in lodash to sort the customer contacts
       // by the firstAvailableDeliveryDate field. sortBy returns a new


### PR DESCRIPTION
## [Jira ticket](https://dp3.atlassian.net/browse/MB-16351)

## Summary
This tickets adds SIT FSC details to the service items tables.

- [ ] Make sure relevant information is visible on the table
- [ ] Run through manual test plan to verify functionality

[this article](tbd) explains more about the approach used.

## Verification Steps for the Author

These are to be checked by the author.

- [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
- [ ] Have the Jira acceptance criteria been met for this change?

## Verification Steps for Reviewers

These are to be checked by a reviewer.

### Setup to Run the Code

- [Instructions for starting storybook](https://transcom.github.io/mymove-docs/docs/frontend/setup/run-storybook)
- [Instructions for starting the MilMove application](https://transcom.github.io/mymove-docs/docs/about/application-setup/milmove-local-client/)
- [Instructions for running tests](https://transcom.github.io/mymove-docs/docs/about/development/testing)

### How to test

1. Login as prime simulator
2. Look at MISHIP or any other move with approved shipments
3. Click on Add Service Item button
4. Select Origin SIT for service item type field and fill out form
5. Click Create Service Item button
6. Repeat steps 4 and 5 for Destination SIT service item type
7.  Login as TOO 
8. Look at the MISHIP and make sure that service item details are there for FSC

### Frontend

- [ ] There are no aXe warnings for UI.
- [ ] This works in [Supported Browsers and their phone views](https://transcom.github.io/mymove-docs/docs/about/supported-browsers) (Chrome, Firefox, Edge).
- [ ] There are no new console errors in the browser devtools.
- [ ] There are no new console errors in the test output.
- [ ] If this PR adds a new component to Storybook, it ensures the component is fully responsive, OR if it is intentionally not, a wrapping div using the `officeApp` class or custom `min-width` styling is used to hide any states the would not be visible to the user.

### Backend

- [ ] Code follows the guidelines for [Logging](https://transcom.github.io/mymove-docs/docs/about/development/logging).
- [ ] The requirements listed in [Querying the Database Safely](https://transcom.github.io/mymove-docs/docs/backend/guides/golang-guide#querying-the-database-safely) have been satisfied.

### Database

#### Any new migrations/schema changes:

- [ ] Follows our guidelines for [Zero-Downtime Deploys](https://transcom.github.io/mymove-docs/docs/backend/setup/database-migrations#zero-downtime-migrations).
- [ ] Have been communicated to #g-database.
- [ ] Secure migrations have been tested following the instructions in our [docs](https://transcom.github.io/mymove-docs/docs/backend/setup/database-migrations#secure-migrations).

## Screenshots
