### PR TITLE
[MB-16548] Reset migration container memory back to default

### DIFF
--- a/scripts/ecs-run-app-migrations-container
+++ b/scripts/ecs-run-app-migrations-container
@@ -19,11 +19,10 @@ readonly name=app-migrations
 readonly image=$1
 readonly environment=$2
 
-#readonly RESERVATION_CPU=256
-readonly RESERVATION_CPU=512
-#readonly RESERVATION_MEM=512
+readonly RESERVATION_CPU=256
+readonly RESERVATION_MEM=512
 # comment out above and uncomment below to fix out of memory errors.
-readonly RESERVATION_MEM=4096
+#readonly RESERVATION_MEM=2048
 
 readonly log_prefix="${name}"
 readonly container_name="${name}-${environment}"


### PR DESCRIPTION
## [Jira ticket](https://dp3.atlassian.net/browse/MB-16548)

## Summary
This cleans up after https://github.com/transcom/mymove/pull/11217
I had to bump up the memory available to the container that did the migrations, and now that they're done, we can go back to a smaller/cheaper container.