### PR TITLE
[MB-16327] Update incorrect transportation office

### DIFF
--- a/migrations/app/migrations_manifest.txt
+++ b/migrations/app/migrations_manifest.txt
@@ -865,3 +865,4 @@
 20230921173336_update_shipping_offices.up.sql
 20230921180020_delete_transportation_offices.up.sql
 20230922174009_update_incorrect_duty_locations.up.sql
+20230922180941_update_incorrect_transportation_office.up.sql

--- a/migrations/app/schema/20230922180941_update_incorrect_transportation_office.up.sql
+++ b/migrations/app/schema/20230922180941_update_incorrect_transportation_office.up.sql
@@ -1,0 +1,14 @@
+-- Jira: MB-16327
+
+UPDATE transportation_offices
+    SET name = 'PPPO Tobyhanna Army Depot - USA',
+        gbloc = 'AGFM'
+    WHERE id = '46898e12-8657-4ece-bb89-9a9e94815db9';
+
+UPDATE addresses
+    SET street_address_1 = '11 Hap Arnold Blvd',
+        street_address_2 = NULL,
+        city = 'Coolbaugh Township',
+        state = 'PA',
+        postal_code = '18466'
+    WHERE id = (SELECT address_id FROM transportation_offices where id = '46898e12-8657-4ece-bb89-9a9e94815db9');


### PR DESCRIPTION
## [Jira ticket](https://dp3.atlassian.net/browse/MB-16327?atlOrigin=eyJpIjoiZjc1MDI3ZjMyMWRjNDc3MjkyZDNjZmRhMWViNDg3NmIiLCJwIjoiaiJ9)

## Summary

For some reason https://github.com/transcom/mymove/pull/11386 didn't update TO `46898e12-8657-4ece-bb89-9a9e94815db9` even though it was explicitly updated [here](https://github.com/transcom/mymove/blob/dd1dc1fa2be33f976fdce5ae7639eae65dadec60/migrations/app/schema/20230809180036_update_transportation_offices.up.sql#L952-L955). All the other TOs seemed to have updated correctly.

At some point that should be looked into, but for now, this PR updates that TO and its corresponding address.

### Database

#### Any new migrations/schema changes:

- [ ] Follows our guidelines for [Zero-Downtime Deploys](https://transcom.github.io/mymove-docs/docs/backend/setup/database-migrations#zero-downtime-migrations).
- [ ] Have been communicated to #g-database.
