### PR TITLE
MB-15211 - Update idle timer to better use inbuilt tools

### DIFF
--- a/src/layout/LogoutOnInactivity.jsx
+++ b/src/layout/LogoutOnInactivity.jsx
@@ -2,75 +2,81 @@ import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import { useNavigate } from 'react-router-dom';
 import { useIdleTimer } from 'react-idle-timer';
-import { useSelector, useDispatch } from 'react-redux';
+import { useSelector } from 'react-redux';
 
 import { selectIsLoggedIn } from 'store/auth/selectors';
 import Alert from 'shared/Alert';
 import { LogoutUser } from 'utils/api';
 
-const defaultMaxIdleTimeInSeconds = 14 * 60;
-const defaultMaxWarningTimeInSeconds = 60;
+const defaultMaxIdleTime = 15_000 * 60;
+const defaultWarningTime = 1_000 * 60;
 const keepAliveEndpoint = '/internal/users/logged_in';
 
-const LogoutOnInactivity = ({ maxIdleTimeInSeconds, maxWarningTimeInSeconds }) => {
-  const [isIdle, setIsIdle] = useState(false);
-  const [timeLeftInSeconds, setTimeLeftInSeconds] = useState(maxWarningTimeInSeconds);
+/**
+ * @description The component that handles logging out inactive users.
+ * @param {int} maxIdleTime the amount of time in milliseconds that the user can be idle before being logged out
+ * @param {int} warningTime the amount of time in milliseconds that the user will be shown a warning before being logged out
+ * @return {JSX.Element}
+ * */
+const LogoutOnInactivity = ({ maxIdleTime, warningTime }) => {
   const navigate = useNavigate();
   const isLoggedIn = useSelector(selectIsLoggedIn);
-  const dispatch = useDispatch();
+  const [showLogoutWarning, setShowLogoutWarning] = useState(false);
+  const [remaining, setRemaining] = useState(0);
+
+  const handleOnPrompt = () => {
+    setShowLogoutWarning(true);
+  };
 
   const handleOnActive = () => {
-    setIsIdle(false);
-    setTimeLeftInSeconds(maxWarningTimeInSeconds);
+    setShowLogoutWarning(false);
     if (isLoggedIn) {
       fetch(keepAliveEndpoint);
     }
   };
 
   const handleOnIdle = () => {
-    setIsIdle(true);
+    if (isLoggedIn) {
+      LogoutUser().then((r) => {
+        const redirectURL = r.body;
+        if (redirectURL) {
+          window.location.href = redirectURL;
+        } else {
+          navigate('/sign-in', { state: { hasLoggedOut: true } });
+        }
+      });
+    }
   };
 
-  useIdleTimer({
+  const { getRemainingTime } = useIdleTimer({
     element: document,
-    timeout: maxIdleTimeInSeconds * 1000,
+    events: ['blur', 'focus', 'mousedown', 'touchstart', 'MSPointerDown'],
     onActive: handleOnActive,
     onIdle: handleOnIdle,
-    events: ['blur', 'focus', 'mousedown', 'touchstart', 'MSPointerDown'],
+    onPrompt: handleOnPrompt,
+    promptBeforeIdle: warningTime,
     startOnMount: true,
+    timeout: maxIdleTime,
   });
 
   useEffect(() => {
-    let warningTimer;
-    if (isIdle && isLoggedIn) {
-      let timeLeft = maxWarningTimeInSeconds;
-      warningTimer = setInterval(() => {
-        setTimeLeftInSeconds((current) => current - 1);
-        if (timeLeft > 1) {
-          timeLeft -= 1;
-        } else {
-          LogoutUser().then((r) => {
-            const redirectURL = r.body;
-            if (redirectURL) {
-              window.location.href = redirectURL;
-            } else {
-              navigate('/sign-in', { state: { hasLoggedOut: true } });
-            }
-          });
-        }
-      }, 1000);
-    }
-    return () => clearInterval(warningTimer);
-  }, [isIdle, isLoggedIn, maxWarningTimeInSeconds, dispatch, navigate]);
+    const interval = setInterval(() => {
+      setRemaining(Math.floor(getRemainingTime() / 1000));
+    }, 500);
+
+    return () => {
+      clearInterval(interval);
+    };
+  });
 
   return (
     isLoggedIn && (
       <div data-testid="logoutOnInactivityWrapper">
-        {isIdle && (
+        {isLoggedIn && showLogoutWarning && (
           <div data-testid="logoutAlert">
             <Alert type="warning" heading="Inactive user">
-              You have been inactive and will be logged out in {timeLeftInSeconds} seconds unless you touch or click on
-              the page.
+              You have been inactive and will be logged out in {remaining} seconds unless you touch or click on the
+              page.
             </Alert>
           </div>
         )}
@@ -80,13 +86,13 @@ const LogoutOnInactivity = ({ maxIdleTimeInSeconds, maxWarningTimeInSeconds }) =
 };
 
 LogoutOnInactivity.defaultProps = {
-  maxIdleTimeInSeconds: defaultMaxIdleTimeInSeconds,
-  maxWarningTimeInSeconds: defaultMaxWarningTimeInSeconds,
+  maxIdleTime: defaultMaxIdleTime,
+  warningTime: defaultWarningTime,
 };
 
 LogoutOnInactivity.propTypes = {
-  maxIdleTimeInSeconds: PropTypes.number,
-  maxWarningTimeInSeconds: PropTypes.number,
+  maxIdleTime: PropTypes.number,
+  warningTime: PropTypes.number,
 };
 
 export default LogoutOnInactivity;

--- a/src/layout/LogoutOnInactivity.jsx
+++ b/src/layout/LogoutOnInactivity.jsx
@@ -8,34 +8,34 @@ import { selectIsLoggedIn } from 'store/auth/selectors';
 import Alert from 'shared/Alert';
 import { LogoutUser } from 'utils/api';
 
-const defaultMaxIdleTime = 15_000 * 60;
+const defaultIdleTimeout = 15_000 * 60;
 const defaultWarningTime = 1_000 * 60;
 const keepAliveEndpoint = '/internal/users/logged_in';
 
 /**
  * @description The component that handles logging out inactive users.
- * @param {int} maxIdleTime the amount of time in milliseconds that the user can be idle before being logged out
+ * @param {int} idleTimeout the amount of time in milliseconds that the user can be idle before being logged out
  * @param {int} warningTime the amount of time in milliseconds that the user will be shown a warning before being logged out
  * @return {JSX.Element}
  * */
-const LogoutOnInactivity = ({ maxIdleTime, warningTime }) => {
+const LogoutOnInactivity = ({ idleTimeout, warningTime }) => {
   const navigate = useNavigate();
   const isLoggedIn = useSelector(selectIsLoggedIn);
   const [showLogoutWarning, setShowLogoutWarning] = useState(false);
   const [remaining, setRemaining] = useState(0);
 
-  const handleOnPrompt = () => {
+  const onPrompt = () => {
     setShowLogoutWarning(true);
   };
 
-  const handleOnActive = () => {
+  const onActive = () => {
     setShowLogoutWarning(false);
     if (isLoggedIn) {
       fetch(keepAliveEndpoint);
     }
   };
 
-  const handleOnIdle = () => {
+  const onIdle = () => {
     if (isLoggedIn) {
       LogoutUser().then((r) => {
         const redirectURL = r.body;
@@ -51,12 +51,12 @@ const LogoutOnInactivity = ({ maxIdleTime, warningTime }) => {
   const { getRemainingTime } = useIdleTimer({
     element: document,
     events: ['blur', 'focus', 'mousedown', 'touchstart', 'MSPointerDown'],
-    onActive: handleOnActive,
-    onIdle: handleOnIdle,
-    onPrompt: handleOnPrompt,
+    onActive,
+    onIdle,
+    onPrompt,
     promptBeforeIdle: warningTime,
     startOnMount: true,
-    timeout: maxIdleTime,
+    timeout: idleTimeout,
   });
 
   useEffect(() => {
@@ -72,7 +72,7 @@ const LogoutOnInactivity = ({ maxIdleTime, warningTime }) => {
   return (
     isLoggedIn && (
       <div data-testid="logoutOnInactivityWrapper">
-        {isLoggedIn && showLogoutWarning && (
+        {showLogoutWarning && (
           <div data-testid="logoutAlert">
             <Alert type="warning" heading="Inactive user">
               You have been inactive and will be logged out in {remaining} seconds unless you touch or click on the
@@ -86,12 +86,12 @@ const LogoutOnInactivity = ({ maxIdleTime, warningTime }) => {
 };
 
 LogoutOnInactivity.defaultProps = {
-  maxIdleTime: defaultMaxIdleTime,
+  idleTimeout: defaultIdleTimeout,
   warningTime: defaultWarningTime,
 };
 
 LogoutOnInactivity.propTypes = {
-  maxIdleTime: PropTypes.number,
+  idleTimeout: PropTypes.number,
   warningTime: PropTypes.number,
 };
 

--- a/src/layout/LogoutOnInactivity.jsx
+++ b/src/layout/LogoutOnInactivity.jsx
@@ -35,6 +35,10 @@ const LogoutOnInactivity = ({ idleTimeout, warningTime }) => {
     }
   };
 
+  const onAction = (_event, idleTimer) => {
+    idleTimer.activate();
+  };
+
   const onIdle = () => {
     if (isLoggedIn) {
       LogoutUser().then((r) => {
@@ -51,6 +55,7 @@ const LogoutOnInactivity = ({ idleTimeout, warningTime }) => {
   const { getRemainingTime } = useIdleTimer({
     element: document,
     events: ['blur', 'focus', 'mousedown', 'touchstart', 'MSPointerDown'],
+    onAction,
     onActive,
     onIdle,
     onPrompt,

--- a/src/layout/LogoutOnInactivity.test.jsx
+++ b/src/layout/LogoutOnInactivity.test.jsx
@@ -17,23 +17,20 @@ const mockState = (loggedIn) => {
 };
 
 // These tests assume that the idle time limit >= 1 second
-const idleTimeLimitSeconds = 1;
-const warningTimeLimitSeconds = 1;
+const idleTimeout = 3000;
+const warningTime = 1000;
 
 const renderComponent = ({ loggedIn }) => {
   render(
     <MockProviders initialState={mockState(loggedIn)}>
-      <LogoutOnInactivity
-        maxIdleTimeInSeconds={idleTimeLimitSeconds}
-        maxWarningTimeInSeconds={warningTimeLimitSeconds}
-      />
+      <LogoutOnInactivity idleTimeout={idleTimeout} warningTime={warningTime} />
     </MockProviders>,
   );
 };
 
-const sleep = (seconds) => {
+const sleep = (time) => {
   return new Promise((resolve) => {
-    setTimeout(resolve, seconds * 1000);
+    setTimeout(resolve, time);
   });
 };
 
@@ -55,27 +52,36 @@ describe('LogoutOnInactivity', () => {
     });
 
     it('becomes idle and triggers a warning', async () => {
-      // alert is missing before the user is idle for the timeout duration
-      expect(screen.queryByTestId('logoutAlert')).not.toBeInTheDocument();
+      // alert is missing before the user is idle for too long
+      expect(
+        screen.queryByText('You have been inactive and will be logged out', { exact: false }),
+      ).not.toBeInTheDocument();
       await act(async () => {
-        return sleep(idleTimeLimitSeconds);
+        return sleep(idleTimeout - warningTime);
       });
 
-      expect(screen.queryByTestId('logoutAlert')).toBeInTheDocument();
+      expect(screen.getByText('You have been inactive and will be logged out', { exact: false })).toBeInTheDocument();
     });
 
     it('removes the idle alert if a user performs a click', async () => {
-      // alert is missing before the user is idle for the timeout duration
-      expect(screen.queryByTestId('logoutAlert')).not.toBeInTheDocument();
+      // alert is missing before the user is idle for too long
+      expect(
+        screen.queryByText('You have been inactive and will be logged out', { exact: false }),
+      ).not.toBeInTheDocument();
       await act(async () => {
-        return sleep(idleTimeLimitSeconds);
+        return sleep(idleTimeout - warningTime);
       });
+
+      // alert is present after user is idle for too long
+      expect(screen.getByText('You have been inactive and will be logged out', { exact: false })).toBeInTheDocument();
 
       const wrapper = screen.getByTestId('logoutOnInactivityWrapper');
       await userEvent.click(wrapper);
 
       // alert is not present after the click
-      expect(screen.queryByTestId('logoutAlert')).not.toBeInTheDocument();
+      expect(
+        screen.queryByText('You have been inactive and will be logged out', { exact: false }),
+      ).not.toBeInTheDocument();
     });
   });
 


### PR DESCRIPTION
## [Jira ticket](https://dp3.atlassian.net/browse/MB-15211)

## Summary

This is a tricky bug 😨 
In deployed environments (but _not_ development environments), the logout-on-idle utility does not behave as expected. If a logged-in user becomes idle and waits > 15 minutes and then returns to the page, the timer will start only when the user returns to the page. This PR should fix the timer such that the user will _always_ recieve a warning alert at 14 minutes and will _always_ be logged out at 15 minutes unless they are no longer idle.

## Verification Steps for the Author

These are to be checked by the author.

- [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
- [ ] Have the Jira acceptance criteria been met for this change?

## Verification Steps for Reviewers

These are to be checked by a reviewer.

### Setup to Run the Code

- [Instructions for starting storybook](https://transcom.github.io/mymove-docs/docs/frontend/setup/run-storybook)
- [Instructions for starting the MilMove application](https://transcom.github.io/mymove-docs/docs/about/application-setup/milmove-local-client/)
- [Instructions for running tests](https://transcom.github.io/mymove-docs/docs/about/development/testing)

### How to test

1. Access an ephemeral deployment of this branch
2. Log in to the office app as a TXO
3. Bring an unrelated tab into focus and leave the milmove tab alone for between 14 and 15 minutes (I recommend setting a timer for exactly 14:30)
4. Return to the tab after the given time and validate that the alert warning is shown at the top of the page and that the expected amount of time is left in the timer
5. Validate that the user is logged out after the timer hits 0
6. Validate that the user is not logged out and the disappears if the user clicks the page before the timer hits 0

### Frontend

- [ ] There are no aXe warnings for UI.
- [ ] This works in [Supported Browsers and their phone views](https://transcom.github.io/mymove-docs/docs/about/supported-browsers) (Chrome, Firefox, Edge).
- [ ] There are no new console errors in the browser devtools.
- [ ] There are no new console errors in the test output.
- [ ] If this PR adds a new component to Storybook, it ensures the component is fully responsive, OR if it is intentionally not, a wrapping div using the `officeApp` class or custom `min-width` styling is used to hide any states the would not be visible to the user.
