### PR TITLE
Fix review app deployment

### DIFF
--- a/Dockerfile.reviewapp
+++ b/Dockerfile.reviewapp
@@ -37,9 +37,9 @@ COPY pkg /build/pkg
 # fake src dir to silence make
 RUN mkdir /build/src
 
-# fake the .go-version
+# fake the go-version via .tool-versions
 RUN set -x \
-  && touch .go-version \
+  && touch .tool-versions \
   && make bin/rds-ca-2019-root.pem \
   && rm -f bin/milmove && make bin/milmove \
   && make bin/generate-test-data


### PR DESCRIPTION
## Fix review app deployment

## Summary

Fixes an error introduced in https://github.com/transcom/mymove/pull/11053 that prevents the review app from building.

The review app relies on a chain of make commands, one of which (checking the go version) requires that the file containing the go version is at least present. This PR updates it to fake .tool-versions instead of .go-version, since that's a make target prereq

## Verification Steps for the Author

These are to be checked by the author.

- [x] Ran review app deploy successfully on this branch:
https://trussworks.slack.com/archives/C01T40WC4G1/p1690232909139089?thread_ts=1690231521.748269&cid=C01T40WC4G1