### PR TITLE
MB-16816 - Standardize messages for escalated price errors

### DIFF
--- a/pkg/services/ghcrateengine/domestic_destination_pricer.go
+++ b/pkg/services/ghcrateengine/domestic_destination_pricer.go
@@ -53,7 +53,7 @@ func (p domesticDestinationPricer) Price(appCtx appcontext.AppContext, contractC
 	basePrice := domServiceAreaPrice.PriceCents.Float64() * finalWeight.ToCWTFloat64()
 	escalatedPrice, contractYear, err := escalatePriceForContractYear(appCtx, domServiceAreaPrice.ContractID, referenceDate, false, basePrice)
 	if err != nil {
-		return 0, nil, fmt.Errorf("unable to calculate escalated total price: %w", err)
+		return 0, nil, fmt.Errorf("could not calculate escalated price: %w", err)
 	}
 
 	totalCost := unit.Cents(math.Round(escalatedPrice))

--- a/pkg/services/ghcrateengine/domestic_destination_pricer_test.go
+++ b/pkg/services/ghcrateengine/domestic_destination_pricer_test.go
@@ -226,7 +226,7 @@ func (suite *GHCRateEngineServiceSuite) TestPriceDomesticDestination() {
 		)
 
 		suite.Error(err)
-		suite.Contains(err.Error(), "unable to calculate escalated total price")
+		suite.Contains(err.Error(), "could not calculate escalated price")
 
 	})
 

--- a/pkg/services/ghcrateengine/domestic_destination_shuttling_pricer_test.go
+++ b/pkg/services/ghcrateengine/domestic_destination_shuttling_pricer_test.go
@@ -75,7 +75,7 @@ func (suite *GHCRateEngineServiceSuite) TestDomesticDestinationShuttlingPricer()
 		twoYearsLaterPickupDate := ddshutTestRequestedPickupDate.AddDate(2, 0, 0)
 		_, _, err := pricer.Price(suite.AppContextForTest(), testdatagen.DefaultContractCode, twoYearsLaterPickupDate, ddshutTestWeight, ddshutTestServiceSchedule)
 		suite.Error(err)
-		suite.Contains(err.Error(), "unable to calculate escalated total price")
+		suite.Contains(err.Error(), "could not calculate escalated price")
 	})
 }
 

--- a/pkg/services/ghcrateengine/domestic_origin_shuttling_pricer_test.go
+++ b/pkg/services/ghcrateengine/domestic_origin_shuttling_pricer_test.go
@@ -75,7 +75,7 @@ func (suite *GHCRateEngineServiceSuite) TestDomesticOriginShuttlingPricer() {
 		twoYearsLaterPickupDate := doshutTestRequestedPickupDate.AddDate(2, 0, 0)
 		_, _, err := pricer.Price(suite.AppContextForTest(), testdatagen.DefaultContractCode, twoYearsLaterPickupDate, doshutTestWeight, doshutTestServiceSchedule)
 		suite.Error(err)
-		suite.Contains(err.Error(), "unable to calculate escalated total price: could not lookup contract year")
+		suite.Contains(err.Error(), "could not calculate escalated price")
 	})
 }
 

--- a/pkg/services/ghcrateengine/domestic_shorthaul_pricer.go
+++ b/pkg/services/ghcrateengine/domestic_shorthaul_pricer.go
@@ -57,7 +57,7 @@ func (p domesticShorthaulPricer) Price(appCtx appcontext.AppContext, contractCod
 	basePrice := domServiceAreaPrice.PriceCents.Float64() * distance.Float64() * weight.ToCWTFloat64()
 	escalatedPrice, contractYear, err := escalatePriceForContractYear(appCtx, domServiceAreaPrice.ContractID, referenceDate, false, basePrice)
 	if err != nil {
-		return 0, nil, fmt.Errorf("could not look up escalated price: %w", err)
+		return 0, nil, fmt.Errorf("could not calculate escalated price: %w", err)
 	}
 	totalCost = unit.Cents(math.Round(escalatedPrice))
 

--- a/pkg/services/ghcrateengine/domestic_shorthaul_pricer_test.go
+++ b/pkg/services/ghcrateengine/domestic_shorthaul_pricer_test.go
@@ -198,7 +198,7 @@ func (suite *GHCRateEngineServiceSuite) TestPriceDomesticShorthaul() {
 
 		suite.Error(err)
 		suite.Nil(rateEngineParams)
-		suite.Contains(err.Error(), "could not look up escalated price")
+		suite.Contains(err.Error(), "could not calculate escalated price")
 	})
 
 	suite.Run("weight below minimum", func() {

--- a/pkg/services/ghcrateengine/pricer_helpers.go
+++ b/pkg/services/ghcrateengine/pricer_helpers.go
@@ -54,7 +54,7 @@ func priceDomesticPackUnpack(appCtx appcontext.AppContext, packUnpackCode models
 	basePrice := domOtherPrice.PriceCents.Float64() * finalWeight.ToCWTFloat64()
 	escalatedPrice, contractYear, err := escalatePriceForContractYear(appCtx, domOtherPrice.ContractID, referenceDate, false, basePrice)
 	if err != nil {
-		return 0, nil, fmt.Errorf("unable to calculate escalated total price: %w", err)
+		return 0, nil, fmt.Errorf("could not calculate escalated price: %w", err)
 	}
 
 	displayParams := services.PricingDisplayParams{
@@ -122,7 +122,7 @@ func priceDomesticFirstDaySIT(appCtx appcontext.AppContext, firstDaySITCode mode
 	baseTotalPrice := serviceAreaPrice.PriceCents.Float64() * weight.ToCWTFloat64()
 	escalatedPrice, contractYear, err := escalatePriceForContractYear(appCtx, serviceAreaPrice.ContractID, referenceDate, false, baseTotalPrice)
 	if err != nil {
-		return 0, nil, fmt.Errorf("unable to calculate escalated total price: %w", err)
+		return 0, nil, fmt.Errorf("could not calculate escalated price: %w", err)
 	}
 	totalPriceCents := unit.Cents(math.Round(escalatedPrice))
 
@@ -159,7 +159,7 @@ func priceDomesticAdditionalDaysSIT(appCtx appcontext.AppContext, additionalDayS
 	baseTotalPrice := serviceAreaPrice.PriceCents.Float64() * weight.ToCWTFloat64()
 	escalatedTotalPrice, contractYear, err := escalatePriceForContractYear(appCtx, serviceAreaPrice.ContractID, referenceDate, false, baseTotalPrice)
 	if err != nil {
-		return 0, nil, fmt.Errorf("unable to calculate escalated total price: %w", err)
+		return 0, nil, fmt.Errorf("could not calculate escalated price: %w", err)
 	}
 
 	totalForNumberOfDaysPrice := escalatedTotalPrice * float64(numberOfDaysInSIT)
@@ -260,7 +260,7 @@ func priceDomesticPickupDeliverySIT(appCtx appcontext.AppContext, pickupDelivery
 	baseTotalPrice := domOtherPrice.PriceCents.Float64() * weight.ToCWTFloat64()
 	escalatedTotalPrice, contractYear, err := escalatePriceForContractYear(appCtx, domOtherPrice.ContractID, referenceDate, false, baseTotalPrice)
 	if err != nil {
-		return 0, nil, fmt.Errorf("unable to calculate escalated total price: %w", err)
+		return 0, nil, fmt.Errorf("could not calculate escalated price: %w", err)
 	}
 	totalPriceCents := unit.Cents(math.Round(escalatedTotalPrice))
 
@@ -313,7 +313,7 @@ func priceDomesticShuttling(appCtx appcontext.AppContext, shuttlingCode models.R
 	basePrice := domAccessorialPrice.PerUnitCents.Float64() * weight.ToCWTFloat64()
 	escalatedPrice, contractYear, err := escalatePriceForContractYear(appCtx, domAccessorialPrice.ContractID, referenceDate, false, basePrice)
 	if err != nil {
-		return 0, nil, fmt.Errorf("unable to calculate escalated total price: %w", err)
+		return 0, nil, fmt.Errorf("could not calculate escalated price: %w", err)
 	}
 	totalCost := unit.Cents(math.Round(escalatedPrice))
 
@@ -350,7 +350,7 @@ func priceDomesticCrating(appCtx appcontext.AppContext, code models.ReServiceCod
 	basePrice := domAccessorialPrice.PerUnitCents.Float64() * float64(billedCubicFeet)
 	escalatedPrice, contractYear, err := escalatePriceForContractYear(appCtx, domAccessorialPrice.ContractID, referenceDate, false, basePrice)
 	if err != nil {
-		return 0, nil, fmt.Errorf("unable to calculate escalated total price: %w", err)
+		return 0, nil, fmt.Errorf("could not calculate escalated price: %w", err)
 	}
 	totalCost := unit.Cents(math.Round(escalatedPrice))
 

--- a/pkg/services/ghcrateengine/pricer_helpers_test.go
+++ b/pkg/services/ghcrateengine/pricer_helpers_test.go
@@ -553,7 +553,7 @@ func (suite *GHCRateEngineServiceSuite) Test_priceDomesticShuttling() {
 		_, _, err := priceDomesticShuttling(suite.AppContextForTest(), models.ReServiceCodeDDSHUT, testdatagen.DefaultContractCode, twoYearsLaterPickupDate, ddshutTestWeight, ddshutTestServiceSchedule)
 
 		suite.Error(err)
-		suite.Contains(err.Error(), "unable to calculate escalated total price: could not lookup contract year")
+		suite.Contains(err.Error(), "could not calculate escalated price: could not lookup contract year")
 	})
 }
 func (suite *GHCRateEngineServiceSuite) Test_priceDomesticCrating() {


### PR DESCRIPTION
## [Jira ticket](https://dp3.atlassian.net/browse/MB-16816)

## Summary

I standardized the error messages returned after calculating the escalated price in the service item pricers.

## Verification Steps for the Author

These are to be checked by the author.

- [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
- [ ] Have the Jira acceptance criteria been met for this change?

## Verification Steps for Reviewers

These are to be checked by a reviewer.

### Setup to Run the Code

- [Instructions for starting storybook](https://transcom.github.io/mymove-docs/docs/frontend/setup/run-storybook)
- [Instructions for starting the MilMove application](https://transcom.github.io/mymove-docs/docs/about/application-setup/milmove-local-client/)
- [Instructions for running tests](https://transcom.github.io/mymove-docs/docs/about/development/testing)

### How to test

1. Ensure the tests pass with `make server_test`

### Backend

- [ ] Code follows the guidelines for [Logging](https://transcom.github.io/mymove-docs/docs/about/development/logging).
- [ ] The requirements listed in [Querying the Database Safely](https://transcom.github.io/mymove-docs/docs/backend/guides/golang-guide#querying-the-database-safely) have been satisfied.
