### PR TITLE
[MB-13917] pass from value to View Orders link on view allowances page

### DIFF
--- a/playwright/tests/office/txo/tioFlows.spec.js
+++ b/playwright/tests/office/txo/tioFlows.spec.js
@@ -187,6 +187,13 @@ test.describe('TIO user', () => {
       await tioFlowPage.waitForLoading();
 
       const form = page.locator('form');
+      // Viewing allowances and then orders still navigates back to the payment request details page
+      await form.getByRole('link', { name: 'View Allowances' }).click();
+      await tioFlowPage.waitForLoading();
+
+      await form.getByRole('link', { name: 'View orders' }).click();
+      await tioFlowPage.waitForLoading();
+      // Edit orders page | Make edits
       await form.locator('input[name="tac"]').clear();
       await form.locator('input[name="tac"]').type('E15A');
       await form.locator('input[name="sac"]').clear();

--- a/src/pages/Office/MoveAllowances/MoveAllowances.jsx
+++ b/src/pages/Office/MoveAllowances/MoveAllowances.jsx
@@ -160,7 +160,7 @@ const MoveAllowances = () => {
                   View Allowances
                 </h2>
                 <div>
-                  <Link className={styles.viewAllowances} data-testid="view-orders" to="../orders">
+                  <Link className={styles.viewAllowances} data-testid="view-orders" state={{ from }} to="../orders">
                     View Orders
                   </Link>
                 </div>


### PR DESCRIPTION
## [Jira ticket](https://dp3.atlassian.net/browse/MB-13917)

## Summary

This PR updates #11086 so that when a TIO starts on the payment request page and navigates to view orders -> view allowances -> back to view orders -> on close they are taken back to the payment request details page

## Verification Steps for the Author

These are to be checked by the author.

- [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
- [x] Have the Jira acceptance criteria been met for this change?

## Verification Steps for Reviewers

These are to be checked by a reviewer.

### Setup to Run the Code

- [Instructions for starting storybook](https://transcom.github.io/mymove-docs/docs/frontend/setup/run-storybook)
- [Instructions for starting the MilMove application](https://transcom.github.io/mymove-docs/docs/about/application-setup/milmove-local-client/)
- [Instructions for running tests](https://transcom.github.io/mymove-docs/docs/about/development/testing)

### How to test

1. Access the office app
2. Login as a TIO
3. Select a payment request that has a Pending Status (these show up in the queue as "Payment Requested"
4. On the payment request tab, scroll to find the "View Orders" link for the payment request and click it
5. Click on View Allowances. 
6. Click on View Orders
7. Close
8. Ensure that clicking X takes you back to the previous page (payment request details tab)

See this [slack message](https://ustcdp3.slack.com/archives/CP6F568DC/p1691002814355719?thread_ts=1691002630.720989&cid=CP6F568DC) for more context

### Frontend

- [ ] There are no aXe warnings for UI.
- [ ] This works in [Supported Browsers and their phone views](https://transcom.github.io/mymove-docs/docs/about/supported-browsers) (Chrome, Firefox, Edge).
- [ ] There are no new console errors in the browser devtools.
- [ ] There are no new console errors in the test output.
- [ ] If this PR adds a new component to Storybook, it ensures the component is fully responsive, OR if it is intentionally not, a wrapping div using the `officeApp` class or custom `min-width` styling is used to hide any states the would not be visible to the user.