### PR TITLE
[MB-16386] Adds authz check to when creating a weight ticket

### DIFF
--- a/pkg/handlers/internalapi/weight_ticket_test.go
+++ b/pkg/handlers/internalapi/weight_ticket_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/transcom/mymove/pkg/gen/internalmessages"
 	"github.com/transcom/mymove/pkg/handlers"
 	"github.com/transcom/mymove/pkg/models"
-	"github.com/transcom/mymove/pkg/models/roles"
 	"github.com/transcom/mymove/pkg/services/mocks"
 	weightticket "github.com/transcom/mymove/pkg/services/weight_ticket"
 	"github.com/transcom/mymove/pkg/testdatagen"
@@ -86,19 +85,19 @@ func (suite *HandlerSuite) TestCreateWeightTicketHandler() {
 		suite.IsType(&weightticketops.CreateWeightTicketUnauthorized{}, response)
 	})
 
-	suite.Run("POST failure - 403- permission denied - wrong application", func() {
+	suite.Run("POST failure - 404- not found - wrong service member", func() {
 		subtestData := makeCreateSubtestData(false)
 
-		officeUser := factory.BuildOfficeUserWithRoles(suite.DB(), nil, []roles.RoleType{roles.RoleTypeTOO})
+		unauthorizedUser := factory.BuildServiceMember(suite.DB(), nil, nil)
 
 		req := subtestData.params.HTTPRequest
-		unauthorizedReq := suite.AuthenticateOfficeRequest(req, officeUser)
+		unauthorizedReq := suite.AuthenticateRequest(req, unauthorizedUser)
 		unauthorizedParams := subtestData.params
 		unauthorizedParams.HTTPRequest = unauthorizedReq
 
 		response := subtestData.handler.Handle(unauthorizedParams)
 
-		suite.IsType(&weightticketops.CreateWeightTicketForbidden{}, response)
+		suite.IsType(&weightticketops.CreateWeightTicketNotFound{}, response)
 	})
 
 	suite.Run("Post failure - 500 - Server Error", func() {

--- a/pkg/handlers/routing/internalapi_test/weight_ticket_test.go
+++ b/pkg/handlers/routing/internalapi_test/weight_ticket_test.go
@@ -1,0 +1,35 @@
+package internalapi_test
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+
+	"github.com/transcom/mymove/pkg/factory"
+)
+
+func (suite *InternalAPISuite) TestUploadWeightTicket() {
+	suite.Run("Authorized post to /ppm-shipments/{ppmShipmentId}/weight-ticket", func() {
+		ppmShipment := factory.BuildPPMShipment(suite.DB(), factory.GetTraitActiveServiceMemberUser(), nil)
+		serviceMember := ppmShipment.Shipment.MoveTaskOrder.Orders.ServiceMember
+		endpointPath := fmt.Sprintf("/internal/ppm-shipments/%s/weight-ticket", ppmShipment.ID.String())
+
+		req := suite.NewAuthenticatedMilRequest("POST", endpointPath, nil, serviceMember)
+		rr := httptest.NewRecorder()
+
+		suite.SetupSiteHandler().ServeHTTP(rr, req)
+		suite.Equal(http.StatusOK, rr.Code)
+	})
+
+	suite.Run("Unauthorized post to /ppm-shipments/{ppmShipmentId}/weight-ticket", func() {
+		ppmShipment := factory.BuildPPMShipment(suite.DB(), nil, nil)
+		serviceMember := factory.BuildServiceMember(suite.DB(), factory.GetTraitActiveServiceMemberUser(), nil)
+		endpointPath := fmt.Sprintf("/internal/ppm-shipments/%s/weight-ticket", ppmShipment.ID.String())
+
+		req := suite.NewAuthenticatedMilRequest("POST", endpointPath, nil, serviceMember)
+		rr := httptest.NewRecorder()
+
+		suite.SetupSiteHandler().ServeHTTP(rr, req)
+		suite.Equal(http.StatusNotFound, rr.Code)
+	})
+}

--- a/pkg/services/weight_ticket/weight_ticket_creator_test.go
+++ b/pkg/services/weight_ticket/weight_ticket_creator_test.go
@@ -10,12 +10,13 @@ import (
 
 func (suite *WeightTicketSuite) TestWeightTicketCreator() {
 	suite.Run("Successfully creates a WeightTicket", func() {
-		serviceMember := factory.BuildServiceMember(suite.DB(), nil, nil)
+		ppmShipment := factory.BuildMinimalPPMShipment(suite.DB(), nil, nil)
+		serviceMember := ppmShipment.Shipment.MoveTaskOrder.Orders.ServiceMember
+
 		session := &auth.Session{
 			ServiceMemberID: serviceMember.ID,
 		}
 
-		ppmShipment := factory.BuildMinimalPPMShipment(suite.DB(), nil, nil)
 		weightTicketCreator := NewCustomerWeightTicketCreator()
 		weightTicket, err := weightTicketCreator.CreateWeightTicket(suite.AppContextWithSessionForTest(session), ppmShipment.ID)
 
@@ -54,7 +55,7 @@ func (suite *WeightTicketSuite) TestWeightTicketCreator() {
 
 		suite.Nil(weightTicket)
 		suite.NotNil(err)
-		suite.IsType(apperror.InvalidInputError{}, err)
-		suite.Equal("Invalid input found while creating the Document.", err.Error())
+		suite.IsType(apperror.NotFoundError{}, err)
+		suite.Contains(err.Error(), "No such shipment found for this service member")
 	})
 }


### PR DESCRIPTION
## [Jira ticket](https://dp3.atlassian.net/browse/MB-16386)

## Summary

This pull request adds an authorization check in the server-side handler for the endpoint used when a customer creates a weight ticket, verifying that the user who is creating the weight ticket is the the same one that's attached (through the Orders <- Move <- Shipment) to the PPMShipment that's getting the weight ticket. Tests are added for this functionality.

(Yes, I did literally just copy all of the text from #11099, removing the words "pro" and "gear.")

## Verification Steps for the Author

These are to be checked by the author.

- [ ] Have the Jira acceptance criteria been met for this change?

## Verification Steps for Reviewers

These are to be checked by a reviewer.

### Setup to Run the Code

- [Instructions for starting the MilMove application](https://transcom.github.io/mymove-docs/docs/about/application-setup/milmove-local-client/)
- [Instructions for running tests](https://transcom.github.io/mymove-docs/docs/about/development/testing)

### How to test

1. Verify that the server tests pass.
2. Log in to the MyMove application as a customer user and create a PPM shipment.
3. Log in to the office application as a service counselor and approve the shipment.
4. Log back into the MyMove application as the customer from step 2, and create a (regular, non-pro gear) weight ticket. Note the ID of the PPM shipment (it'll display as the UUID fragment in something like `/ppm-shipments/f45e42cd-a136-491d-bc8d-9f7c46089728`)
6. Using Postman/cURL, authenticate as a _different_ customer user, then make a POST request to `/ppm-shipments/{:ppmShipmentId}/weight-ticket` to create another weight ticket for the customer from steps 2 and 4.
7. Verify that the response is a 404 status code and that the weight ticket is not created for the other user's shipment.

### Backend

- [ ] Code follows the guidelines for [Logging](https://transcom.github.io/mymove-docs/docs/about/development/logging).
- [ ] The requirements listed in [Querying the Database Safely](https://transcom.github.io/mymove-docs/docs/backend/guides/golang-guide#querying-the-database-safely) have been satisfied.
