### PR TITLE
Disable unused service worker registration

### DIFF
--- a/src/index.jsx
+++ b/src/index.jsx
@@ -6,8 +6,11 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 
 import App from './App';
-import registerServiceWorker from './registerServiceWorker';
+// import registerServiceWorker from './registerServiceWorker';
 import './index.scss';
 
 ReactDOM.render(<App />, document.getElementById('root'));
-registerServiceWorker();
+
+// MilMove does not have or use a service worker as of 2023-09-07
+// so disable this to prevent logging errors
+// registerServiceWorker();

--- a/src/registerServiceWorker.js
+++ b/src/registerServiceWorker.js
@@ -83,6 +83,8 @@ export function unregister() {
   }
 }
 
+// MilMove does not have or use a service worker as of 2023-09-07
+// See src/index.jsx for how to re-enable this should that change
 export default function register() {
   const isServiceWorkerEnv = process.env.NODE_ENV === 'production' || process.env.REACT_APP_SERVICE_WORKER === 'true';
   if (isServiceWorkerEnv && 'serviceWorker' in navigator) {


### PR DESCRIPTION
## Summary

Currently we try to register a service worker, but it always fails, creating error logs that only add noise.

I chose to comment it out to make it easier to re-enable should we decide we want a service worker.

## Verification Steps for the Author

These are to be checked by the author.

- [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
- [ ] Have the Jira acceptance criteria been met for this change?

## Verification Steps for Reviewers

Because this is commenting out code, I don't think there's all that much to verify. You could, I suppose, confirm that we do not have a `service-worker.js`
