### PR TITLE
Check whether pre-commit is installed by `which` rather than static path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,8 +65,15 @@ help:  ## Print the help documentation
 # This target ensures that the pre-commit hook is installed and kept up to date
 # if pre-commit updates.
 .PHONY: ensure_pre_commit
-ensure_pre_commit: .git/hooks/pre-commit install_pre_commit ## Ensure pre-commit is installed
-.git/hooks/pre-commit: /usr/local/bin/pre-commit
+ensure_pre_commit: .git/hooks/pre-commit install_pre_commit ## Ensure pre-commit hooks are installed
+.git/hooks/pre-commit: .check_pre-commit_installed.stamp
+.check_pre-commit_installed.stamp:
+ifeq (, $(shell which pre-commit))
+	$(error pre-commit is not installed. Install with `brew install pre-commit`.)
+else
+	@echo "pre-commit is installed"
+	touch .check_pre-commit_installed.stamp
+endif
 
 .PHONY: install_pre_commit
 install_pre_commit:  ## Installs pre-commit hooks

--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,7 @@ help:  ## Print the help documentation
 .PHONY: ensure_pre_commit
 ensure_pre_commit: .git/hooks/pre-commit install_pre_commit ## Ensure pre-commit hooks are installed
 .git/hooks/pre-commit: .check_pre-commit_installed.stamp
-.check_pre-commit_installed.stamp:
+.check_pre-commit_installed.stamp: ## Ensure pre-commit is installed
 ifeq (, $(shell which pre-commit))
 	$(error pre-commit is not installed. Install with `brew install pre-commit`.)
 else


### PR DESCRIPTION
## Summary

Pre-commit may not have the same PATH location for all users.

For example: while going through setup, my pre-commit was installed at the previously specified path. Hwoever @mandaem's pre-commit lives in `/opt/homebrew/bin/pre-commit`

> Is there anything you would like reviewers to give additional scrutiny?

Yep! I'm not great with shell scripting or even Makefile intricacies. I do wonder if there's a much simpler way to do what I'm trying to do here. If so, please let me know

### How to test

1. Run `make ensure_pre_commit`
2. Verify no errors occur
