### PR TITLE
[MB-16917] Add helper function to domestic pickup delivery sit pricer

### DIFF
--- a/pkg/services/ghcrateengine/domestic_destination_sit_delivery_pricer_test.go
+++ b/pkg/services/ghcrateengine/domestic_destination_sit_delivery_pricer_test.go
@@ -201,7 +201,7 @@ func (suite *GHCRateEngineServiceSuite) TestDomesticDestinationSITDeliveryPricer
 		twoYearsLaterPickupDate := dddsitTestRequestedPickupDate.AddDate(2, 0, 0)
 		_, _, err := pricer.Price(suite.AppContextForTest(), testdatagen.DefaultContractCode, twoYearsLaterPickupDate, dddsitTestWeight, dddsitTestServiceArea, dddsitTestSchedule, zipDest, zipSITDest, distance)
 		suite.Error(err)
-		suite.Contains(err.Error(), "could not look up contract year")
+		suite.Contains(err.Error(), "could not lookup contract year")
 	})
 }
 

--- a/pkg/services/ghcrateengine/domestic_destination_sit_delivery_pricer_test.go
+++ b/pkg/services/ghcrateengine/domestic_destination_sit_delivery_pricer_test.go
@@ -201,7 +201,7 @@ func (suite *GHCRateEngineServiceSuite) TestDomesticDestinationSITDeliveryPricer
 		twoYearsLaterPickupDate := dddsitTestRequestedPickupDate.AddDate(2, 0, 0)
 		_, _, err := pricer.Price(suite.AppContextForTest(), testdatagen.DefaultContractCode, twoYearsLaterPickupDate, dddsitTestWeight, dddsitTestServiceArea, dddsitTestSchedule, zipDest, zipSITDest, distance)
 		suite.Error(err)
-		suite.Contains(err.Error(), "could not fetch contract year")
+		suite.Contains(err.Error(), "could not look up contract year")
 	})
 }
 

--- a/pkg/services/ghcrateengine/domestic_origin_sit_pickup_pricer_test.go
+++ b/pkg/services/ghcrateengine/domestic_origin_sit_pickup_pricer_test.go
@@ -194,7 +194,7 @@ func (suite *GHCRateEngineServiceSuite) TestDomesticOriginSITPickupPricer50Miles
 		twoYearsLaterPickupDate := dopsitTestRequestedPickupDate.AddDate(2, 0, 0)
 		_, _, err := pricer.Price(suite.AppContextForTest(), testdatagen.DefaultContractCode, twoYearsLaterPickupDate, dopsitTestWeight, dopsitTestServiceArea, dopsitTestSchedule, zipOriginal, zipActual, distance)
 		suite.Error(err)
-		suite.Contains(err.Error(), "could not fetch contract year")
+		suite.Contains(err.Error(), "could not lookup contract year")
 	})
 }
 

--- a/pkg/services/ghcrateengine/pricer_helpers.go
+++ b/pkg/services/ghcrateengine/pricer_helpers.go
@@ -260,13 +260,11 @@ func priceDomesticPickupDeliverySIT(appCtx appcontext.AppContext, pickupDelivery
 	if err != nil {
 		return unit.Cents(0), nil, fmt.Errorf("could not fetch domestic %s SIT %s rate: %w", sitType, sitModifier, err)
 	}
-	contractYear, err := fetchContractYear(appCtx, domOtherPrice.ContractID, referenceDate)
-	if err != nil {
-		return unit.Cents(0), nil, fmt.Errorf("could not fetch contract year: %w", err)
-	}
-
 	baseTotalPrice := domOtherPrice.PriceCents.Float64() * weight.ToCWTFloat64()
-	escalatedTotalPrice := baseTotalPrice * contractYear.EscalationCompounded
+	escalatedTotalPrice, contractYear, err := escalatePriceForContractYear(appCtx, domOtherPrice.ContractID, referenceDate, false, baseTotalPrice)
+	if err != nil {
+		return 0, nil, fmt.Errorf("could not look up contract year: %w", err)
+	}
 	totalPriceCents := unit.Cents(math.Round(escalatedTotalPrice))
 
 	displayParams := services.PricingDisplayParams{

--- a/pkg/services/ghcrateengine/pricer_helpers.go
+++ b/pkg/services/ghcrateengine/pricer_helpers.go
@@ -263,7 +263,7 @@ func priceDomesticPickupDeliverySIT(appCtx appcontext.AppContext, pickupDelivery
 	baseTotalPrice := domOtherPrice.PriceCents.Float64() * weight.ToCWTFloat64()
 	escalatedTotalPrice, contractYear, err := escalatePriceForContractYear(appCtx, domOtherPrice.ContractID, referenceDate, false, baseTotalPrice)
 	if err != nil {
-		return 0, nil, fmt.Errorf("could not look up contract year: %w", err)
+		return 0, nil, fmt.Errorf("unable to calculate escalated total price: %w", err)
 	}
 	totalPriceCents := unit.Cents(math.Round(escalatedTotalPrice))
 

--- a/pkg/services/ghcrateengine/pricer_helpers_test.go
+++ b/pkg/services/ghcrateengine/pricer_helpers_test.go
@@ -365,7 +365,7 @@ func (suite *GHCRateEngineServiceSuite) Test_priceDomesticPickupDeliverySIT50Mil
 		twoYearsLaterPickupDate := dddsitTestRequestedPickupDate.AddDate(2, 0, 0)
 		_, _, err = priceDomesticPickupDeliverySIT(suite.AppContextForTest(), models.ReServiceCodeDDDSIT, testdatagen.DefaultContractCode, twoYearsLaterPickupDate, dddsitTestWeight, dddsitTestServiceArea, dddsitTestSchedule, domOtherZipDest, domOtherZipSITDest, domOtherDistance)
 		suite.Error(err)
-		suite.Contains(err.Error(), "could not look up contract year")
+		suite.Contains(err.Error(), "could not lookup contract year")
 	})
 }
 

--- a/pkg/services/ghcrateengine/pricer_helpers_test.go
+++ b/pkg/services/ghcrateengine/pricer_helpers_test.go
@@ -365,7 +365,7 @@ func (suite *GHCRateEngineServiceSuite) Test_priceDomesticPickupDeliverySIT50Mil
 		twoYearsLaterPickupDate := dddsitTestRequestedPickupDate.AddDate(2, 0, 0)
 		_, _, err = priceDomesticPickupDeliverySIT(suite.AppContextForTest(), models.ReServiceCodeDDDSIT, testdatagen.DefaultContractCode, twoYearsLaterPickupDate, dddsitTestWeight, dddsitTestServiceArea, dddsitTestSchedule, domOtherZipDest, domOtherZipSITDest, domOtherDistance)
 		suite.Error(err)
-		suite.Contains(err.Error(), "could not fetch contract year")
+		suite.Contains(err.Error(), "could not look up contract year")
 	})
 }
 


### PR DESCRIPTION
## [Jira ticket](https://dp3.atlassian.net/browse/MB-16917)

## Summary

Add rounding to domestic destination pricer so that when price is calculated then the escalated factor is applied the price is rounded to the nearest cent.

Apply to service items:
- DDDSIT
- DOPSIT

## Verification Steps for the Author

These are to be checked by the author.

- [ ] Have the Jira acceptance criteria been met for this change?

## Verification Steps for Reviewers

These are to be checked by a reviewer.

### Setup to Run the Code

- [Instructions for starting storybook](https://transcom.github.io/mymove-docs/docs/frontend/setup/run-storybook)
- [Instructions for starting the MilMove application](https://transcom.github.io/mymove-docs/docs/about/application-setup/milmove-local-client/)
- [Instructions for running tests](https://transcom.github.io/mymove-docs/docs/about/development/testing)

### Backend

- [ ] Code follows the guidelines for [Logging](https://transcom.github.io/mymove-docs/docs/about/development/logging).
- [ ] The requirements listed in [Querying the Database Safely](https://transcom.github.io/mymove-docs/docs/backend/guides/golang-guide#querying-the-database-safely) have been satisfied.
