### PR TITLE
Revert logs in patchServiceMemberHandler.

### DIFF
--- a/pkg/handlers/internalapi/service_members.go
+++ b/pkg/handlers/internalapi/service_members.go
@@ -7,7 +7,6 @@ import (
 	"github.com/gobuffalo/validate/v3"
 	"github.com/gofrs/uuid"
 	"github.com/pkg/errors"
-	"go.uber.org/zap"
 
 	"github.com/transcom/mymove/pkg/appcontext"
 	"github.com/transcom/mymove/pkg/apperror"
@@ -189,12 +188,12 @@ func (h PatchServiceMemberHandler) Handle(params servicememberop.PatchServiceMem
 
 			serviceMemberID, _ := uuid.FromString(params.ServiceMemberID.String())
 
-			appCtx.Logger().Info("Patching service member", zap.String("serviceMemberID", serviceMemberID.String()), zap.Any("payload", params.PatchServiceMemberPayload))
 			var err error
 			var serviceMember models.ServiceMember
 			var verrs *validate.Errors
 
 			serviceMember, err = models.FetchServiceMemberForUser(appCtx.DB(), appCtx.Session(), serviceMemberID)
+
 			if err != nil {
 				return handlers.ResponseForError(appCtx.Logger(), err), err
 			}
@@ -248,7 +247,6 @@ func (h PatchServiceMemberHandler) Handle(params servicememberop.PatchServiceMem
 			}
 
 			serviceMemberPayload := payloadForServiceMemberModel(h.FileStorer(), serviceMember)
-			appCtx.Logger().Info("Finished patchServiceMemberHandler.")
 			return servicememberop.NewPatchServiceMemberOK().WithPayload(serviceMemberPayload), nil
 		})
 }


### PR DESCRIPTION
Reverts logs in the `patchServiceMemberHandler` added as debugging. These logs contain PII and [should not be present](https://trussworks.slack.com/archives/C02KKS13KQE/p1689283607433579?thread_ts=1678128898.444219&cid=C02KKS13KQE). I removed all the logging I previously added since, in the processing of reproducing the bug, this handler is never actually hit anyway, and the only useful non-PII data that could be logged here is present from the `request_logger`'s log.