### PR TITLE
Revert "MB-16767 SIT delivery pricer checks distance before Zip3"

### DIFF
--- a/pkg/services/ghcrateengine/pricer_helpers.go
+++ b/pkg/services/ghcrateengine/pricer_helpers.go
@@ -228,7 +228,21 @@ func priceDomesticPickupDeliverySIT(appCtx appcontext.AppContext, pickupDelivery
 
 	// Three different pricing scenarios below.
 
-	// 1) distance > 50 miles
+	// 1) Zip3 to same zip3
+	if zip3Original == zip3Actual {
+		// Do a normal shorthaul calculation
+		shorthaulPricer := NewDomesticShorthaulPricer()
+		totalPriceCents, displayParams, err := shorthaulPricer.Price(appCtx, contractCode, referenceDate, distance, weight, serviceArea)
+		if err != nil {
+			return unit.Cents(0), nil, fmt.Errorf("could not price shorthaul: %w", err)
+		}
+
+		return totalPriceCents, displayParams, nil
+	}
+
+	// Zip3s must be different at this point.  Now examine distance.
+
+	// 2) Zip3 to different zip3 and > 50 miles
 	if distance > 50 {
 		// Do a normal linehaul calculation
 		linehaulPricer := NewDomesticLinehaulPricer()
@@ -242,17 +256,7 @@ func priceDomesticPickupDeliverySIT(appCtx appcontext.AppContext, pickupDelivery
 		return totalPriceCents, displayParams, nil
 	}
 
-	// 2) Zip3 to same zip3
-	if zip3Original == zip3Actual {
-		// Do a normal shorthaul calculation
-		shorthaulPricer := NewDomesticShorthaulPricer()
-		totalPriceCents, displayParams, err := shorthaulPricer.Price(appCtx, contractCode, referenceDate, distance, weight, serviceArea)
-		if err != nil {
-			return unit.Cents(0), nil, fmt.Errorf("could not price shorthaul: %w", err)
-		}
-
-		return totalPriceCents, displayParams, nil
-	}
+	// Zip3s must be different at this point and distance is <= 50.
 
 	// 3) Zip3 to different zip3 and <= 50 miles
 

--- a/pkg/services/ghcrateengine/pricer_helpers_test.go
+++ b/pkg/services/ghcrateengine/pricer_helpers_test.go
@@ -300,7 +300,6 @@ func (suite *GHCRateEngineServiceSuite) Test_priceDomesticPickupDeliverySITSameZ
 
 func (suite *GHCRateEngineServiceSuite) Test_priceDomesticPickupDeliverySIT50PlusMilesDiffZip3s() {
 	dlhZipDest := "30907"
-	dlhSameZip3Dest := "30901"     // same zip3
 	dlhZipSITDest := "36106"       // different zip3
 	dlhDistance := unit.Miles(305) // > 50 miles
 	dlhContractName := "dhlTestYear"
@@ -308,25 +307,6 @@ func (suite *GHCRateEngineServiceSuite) Test_priceDomesticPickupDeliverySIT50Plu
 	suite.Run("destination golden path for > 50 miles with different zip3s", func() {
 		suite.setupDomesticLinehaulPrice(dddsitTestServiceArea, dddsitTestIsPeakPeriod, dddsitTestWeightLower, dddsitTestWeightUpper, dddsitTestMilesLower, dddsitTestMilesUpper, dddsitTestDomesticLinehaulBasePriceMillicents, dlhContractName, dddsitTestEscalationCompounded)
 		priceCents, displayParams, err := priceDomesticPickupDeliverySIT(suite.AppContextForTest(), models.ReServiceCodeDDDSIT, testdatagen.DefaultContractCode, dddsitTestRequestedPickupDate, dddsitTestWeight, dddsitTestServiceArea, dddsitTestSchedule, dlhZipDest, dlhZipSITDest, dlhDistance)
-		suite.NoError(err)
-		expectedPriceMillicents := unit.Millicents(45944438) // dddsitTestDomesticLinehaulBasePriceMillicents * (dddsitTestWeight / 100) * distance * dddsitTestEscalationCompounded
-		expectedPrice := expectedPriceMillicents.ToCents()
-
-		suite.Equal(expectedPrice, priceCents)
-
-		expectedParams := services.PricingDisplayParams{
-			{Key: models.ServiceItemParamNameContractYearName, Value: dlhContractName},
-			{Key: models.ServiceItemParamNameEscalationCompounded, Value: FormatEscalation(dddsitTestEscalationCompounded)},
-			{Key: models.ServiceItemParamNameIsPeak, Value: FormatBool(dddsitTestIsPeakPeriod)},
-			{Key: models.ServiceItemParamNamePriceRateOrFactor, Value: FormatFloat(dddsitTestDomesticLinehaulBasePriceMillicents.ToDollarFloatNoRound(), 3)},
-		}
-		suite.validatePricerCreatedParams(expectedParams, displayParams)
-	})
-
-	// Added this case in to make sure that the greater than 50 miles logic is taking precedence over the same zip3 logic
-	suite.Run("greater than 50 miles with same zip3s", func() {
-		suite.setupDomesticLinehaulPrice(dddsitTestServiceArea, dddsitTestIsPeakPeriod, dddsitTestWeightLower, dddsitTestWeightUpper, dddsitTestMilesLower, dddsitTestMilesUpper, dddsitTestDomesticLinehaulBasePriceMillicents, dlhContractName, dddsitTestEscalationCompounded)
-		priceCents, displayParams, err := priceDomesticPickupDeliverySIT(suite.AppContextForTest(), models.ReServiceCodeDDDSIT, testdatagen.DefaultContractCode, dddsitTestRequestedPickupDate, dddsitTestWeight, dddsitTestServiceArea, dddsitTestSchedule, dlhZipDest, dlhSameZip3Dest, dlhDistance)
 		suite.NoError(err)
 		expectedPriceMillicents := unit.Millicents(45944438) // dddsitTestDomesticLinehaulBasePriceMillicents * (dddsitTestWeight / 100) * distance * dddsitTestEscalationCompounded
 		expectedPrice := expectedPriceMillicents.ToCents()


### PR DESCRIPTION
Reverts transcom/mymove#11153

I turns out the interpretation of this we got wasn't quite right. The way we had it with zip3 primacy for the check was in alignment with what's needed.