### PR TITLE
[ MB-16540 ] Better developer experience for testharness data scenarios

### DIFF
--- a/pkg/handlers/testharnessapi/api.go
+++ b/pkg/handlers/testharnessapi/api.go
@@ -47,7 +47,7 @@ func NewDefaultBuilder(handlerConfig handlers.HandlerConfig) http.Handler {
 				t := template.Must(template.New("users").Parse(`
 				  <html>
 				  <head>
-					<link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css" integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T" crossorigin="anonymous">
+					<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/css/bootstrap.min.css" integrity="sha384-rbsA2VBKQhggwzxH7pPCaAqO46MgnOM80zW1RWuH61DGLwZJEdK2Kadq2F9CUG65" crossorigin="anonymous">
 				  </head>
 				  <body class="py-4">
 					<div class="container">
@@ -78,7 +78,7 @@ func NewBuilderList(handlerConfig handlers.HandlerConfig) http.Handler {
 			t := template.Must(template.New("actions").Parse(`
 	  <html>
 	  <head>
-		<link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css" integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T" crossorigin="anonymous">
+		<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/css/bootstrap.min.css" integrity="sha384-rbsA2VBKQhggwzxH7pPCaAqO46MgnOM80zW1RWuH61DGLwZJEdK2Kadq2F9CUG65" crossorigin="anonymous">
 	  </head>
 	  <body class="py-4">
 		<div class="container">

--- a/pkg/handlers/testharnessapi/api.go
+++ b/pkg/handlers/testharnessapi/api.go
@@ -82,6 +82,10 @@ func NewBuilderList(handlerConfig handlers.HandlerConfig) http.Handler {
 	  </head>
 	  <body class="py-4">
 		<div class="container">
+			<h1>Welcome to the Testharness data scenarios <span class="badge bg-primary text-bg-primary">New</span></h1>
+		  <div class="alert alert-info">
+			<p>These scenarios were introduced in <a href="https://transcom.github.io/mymove-docs/docs/adrs/use-playwright/">ADR 0076</a> and addressed further in <a href="https://transcom.github.io/mymove-docs/docs/adrs/deprecating-devseed-scenarios">ADR 0083</a>. These scenarios can be used to create Moves in the MilMove system when working locally or with Ephemeral deployments. <mark>Click any of the buttons below to create a Move data scenario.</mark></p>
+		  </div>
 		  <div class="row mb-3">
 			<div class="col-md-8">
 			{{range .}}

--- a/pkg/handlers/testharnessapi/api.go
+++ b/pkg/handlers/testharnessapi/api.go
@@ -51,6 +51,11 @@ func NewDefaultBuilder(handlerConfig handlers.HandlerConfig) http.Handler {
 				  </head>
 				  <body class="py-4">
 					<div class="container">
+					  <a class="btn btn-primary" href="/testharness/list" role="button">Back to Testharness data scenarios list</a>
+					  <h1>Testharness data scenario created <span class="badge bg-success text-bg-success">Success</span></h1>
+					  <div class="alert alert-success">
+						<p>The Testharness scenario was created successfully. The raw JSON output below contains information on the created scenario.</p>
+					  </div>
 					  <div class="row mb-3">
 						<pre>{{.}}</pre>
 					  </div>

--- a/src/containers/LoginButton/LoginButton.jsx
+++ b/src/containers/LoginButton/LoginButton.jsx
@@ -17,7 +17,7 @@ import ConnectedEulaModal from 'components/EulaModal';
 import { customerRoutes } from 'constants/routes';
 import { selectIsProfileComplete } from 'store/entities/selectors';
 
-const LoginButton = ({ isLoggedIn, logOut, showDevlocalButton, isProfileComplete }) => {
+const LoginButton = ({ isLoggedIn, logOut, showDevlocalButton, showTestharnessList, isProfileComplete }) => {
   const [showEula, setShowEula] = useState(false);
 
   if (!isLoggedIn) {
@@ -39,6 +39,13 @@ const LoginButton = ({ isLoggedIn, logOut, showDevlocalButton, isProfileComplete
               href="/devlocal-auth/login"
             >
               Local Sign In
+            </a>
+          </li>
+        )}
+        {showTestharnessList && (
+          <li className="usa-nav__primary-item">
+            <a className="usa-button" data-testid="devlocal-testharnesslist" href="/testharness/list">
+              View Testharness Data Scenarios
             </a>
           </li>
         )}
@@ -102,6 +109,7 @@ function mapStateToProps(state) {
     isLoggedIn: selectIsLoggedIn(state),
     isProfileComplete: selectIsProfileComplete(state),
     showDevlocalButton: get(state, 'isDevelopment', isDevelopment),
+    showTestharnessList: get(state, 'isDevelopment', isDevelopment),
   };
 }
 

--- a/src/containers/LoginButton/LoginButton.test.jsx
+++ b/src/containers/LoginButton/LoginButton.test.jsx
@@ -49,4 +49,11 @@ describe('LoginButton tests', () => {
     expect(wrapper.find('button[data-testid="signin"]').length).toEqual(1);
     expect(wrapper.find('a[data-testid="devlocal-signin"]').length).toEqual(1);
   });
+
+  it('renders the devlocal testharness list button when running in development', () => {
+    const store = mockStore({ ...initialState, isDevelopment: true });
+    const wrapper = mount(<LoginButton store={store} />);
+    expect(wrapper.find('button[data-testid="signin"]').length).toEqual(1);
+    expect(wrapper.find('a[data-testid="devlocal-testharnesslist"]').length).toEqual(1);
+  });
 });

--- a/src/pages/SignIn/SignIn.jsx
+++ b/src/pages/SignIn/SignIn.jsx
@@ -15,7 +15,7 @@ import ConnectedEulaModal from 'components/EulaModal';
 import { isDevelopment } from 'shared/constants';
 import { useTitle } from 'hooks/custom';
 
-const SignIn = ({ context, showLocalDevLogin }) => {
+const SignIn = ({ context, showLocalDevLogin, showTestharnessList }) => {
   const location = useLocation();
   const [showEula, setShowEula] = useState(false);
   const navigate = useNavigate();
@@ -101,6 +101,11 @@ const SignIn = ({ context, showLocalDevLogin }) => {
                   Local Sign In
                 </a>
               )}
+              {showTestharnessList && (
+                <a className="usa-button" data-testid="devlocal-testharnesslist" href="/testharness/list">
+                  View Testharness Data Scenarios
+                </a>
+              )}
             </ButtonGroup>
           </div>
         </div>
@@ -115,10 +120,12 @@ SignIn.propTypes = {
     showLoginWarning: bool,
   }).isRequired,
   showLocalDevLogin: bool,
+  showTestharnessList: bool,
 };
 
 SignIn.defaultProps = {
   showLocalDevLogin: isDevelopment,
+  showTestharnessList: isDevelopment,
 };
 
 export default withContext(SignIn);


### PR DESCRIPTION
## [Jira ticket](https://dp3.atlassian.net/browse/MB-16540)

## Summary

- [x] Upgrading Bootstrap to 5.2.3;
- [x] Adding some descriptive text for the landing page(s);
- [x] Adding a Testharness button for local development;
- [x] Adding tests for the new Testharness button

This add improves DX and UX on the project by making the Testharness data
scenarios more accessible to folks running the application either locally or in
an Ephemeral environment. This utilizes the same logic as `showLocalDevLogin`
and is only available in the environments mentioned before.

We didn't have anything on the Testharness landing page before, so I added some
links for folks who may have questions about what this page is. This is not an
exhaustive description, so if there's anything to add here please do! The page
is using a Bootstrap stylesheet and vanilla HTML.

Finally, the Bootstrap update here is because of a bug in twbs/bootstrap#35297.

## Verification Steps for Reviewers

These are to be checked by a reviewer.

### Setup to Run the Code

- [Instructions for starting storybook](https://transcom.github.io/mymove-docs/docs/frontend/setup/run-storybook)
- [Instructions for starting the MilMove application](https://transcom.github.io/mymove-docs/docs/about/application-setup/milmove-local-client/)
- [Instructions for running tests](https://transcom.github.io/mymove-docs/docs/about/development/testing)

### How to test

1. Run the `scripts/server-dev --standalone` command.
1. Go to `officelocal:8080/` and see the new **View Testharness Data
   Scenarios**.
1. Click the button, and see the new title and description on the top of that
   page.
