### PR TITLE
[MB-17061] Delete Fort Lee duty location

### DIFF
--- a/migrations/app/migrations_manifest.txt
+++ b/migrations/app/migrations_manifest.txt
@@ -867,3 +867,4 @@
 20230922174009_update_incorrect_duty_locations.up.sql
 20230922180941_update_incorrect_transportation_office.up.sql
 20230925170109_update_deletion_fk_policies_duty_location.up.sql
+20230925221618_delete_fort_lee_dutylocation.up.sql

--- a/migrations/app/schema/20230925221618_delete_fort_lee_dutylocation.up.sql
+++ b/migrations/app/schema/20230925221618_delete_fort_lee_dutylocation.up.sql
@@ -1,0 +1,8 @@
+-- Jira: MB-17061
+
+-- Delete 'Fort Lee, VA 23801' duty location
+DELETE FROM orders
+	WHERE origin_duty_location_id = 'bb7cf211-bada-4129-9ec9-a8936613f034'
+	OR new_duty_location_id = 'bb7cf211-bada-4129-9ec9-a8936613f034';
+
+DELETE FROM duty_locations WHERE id = 'bb7cf211-bada-4129-9ec9-a8936613f034';


### PR DESCRIPTION
## [Jira ticket](https://dp3.atlassian.net/browse/MB-17061)

## Summary

Follow-up to https://github.com/transcom/mymove/pull/11452, this deletes the 'Fort Lee, VA 23801' duty location.

Will deploy to exp first before merging!

### Database

#### Any new migrations/schema changes:

- [ ] Follows our guidelines for [Zero-Downtime Deploys](https://transcom.github.io/mymove-docs/docs/backend/setup/database-migrations#zero-downtime-migrations).
- [ ] Have been communicated to #g-database.
- [ ] Secure migrations have been tested following the instructions in our [docs](https://transcom.github.io/mymove-docs/docs/backend/setup/database-migrations#secure-migrations).

