### PR TITLE
[MB-10466] REFINE 2: Same Service Items are being requested for payment-Prime bug 

### DIFF
--- a/pkg/services/move_task_order.go
+++ b/pkg/services/move_task_order.go
@@ -40,6 +40,7 @@ type MoveTaskOrderFetcher interface {
 	FetchMoveTaskOrder(appCtx appcontext.AppContext, searchParams *MoveTaskOrderFetcherParams) (*models.Move, error)
 	ListAllMoveTaskOrders(appCtx appcontext.AppContext, searchParams *MoveTaskOrderFetcherParams) (models.Moves, error)
 	ListPrimeMoveTaskOrders(appCtx appcontext.AppContext, searchParams *MoveTaskOrderFetcherParams) (models.Moves, error)
+	GetMoveForPaymentRequests(appCtx appcontext.AppContext, moveID uuid.UUID, eagerAssociations ...string) (*models.Move, error)
 }
 
 // MoveTaskOrderUpdater is the service object interface for updating fields of a MoveTaskOrder

--- a/pkg/services/payment_request/rules.go
+++ b/pkg/services/payment_request/rules.go
@@ -6,7 +6,6 @@ import (
 	"github.com/transcom/mymove/pkg/appcontext"
 	"github.com/transcom/mymove/pkg/apperror"
 	"github.com/transcom/mymove/pkg/models"
-	"github.com/transcom/mymove/pkg/services"
 	mtoFetcher "github.com/transcom/mymove/pkg/services/move_task_order"
 	mtoshipment "github.com/transcom/mymove/pkg/services/mto_shipment"
 )
@@ -43,11 +42,18 @@ func checkStatusOfExistingPaymentRequest() paymentRequestValidator {
 		moveID := paymentRequest.MoveTaskOrderID
 		shipmentID := paymentRequest.PaymentServiceItems[0].MTOServiceItem.MTOShipmentID
 
-		searchParams := services.MoveTaskOrderFetcherParams{
-			MoveTaskOrderID: moveID,
-		}
+		// searchParams := services.MoveTaskOrderFetcherParams{
+		// 	MoveTaskOrderID: moveID,
+		// }
 
-		move, err := mtoFetcher.NewMoveTaskOrderFetcher().FetchMoveTaskOrder(appCtx, &searchParams)
+		// move, err := mtoFetcher.NewMoveTaskOrderFetcher().FetchMoveTaskOrder(appCtx, &searchParams)
+		// if err != nil {
+		// 	return err
+		// }
+
+		move, err := mtoFetcher.NewMoveTaskOrderFetcher().GetMoveForPaymentRequests(appCtx, moveID,
+			"PaymentRequests.PaymentServiceItems.MTOServiceItem.ReService.Code",
+		)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION

## [Jira ticket](https://dp3.atlassian.net/browse/MB-10466?atlOrigin=eyJpIjoiOWUzOWZlNjZmODEwNGE4ZGI2MWQwMTdjOWIyODE1NmEiLCJwIjoiaiJ9)

## Summary

Is there anything you would like reviewers to give additional scrutiny?

[this article](tbd) explains more about the approach used.

## Verification Steps for the Author

These are to be checked by the author.

- [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
- [ ] Have the Jira acceptance criteria been met for this change?

## Verification Steps for Reviewers

These are to be checked by a reviewer.

### Setup to Run the Code

- [Instructions for starting storybook](https://transcom.github.io/mymove-docs/docs/frontend/setup/run-storybook)
- [Instructions for starting the MilMove application](https://transcom.github.io/mymove-docs/docs/about/application-setup/milmove-local-client/)
- [Instructions for running tests](https://transcom.github.io/mymove-docs/docs/about/development/testing)

### How to test

1. Access the
2. Login as a
3.

### Frontend

- [ ] There are no aXe warnings for UI.
- [ ] This works in [Supported Browsers and their phone views](https://transcom.github.io/mymove-docs/docs/about/supported-browsers) (Chrome, Firefox, Edge).
- [ ] There are no new console errors in the browser devtools.
- [ ] There are no new console errors in the test output.
- [ ] If this PR adds a new component to Storybook, it ensures the component is fully responsive, OR if it is intentionally not, a wrapping div using the `officeApp` class or custom `min-width` styling is used to hide any states the would not be visible to the user.

### Backend

- [ ] Code follows the guidelines for [Logging](https://transcom.github.io/mymove-docs/docs/about/development/logging).
- [ ] The requirements listed in [Querying the Database Safely](https://transcom.github.io/mymove-docs/docs/backend/guides/golang-guide#querying-the-database-safely) have been satisfied.

### Database

#### Any new migrations/schema changes:

- [ ] Follows our guidelines for [Zero-Downtime Deploys](https://transcom.github.io/mymove-docs/docs/backend/setup/database-migrations#zero-downtime-migrations).
- [ ] Have been communicated to #g-database.
- [ ] Secure migrations have been tested following the instructions in our [docs](https://transcom.github.io/mymove-docs/docs/backend/setup/database-migrations#secure-migrations).

## Screenshots
