### PR TITLE
[MB-16878] modify EDI 997 AK4 parser to expect fewer than 6 values

### DIFF
--- a/pkg/edi/segment/ak4.go
+++ b/pkg/edi/segment/ak4.go
@@ -41,9 +41,11 @@ func (s *AK4) StringArray() []string {
 
 // Parse parses an X12 string that's split into an array into the AK4 struct
 func (s *AK4) Parse(elements []string) error {
-	expectedNumElements := 6
-	if len(elements) != expectedNumElements {
-		return fmt.Errorf("AK4: Wrong number of fields, expected %d, got %d", expectedNumElements, len(elements))
+	elementsLength := len(elements)
+	expectedMinimumNumElements := 3 // ElementPositionInSegment might be blank
+
+	if elementsLength < expectedMinimumNumElements {
+		return fmt.Errorf("AK4: Wrong number of fields, expected at least %d, got %d %q %v", expectedMinimumNumElements, len(elements), elements, s)
 	}
 
 	var err error
@@ -52,34 +54,64 @@ func (s *AK4) Parse(elements []string) error {
 		return err
 	}
 
-	s.ElementPositionInSegment, err = strconv.Atoi(elements[1])
-	if err != nil {
-		return err
-	}
-
-	// For the optional int fields, make sure we map an empty string to a zero.
-	strComponentDataElementPositionInComposite := elements[2]
-	if strComponentDataElementPositionInComposite == "" {
-		s.ComponentDataElementPositionInComposite = 0
+	if elements[1] == "" {
+		s.ElementPositionInSegment = 0
 	} else {
-		s.ComponentDataElementPositionInComposite, err = strconv.Atoi(strComponentDataElementPositionInComposite)
+		s.ElementPositionInSegment, err = strconv.Atoi(elements[1])
 		if err != nil {
 			return err
 		}
 	}
 
-	strDataElementReferenceNumber := elements[3]
-	if strDataElementReferenceNumber == "" {
-		s.DataElementReferenceNumber = 0
-	} else {
-		s.DataElementReferenceNumber, err = strconv.Atoi(strDataElementReferenceNumber)
+	if elementsLength == 3 {
+		// If we only have 3 segments then it must be the required DataElementSyntaxErrorCode
+		s.DataElementSyntaxErrorCode = elements[2]
+	} else if elementsLength == 4 {
+		s.DataElementReferenceNumber, err = strconv.Atoi(elements[2])
 		if err != nil {
 			return err
 		}
-	}
+		s.CopyOfBadDataElement = elements[3]
+	} else if elementsLength == 5 {
+		// For the optional int fields, make sure we map an empty string to a zero.
+		strComponentDataElementPositionInComposite := elements[2]
+		if strComponentDataElementPositionInComposite == "" {
+			s.ComponentDataElementPositionInComposite = 0
+		} else {
+			s.ComponentDataElementPositionInComposite, err = strconv.Atoi(strComponentDataElementPositionInComposite)
+			if err != nil {
+				return err
+			}
+		}
 
-	s.DataElementSyntaxErrorCode = elements[4]
-	s.CopyOfBadDataElement = elements[5]
+		s.DataElementSyntaxErrorCode = elements[3]
+		// Not sure here what field to fill but the validation is more permissive
+		s.CopyOfBadDataElement = elements[4]
+
+	} else {
+		// For the optional int fields, make sure we map an empty string to a zero.
+		strComponentDataElementPositionInComposite := elements[2]
+		if strComponentDataElementPositionInComposite == "" {
+			s.ComponentDataElementPositionInComposite = 0
+		} else {
+			s.ComponentDataElementPositionInComposite, err = strconv.Atoi(strComponentDataElementPositionInComposite)
+			if err != nil {
+				return err
+			}
+		}
+
+		strDataElementReferenceNumber := elements[3]
+		if strDataElementReferenceNumber == "" {
+			s.DataElementReferenceNumber = 0
+		} else {
+			s.DataElementReferenceNumber, err = strconv.Atoi(strDataElementReferenceNumber)
+			if err != nil {
+				return err
+			}
+		}
+		s.DataElementSyntaxErrorCode = elements[4]
+		s.CopyOfBadDataElement = elements[5]
+	}
 
 	return nil
 }

--- a/pkg/edi/segment/ak4_test.go
+++ b/pkg/edi/segment/ak4_test.go
@@ -108,11 +108,44 @@ func (suite *SegmentSuite) TestParseAK4() {
 	})
 
 	suite.Run("parse success only required fields", func() {
-		arrayValidOptionalAK4 := []string{"1", "1", "", "", "ABC", ""}
+		arrayValidOptionalAK4 := []string{"1", "", "3"}
 		expectedOptionalAK4 := AK4{
 			PositionInSegment:          1,
-			ElementPositionInSegment:   1,
-			DataElementSyntaxErrorCode: "ABC",
+			ElementPositionInSegment:   0,
+			DataElementSyntaxErrorCode: "3",
+		}
+
+		var validOptionalAK4 AK4
+		err := validOptionalAK4.Parse(arrayValidOptionalAK4)
+		if suite.NoError(err) {
+			suite.Equal(expectedOptionalAK4, validOptionalAK4)
+		}
+	})
+
+	suite.Run("parse success only 4 values", func() {
+		arrayValidOptionalAK4 := []string{"1", "", "7", "YE"}
+		expectedOptionalAK4 := AK4{
+			PositionInSegment:          1,
+			ElementPositionInSegment:   0,
+			DataElementReferenceNumber: 7,
+			CopyOfBadDataElement:       "YE",
+		}
+
+		var validOptionalAK4 AK4
+		err := validOptionalAK4.Parse(arrayValidOptionalAK4)
+		if suite.NoError(err) {
+			suite.Equal(expectedOptionalAK4, validOptionalAK4)
+		}
+	})
+
+	suite.Run("parse success only 5 values", func() {
+		arrayValidOptionalAK4 := []string{"2", "", "5", "YE", "Bad data element"}
+		expectedOptionalAK4 := AK4{
+			PositionInSegment:                       2,
+			ElementPositionInSegment:                0,
+			ComponentDataElementPositionInComposite: 5,
+			DataElementSyntaxErrorCode:              "YE",
+			CopyOfBadDataElement:                    "Bad data element",
 		}
 
 		var validOptionalAK4 AK4

--- a/pkg/services/invoice/process_edi997_test.go
+++ b/pkg/services/invoice/process_edi997_test.go
@@ -64,6 +64,82 @@ IEA*1*000000022
 		suite.NoError(err)
 	})
 
+	suite.Run("successfully processes a valid EDI997 with minimum AK4 values", func() {
+		sample997EDIString := `
+ISA*00*0084182369*00*0000000000*ZZ*MILMOVE        *12*8004171844     *201002*1504*U*00401*00000999*0*T*|
+GS*SI*MILMOVE*8004171844*20190903*1617*9999*X*004010
+ST*997*0001
+AK1*SI*100001251
+AK2*858*0001
+AK3*ab*123
+AK4*3**1
+AK5*A
+AK9*A*1*1*1
+SE*6*0001
+GE*1*220001
+IEA*1*000000022
+`
+		paymentRequest := factory.BuildPaymentRequest(suite.DB(), []factory.Customization{
+			{
+				Model: models.PaymentRequest{
+					Status: models.PaymentRequestStatusSentToGex,
+				},
+			},
+		}, nil)
+		factory.BuildPaymentRequestToInterchangeControlNumber(suite.DB(), []factory.Customization{
+			{
+				Model: models.PaymentRequestToInterchangeControlNumber{
+					InterchangeControlNumber: 100001251,
+					EDIType:                  models.EDIType858,
+				},
+			},
+			{
+				Model:    paymentRequest,
+				LinkOnly: true,
+			},
+		}, nil)
+		err := edi997Processor.ProcessFile(suite.AppContextForTest(), "", sample997EDIString)
+		suite.NoError(err)
+	})
+
+	suite.Run("successfully processes a valid EDI997 with 4 AK4 values", func() {
+		sample997EDIString := `
+ISA*00*0084182369*00*0000000000*ZZ*MILMOVE        *12*8004171844     *201002*1504*U*00401*00000999*0*T*|
+GS*SI*MILMOVE*8004171844*20190903*1617*9999*X*004010
+ST*997*0001
+AK1*SI*100001251
+AK2*858*0001
+AK3*ab*123
+AK4*1**7*YE
+AK5*A
+AK9*A*1*1*1
+SE*6*0001
+GE*1*220001
+IEA*1*000000022
+`
+		paymentRequest := factory.BuildPaymentRequest(suite.DB(), []factory.Customization{
+			{
+				Model: models.PaymentRequest{
+					Status: models.PaymentRequestStatusSentToGex,
+				},
+			},
+		}, nil)
+		factory.BuildPaymentRequestToInterchangeControlNumber(suite.DB(), []factory.Customization{
+			{
+				Model: models.PaymentRequestToInterchangeControlNumber{
+					InterchangeControlNumber: 100001251,
+					EDIType:                  models.EDIType858,
+				},
+			},
+			{
+				Model:    paymentRequest,
+				LinkOnly: true,
+			},
+		}, nil)
+		err := edi997Processor.ProcessFile(suite.AppContextForTest(), "", sample997EDIString)
+		suite.NoError(err)
+	})
+
 	suite.Run("throw error when parsing an EDI997 when an EDI997 is expected", func() {
 		sample997EDIString := `
 		ISA*00*0084182369*00*0000000000*ZZ*MILMOVE        *12*8004171844     *201002*1504*U*00401*00000995*0*T*|


### PR DESCRIPTION
## [Jira ticket](https://dp3.atlassian.net/browse/MB-16878?atlOrigin=eyJpIjoiYjZkOTkwMmNhNTM1NDAyNWFhMGMwNGU5MjdjZTExMGYiLCJwIjoiamlyYS1zbGFjay1pbnQifQ)

## Summary

Reviewing our process EDIs scheduled task, our EDI 997 parser was failing when an AK4 segment with fewer than 6 values would be included in the response.

It seems like while we figured out what fields are required and optional from the spec, we expected Syncada to send all 6 values with blanks, and only the required field is included as a blank in the case of 3 values.


Specification for AK4 segment https://www.dla.mil/Portals/104/Documents/DLMS/Transformats/ICs/4010/41f997_a.pdf

https://learn.microsoft.com/en-us/azure/logic-apps/logic-apps-enterprise-integration-x12-997-acknowledgment#997-ack-error-codes

## Verification Steps for the Author

These are to be checked by the author.

- [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
- [ ] Have the Jira acceptance criteria been met for this change?

## Verification Steps for Reviewers

These are to be checked by a reviewer.

### Setup to Run the Code

- [Instructions for starting storybook](https://transcom.github.io/mymove-docs/docs/frontend/setup/run-storybook)
- [Instructions for starting the MilMove application](https://transcom.github.io/mymove-docs/docs/about/application-setup/milmove-local-client/)
- [Instructions for running tests](https://transcom.github.io/mymove-docs/docs/about/development/testing)

### How to test

Once this is merged we can verify in the staging logs that we are no longer failing to parse the EDI 997s in the hourly process edis scheduled task.

### Frontend

- [ ] There are no aXe warnings for UI.
- [ ] This works in [Supported Browsers and their phone views](https://transcom.github.io/mymove-docs/docs/about/supported-browsers) (Chrome, Firefox, Edge).
- [ ] There are no new console errors in the browser devtools.
- [ ] There are no new console errors in the test output.
- [ ] If this PR adds a new component to Storybook, it ensures the component is fully responsive, OR if it is intentionally not, a wrapping div using the `officeApp` class or custom `min-width` styling is used to hide any states the would not be visible to the user.

### Backend

- [ ] Code follows the guidelines for [Logging](https://transcom.github.io/mymove-docs/docs/about/development/logging).
- [ ] The requirements listed in [Querying the Database Safely](https://transcom.github.io/mymove-docs/docs/backend/guides/golang-guide#querying-the-database-safely) have been satisfied.

### Database

#### Any new migrations/schema changes:

- [ ] Follows our guidelines for [Zero-Downtime Deploys](https://transcom.github.io/mymove-docs/docs/backend/setup/database-migrations#zero-downtime-migrations).
- [ ] Have been communicated to #g-database.
- [ ] Secure migrations have been tested following the instructions in our [docs](https://transcom.github.io/mymove-docs/docs/backend/setup/database-migrations#secure-migrations).

## Screenshots

![Screenshot 2023-08-16 at 2 54 44 PM](https://github.com/transcom/mymove/assets/52669884/78a92cec-f82c-45c8-9928-e440bfb69f04)
![Screenshot 2023-08-16 at 10 59 32 AM](https://github.com/transcom/mymove/assets/52669884/e220028f-ec26-4616-9166-4204571769a5)
![Screenshot 2023-08-16 at 10 52 18 AM](https://github.com/transcom/mymove/assets/52669884/3b812331-d91e-4b31-916f-84c228341178)
