### PR TITLE
For the SIT delivery pricer have it check distance before Zip3

### DIFF
--- a/pkg/services/ghcrateengine/pricer_helpers.go
+++ b/pkg/services/ghcrateengine/pricer_helpers.go
@@ -228,21 +228,7 @@ func priceDomesticPickupDeliverySIT(appCtx appcontext.AppContext, pickupDelivery
 
 	// Three different pricing scenarios below.
 
-	// 1) Zip3 to same zip3
-	if zip3Original == zip3Actual {
-		// Do a normal shorthaul calculation
-		shorthaulPricer := NewDomesticShorthaulPricer()
-		totalPriceCents, displayParams, err := shorthaulPricer.Price(appCtx, contractCode, referenceDate, distance, weight, serviceArea)
-		if err != nil {
-			return unit.Cents(0), nil, fmt.Errorf("could not price shorthaul: %w", err)
-		}
-
-		return totalPriceCents, displayParams, nil
-	}
-
-	// Zip3s must be different at this point.  Now examine distance.
-
-	// 2) Zip3 to different zip3 and > 50 miles
+	// 1) distance > 50 miles
 	if distance > 50 {
 		// Do a normal linehaul calculation
 		linehaulPricer := NewDomesticLinehaulPricer()
@@ -256,7 +242,17 @@ func priceDomesticPickupDeliverySIT(appCtx appcontext.AppContext, pickupDelivery
 		return totalPriceCents, displayParams, nil
 	}
 
-	// Zip3s must be different at this point and distance is <= 50.
+	// 2) Zip3 to same zip3
+	if zip3Original == zip3Actual {
+		// Do a normal shorthaul calculation
+		shorthaulPricer := NewDomesticShorthaulPricer()
+		totalPriceCents, displayParams, err := shorthaulPricer.Price(appCtx, contractCode, referenceDate, distance, weight, serviceArea)
+		if err != nil {
+			return unit.Cents(0), nil, fmt.Errorf("could not price shorthaul: %w", err)
+		}
+
+		return totalPriceCents, displayParams, nil
+	}
 
 	// 3) Zip3 to different zip3 and <= 50 miles
 


### PR DESCRIPTION
## Summary

We were told that the distance check takes precedence over the zip3 check on the pricing rate. So this moves that if statement upward.

## Verification Steps for the Author

These are to be checked by the author.

- [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
- [ ] Have the Jira acceptance criteria been met for this change?

## Verification Steps for Reviewers

These are to be checked by a reviewer.

### Setup to Run the Code

- [Instructions for starting storybook](https://transcom.github.io/mymove-docs/docs/frontend/setup/run-storybook)
- [Instructions for starting the MilMove application](https://transcom.github.io/mymove-docs/docs/about/application-setup/milmove-local-client/)
- [Instructions for running tests](https://transcom.github.io/mymove-docs/docs/about/development/testing)

### How to test

1. Access the
2. Login as a
3.

### Frontend

- [ ] There are no aXe warnings for UI.
- [ ] This works in [Supported Browsers and their phone views](https://transcom.github.io/mymove-docs/docs/about/supported-browsers) (Chrome, Firefox, Edge).
- [ ] There are no new console errors in the browser devtools.
- [ ] There are no new console errors in the test output.
- [ ] If this PR adds a new component to Storybook, it ensures the component is fully responsive, OR if it is intentionally not, a wrapping div using the `officeApp` class or custom `min-width` styling is used to hide any states the would not be visible to the user.

### Backend

- [ ] Code follows the guidelines for [Logging](https://transcom.github.io/mymove-docs/docs/about/development/logging).
- [ ] The requirements listed in [Querying the Database Safely](https://transcom.github.io/mymove-docs/docs/backend/guides/golang-guide#querying-the-database-safely) have been satisfied.

### Database

#### Any new migrations/schema changes:

- [ ] Follows our guidelines for [Zero-Downtime Deploys](https://transcom.github.io/mymove-docs/docs/backend/setup/database-migrations#zero-downtime-migrations).
- [ ] Have been communicated to #g-database.
- [ ] Secure migrations have been tested following the instructions in our [docs](https://transcom.github.io/mymove-docs/docs/backend/setup/database-migrations#secure-migrations).

## Screenshots
