### PR TITLE
[MB-16480] Adding unit tests for error page

### DIFF
--- a/src/shared/SomethingWentWrong/index.jsx
+++ b/src/shared/SomethingWentWrong/index.jsx
@@ -17,7 +17,7 @@ const SomethingWentWrong = ({ error, info }) => (
       <br />
       <br />
       <br />
-      <p>
+      <p data-testid="contactMsg">
         If you continue to receive this error, call (800) 462-2176, Option 2 or{' '}
         <a href="mailto:usarmy.scott.sddc.mbx.g6-src-dps-hd@mail.mil" className="usa-link">
           email us

--- a/src/shared/SomethingWentWrong/index.test.js
+++ b/src/shared/SomethingWentWrong/index.test.js
@@ -1,13 +1,42 @@
 import React from 'react';
-import { shallow } from 'enzyme';
+import { render, screen } from '@testing-library/react';
 
-import SomethingWentWrong from '.';
+import SomethingWentWrong from './index';
 
 describe('SomethingWentWrong tests', () => {
-  let wrapper;
-  it('renders without crashing', () => {
-    const div = document.createElement('div');
-    wrapper = shallow(<SomethingWentWrong />, div);
-    expect(wrapper.find('.usa-grid').length).toEqual(1);
+  it('renders without crashing', async () => {
+    const { container } = render(<SomethingWentWrong />);
+
+    const errorPage = await container.querySelector('.usa-grid');
+    expect(errorPage).toBeInTheDocument();
+  });
+
+  it('should render the correct image on the page', () => {
+    render(<SomethingWentWrong />);
+
+    const image = screen.getByRole('img');
+    expect(image).toBeInTheDocument();
+    expect(image).toHaveAttribute('src', 'sad-computer.png');
+  });
+
+  it('should render the correct text on the page', () => {
+    render(<SomethingWentWrong />);
+
+    const oopsMsg = screen.getByRole('heading', { level: 2 });
+    expect(oopsMsg).toBeInTheDocument();
+    expect(oopsMsg).toHaveTextContent('Oops!Something went wrong.');
+
+    const tryAgainMsg = screen.getByText('Please try again in a few moments.');
+    expect(tryAgainMsg).toBeInTheDocument();
+
+    const contactMsg = screen.getByTestId('contactMsg');
+    expect(contactMsg).toBeInTheDocument();
+    expect(contactMsg).toHaveTextContent(
+      'If you continue to receive this error, call (800) 462-2176, Option 2 or email us.',
+    );
+
+    const email = screen.getByRole('link', { name: 'email us' });
+    expect(email).toBeInTheDocument();
+    expect(email).toHaveAttribute('href', 'mailto:usarmy.scott.sddc.mbx.g6-src-dps-hd@mail.mil');
   });
 });


### PR DESCRIPTION
## [Jira ticket](https://dp3.atlassian.net/browse/MB-16480)

## Summary

Connected to this [PR](https://github.com/transcom/mymove/pull/11060) - this PR adds unit tests for the mymove error page.

## Verification Steps for Reviewers

These are to be checked by a reviewer.

### Setup to Run the Code

- [Instructions for starting storybook](https://transcom.github.io/mymove-docs/docs/frontend/setup/run-storybook)
- [Instructions for starting the MilMove application](https://transcom.github.io/mymove-docs/docs/about/application-setup/milmove-local-client/)
- [Instructions for running tests](https://transcom.github.io/mymove-docs/docs/about/development/testing)

### How to test

1. run the command `make client_test`
2. All tests should pass 🎉 
