### PR TITLE
[MB-17008] recommit work that was lost from PR #11433

### DIFF
--- a/pkg/services/invoice/ghc_payment_request_invoice_generator.go
+++ b/pkg/services/invoice/ghc_payment_request_invoice_generator.go
@@ -764,6 +764,15 @@ func (g ghcPaymentRequestInvoiceGenerator) createLongLoaSegments(appCtx appconte
 		concatDate = &blankValue
 	}
 
+	// The FA2 L1 segment must be exactly six characters in length. Our imported database values from TRDM are numeric
+	// strings and so we need to left pad with zeros to meet the threshold.  This may not be needed when the real TGET
+	// integration is introduced.
+	var accountingInstallationNumber *string
+	if loa.LoaInstlAcntgActID != nil {
+		zeroPaddedInstlAcntgActID := fmt.Sprintf("%06s", *loa.LoaInstlAcntgActID)
+		accountingInstallationNumber = &zeroPaddedInstlAcntgActID
+	}
+
 	// Create long LOA FA2 segments
 	segmentInputs := []struct {
 		detailCode edisegment.FA2DetailCode
@@ -794,7 +803,7 @@ func (g ghcPaymentRequestInvoiceGenerator) createLongLoaSegments(appCtx appconte
 		{edisegment.FA2DetailCodeI1, loa.LoaBdgtAcntClsNm},
 		{edisegment.FA2DetailCodeJ1, loa.LoaDocID},
 		{edisegment.FA2DetailCodeK6, loa.LoaClsRefID},
-		{edisegment.FA2DetailCodeL1, loa.LoaInstlAcntgActID},
+		{edisegment.FA2DetailCodeL1, accountingInstallationNumber},
 		{edisegment.FA2DetailCodeM1, loa.LoaLclInstlID},
 		{edisegment.FA2DetailCodeN1, loa.LoaTrnsnID},
 		{edisegment.FA2DetailCodeP5, loa.LoaFmsTrnsactnID},


### PR DESCRIPTION
## [Jira ticket](https://dp3.atlassian.net/browse/MB-17008)

## Summary

We received feedback from DFAS about the EDI 858 LOA segments we were sending that the LOA L1 segment should always be six characters in length.  While some of the LOAs in our dataset have six character values for the `LoaInstlAcntgActID` others can be as small as three digit numerals (stored as string types).

This PR uses the format string to ensure we're left padding with zeroes to exactly 6 characters of length everytime unless we get a null value from the database.  In the case of a null value we will omit the L1 segment from the EDI like other fields instead of say sending "000000".  There is already a test that nil values get omitted so I didn't add a test for that.

## Verification Steps for the Author

These are to be checked by the author.

- [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
- [ ] Have the Jira acceptance criteria been met for this change?

## Verification Steps for Reviewers

These are to be checked by a reviewer.

### Setup to Run the Code

- [Instructions for starting storybook](https://transcom.github.io/mymove-docs/docs/frontend/setup/run-storybook)
- [Instructions for starting the MilMove application](https://transcom.github.io/mymove-docs/docs/about/application-setup/milmove-local-client/)
- [Instructions for running tests](https://transcom.github.io/mymove-docs/docs/about/development/testing)

### How to test

The easiest way to validate this PR is using the new test harness data:

1. Go to the test harness data: http://officelocal:3000/testharness/list
2. Click **MakeMoveReadyForEDI**
3. Search for and retain the payment request number it should look like: `"payment_request_number": "6841-8898-1"`
4. Build the generate-payment-request-edi cmd with `make bin/generate-payment-request-edi` to ensure you've compiled the latest changes.
5. Generate an EDI locally for the retained payment request number `bin/generate-payment-request-edi --payment-request-number <payment_request_number>`
6. Inspect the FA2 lines of the EDI, they should all contain the same data so verifying the first section is fine. You should see that the L1 value is now "000102" instead of "102", which is the value in the lines_of_accounting database table.
 
### Frontend

- [ ] There are no aXe warnings for UI.
- [ ] This works in [Supported Browsers and their phone views](https://transcom.github.io/mymove-docs/docs/about/supported-browsers) (Chrome, Firefox, Edge).
- [ ] There are no new console errors in the browser devtools.
- [ ] There are no new console errors in the test output.
- [ ] If this PR adds a new component to Storybook, it ensures the component is fully responsive, OR if it is intentionally not, a wrapping div using the `officeApp` class or custom `min-width` styling is used to hide any states the would not be visible to the user.

### Backend

- [ ] Code follows the guidelines for [Logging](https://transcom.github.io/mymove-docs/docs/about/development/logging).
- [ ] The requirements listed in [Querying the Database Safely](https://transcom.github.io/mymove-docs/docs/backend/guides/golang-guide#querying-the-database-safely) have been satisfied.

### Database

#### Any new migrations/schema changes:

- [ ] Follows our guidelines for [Zero-Downtime Deploys](https://transcom.github.io/mymove-docs/docs/backend/setup/database-migrations#zero-downtime-migrations).
- [ ] Have been communicated to #g-database.
- [ ] Secure migrations have been tested following the instructions in our [docs](https://transcom.github.io/mymove-docs/docs/backend/setup/database-migrations#secure-migrations).

## Screenshots

<img width="280" alt="Screenshot 2023-09-21 at 6 16 50 PM" src="https://github.com/transcom/mymove/assets/52669884/cb2ea70b-9540-4367-af74-84174caa8455">
