### PR TITLE
[ MB-16540 ] Fixing the rendering of the Danger message around `devseed` Scenarios

### DIFF
--- a/dangerfile.ts
+++ b/dangerfile.ts
@@ -58,15 +58,15 @@ View the [frontend file org ADR](https://github.com/transcom/mymove/blob/main/do
   if (deprecatedDevSeedFiles.modified) {
     fail(`One of these files have been edited:
 
-        * ${'`'}pkg/testdatagen/scenario/devseed.go${'`'}
-        * ${'`'}pkg/testdatagen/scenario/subscenarios.go${'`'}
-        * ${'`'}cmd/generate-test-data/main.go${'`'}
+* ${'`'}pkg/testdatagen/scenario/devseed.go${'`'}
+* ${'`'}pkg/testdatagen/scenario/subscenarios.go${'`'}
+* ${'`'}cmd/generate-test-data/main.go${'`'}
 
-    Please undo changes to these files as we have deprecated
-    ${'`'}devseed${'`'} data functions from MilMove entirely and will be
-    deleting this code on the 8th of November 2023.
+Please undo changes to these files as we have deprecated
+${'`'}devseed${'`'} data functions from MilMove entirely and will be
+deleting this code on the 8th of November 2023.
 
-    View the [ADR 0083](https://transcom.github.io/mymove-docs/docs/adrs/deprecating-devseed-scenarios) for more information`);
+View the [ADR 0083](https://transcom.github.io/mymove-docs/docs/adrs/deprecating-devseed-scenarios) for more information`);
   }
 
   // Request changes to app code to also include changes to tests.


### PR DESCRIPTION
## [Jira ticket](https://dp3.atlassian.net/browse/MB-16540)

## Summary

When this was tested in PR #11196, it rendered as a codeblock due to the
indentation on the left. Markdown interprets indentation of four or more spaces
as codeblocks according to the specification.

[➡️ Specification on Markdown](https://www.markdownguide.org/basic-syntax/#code-blocks)

## Verification Steps for the Reviewer / Author

Pull in the changes from this branch into #11196 and add comment lines and
commit modifications that trigger the Danger checks:

- `pkg/testdatagen/scenario/devseed.go`
- `pkg/testdatagen/scenario/subscenarios.go`
- `cmd/generate-test-data/main.go`
