### PR TITLE
MB-16478 - Fix brittle service item tests

### DIFF
--- a/playwright/tests/office/txo/tooFlows.spec.js
+++ b/playwright/tests/office/txo/tooFlows.spec.js
@@ -106,12 +106,15 @@ test.describe('TOO user', () => {
       await expect(page.getByTestId('ShipmentContainer')).toHaveCount(1);
 
       /**
-       * This test approves and rejects service items, which moves them from one table to another
+       * @function
+       * @description This test approves and rejects service items, which moves them from one table to another
        * and expects the counts of each table to increment/decrement by one item each time
        * This function gets the service items for a given table to help count them
+       * @param {import("playwright-core").Locator} table
+       * @returns {import("playwright-core").Locator}
        */
-      const getServiceItemsInTable = (/** @type {import("playwright-core").Locator} */ table) => {
-        return table.locator('tbody tr');
+      const getServiceItemsInTable = (table) => {
+        return table.getByRole('rowgroup').nth(1).getByRole('row');
       };
 
       const requestedServiceItemsTable = page.getByTestId('RequestedServiceItemsTable');
@@ -123,13 +126,13 @@ test.describe('TOO user', () => {
 
       // This test requires at least two requested service items
       await expect(page.getByText('Requested service items', { exact: false })).toBeVisible();
-      await expect(requestedServiceItemsTable.locator('tbody tr >> nth=1')).toBeVisible();
+      await expect(getServiceItemsInTable(requestedServiceItemsTable).nth(1)).toBeVisible();
 
       await expect(page.getByTestId('modal')).not.toBeVisible();
 
       // Approve a requested service item
       expect((await getServiceItemsInTable(requestedServiceItemsTable).count()) > 0);
-      await requestedServiceItemsTable.locator('.acceptButton').first().click();
+      await requestedServiceItemsTable.getByRole('button', { name: 'Accept' }).first().click();
       await tooFlowPage.waitForLoading();
 
       await expect(page.getByText('Approved service items', { exact: false })).toBeVisible();
@@ -142,14 +145,14 @@ test.describe('TOO user', () => {
       // Reject a requested service item
       await expect(page.getByText('Requested service items', { exact: false })).toBeVisible();
       expect((await getServiceItemsInTable(requestedServiceItemsTable).count()) > 0);
-      await requestedServiceItemsTable.locator('.rejectButton').first().click();
+      await requestedServiceItemsTable.getByRole('button', { name: 'Reject' }).first().click();
 
       await expect(page.getByTestId('modal')).toBeVisible();
       let modal = page.getByTestId('modal');
 
-      await expect(modal.locator('button[type="submit"]')).toBeDisabled();
-      await modal.locator('[data-testid="textInput"]').type('my very valid reason');
-      await modal.locator('button[type="submit"]').click();
+      await expect(modal.getByRole('button', { name: 'Submit' })).toBeDisabled();
+      await modal.getByRole('textbox').type('my very valid reason');
+      await modal.getByRole('button', { name: 'Submit' }).click();
 
       await expect(page.getByTestId('modal')).not.toBeVisible();
 
@@ -161,7 +164,7 @@ test.describe('TOO user', () => {
       requestedServiceItemCount = await getServiceItemsInTable(requestedServiceItemsTable).count();
 
       // Accept a previously rejected service item
-      await page.locator('[data-testid="RejectedServiceItemsTable"] button').click();
+      await rejectedServiceItemsTable.getByRole('button').first().click();
 
       await expect(page.getByText('Approved service items', { exact: false })).toBeVisible();
       await expect(getServiceItemsInTable(approvedServiceItemsTable)).toHaveCount(approvedServiceItemCount + 1);
@@ -171,13 +174,13 @@ test.describe('TOO user', () => {
       rejectedServiceItemCount = await getServiceItemsInTable(rejectedServiceItemsTable).count();
 
       // Reject a previously accepted service item
-      await approvedServiceItemsTable.locator('button').first().click();
+      await approvedServiceItemsTable.getByRole('button').first().click();
 
       await expect(page.getByTestId('modal')).toBeVisible();
       modal = page.getByTestId('modal');
-      await expect(modal.locator('button[type="submit"]')).toBeDisabled();
+      await expect(modal.getByRole('button', { name: 'Submit' })).toBeDisabled();
       await modal.getByTestId('textInput').type('changed my mind about this one');
-      await modal.locator('button[type="submit"]').click();
+      await modal.getByRole('button', { name: 'Submit' }).click();
 
       await expect(page.getByTestId('modal')).not.toBeVisible();
 

--- a/playwright/tests/office/txo/tooFlows.spec.js
+++ b/playwright/tests/office/txo/tooFlows.spec.js
@@ -112,8 +112,9 @@ test.describe('TOO user', () => {
       const rejectedServiceItemsTable = page.getByTestId('RejectedServiceItemsTable');
       let rejectedServiceItemCount = await rejectedServiceItemsTable.locator('tbody tr').count();
 
-      await expect(page.getByText('Approved service items', { exact: false })).toBeVisible();
-      await expect(page.getByText('Rejected service items')).not.toBeVisible();
+      // This test requires at least two requested service items
+      await expect(page.getByText('Requested service items', { exact: false })).toBeVisible();
+      await expect(requestedServiceItemsTable.locator('tbody tr >> nth=1')).toBeVisible();
 
       await expect(page.getByTestId('modal')).not.toBeVisible();
 
@@ -157,7 +158,6 @@ test.describe('TOO user', () => {
       await expect(approvedServiceItemsTable.locator('tbody tr')).toHaveCount(approvedServiceItemCount + 1);
       approvedServiceItemCount = await approvedServiceItemsTable.locator('tbody tr').count();
 
-      await expect(page.getByText('Rejected service items')).not.toBeVisible();
       await expect(rejectedServiceItemsTable.locator('tbody tr')).toHaveCount(rejectedServiceItemCount - 1);
       rejectedServiceItemCount = await rejectedServiceItemsTable.locator('tbody tr').count();
 
@@ -176,7 +176,6 @@ test.describe('TOO user', () => {
       await expect(rejectedServiceItemsTable.locator('tbody tr')).toHaveCount(rejectedServiceItemCount + 1);
       rejectedServiceItemCount = await rejectedServiceItemsTable.locator('tbody tr').count();
 
-      // await expect(page.getByText('Requested service items')).not.toBeVisible();
       await expect(page.getByText('Approved service items', { exact: false })).toBeVisible();
       await expect(approvedServiceItemsTable.locator('tbody tr')).toHaveCount(approvedServiceItemCount - 1);
       approvedServiceItemCount = await approvedServiceItemsTable.locator('tbody tr').count();

--- a/playwright/tests/office/txo/tooFlows.spec.js
+++ b/playwright/tests/office/txo/tooFlows.spec.js
@@ -105,12 +105,21 @@ test.describe('TOO user', () => {
       // Move Task Order page
       await expect(page.getByTestId('ShipmentContainer')).toHaveCount(1);
 
+      /**
+       * This test approves and rejects service items, which moves them from one table to another
+       * and expects the counts of each table to increment/decrement by one item each time
+       * This function gets the service items for a given table to help count them
+       */
+      const getServiceItemsInTable = (/** @type {import("playwright-core").Locator} */ table) => {
+        return table.locator('tbody tr');
+      };
+
       const requestedServiceItemsTable = page.getByTestId('RequestedServiceItemsTable');
-      let requestedServiceItemCount = await requestedServiceItemsTable.locator('tbody tr').count();
+      let requestedServiceItemCount = await getServiceItemsInTable(requestedServiceItemsTable).count();
       const approvedServiceItemsTable = page.getByTestId('ApprovedServiceItemsTable');
-      let approvedServiceItemCount = await approvedServiceItemsTable.locator('tbody tr').count();
+      let approvedServiceItemCount = await getServiceItemsInTable(approvedServiceItemsTable).count();
       const rejectedServiceItemsTable = page.getByTestId('RejectedServiceItemsTable');
-      let rejectedServiceItemCount = await rejectedServiceItemsTable.locator('tbody tr').count();
+      let rejectedServiceItemCount = await getServiceItemsInTable(rejectedServiceItemsTable).count();
 
       // This test requires at least two requested service items
       await expect(page.getByText('Requested service items', { exact: false })).toBeVisible();
@@ -119,20 +128,20 @@ test.describe('TOO user', () => {
       await expect(page.getByTestId('modal')).not.toBeVisible();
 
       // Approve a requested service item
-      expect((await requestedServiceItemsTable.locator('tbody tr').count()) > 0);
+      expect((await getServiceItemsInTable(requestedServiceItemsTable).count()) > 0);
       await requestedServiceItemsTable.locator('.acceptButton').first().click();
       await tooFlowPage.waitForLoading();
 
       await expect(page.getByText('Approved service items', { exact: false })).toBeVisible();
-      await expect(approvedServiceItemsTable.locator('tbody tr')).toHaveCount(approvedServiceItemCount + 1);
-      approvedServiceItemCount = await approvedServiceItemsTable.locator('tbody tr').count();
+      await expect(getServiceItemsInTable(approvedServiceItemsTable)).toHaveCount(approvedServiceItemCount + 1);
+      approvedServiceItemCount = await getServiceItemsInTable(approvedServiceItemsTable).count();
 
-      await expect(requestedServiceItemsTable.locator('tbody tr')).toHaveCount(requestedServiceItemCount - 1);
-      requestedServiceItemCount = await requestedServiceItemsTable.locator('tbody tr').count();
+      await expect(getServiceItemsInTable(requestedServiceItemsTable)).toHaveCount(requestedServiceItemCount - 1);
+      requestedServiceItemCount = await getServiceItemsInTable(requestedServiceItemsTable).count();
 
       // Reject a requested service item
       await expect(page.getByText('Requested service items', { exact: false })).toBeVisible();
-      expect((await requestedServiceItemsTable.locator('tbody tr').count()) > 0);
+      expect((await getServiceItemsInTable(requestedServiceItemsTable).count()) > 0);
       await requestedServiceItemsTable.locator('.rejectButton').first().click();
 
       await expect(page.getByTestId('modal')).toBeVisible();
@@ -145,21 +154,21 @@ test.describe('TOO user', () => {
       await expect(page.getByTestId('modal')).not.toBeVisible();
 
       await expect(page.getByText('Rejected service items', { exact: false })).toBeVisible();
-      await expect(rejectedServiceItemsTable.locator('tbody tr')).toHaveCount(rejectedServiceItemCount + 1);
-      rejectedServiceItemCount = await rejectedServiceItemsTable.locator('tbody tr').count();
+      await expect(getServiceItemsInTable(rejectedServiceItemsTable)).toHaveCount(rejectedServiceItemCount + 1);
+      rejectedServiceItemCount = await getServiceItemsInTable(rejectedServiceItemsTable).count();
 
-      await expect(requestedServiceItemsTable.locator('tbody tr')).toHaveCount(requestedServiceItemCount - 1);
-      requestedServiceItemCount = await requestedServiceItemsTable.locator('tbody tr').count();
+      await expect(getServiceItemsInTable(requestedServiceItemsTable)).toHaveCount(requestedServiceItemCount - 1);
+      requestedServiceItemCount = await getServiceItemsInTable(requestedServiceItemsTable).count();
 
       // Accept a previously rejected service item
       await page.locator('[data-testid="RejectedServiceItemsTable"] button').click();
 
       await expect(page.getByText('Approved service items', { exact: false })).toBeVisible();
-      await expect(approvedServiceItemsTable.locator('tbody tr')).toHaveCount(approvedServiceItemCount + 1);
-      approvedServiceItemCount = await approvedServiceItemsTable.locator('tbody tr').count();
+      await expect(getServiceItemsInTable(approvedServiceItemsTable)).toHaveCount(approvedServiceItemCount + 1);
+      approvedServiceItemCount = await getServiceItemsInTable(approvedServiceItemsTable).count();
 
-      await expect(rejectedServiceItemsTable.locator('tbody tr')).toHaveCount(rejectedServiceItemCount - 1);
-      rejectedServiceItemCount = await rejectedServiceItemsTable.locator('tbody tr').count();
+      await expect(getServiceItemsInTable(rejectedServiceItemsTable)).toHaveCount(rejectedServiceItemCount - 1);
+      rejectedServiceItemCount = await getServiceItemsInTable(rejectedServiceItemsTable).count();
 
       // Reject a previously accepted service item
       await approvedServiceItemsTable.locator('button').first().click();
@@ -173,12 +182,12 @@ test.describe('TOO user', () => {
       await expect(page.getByTestId('modal')).not.toBeVisible();
 
       await expect(page.getByText('Rejected service items', { exact: false })).toBeVisible();
-      await expect(rejectedServiceItemsTable.locator('tbody tr')).toHaveCount(rejectedServiceItemCount + 1);
-      rejectedServiceItemCount = await rejectedServiceItemsTable.locator('tbody tr').count();
+      await expect(getServiceItemsInTable(rejectedServiceItemsTable)).toHaveCount(rejectedServiceItemCount + 1);
+      rejectedServiceItemCount = await getServiceItemsInTable(rejectedServiceItemsTable).count();
 
       await expect(page.getByText('Approved service items', { exact: false })).toBeVisible();
-      await expect(approvedServiceItemsTable.locator('tbody tr')).toHaveCount(approvedServiceItemCount - 1);
-      approvedServiceItemCount = await approvedServiceItemsTable.locator('tbody tr').count();
+      await expect(getServiceItemsInTable(approvedServiceItemsTable)).toHaveCount(approvedServiceItemCount - 1);
+      approvedServiceItemCount = await getServiceItemsInTable(approvedServiceItemsTable).count();
     });
 
     test('is able to edit orders', async ({ page }) => {


### PR DESCRIPTION
## [Jira ticket](https://dp3.atlassian.net/browse/MB-16478)

## Summary

These changes update a playwright test to no longer expect precise numbers of service items to be requested, accepted, and rejected prior to the start of a test. Instead, it keeps counts of these numbers and performs validations against those counts. 

Two things to consider when reviewing this PR:
1. Does the new "counting" strategy for this test make sense? Can it be improved upon?
2. An extra wait, `waitForLoadState();`, was added at the beginning of the test to ensure that all of the table items have loaded before counting them. Is this an acceptable practice?

## Verification Steps for the Author

These are to be checked by the author.

- [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
- [ ] Have the Jira acceptance criteria been met for this change?

## Verification Steps for Reviewers

These are to be checked by a reviewer.

### Setup to Run the Code

- [Instructions for starting storybook](https://transcom.github.io/mymove-docs/docs/frontend/setup/run-storybook)
- [Instructions for starting the MilMove application](https://transcom.github.io/mymove-docs/docs/about/application-setup/milmove-local-client/)
- [Instructions for running tests](https://transcom.github.io/mymove-docs/docs/about/development/testing)

### How to test

1. `npx playwright test office/txo/tooFlows.spec.js`

### Frontend

- [ ] There are no aXe warnings for UI.
- [ ] This works in [Supported Browsers and their phone views](https://transcom.github.io/mymove-docs/docs/about/supported-browsers) (Chrome, Firefox, Edge).
- [ ] There are no new console errors in the browser devtools.
- [ ] There are no new console errors in the test output.
- [ ] If this PR adds a new component to Storybook, it ensures the component is fully responsive, OR if it is intentionally not, a wrapping div using the `officeApp` class or custom `min-width` styling is used to hide any states the would not be visible to the user.

