### PR TITLE
[MB-16911] Adds rounding function to the domestic linehaul pricer

### DIFF
--- a/pkg/services/ghcrateengine/domestic_linehaul_pricer_test.go
+++ b/pkg/services/ghcrateengine/domestic_linehaul_pricer_test.go
@@ -198,6 +198,10 @@ func (suite *GHCRateEngineServiceSuite) TestPriceDomesticLinehaul() {
 		_, _, err = linehaulServicePricer.Price(suite.AppContextForTest(), testdatagen.DefaultContractCode, dlhRequestedPickupDate, dlhTestDistance, dlhTestWeight, "", isPPM)
 		suite.Error(err)
 		suite.Equal("ServiceArea is required", err.Error())
+
+		_, _, err = linehaulServicePricer.Price(suite.AppContextForTest(), testdatagen.DefaultContractCode, time.Date(testdatagen.TestYear+1, 1, 1, 1, 1, 1, 1, time.UTC), dlhTestDistance, dlhTestWeight, dlhTestServiceArea, isPPM)
+		suite.Error(err)
+		suite.Contains(err.Error(), "could not fetch domestic linehaul rate")
 	})
 }
 


### PR DESCRIPTION
## [Jira ticket](https://dp3.atlassian.net/browse/MB-16911)

## Summary

This updates the domestic linehaul pricer to use the new escalated pricing helper that includes rounding. There wasn't a test case for the contract year not being available, so I've gone ahead and added one (rather than editing the message expected by an existing one, which is what most of the rest of the similar PRs are doing).

## Verification Steps for the Author

These are to be checked by the author.

- [ ] Have the Jira acceptance criteria been met for this change?

### How to test

1. Verify that the server tests are passing.