### PR TITLE
[MB-9454] convert edi 824 error condition to verify move referenceID instead of…

### DIFF
--- a/pkg/services/invoice/process_edi824_test.go
+++ b/pkg/services/invoice/process_edi824_test.go
@@ -42,7 +42,7 @@ TED*K*DOCUMENT OWNER CANNOT BE DETERMINED
 SE*5*000000001
 GE*1*1
 IEA*1*000000995
-`, paymentRequest.PaymentRequestNumber, *paymentRequest.MoveTaskOrder.ReferenceID)
+`, *paymentRequest.MoveTaskOrder.ReferenceID, *paymentRequest.MoveTaskOrder.ReferenceID)
 		factory.BuildPaymentRequestToInterchangeControlNumber(suite.DB(), []factory.Customization{
 			{
 				Model: models.PaymentRequestToInterchangeControlNumber{
@@ -108,7 +108,7 @@ IEA*1*000000995
 ISA*00*0084182369*00*0000000000*ZZ*MILMOVE        *12*8004171844     *201002*1504*U*00401*00000995*0*T*|
 GS*AG*8004171844*MILMOVE*20210217*1544*1*X*004010
 ST*824*000000001
-BGN*11*1126-9404-2*20210217
+BGN*11*1126-9404*20210217
 OTI*TR*BM*1126-9404*MILMOVE*8004171844*20210217**100001253*0001
 TED*K*DOCUMENT OWNER CANNOT BE DETERMINED
 SE*5*000000001
@@ -130,7 +130,7 @@ IEA*1*000000995
 		}, nil)
 		err := edi824Processor.ProcessFile(suite.AppContextForTest(), "", sample824EDIString)
 		suite.NotNil(err)
-		suite.Contains(err.Error(), fmt.Sprintf("The BGN02 Reference Identification field: 1126-9404-2 doesn't match the PaymentRequestNumber %s of the associated payment request", paymentRequest.PaymentRequestNumber))
+		suite.Contains(err.Error(), fmt.Sprintf("The BGN02 Reference Identification field: 1126-9404 doesn't match the MTO reference ID %s of the associated payment request", *paymentRequest.MoveTaskOrder.ReferenceID))
 	})
 
 	suite.Run("throw error when parsing an EDI997 when an EDI824 is expected", func() {
@@ -163,7 +163,7 @@ TED*K*DOCUMENT OWNER CANNOT BE DETERMINED
 SE*5*000000001
 GE*1*1
 IEA*1*000000996
-`, paymentRequest.PaymentRequestNumber, *paymentRequest.MoveTaskOrder.ReferenceID)
+`, *paymentRequest.MoveTaskOrder.ReferenceID, *paymentRequest.MoveTaskOrder.ReferenceID)
 		factory.BuildPaymentRequestToInterchangeControlNumber(suite.DB(), []factory.Customization{
 			{
 				Model: models.PaymentRequestToInterchangeControlNumber{
@@ -190,7 +190,7 @@ IEA*1*000000996
 ISA*00*0084182369*00*0000000000*ZZ*MILMOVE        *12*8004171844     *201002*1504*U*00401*0000005*0*T*|
 GS*AG*8004171844*MILMOVE*20210217*1544*1*X*004010
 ST*824*000000001
-BGN*11*1126-9404-1*20210217
+BGN*11*1126-9404*20210217
 OTI*TR*BM*1126-9404*MILMOVE*8004171844*20210217**100001251*0001
 TED*K*DOCUMENT OWNER CANNOT BE DETERMINED
 SE*5*000000001
@@ -222,7 +222,7 @@ TED*K*MISSING DATA
 SE*5*000000001
 GE*1*1
 IEA*1*000000997
-`, paymentRequest.PaymentRequestNumber, *paymentRequest.MoveTaskOrder.ReferenceID)
+`, *paymentRequest.MoveTaskOrder.ReferenceID, *paymentRequest.MoveTaskOrder.ReferenceID)
 		factory.BuildPaymentRequestToInterchangeControlNumber(suite.DB(), []factory.Customization{
 			{
 				Model: models.PaymentRequestToInterchangeControlNumber{
@@ -270,7 +270,7 @@ TED*007*Missing Data
 SE*5*000000001
 GE*2*1
 IEA*1*000000001
-`, paymentRequest.PaymentRequestNumber, *paymentRequest.MoveTaskOrder.ReferenceID)
+`, *paymentRequest.MoveTaskOrder.ReferenceID, *paymentRequest.MoveTaskOrder.ReferenceID)
 		factory.BuildPaymentRequestToInterchangeControlNumber(suite.DB(), []factory.Customization{
 			{
 				Model: models.PaymentRequestToInterchangeControlNumber{


### PR DESCRIPTION
… payment request number

## [Jira ticket](https://dp3.atlassian.net/browse/MB-9454)

## Summary

Looking in the staging logs for the process_edis scheduled task I saw that 824 responses were throwing errors because the BGN value did not match the Payment Request number retrieved by the ICN.

We had to make updates to the 858 in the past to send the move reference ID instead of the payment request number, so this is why the values aren't matching anymore https://github.com/transcom/mymove/pull/10663.

I changed it to still verify the move referenceID

## Verification Steps for the Author

These are to be checked by the author.

- [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
- [ ] Have the Jira acceptance criteria been met for this change?

## Verification Steps for Reviewers

These are to be checked by a reviewer.

### Setup to Run the Code

- [Instructions for starting storybook](https://transcom.github.io/mymove-docs/docs/frontend/setup/run-storybook)
- [Instructions for starting the MilMove application](https://transcom.github.io/mymove-docs/docs/about/application-setup/milmove-local-client/)
- [Instructions for running tests](https://transcom.github.io/mymove-docs/docs/about/development/testing)

### How to test

1. Access the
2. Login as a
3.

### Frontend

- [ ] There are no aXe warnings for UI.
- [ ] This works in [Supported Browsers and their phone views](https://transcom.github.io/mymove-docs/docs/about/supported-browsers) (Chrome, Firefox, Edge).
- [ ] There are no new console errors in the browser devtools.
- [ ] There are no new console errors in the test output.
- [ ] If this PR adds a new component to Storybook, it ensures the component is fully responsive, OR if it is intentionally not, a wrapping div using the `officeApp` class or custom `min-width` styling is used to hide any states the would not be visible to the user.

### Backend

- [x] Code follows the guidelines for [Logging](https://transcom.github.io/mymove-docs/docs/about/development/logging).
- [ ] The requirements listed in [Querying the Database Safely](https://transcom.github.io/mymove-docs/docs/backend/guides/golang-guide#querying-the-database-safely) have been satisfied.

### Database

#### Any new migrations/schema changes:

- [ ] Follows our guidelines for [Zero-Downtime Deploys](https://transcom.github.io/mymove-docs/docs/backend/setup/database-migrations#zero-downtime-migrations).
- [ ] Have been communicated to #g-database.
- [ ] Secure migrations have been tested following the instructions in our [docs](https://transcom.github.io/mymove-docs/docs/backend/setup/database-migrations#secure-migrations).

## Screenshots

<img width="1307" alt="Screenshot 2023-08-14 at 7 00 38 PM" src="https://github.com/transcom/mymove/assets/52669884/f6c9ab06-fd0e-4306-baf1-f91b71ce9312">
