### PR TITLE
MB-15530: wait for tasks to stop when doing a deployment

### DIFF
--- a/scripts/ecs-deploy-service-container
+++ b/scripts/ecs-deploy-service-container
@@ -41,6 +41,11 @@ update_service() {
     local arn="$1"
     echo "* Updating service ${name} with ARN ${arn}"
 
+    # read the currently running tasks into an array so later on we
+    # can query to ensure they have been stopped
+    local old_tasks
+    read -ra old_tasks <<< "$(aws ecs list-tasks --service-name "${name}" --cluster "${cluster}" --query='taskArns[]' --output text)"
+
     local network_config
     network_config=$(aws ecs describe-services --services "${name}" --cluster "${cluster}" --query 'services[0].networkConfiguration')
 
@@ -50,8 +55,14 @@ update_service() {
     aws ecs list-tasks --service "${name}" --cluster "${cluster}" --desired-status=RUNNING
     echo "* Updating ${name} service to use ${arn}"
     aws ecs update-service --cluster "${cluster}" --service "${name}" --task-definition "${arn}" --query 'service.deployments' --network-configuration "${network_config}" || return 1
-    echo "* Newly started ECS tasks:"
-    aws ecs list-tasks --service "${name}" --cluster "${cluster}" --desired-status=PENDING
+
+    # According to the help for the AWS CLI,
+    #
+    # "Although you can filter results based on  a  desired  status
+    # of PENDING , this doesn't return any results."
+    #
+    echo "* All ECS tasks:"
+    aws ecs list-tasks --service "${name}" --cluster "${cluster}" --desired-status=RUNNING
     echo "* Waiting for service to stabilize (this takes a while)"
     time aws ecs wait services-stable --services "${name}" --cluster "${cluster}"
     local exit_code=$?
@@ -61,6 +72,19 @@ update_service() {
     echo "Last 5 service events:"
     aws ecs describe-services --service "${name}" --cluster "${cluster}" --query 'services[].events[:5]'
     echo
+
+    if [[ $exit_code -gt 0 ]]; then
+        return $exit_code
+    fi
+
+    # Are there any tasks that should be stopped that aren't? Maybe
+    # this is how we can fix the flaky deployments?
+    time aws ecs wait tasks-stopped --cluster "${cluster}" --tasks "${old_tasks[@]}"
+    exit_code=$?
+
+    if [[ $exit_code -gt 0 ]]; then
+        echo "The original tasks did not stop as expected"
+    fi
 
     return $exit_code
 }

--- a/scripts/ecs-deploy-service-container
+++ b/scripts/ecs-deploy-service-container
@@ -128,7 +128,7 @@ if update_service "$green_task_def_arn"; then
     exit 0
 fi
 echo "Service failed to stabilize!"
-put_metric DeployFail "${cluster}"
+put_metric "${name}.DeployFail" "${cluster}"
 
 echo
 echo "Showing logs from recently stopped tasks:"
@@ -138,9 +138,9 @@ echo
 echo "* Rolling back to $blue_task_def_arn"
 if update_service "$blue_task_def_arn"; then
     echo "Rollback complete."
-    put_metric RollbackCount "${cluster}"
+    put_metric "${name}.RollbackCount" "${cluster}"
     exit 1
 fi
 echo "Rollback failed!"
-put_metric RollbackFail "${cluster}"
+put_metric "${name}.RollbackFail" "${cluster}"
 exit 1

--- a/scripts/ecs-deploy-service-container
+++ b/scripts/ecs-deploy-service-container
@@ -77,8 +77,11 @@ update_service() {
         return $exit_code
     fi
 
-    # Are there any tasks that should be stopped that aren't? Maybe
-    # this is how we can fix the flaky deployments?
+    # Are there any tasks that should be stopped that aren't? If so,
+    # wait for them to stop.
+    #
+    # Try to fix the flaky deployment failures documented in MB-15530
+    # If we stop seeing failures, we can update this comment
     time aws ecs wait tasks-stopped --cluster "${cluster}" --tasks "${old_tasks[@]}"
     exit_code=$?
 


### PR DESCRIPTION
## [Jira ticket](https://dp3.atlassian.net/browse/MB-15530)

## Summary

To try to fix the flaky deployment errors, get the list of running tasks prior to a deployment and then wait for all them to stop after a deployment before continuing.

It's hard to prove a negative, but I've not seen a single error in the loadtest environment since testing this change there.

While updating the scripts, ensure we namespace the metrics where we track errors so that we can distinguish betwen failures to `app` and `app-client-tls`

## Verification Steps for the Author

- [ ] Tested in the Loadtest environment (for changes to containers, app startup, or connection to data stores)
- [ ] Have the Jira acceptance criteria been met for this change?

## Verification Steps for Reviewers

This is entirely a deploy time change