### PR TITLE
MB-16893 allow zero value for AK9 Accepted Transaction Sets

### DIFF
--- a/pkg/edi/segment/ak9.go
+++ b/pkg/edi/segment/ak9.go
@@ -8,9 +8,9 @@ import (
 // AK9 represents the AK9 EDI segment
 type AK9 struct {
 	FunctionalGroupAcknowledgeCode      string `validate:"oneof=A E P R"`
-	NumberOfTransactionSetsIncluded     int    `validate:"min=1,max=999999"`
-	NumberOfReceivedTransactionSets     int    `validate:"min=1,max=999999"`
-	NumberOfAcceptedTransactionSets     int    `validate:"min=1,max=999999"`
+	NumberOfTransactionSetsIncluded     int    `validate:"min=0,max=999999"`
+	NumberOfReceivedTransactionSets     int    `validate:"min=0,max=999999"`
+	NumberOfAcceptedTransactionSets     int    `validate:"min=0,max=999999"`
 	FunctionalGroupSyntaxErrorCodeAK905 string `validate:"omitempty,max=3"`
 	FunctionalGroupSyntaxErrorCodeAK906 string `validate:"omitempty,max=3"`
 	FunctionalGroupSyntaxErrorCodeAK907 string `validate:"omitempty,max=3"`

--- a/pkg/edi/segment/ak9.go
+++ b/pkg/edi/segment/ak9.go
@@ -8,8 +8,8 @@ import (
 // AK9 represents the AK9 EDI segment
 type AK9 struct {
 	FunctionalGroupAcknowledgeCode      string `validate:"oneof=A E P R"`
-	NumberOfTransactionSetsIncluded     int    `validate:"min=0,max=999999"`
-	NumberOfReceivedTransactionSets     int    `validate:"min=0,max=999999"`
+	NumberOfTransactionSetsIncluded     int    `validate:"min=1,max=999999"`
+	NumberOfReceivedTransactionSets     int    `validate:"min=1,max=999999"`
 	NumberOfAcceptedTransactionSets     int    `validate:"min=0,max=999999"`
 	FunctionalGroupSyntaxErrorCodeAK905 string `validate:"omitempty,max=3"`
 	FunctionalGroupSyntaxErrorCodeAK906 string `validate:"omitempty,max=3"`

--- a/pkg/edi/segment/ak9_test.go
+++ b/pkg/edi/segment/ak9_test.go
@@ -112,6 +112,7 @@ func (suite *SegmentSuite) TestValidateAK9() {
 		err := suite.validator.Struct(ak9)
 		suite.ValidateError(err, "FunctionalGroupAcknowledgeCode", "oneof")
 		suite.ValidateError(err, "NumberOfTransactionSetsIncluded", "min")
+		suite.ValidateError(err, "NumberOfReceivedTransactionSets", "min")
 		suite.ValidateErrorLen(err, 3)
 	})
 }

--- a/pkg/edi/segment/ak9_test.go
+++ b/pkg/edi/segment/ak9_test.go
@@ -72,7 +72,7 @@ func (suite *SegmentSuite) TestValidateAK9() {
 		suite.ValidateError(err, "NumberOfTransactionSetsIncluded", "min")
 		suite.ValidateError(err, "NumberOfReceivedTransactionSets", "min")
 		suite.ValidateError(err, "NumberOfAcceptedTransactionSets", "min")
-		suite.ValidateErrorLen(err, 4)
+		suite.ValidateErrorLen(err, 3)
 	})
 
 	suite.Run("validate failure max", func() {
@@ -116,7 +116,7 @@ func (suite *SegmentSuite) TestValidateAK9() {
 		suite.ValidateError(err, "NumberOfTransactionSetsIncluded", "min")
 		suite.ValidateError(err, "NumberOfReceivedTransactionSets", "min")
 		suite.ValidateError(err, "NumberOfAcceptedTransactionSets", "min")
-		suite.ValidateErrorLen(err, 4)
+		suite.ValidateErrorLen(err, 3)
 	})
 }
 

--- a/pkg/edi/segment/ak9_test.go
+++ b/pkg/edi/segment/ak9_test.go
@@ -102,11 +102,12 @@ func (suite *SegmentSuite) TestValidateAK9() {
 	})
 
 	suite.Run("validate failure min", func() {
-		// length of characters are less than min
+		// length of characters are less than min, note that 0 is acceptable for Accepted Transaction Sets
 		ak9 := AK9{
 			FunctionalGroupAcknowledgeCode:  "",
 			NumberOfTransactionSetsIncluded: 0,
 			NumberOfReceivedTransactionSets: 0,
+			NumberOfAcceptedTransactionSets: 0,
 		}
 
 		err := suite.validator.Struct(ak9)

--- a/pkg/edi/segment/ak9_test.go
+++ b/pkg/edi/segment/ak9_test.go
@@ -71,7 +71,6 @@ func (suite *SegmentSuite) TestValidateAK9() {
 		suite.ValidateError(err, "FunctionalGroupAcknowledgeCode", "oneof")
 		suite.ValidateError(err, "NumberOfTransactionSetsIncluded", "min")
 		suite.ValidateError(err, "NumberOfReceivedTransactionSets", "min")
-		suite.ValidateError(err, "NumberOfAcceptedTransactionSets", "min")
 		suite.ValidateErrorLen(err, 3)
 	})
 
@@ -108,14 +107,11 @@ func (suite *SegmentSuite) TestValidateAK9() {
 			FunctionalGroupAcknowledgeCode:  "",
 			NumberOfTransactionSetsIncluded: 0,
 			NumberOfReceivedTransactionSets: 0,
-			NumberOfAcceptedTransactionSets: 0,
 		}
 
 		err := suite.validator.Struct(ak9)
 		suite.ValidateError(err, "FunctionalGroupAcknowledgeCode", "oneof")
 		suite.ValidateError(err, "NumberOfTransactionSetsIncluded", "min")
-		suite.ValidateError(err, "NumberOfReceivedTransactionSets", "min")
-		suite.ValidateError(err, "NumberOfAcceptedTransactionSets", "min")
 		suite.ValidateErrorLen(err, 3)
 	})
 }


### PR DESCRIPTION
## [Jira ticket](https://dp3.atlassian.net/browse/MB-16893?atlOrigin=eyJpIjoiZTU3ZWVlODQ5ZDAxNDE0MDhiYjA1OTE5YTE3ZDc1MzYiLCJwIjoiaiJ9)

## Summary

The number of Accepted Transaction Sets, specifically, can be zero, so this PR modifies min value to allow that. You can have a scenario where is it 0 and then make sure it's ok.

## Verification Steps for the Author

These are to be checked by the author.

- [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
- [ ] Have the Jira acceptance criteria been met for this change?

## Verification Steps for Reviewers

These are to be checked by a reviewer.

### Setup to Run the Code

- [Instructions for starting storybook](https://transcom.github.io/mymove-docs/docs/frontend/setup/run-storybook)
- [Instructions for starting the MilMove application](https://transcom.github.io/mymove-docs/docs/about/application-setup/milmove-local-client/)
- [Instructions for running tests](https://transcom.github.io/mymove-docs/docs/about/development/testing)

### How to test

1. Access the
2. Login as a
3.

### Frontend

- [ ] There are no aXe warnings for UI.
- [ ] This works in [Supported Browsers and their phone views](https://transcom.github.io/mymove-docs/docs/about/supported-browsers) (Chrome, Firefox, Edge).
- [ ] There are no new console errors in the browser devtools.
- [ ] There are no new console errors in the test output.
- [ ] If this PR adds a new component to Storybook, it ensures the component is fully responsive, OR if it is intentionally not, a wrapping div using the `officeApp` class or custom `min-width` styling is used to hide any states the would not be visible to the user.

### Backend

- [ ] Code follows the guidelines for [Logging](https://transcom.github.io/mymove-docs/docs/about/development/logging).
- [ ] The requirements listed in [Querying the Database Safely](https://transcom.github.io/mymove-docs/docs/backend/guides/golang-guide#querying-the-database-safely) have been satisfied.

### Database

#### Any new migrations/schema changes:

- [ ] Follows our guidelines for [Zero-Downtime Deploys](https://transcom.github.io/mymove-docs/docs/backend/setup/database-migrations#zero-downtime-migrations).
- [ ] Have been communicated to #g-database.
- [ ] Secure migrations have been tested following the instructions in our [docs](https://transcom.github.io/mymove-docs/docs/backend/setup/database-migrations#secure-migrations).

## Screenshots
