### PR TITLE
MB-16962 - Add additional linehaul rounding

### DIFF
--- a/pkg/services/ghcrateengine/domestic_linehaul_pricer_test.go
+++ b/pkg/services/ghcrateengine/domestic_linehaul_pricer_test.go
@@ -18,12 +18,12 @@ const (
 	dlhTestWeightUpper          = unit.Pound(4999)
 	dlhTestMilesLower           = 1001
 	dlhTestMilesUpper           = 1500
-	dlhTestBasePriceMillicents  = unit.Millicents(5100)
+	dlhTestBasePriceMillicents  = unit.Millicents(5111)
 	dlhTestContractYearName     = "DLH Test Year"
 	dlhTestEscalationCompounded = 1.04071
-	dlhTestDistance             = unit.Miles(1200)
-	dlhTestWeight               = unit.Pound(4000)
-	dlhPriceCents               = unit.Cents(254766)
+	dlhTestDistance             = unit.Miles(1201)
+	dlhTestWeight               = unit.Pound(4001)
+	dlhPriceCents               = unit.Cents(255592)
 )
 
 var dlhRequestedPickupDate = time.Date(testdatagen.TestYear, time.June, 5, 7, 33, 11, 456, time.UTC)
@@ -32,6 +32,7 @@ func (suite *GHCRateEngineServiceSuite) TestPriceDomesticLinehaul() {
 	linehaulServicePricer := NewDomesticLinehaulPricer()
 
 	suite.Run("success using PaymentServiceItemParams", func() {
+		// serviceArea := "sa0"
 		suite.setupDomesticLinehaulPrice(dlhTestServiceArea, dlhTestIsPeakPeriod, dlhTestWeightLower, dlhTestWeightUpper, dlhTestMilesLower, dlhTestMilesUpper, dlhTestBasePriceMillicents, dlhTestContractYearName, dlhTestEscalationCompounded)
 		paymentServiceItem := suite.setupDomesticLinehaulServiceItem()
 		priceCents, displayParams, err := linehaulServicePricer.PriceUsingParams(suite.AppContextForTest(), paymentServiceItem.PaymentServiceItemParams)
@@ -86,7 +87,7 @@ func (suite *GHCRateEngineServiceSuite) TestPriceDomesticLinehaul() {
 		// < 50 mile distance with PPM
 		priceCents, _, err := linehaulServicePricer.Price(suite.AppContextForTest(), testdatagen.DefaultContractCode, dlhRequestedPickupDate, unit.Miles(49), dlhTestWeight, dlhTestServiceArea, isPPM)
 		suite.NoError(err)
-		suite.Equal(unit.Cents(10403), priceCents)
+		suite.Equal(unit.Cents(10428), priceCents)
 	})
 
 	suite.Run("successfully finds linehaul price for ppm with distance < 50 miles with PriceUsingParams method", func() {

--- a/pkg/services/ghcrateengine/pricer_helpers.go
+++ b/pkg/services/ghcrateengine/pricer_helpers.go
@@ -417,22 +417,31 @@ func createPricerGeneratedParams(appCtx appcontext.AppContext, paymentServiceIte
 
 // escalatePriceForContractYear calculates the escalated price from the base price, which is provided by the caller/pricer,
 // and the escalation factor, which is provided by the contract year. The result is rounded to the nearest cent, or to the
-// nearest tenth-cent for linehaul prices. The contract year is also returned.
+// nearest tenth-cent before and after the escalation factor for linehaul prices. The contract year is also returned.
 func escalatePriceForContractYear(appCtx appcontext.AppContext, contractID uuid.UUID, referenceDate time.Time, isLinehaul bool, basePrice float64) (float64, models.ReContractYear, error) {
 	contractYear, err := fetchContractYear(appCtx, contractID, referenceDate)
 	if err != nil {
 		return 0, contractYear, fmt.Errorf("could not lookup contract year: %w", err)
 	}
 
-	escalatedPrice := basePrice * contractYear.EscalationCompounded
+	escalatedPrice := basePrice
 
 	// round escalated price to the nearest cent, or the nearest tenth-of-a-cent if linehaul
 	precision := 0
 	if isLinehaul {
 		precision = 1
+		escalatedPrice = roundToPrecision(escalatedPrice, precision)
 	}
 
-	ratio := math.Pow(10, float64(precision))
-	escalatedPrice = math.Round(escalatedPrice*ratio) / ratio
+	escalatedPrice = escalatedPrice * contractYear.EscalationCompounded
+
+	escalatedPrice = roundToPrecision(escalatedPrice, precision)
 	return escalatedPrice, contractYear, nil
+}
+
+// roundToPrecision rounds a float64 value to the number of decimal points indicated by the precision.
+// TODO: Future cleanup could involve moving this function to a math/utility package with some simple tests
+func roundToPrecision(value float64, precision int) float64 {
+	ratio := math.Pow(10, float64(precision))
+	return math.Round(value*ratio) / ratio
 }


### PR DESCRIPTION
## [Jira ticket](https://dp3.atlassian.net/browse/MB-16962)

## Summary

In linehaul price calculations, the price must be rounded to the nearest tenth-cent before applying the escalation factor.
Something to have an opinion about: should I move the `roundToPrecision` function to a new rounding package as part of this PR? It seems pretty useful 🤷 

## Verification Steps for the Author

These are to be checked by the author.

- [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
- [ ] Have the Jira acceptance criteria been met for this change?

## Verification Steps for Reviewers

These are to be checked by a reviewer.

### Setup to Run the Code

- [Instructions for starting storybook](https://transcom.github.io/mymove-docs/docs/frontend/setup/run-storybook)
- [Instructions for starting the MilMove application](https://transcom.github.io/mymove-docs/docs/about/application-setup/milmove-local-client/)
- [Instructions for running tests](https://transcom.github.io/mymove-docs/docs/about/development/testing)

### How to test

1. Run `make server_test` to ensure that the tests are passing
2. Debug through domestic_linehaul_pricer_test.go and ensure that the calculations make sense


### Backend

- [ ] Code follows the guidelines for [Logging](https://transcom.github.io/mymove-docs/docs/about/development/logging).
- [ ] The requirements listed in [Querying the Database Safely](https://transcom.github.io/mymove-docs/docs/backend/guides/golang-guide#querying-the-database-safely) have been satisfied.

