### PR TITLE
[MB-16327] Update Red River Army Depot and Presidio of Monterey duty locations

### DIFF
--- a/migrations/app/migrations_manifest.txt
+++ b/migrations/app/migrations_manifest.txt
@@ -864,3 +864,4 @@
 20230921144719_update_dutylocation_mayport_fl_govt_counseling.up.sql
 20230921173336_update_shipping_offices.up.sql
 20230921180020_delete_transportation_offices.up.sql
+20230922174009_update_incorrect_duty_locations.up.sql

--- a/migrations/app/schema/20230922174009_update_incorrect_duty_locations.up.sql
+++ b/migrations/app/schema/20230922174009_update_incorrect_duty_locations.up.sql
@@ -1,0 +1,9 @@
+-- Jira: MB-16327
+
+UPDATE duty_locations
+    SET name = 'Red River Army Depot, TX 75507'
+    WHERE name = 'Red River Army Depot';
+
+UPDATE duty_locations
+    SET name = 'Presidio of Monterey, CA 93944'
+    WHERE name = 'Presidio of Monterey';


### PR DESCRIPTION
## [Jira ticket](https://dp3.atlassian.net/browse/MB-16327?atlOrigin=eyJpIjoiZjc1MDI3ZjMyMWRjNDc3MjkyZDNjZmRhMWViNDg3NmIiLCJwIjoiaiJ9)

## Summary

Follow-up from https://github.com/transcom/mymove/pull/11365. That migration was missing updates for a couple duty locations:

- Red River Army Depot -> Red River Army Depot, TX 75507
- Presidio of Monterey -> Presidio of Monterey, CA 93944

This PR updates those duty locations

### Database

#### Any new migrations/schema changes:

- [x] Follows our guidelines for [Zero-Downtime Deploys](https://transcom.github.io/mymove-docs/docs/backend/setup/database-migrations#zero-downtime-migrations).
- [x] Have been communicated to #g-database.
