### PR TITLE
Use ReactUSWDS CTA instead of shared/Alert onRemove prop

### DIFF
--- a/src/components/Office/ShipmentAddressUpdateReviewRequestModal/ShipmentAddressUpdateReviewRequestModal.jsx
+++ b/src/components/Office/ShipmentAddressUpdateReviewRequestModal/ShipmentAddressUpdateReviewRequestModal.jsx
@@ -1,9 +1,10 @@
 import React from 'react';
-import { Button, Textarea, Label, FormGroup, Radio } from '@trussworks/react-uswds'; // Tag Label
+import { Alert, Button, Textarea, Label, FormGroup, Radio } from '@trussworks/react-uswds'; // Tag Label
 import { Formik, Field } from 'formik';
 import * as Yup from 'yup';
 import * as PropTypes from 'prop-types';
 import classnames from 'classnames';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
 import styles from './ShipmentAddressUpdateReviewRequestModal.module.scss';
 
@@ -15,14 +16,19 @@ import ShipmentTag from 'components/ShipmentTag/ShipmentTag';
 import { ShipmentShape } from 'types';
 import Fieldset from 'shared/Fieldset';
 import { ADDRESS_UPDATE_STATUS } from 'constants/shipments';
-import Alert from 'shared/Alert';
 
 const formSchema = Yup.object().shape({
   addressUpdateReviewStatus: Yup.string().required('Required'),
   officeRemarks: Yup.string().required('Required'),
 });
 
-export const ShipmentAddressUpdateReviewRequestModal = ({ onSubmit, shipment, errorMessage, onClose }) => {
+export const ShipmentAddressUpdateReviewRequestModal = ({
+  onSubmit,
+  shipment,
+  errorMessage,
+  setErrorMessage,
+  onClose,
+}) => {
   const handleSubmit = async (values, { setSubmitting }) => {
     const { addressUpdateReviewStatus, officeRemarks } = values;
 
@@ -31,6 +37,12 @@ export const ShipmentAddressUpdateReviewRequestModal = ({ onSubmit, shipment, er
     setSubmitting(false);
   };
 
+  const errorMessageAlertControl = (
+    <Button type="button" onClick={() => setErrorMessage(null)} unstyled>
+      <FontAwesomeIcon icon="times" style={styles.alertClose} />
+    </Button>
+  );
+
   return (
     <Modal>
       <ModalClose handleClick={() => onClose()} />
@@ -38,7 +50,7 @@ export const ShipmentAddressUpdateReviewRequestModal = ({ onSubmit, shipment, er
         <ShipmentTag shipmentType={shipment.shipmentType} />
         <h2 className={styles.modalTitle}>Review request</h2>
         {errorMessage && (
-          <Alert type="error" role="alert">
+          <Alert type="error" role="alert" cta={errorMessageAlertControl}>
             {errorMessage}
           </Alert>
         )}
@@ -111,10 +123,12 @@ ShipmentAddressUpdateReviewRequestModal.propTypes = {
   onSubmit: PropTypes.func.isRequired,
   onClose: PropTypes.func.isRequired,
   errorMessage: PropTypes.node,
+  setErrorMessage: PropTypes.func,
 };
 
 ShipmentAddressUpdateReviewRequestModal.defaultProps = {
   errorMessage: null,
+  setErrorMessage: undefined,
 };
 
 ShipmentAddressUpdateReviewRequestModal.displayName = 'ShipmentAddressUpdateReviewRequestModal';

--- a/src/components/Office/ShipmentAddressUpdateReviewRequestModal/ShipmentAddressUpdateReviewRequestModal.module.scss
+++ b/src/components/Office/ShipmentAddressUpdateReviewRequestModal/ShipmentAddressUpdateReviewRequestModal.module.scss
@@ -6,6 +6,10 @@
   padding-top: 1rem;
 }
 
+.alertClose {
+  color: $base-darkest;
+}
+
 .modalbody {
   @include u-border('base-lighter');
   @include u-border('1px');

--- a/src/components/Office/ShipmentForm/ShipmentForm.jsx
+++ b/src/components/Office/ShipmentForm/ShipmentForm.jsx
@@ -5,6 +5,7 @@ import { generatePath, useNavigate, useParams } from 'react-router-dom';
 import { useQueryClient, useMutation } from '@tanstack/react-query';
 import { Alert, Button, Checkbox, Fieldset, FormGroup, Radio } from '@trussworks/react-uswds';
 import classNames from 'classnames';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
 import getShipmentOptions from '../../Customer/MtoShipmentForm/getShipmentOptions';
 import { CloseoutOfficeInput } from '../../form/fields/CloseoutOfficeInput';
@@ -39,7 +40,6 @@ import { ADDRESS_UPDATE_STATUS, shipmentDestinationTypes } from 'constants/shipm
 import { officeRoles, roleTypes } from 'constants/userRoles';
 import { deleteShipment, reviewShipmentAddressUpdate, updateMoveCloseoutOffice } from 'services/ghcApi';
 import { SHIPMENT_OPTIONS } from 'shared/constants';
-import MilMoveAlert from 'shared/Alert';
 import formStyles from 'styles/form.module.scss';
 import { AccountingCodesShape } from 'types/accountingCodes';
 import { AddressShape, SimpleAddressShape } from 'types/address';
@@ -169,6 +169,12 @@ const ShipmentForm = (props) => {
   const handleShowCancellationModal = () => {
     setIsCancelModalVisible(true);
   };
+
+  const successMessageAlertControl = (
+    <Button type="button" onClick={() => setSuccessMessage(null)} unstyled>
+      <FontAwesomeIcon icon="times" className={styles.alertClose} />
+    </Button>
+  );
 
   const deliveryAddressUpdateRequested = mtoShipment?.deliveryAddressUpdate?.status === ADDRESS_UPDATE_STATUS.REQUESTED;
 
@@ -526,6 +532,7 @@ const ShipmentForm = (props) => {
                 );
               }}
               errorMessage={shipmentAddressUpdateReviewErrorMessage}
+              setErrorMessage={setShipmentAddressUpdateReviewErrorMessage}
             />
             <NotificationScrollToTop dependency={errorMessage} />
             {errorMessage && (
@@ -535,9 +542,9 @@ const ShipmentForm = (props) => {
             )}
             <NotificationScrollToTop dependency={successMessage} />
             {successMessage && (
-              <MilMoveAlert type="success" onRemove={() => setSuccessMessage(null)}>
+              <Alert type="success" cta={successMessageAlertControl}>
                 {successMessage}
-              </MilMoveAlert>
+              </Alert>
             )}
             {isTOO && mtoShipment.usesExternalVendor && (
               <Alert headingLevel="h4" type="warning">

--- a/src/components/Office/ShipmentForm/ShipmentForm.module.scss
+++ b/src/components/Office/ShipmentForm/ShipmentForm.module.scss
@@ -111,6 +111,10 @@
   }
 }
 
+.alertClose {
+  color: $base-darkest;
+}
+
 .Fieldset {
   h2 {
     @include u-margin-bottom(2);


### PR DESCRIPTION
## Summary

For MB-16271 (https://github.com/transcom/mymove/pull/11159) we added in these alerts, however I used the shared alert because I noticed it had an inbuilt onRemove prop (which no other part of the app was using at the time). I didn't know about the ReactUSWDS cta prop, which we already use elsewhere ([example](https://github.com/transcom/mymove/blob/a6b544a44cff9baaf54b67f6821fc63af81009fe/src/pages/Office/MoveTaskOrder/MoveTaskOrder.jsx#L992)).

This PR makes use of the ReactUSWDS Alert and removes dependence on the (I assume) legacy shared alert component

## Verification Steps for Reviewers

These are to be checked by a reviewer.

### Setup to Run the Code

- [Instructions for starting storybook](https://transcom.github.io/mymove-docs/docs/frontend/setup/run-storybook)
- [Instructions for starting the MilMove application](https://transcom.github.io/mymove-docs/docs/about/application-setup/milmove-local-client/)
- [Instructions for running tests](https://transcom.github.io/mymove-docs/docs/about/development/testing)

### How to test

1. Use the test harness to generate an HHGMoveWithAddressChangeRequest, take note of the move code/locator
2. Login to office as TOO
3. Go to the move code/locator from step 1
4. Click edit shipment
5. Review the request
6. Click submit
7. Note the success modal

## Screenshots

https://github.com/transcom/mymove/assets/15805554/8698a407-564d-49ca-8475-752c3e3ce8f8
