### PR TITLE
MB-16910 - Add function to calculate contract escalated price

### DIFF
--- a/pkg/services/ghcrateengine/pricer_helpers.go
+++ b/pkg/services/ghcrateengine/pricer_helpers.go
@@ -428,3 +428,25 @@ func createPricerGeneratedParams(appCtx appcontext.AppContext, paymentServiceIte
 	}
 	return paymentServiceItemParams, nil
 }
+
+// escalatePriceForContractYear calculates the escalated price from the base price, which is provided by the caller/pricer,
+// and the escalation factor, which is provded by the contract year. The result is rounded to the nearest cent, or to the
+// nearest tenth-cent for linehaul prices. The contract year is also returned.
+func escalatePriceForContractYear(appCtx appcontext.AppContext, contractID uuid.UUID, referenceDate time.Time, isLinehaul bool, basePrice float64) (float64, models.ReContractYear, error) {
+	contractYear, err := fetchContractYear(appCtx, contractID, referenceDate)
+	if err != nil {
+		return 0, contractYear, fmt.Errorf("could not lookup contract year: %w", err)
+	}
+
+	escalatedPrice := basePrice * contractYear.EscalationCompounded
+
+	// round escalated price to the nearest cent, or the nearest tenth-of-a-cent if linehaul
+	precision := 0
+	if isLinehaul {
+		precision = 1
+	}
+
+	ratio := math.Pow(10, float64(precision))
+	escalatedPrice = math.Round(escalatedPrice*ratio) / ratio
+	return escalatedPrice, contractYear, nil
+}


### PR DESCRIPTION
## [Jira ticket](https://dp3.atlassian.net/browse/MB-16910)

## Summary

This PR creates a function that calculates escalated prices that should be reused by any relevant pricers.
Would this be straightforward to call from a pricer like the [domestic destination pricer](https://github.com/transcom/mymove/blob/ea75f243ac2f0c534ba4f069a0dbdcfcc414b310/pkg/services/ghcrateengine/domestic_destination_pricer.go#L25)?

## Verification Steps for the Author

These are to be checked by the author.

- [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
- [ ] Have the Jira acceptance criteria been met for this change?

## Verification Steps for Reviewers

These are to be checked by a reviewer.

### Setup to Run the Code

- [Instructions for starting storybook](https://transcom.github.io/mymove-docs/docs/frontend/setup/run-storybook)
- [Instructions for starting the MilMove application](https://transcom.github.io/mymove-docs/docs/about/application-setup/milmove-local-client/)
- [Instructions for running tests](https://transcom.github.io/mymove-docs/docs/about/development/testing)

### How to test

1. Run `go test ./pkg/services/ghcrateengine` to ensure that none of the new tests are failing

### Backend

- [ ] Code follows the guidelines for [Logging](https://transcom.github.io/mymove-docs/docs/about/development/logging).
- [ ] The requirements listed in [Querying the Database Safely](https://transcom.github.io/mymove-docs/docs/backend/guides/golang-guide#querying-the-database-safely) have been satisfied.
