### PR TITLE
Nix fixes for brand new nix users

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -288,6 +288,13 @@ export GOTENBERG_PORT=2000
 # interactions
 export DTOD_USE_MOCK=true
 
+# Client build flags
+#
+# Send error logs to the console for local development. Set to 'otel'
+# to send to the backend
+export REACT_APP_ERROR_LOGGING=console
+
+
 # Anti-Virus Settings
 export AV_DIR="${MYMOVE_DIR}"
 # WARNING: IGNORE FILES AT OUR PERIL. IF ADDING HERE ADD NOTES!

--- a/.envrc
+++ b/.envrc
@@ -288,13 +288,6 @@ export GOTENBERG_PORT=2000
 # interactions
 export DTOD_USE_MOCK=true
 
-# Client build flags
-#
-# Send error logs to the console for local development. Set to 'otel'
-# to send to the backend
-export REACT_APP_ERROR_LOGGING=console
-
-
 # Anti-Virus Settings
 export AV_DIR="${MYMOVE_DIR}"
 # WARNING: IGNORE FILES AT OUR PERIL. IF ADDING HERE ADD NOTES!
@@ -311,11 +304,7 @@ if [ ! -r .nix-disable  ] && has nix-env; then
   # set NIX_PROFILE so nix-env operations don't need to manually
   # specify the profile path
   #
-  if [ -w "/nix/var/nix/profiles/per-user/${LOGNAME}" ]; then
-    export NIX_PROFILE="/nix/var/nix/profiles/per-user/${LOGNAME}/mymove"
-  else
-    log_error "Cannot determine writable location for your NIX_PROFILE"
-  fi
+  export NIX_PROFILE="/nix/var/nix/profiles/per-user/${LOGNAME}/mymove"
 
   # Having NIX_SSL_CERT_FILE set means go won't use macOS keychain based certs
   export NIX_SSL_CERT_FILE_ORIG=$NIX_SSL_CERT_FILE

--- a/nix/update.sh
+++ b/nix/update.sh
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-if [ ! -v NIX_PROFILE ]; then
+if [ -z "${NIX_PROFILE:-}" ]; then
   echo "NIX_PROFILE not set, not installing globally"
   echo "Try running 'direnv allow'"
   exit 1
@@ -16,10 +16,6 @@ export NIXPKGS_ALLOW_UNSUPPORTED_SYSTEM=1
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 # install packages
 nix-env -f "${DIR}" -i
-
-# install yarn using the node that was just installed
-npm install -g yarn
-
 # Store a hash of this file to the hash of the nix profile
 # This way if the config changes, we can warn about it via direnv
 # See the nix config in .envrc


### PR DESCRIPTION
## Summary

* Always set the `NIX_PROFILE` as our prior check would fail for new users
* Don't try to use bash4+ features when checking for `NIX_PROFILE`

## Verification Steps for the Author

I tested this in a fresh VM and it seems to fix the problem for me
