### PR TITLE
Add logging to EDI 824 processing to reveal OTI acknowledgement code

### DIFF
--- a/pkg/services/invoice/process_edi824.go
+++ b/pkg/services/invoice/process_edi824.go
@@ -124,7 +124,11 @@ func (e *edi824Processor) ProcessFile(appCtx appcontext.AppContext, _ string, st
 			return fmt.Errorf("The BGN02 Reference Identification field: %s doesn't match the MTO reference ID %v of the associated payment request", bgnRefIdentification, moveReferenceID)
 		}
 
-		teds := fetchTEDSegments(edi824)
+		otis, teds := fetchTransactionSetSegments(edi824)
+
+		for i, oti := range otis {
+			txnAppCtx.Logger().Info(fmt.Sprintf("EDI 824 OTI %d/%d", i+1, len(otis)), zap.Any("oti", oti))
+		}
 
 		for _, ted := range teds {
 			code := ted.ApplicationErrorConditionCode
@@ -164,14 +168,16 @@ func (e *edi824Processor) ProcessFile(appCtx appcontext.AppContext, _ string, st
 	return nil
 }
 
-func fetchTEDSegments(edi ediResponse824.EDI) []edisegment.TED {
+func fetchTransactionSetSegments(edi ediResponse824.EDI) ([]edisegment.OTI, []edisegment.TED) {
+	var otis []edisegment.OTI
 	var teds []edisegment.TED
 	for _, functionalGroup := range edi.InterchangeControlEnvelope.FunctionalGroups {
 		for _, transactionSet := range functionalGroup.TransactionSets {
+			otis = append(otis, transactionSet.OTIs...)
 			teds = append(teds, transactionSet.TEDs...)
 		}
 	}
-	return teds
+	return otis, teds
 }
 
 func (e *edi824Processor) EDIType() models.EDIType {

--- a/pkg/services/invoice/process_edi824_test.go
+++ b/pkg/services/invoice/process_edi824_test.go
@@ -316,14 +316,14 @@ IEA*1*000000001
 	})
 }
 
-func (suite *ProcessEDI824Suite) TestIdentifyingTEDs() {
-	suite.Run("fetchTEDSegments can fetch all TED segments", func() {
+func (suite *ProcessEDI824Suite) TestIdentifyingOTIsAndTEDs() {
+	suite.Run("fetchTransactionSetSegments can fetch all OTI and TED segments", func() {
 		sample824EDIString := `
 ISA*00*0084182369*00*0000000000*ZZ*MILMOVE        *12*8004171844     *210217*1530*U*00401*2000000000*8*A*|
 GS*SA*MILMOVE*8004171844*20190903*1617*2000000000*X*004010
 ST*824*000000001
 BGN*19**20211313
-OTI*VA*MM**X*X*20211311**-1*AB
+OTI*TR*MM**X*X*20211311**-1*AB
 TED*k*Missing Data
 TED*k*Missing Data
 TED*k*Missing Data
@@ -332,7 +332,7 @@ GE*2*1
 GS*SA*MILMOVE*8004171844*20190903*1617*2000000000*X*004010
 ST*824*000000001
 BGN*19**20211313
-OTI*VA*MM**X*X*20211311**-1*AB
+OTI*TE*MM**X*X*20211311**-1*AB
 TED*K*DOCUMENT OWNER CANNOT BE DETERMINED
 TED*K*DOCUMENT OWNER CANNOT BE DETERMINED
 TED*K*DOCUMENT OWNER CANNOT BE DETERMINED
@@ -343,7 +343,8 @@ IEA*1*000000001
 		edi824 := ediResponse824.EDI{}
 		err := edi824.Parse(sample824EDIString)
 		suite.NoError(err)
-		teds := fetchTEDSegments(edi824)
+		otis, teds := fetchTransactionSetSegments(edi824)
+		suite.Equal(2, len(otis))
 		suite.Equal(6, len(teds))
 	})
 }


### PR DESCRIPTION
## [Jira ticket](tbd)

## Summary

After merging https://github.com/transcom/mymove/pull/11328, I expected to see technical error segments coming back in the EDI 824 responses in the Cloudwatch logs.  When I didn't see any from a new payment request I created, I went to look at the EDI 824 spec more closely.  I began wondering when the TED segments are required and if we were getting a successful acknowledgement code instead.

Here I've added logging to our processing of EDI 824s to see which acknowledgement code is coming back from Syncada (`TA`, `TE`, or `TR`).  `TA` would seem to indicate that what we sent was accepted and the payment request status should not be marked as an error.

https://ustcdp3.slack.com/archives/C04PL9ZLHFD/p1694200944407709
https://drive.google.com/file/d/144rKMw_aFFPgHwLfOhMKqvmkFO4SzJ2M/view

## Verification Steps for the Author

These are to be checked by the author.

- [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
- [ ] Have the Jira acceptance criteria been met for this change?

## Verification Steps for Reviewers

These are to be checked by a reviewer.

### Setup to Run the Code

- [Instructions for starting storybook](https://transcom.github.io/mymove-docs/docs/frontend/setup/run-storybook)
- [Instructions for starting the MilMove application](https://transcom.github.io/mymove-docs/docs/about/application-setup/milmove-local-client/)
- [Instructions for running tests](https://transcom.github.io/mymove-docs/docs/about/development/testing)

### How to test

1. Access the
2. Login as a
3.

### Frontend

- [ ] There are no aXe warnings for UI.
- [ ] This works in [Supported Browsers and their phone views](https://transcom.github.io/mymove-docs/docs/about/supported-browsers) (Chrome, Firefox, Edge).
- [ ] There are no new console errors in the browser devtools.
- [ ] There are no new console errors in the test output.
- [ ] If this PR adds a new component to Storybook, it ensures the component is fully responsive, OR if it is intentionally not, a wrapping div using the `officeApp` class or custom `min-width` styling is used to hide any states the would not be visible to the user.

### Backend

- [ ] Code follows the guidelines for [Logging](https://transcom.github.io/mymove-docs/docs/about/development/logging).
- [ ] The requirements listed in [Querying the Database Safely](https://transcom.github.io/mymove-docs/docs/backend/guides/golang-guide#querying-the-database-safely) have been satisfied.

### Database

#### Any new migrations/schema changes:

- [ ] Follows our guidelines for [Zero-Downtime Deploys](https://transcom.github.io/mymove-docs/docs/backend/setup/database-migrations#zero-downtime-migrations).
- [ ] Have been communicated to #g-database.
- [ ] Secure migrations have been tested following the instructions in our [docs](https://transcom.github.io/mymove-docs/docs/backend/setup/database-migrations#secure-migrations).

## Screenshots

![image](https://github.com/transcom/mymove/assets/52669884/c16bf770-6573-4406-b6e3-d48d00799f1c)