### PR TITLE
[MB-16907] Add auth check to move task order fetcher service

### DIFF
--- a/pkg/handlers/primeapi/payment_request_test.go
+++ b/pkg/handlers/primeapi/payment_request_test.go
@@ -730,10 +730,7 @@ func (suite *HandlerSuite) TestCreatePaymentRequestHandlerNewPaymentRequestCreat
 		move, mtoServiceItems := suite.setupDomesticLinehaulData()
 		moveTaskOrderID := move.ID
 
-		requestUser := factory.BuildUser(nil, nil, nil)
-
 		req := httptest.NewRequest("POST", "/payment_requests", nil)
-		req = suite.AuthenticateUserRequest(req, requestUser)
 
 		planner := &routemocks.Planner{}
 		planner.On("Zip5TransitDistanceLineHaul",
@@ -802,10 +799,7 @@ func (suite *HandlerSuite) TestCreatePaymentRequestHandlerNewPaymentRequestCreat
 		mtoServiceItems[0].Status = models.MTOServiceItemStatusSubmitted
 		suite.MustSave(&mtoServiceItems[0])
 
-		requestUser := factory.BuildUser(nil, nil, nil)
-
 		req := httptest.NewRequest("POST", "/payment_requests", nil)
-		req = suite.AuthenticateUserRequest(req, requestUser)
 
 		planner := &routemocks.Planner{}
 
@@ -849,10 +843,7 @@ func (suite *HandlerSuite) TestCreatePaymentRequestHandlerNewPaymentRequestCreat
 		mtoServiceItems[0].Status = models.MTOServiceItemStatusRejected
 		suite.MustSave(&mtoServiceItems[0])
 
-		requestUser := factory.BuildUser(nil, nil, nil)
-
 		req := httptest.NewRequest("POST", "/payment_requests", nil)
-		req = suite.AuthenticateUserRequest(req, requestUser)
 
 		planner := &routemocks.Planner{}
 

--- a/pkg/handlers/primeapi/payment_request_test.go
+++ b/pkg/handlers/primeapi/payment_request_test.go
@@ -899,10 +899,7 @@ func (suite *HandlerSuite) TestCreatePaymentRequestHandlerInvalidMTOReferenceID(
 		move, mtoServiceItems := suite.setupDomesticLinehaulData()
 		moveTaskOrderID := move.ID
 
-		requestUser := factory.BuildUser(nil, nil, nil)
-
 		req := httptest.NewRequest("POST", "/payment_requests", nil)
-		req = suite.AuthenticateUserRequest(req, requestUser)
 
 		planner := &routemocks.Planner{}
 		planner.On("Zip5TransitDistanceLineHaul",
@@ -967,10 +964,7 @@ func (suite *HandlerSuite) TestCreatePaymentRequestHandlerInvalidMTOReferenceID(
 		move, mtoServiceItems := suite.setupDomesticLinehaulData()
 		moveTaskOrderID := move.ID
 
-		requestUser := factory.BuildUser(nil, nil, nil)
-
 		req := httptest.NewRequest("POST", "/payment_requests", nil)
-		req = suite.AuthenticateUserRequest(req, requestUser)
 
 		planner := &routemocks.Planner{}
 		planner.On("Zip5TransitDistanceLineHaul",

--- a/pkg/services/move_task_order/move_task_order_fetcher.go
+++ b/pkg/services/move_task_order/move_task_order_fetcher.go
@@ -249,6 +249,12 @@ func (f moveTaskOrderFetcher) GetMove(appCtx appcontext.AppContext, searchParams
 		findMoveQuery.EagerPreload(eagerAssociations...)
 	}
 
+	if appCtx.Session() != nil && appCtx.Session().IsMilApp() {
+		findMoveQuery.
+			InnerJoin("orders", "orders.id = moves.orders_id").
+			Where("orders.service_member_id = ?", appCtx.Session().ServiceMemberID)
+	}
+
 	setMTOQueryFilters(findMoveQuery, searchParams)
 
 	err := findMoveQuery.First(move)

--- a/pkg/services/move_task_order/move_task_order_fetcher.go
+++ b/pkg/services/move_task_order/move_task_order_fetcher.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/gobuffalo/pop/v6"
 	"github.com/gofrs/uuid"
+	"go.uber.org/zap"
 
 	"github.com/transcom/mymove/pkg/appcontext"
 	"github.com/transcom/mymove/pkg/apperror"
@@ -233,16 +234,16 @@ func (f moveTaskOrderFetcher) GetMove(appCtx appcontext.AppContext, searchParams
 	findMoveQuery := appCtx.DB().Q()
 
 	if searchParams == nil {
-		return &models.Move{}, errors.New("searchParams should not be nil since move ID or locator are required")
+		return nil, errors.New("searchParams should not be nil since move ID or locator are required")
 	}
 
 	// Find the move by ID or Locator
 	if searchParams.MoveTaskOrderID != uuid.Nil {
-		findMoveQuery.Where("id = $1", searchParams.MoveTaskOrderID)
+		findMoveQuery.Where("moves.id = ?", searchParams.MoveTaskOrderID)
 	} else if searchParams.Locator != "" {
-		findMoveQuery.Where("locator = $1", searchParams.Locator)
+		findMoveQuery.Where("locator = ?", searchParams.Locator)
 	} else {
-		return &models.Move{}, errors.New("searchParams should have either a move ID or locator set")
+		return nil, errors.New("searchParams should have either a move ID or locator set")
 	}
 
 	if len(eagerAssociations) > 0 {
@@ -258,15 +259,16 @@ func (f moveTaskOrderFetcher) GetMove(appCtx appcontext.AppContext, searchParams
 	setMTOQueryFilters(findMoveQuery, searchParams)
 
 	err := findMoveQuery.First(move)
+
 	if err != nil {
+		appCtx.Logger().Error("error fetching move", zap.Error(err))
 		switch err {
 		case sql.ErrNoRows:
-			return &models.Move{}, apperror.NewNotFoundError(searchParams.MoveTaskOrderID, "")
+			return nil, apperror.NewNotFoundError(searchParams.MoveTaskOrderID, "")
 		default:
-			return &models.Move{}, apperror.NewQueryError("Move", err, "")
+			return nil, apperror.NewQueryError("Move", err, "")
 		}
 	}
-
 	return move, nil
 }
 


### PR DESCRIPTION
## [Jira ticket](https://dp3.atlassian.net/browse/MB-16907?atlOrigin=eyJpIjoiY2M0OWVhMGViMWUwNGJmYWE4M2MwZTg3MmIxOGY3NzciLCJwIjoiaiJ9)

## Summary

Add auth check in customer app for `GetMove` service in `move_task_order_fetcher` 
Added tests accordingly in `move_task_order_fetcher_test.go`

## Verification Steps for the Author

These are to be checked by the author.

- [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
- [ ] Have the Jira acceptance criteria been met for this change?

## Verification Steps for Reviewers

These are to be checked by a reviewer.

### Setup to Run the Code

- [Instructions for starting storybook](https://transcom.github.io/mymove-docs/docs/frontend/setup/run-storybook)
- [Instructions for starting the MilMove application](https://transcom.github.io/mymove-docs/docs/about/application-setup/milmove-local-client/)
- [Instructions for running tests](https://transcom.github.io/mymove-docs/docs/about/development/testing)

### How to test

Run `make_server_test`

### Backend

- [ ] Code follows the guidelines for [Logging](https://transcom.github.io/mymove-docs/docs/about/development/logging).
- [ ] The requirements listed in [Querying the Database Safely](https://transcom.github.io/mymove-docs/docs/backend/guides/golang-guide#querying-the-database-safely) have been satisfied.

### Database

#### Any new migrations/schema changes:

- [ ] Follows our guidelines for [Zero-Downtime Deploys](https://transcom.github.io/mymove-docs/docs/backend/setup/database-migrations#zero-downtime-migrations).
- [ ] Have been communicated to #g-database.
- [ ] Secure migrations have been tested following the instructions in our [docs](https://transcom.github.io/mymove-docs/docs/backend/setup/database-migrations#secure-migrations).

## Screenshots
