### PR TITLE
[MB-16997] TIO needs clearer view of SIT start and end dates for payment request review

### DIFF
--- a/src/components/Office/DaysInSITAllowance/DaysInSITAllowance.jsx
+++ b/src/components/Office/DaysInSITAllowance/DaysInSITAllowance.jsx
@@ -6,42 +6,31 @@ import { ShipmentPaymentSITBalanceShape } from '../../../types/serviceItems';
 
 import styles from './DaysInSITAllowance.module.scss';
 
-import { formatDate, formatDaysInTransit, formatDaysRemaining } from 'utils/formatters';
+import { formatDate } from 'utils/formatters';
 
 const DaysInSITAllowance = ({ className, shipmentPaymentSITBalance }) => {
   const {
     previouslyBilledDays,
-    previouslyBilledEndDate,
-    pendingSITDaysInvoiced,
     pendingBilledEndDate,
+    pendingBilledStartDate,
     totalSITDaysAuthorized,
     totalSITDaysRemaining,
-    totalSITEndDate,
   } = shipmentPaymentSITBalance;
   return (
     <div className={classNames(className, styles.DaysInSITAllowance)} data-testid="DaysInSITAllowance">
       <dl className={styles.daysInSITList}>
-        <dt>Prev. billed & accepted</dt>
-        <dd data-testid="previouslyBilled">
-          {formatDaysInTransit(previouslyBilledDays)}
-          {!!previouslyBilledDays && (
-            <>
-              {', through '}
-              {formatDate(previouslyBilledEndDate, 'YYYY-MM-DD', 'DD MMM YYYY')}
-            </>
-          )}
-        </dd>
-        <dt>Invoiced & pending</dt>
-        <dd data-testid="pendingInvoiced">
-          {formatDaysInTransit(pendingSITDaysInvoiced)}, through{' '}
+        <dt>Prev. billed & accepted days</dt>
+        <dd data-testid="previouslyBilled">{previouslyBilledDays || '0'}</dd>
+        <dt>Payment start - end date</dt>
+        <dd data-testid="pendingBilledStartEndDate">
+          {formatDate(pendingBilledStartDate, 'YYYY-MM-DD', 'DD MMM YYYY')}
+          {` - `}
           {formatDate(pendingBilledEndDate, 'YYYY-MM-DD', 'DD MMM YYYY')}
         </dd>
-        <dt>Total authorized</dt>
-        <dd>{formatDaysInTransit(totalSITDaysAuthorized)}</dd>
-        <dt>Authorized remaining</dt>
-        <dd data-testid="totalRemaining">
-          {formatDaysRemaining(totalSITDaysRemaining)} {formatDate(totalSITEndDate, 'YYYY-MM-DD', 'DD MMM YYYY')}
-        </dd>
+        <dt>Total days of SIT approved</dt>
+        <dd>{totalSITDaysAuthorized}</dd>
+        <dt>Total approved days remaining</dt>
+        <dd data-testid="totalRemaining">{totalSITDaysRemaining > 0 ? totalSITDaysRemaining : '0'}</dd>
       </dl>
     </div>
   );

--- a/src/components/Office/DaysInSITAllowance/DaysInSITAllowance.stories.jsx
+++ b/src/components/Office/DaysInSITAllowance/DaysInSITAllowance.stories.jsx
@@ -20,6 +20,11 @@ export default {
       type: 'number',
       defaultValue: 60,
     },
+    pendingBilledStartDate: {
+      type: 'string',
+      defaultValue: '2021-07-08',
+      required: false,
+    },
     pendingBilledEndDate: {
       type: 'string',
       defaultValue: '2021-08-08',
@@ -43,6 +48,7 @@ const defaultArgs = {
   previouslyBilledDays: 30,
   previouslyBilledEndDate: '2021-06-08',
   pendingSITDaysInvoiced: 60,
+  pendingBilledStartDate: '2021-07-08',
   pendingBilledEndDate: '2021-08-08',
   totalSITDaysAuthorized: 120,
   totalSITDaysRemaining: 30,

--- a/src/components/Office/DaysInSITAllowance/DaysInSITAllowance.test.jsx
+++ b/src/components/Office/DaysInSITAllowance/DaysInSITAllowance.test.jsx
@@ -9,6 +9,7 @@ describe('DaysInSITAllowance Component', () => {
     previouslyBilledEndDate: '2021-06-08',
     pendingSITDaysInvoiced: 60,
     pendingBilledEndDate: '2021-08-08',
+    pendingBilledStartDate: '2021-07-08',
     totalSITDaysAuthorized: 120,
     totalSITDaysRemaining: 30,
     totalSITEndDate: '2021-09-08',
@@ -17,6 +18,7 @@ describe('DaysInSITAllowance Component', () => {
   const pendingShipmentSITBalance = {
     previouslyBilledDays: 0,
     pendingSITDaysInvoiced: 60,
+    pendingBilledStartDate: '2021-07-08',
     pendingBilledEndDate: '2021-08-08',
     totalSITDaysAuthorized: 120,
     totalSITDaysRemaining: 30,
@@ -26,34 +28,34 @@ describe('DaysInSITAllowance Component', () => {
   it('renders the billed, pending, and total SIT balances', () => {
     render(<DaysInSITAllowance shipmentPaymentSITBalance={shipmentPaymentSITBalance} />);
 
-    expect(screen.getByText('Prev. billed & accepted')).toBeInTheDocument();
+    expect(screen.getByText('Prev. billed & accepted days')).toBeInTheDocument();
     // due to the fragments using getByText here doesn't work, another option would be create a function that renders a
     // single string fragment in the component
-    expect(screen.getByTestId('previouslyBilled')).toHaveTextContent('30 days, through 08 Jun 2021');
+    expect(screen.getByTestId('previouslyBilled')).toHaveTextContent('30');
 
-    expect(screen.getByText('Invoiced & pending')).toBeInTheDocument();
-    expect(screen.getByTestId('pendingInvoiced')).toHaveTextContent('60 days, through 08 Aug 2021');
+    expect(screen.getByText('Payment start - end date')).toBeInTheDocument();
+    expect(screen.getByTestId('pendingBilledStartEndDate')).toHaveTextContent('08 Jul 2021 - 08 Aug 2021');
 
-    expect(screen.getByText('Total authorized')).toBeInTheDocument();
-    expect(screen.getByText('120 days')).toBeInTheDocument();
+    expect(screen.getByText('Total days of SIT approved')).toBeInTheDocument();
+    expect(screen.getByText('120')).toBeInTheDocument();
 
-    expect(screen.getByText('Authorized remaining')).toBeInTheDocument();
-    expect(screen.getByTestId('totalRemaining')).toHaveTextContent('30 days, ends 08 Sep 2021');
+    expect(screen.getByText('Total approved days remaining')).toBeInTheDocument();
+    expect(screen.getByTestId('totalRemaining')).toHaveTextContent('30');
   });
 
   it('renders zero when no SIT days were previously billed', () => {
     render(<DaysInSITAllowance shipmentPaymentSITBalance={pendingShipmentSITBalance} />);
 
-    expect(screen.getByText('Prev. billed & accepted')).toBeInTheDocument();
-    expect(screen.getByTestId('previouslyBilled')).toHaveTextContent('0 days');
+    expect(screen.getByText('Prev. billed & accepted days')).toBeInTheDocument();
+    expect(screen.getByTestId('previouslyBilled')).toHaveTextContent('0');
 
-    expect(screen.getByText('Invoiced & pending')).toBeInTheDocument();
-    expect(screen.getByTestId('pendingInvoiced')).toHaveTextContent('60 days, through 08 Aug 2021');
+    expect(screen.getByText('Payment start - end date')).toBeInTheDocument();
+    expect(screen.getByTestId('pendingBilledStartEndDate')).toHaveTextContent('08 Jul 2021 - 08 Aug 2021');
 
-    expect(screen.getByText('Total authorized')).toBeInTheDocument();
-    expect(screen.getByText('120 days')).toBeInTheDocument();
+    expect(screen.getByText('Total days of SIT approved')).toBeInTheDocument();
+    expect(screen.getByText('120')).toBeInTheDocument();
 
-    expect(screen.getByText('Authorized remaining')).toBeInTheDocument();
-    expect(screen.getByTestId('totalRemaining')).toHaveTextContent('30 days, ends 08 Sep 2021');
+    expect(screen.getByText('Total approved days remaining')).toBeInTheDocument();
+    expect(screen.getByTestId('totalRemaining')).toHaveTextContent('30');
   });
 });


### PR DESCRIPTION
## [Jira ticket](https://dp3.atlassian.net/browse/MB-16997)

## Verification Steps for Reviewers

>>[!Important]
>> This PR does not fix number of days previously invoice bug.

- [ ] Copy changes match the figma file in JIRA ticket

### Setup to Run the Code

- [Instructions for starting storybook](https://transcom.github.io/mymove-docs/docs/frontend/setup/run-storybook)
- [Instructions for starting the MilMove application](https://transcom.github.io/mymove-docs/docs/about/application-setup/milmove-local-client/)
- [Instructions for running tests](https://transcom.github.io/mymove-docs/docs/about/development/testing)

### How to test

1. Access the Office
2. Login as a TIO
3. Find move `DSTSIT` and navigate to payment request page.
   - [x] Sit service item section should display updated copy
4. Review the payment request
   - [x] Sit service item section should display updated copy
3. Find move `ORGSIT` and navigate to payment request page.
4. Review the payment request
   - [x] Sit service item section should display updated copy
3. Find move `PARSIT` and navigate to payment request page.
4. Review the payment request


### Frontend

- [ ] There are no aXe warnings for UI.
- [ ] This works in [Supported Browsers and their phone views](https://transcom.github.io/mymove-docs/docs/about/supported-browsers) (Chrome, Firefox, Edge).
- [ ] There are no new console errors in the browser devtools.
- [ ] There are no new console errors in the test output.
- [ ] If this PR adds a new component to Storybook, it ensures the component is fully responsive, OR if it is intentionally not, a wrapping div using the `officeApp` class or custom `min-width` styling is used to hide any states the would not be visible to the user.


## Screenshots
<img width="413" alt="Screenshot 2023-09-13 at 11 33 13 AM" src="https://github.com/transcom/mymove/assets/28371460/ea7a4120-d835-420a-b67b-7764271ba71a">
