### PR TITLE
MB-169-19 supplement: Simplify the cubic feet rounding logic so it's less error prone

### DIFF
--- a/pkg/services/ghcrateengine/pricer_helpers_test.go
+++ b/pkg/services/ghcrateengine/pricer_helpers_test.go
@@ -571,6 +571,20 @@ func (suite *GHCRateEngineServiceSuite) Test_priceDomesticCrating() {
 		suite.validatePricerCreatedParams(expectedParams, displayParams)
 	})
 
+	suite.Run("crating golden path with truncation", func() {
+		suite.setupDomesticAccessorialPrice(models.ReServiceCodeDCRT, dcrtTestServiceSchedule, dcrtTestBasePriceCents, testdatagen.DefaultContractCode, dcrtTestEscalationCompounded)
+		priceCents, displayParams, err := priceDomesticCrating(suite.AppContextForTest(), models.ReServiceCodeDCRT, testdatagen.DefaultContractCode, dcrtTestRequestedPickupDate, unit.CubicFeet(8.90625), dcrtTestServiceSchedule)
+		suite.NoError(err)
+		suite.Equal(unit.Cents(23049), priceCents)
+
+		expectedParams := services.PricingDisplayParams{
+			{Key: models.ServiceItemParamNameContractYearName, Value: testdatagen.DefaultContractCode},
+			{Key: models.ServiceItemParamNameEscalationCompounded, Value: FormatEscalation(dcrtTestEscalationCompounded)},
+			{Key: models.ServiceItemParamNamePriceRateOrFactor, Value: FormatCents(dcrtTestBasePriceCents)},
+		}
+		suite.validatePricerCreatedParams(expectedParams, displayParams)
+	})
+
 	suite.Run("invalid service code", func() {
 		suite.setupDomesticAccessorialPrice(models.ReServiceCodeDCRT, dcrtTestServiceSchedule, dcrtTestBasePriceCents, testdatagen.DefaultContractCode, dcrtTestEscalationCompounded)
 		_, _, err := priceDomesticCrating(suite.AppContextForTest(), models.ReServiceCodeCS, testdatagen.DefaultContractCode, dcrtTestRequestedPickupDate, dcrtTestBilledCubicFeet, dcrtTestServiceSchedule)

--- a/pkg/unit/volume.go
+++ b/pkg/unit/volume.go
@@ -2,8 +2,6 @@ package unit
 
 import (
 	"fmt"
-	"math"
-	"math/big"
 )
 
 // CubicFeet represents cubic feet
@@ -12,19 +10,9 @@ type CubicFeet float64
 // CubicThousandthInch represents values in cubic thousandths of an inch
 type CubicThousandthInch int
 
-// truncateFloat truncates a float to the given number of decimal places
+// truncateFloat truncates a float to 2 decimal places
 func truncateFloat(f float64) float64 {
-	// use big package to create a new float and get a minimum precision value before rounding would occur
-	value := big.NewFloat(f)
-	minPrec := value.MinPrec()
-
-	// 52 is the MinPrec return for 2 decimal places, so we're checking if our values is equal to or less than that
-	if minPrec <= 52 {
-		return f
-	}
-	// if we have more than 2 decimal places, we need to truncate
-	shift := math.Pow(10, float64(2))
-	return math.Floor(f*shift) / shift
+	return float64(int(f*100)) / 100
 }
 
 // String converts a CubicFeet value into a string

--- a/pkg/unit/volume_test.go
+++ b/pkg/unit/volume_test.go
@@ -28,6 +28,31 @@ func Test_CubicFeetStringConversion(t *testing.T) {
 	if result != expected {
 		t.Errorf("wrong string of CubicFeet: expected %s, got %s", expected, result)
 	}
+
+	cubicFeet = CubicFeet(9.001)
+	result = cubicFeet.String()
+
+	expected = "9.00"
+	if result != expected {
+		t.Errorf("wrong string of CubicFeet: expected %s, got %s", expected, result)
+	}
+
+	cubicFeet = CubicFeet(9.0001)
+	result = cubicFeet.String()
+
+	expected = "9.00"
+	if result != expected {
+		t.Errorf("wrong string of CubicFeet: expected %s, got %s", expected, result)
+	}
+
+	cubicFeet = CubicFeet(8.90625)
+	result = cubicFeet.String()
+
+	expected = "8.90"
+	if result != expected {
+		t.Errorf("wrong string of CubicFeet: expected %s, got %s", expected, result)
+	}
+
 	cubicFeet = CubicFeet(9.90000000000000000000000001)
 	result = cubicFeet.String()
 


### PR DESCRIPTION
## [Jira ticket](https://dp3.atlassian.net/browse/MB-16919)

## Summary

This modifies the math we're doing for truncation to make it simpler. The precision calculation thing I was doing before was yielding some unexpected results, which is likely a sign it doesn't quite do what I thought it was doing. So I took a step back and went with a less complicated method. 

I also added in unit tests cases for the specific scenario that was brought up as an issue.

## Verification Steps for the Author

These are to be checked by the author.

- [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
- [ ] Have the Jira acceptance criteria been met for this change?

## Verification Steps for Reviewers

These are to be checked by a reviewer.

### Setup to Run the Code

- [Instructions for starting storybook](https://transcom.github.io/mymove-docs/docs/frontend/setup/run-storybook)
- [Instructions for starting the MilMove application](https://transcom.github.io/mymove-docs/docs/about/application-setup/milmove-local-client/)
- [Instructions for running tests](https://transcom.github.io/mymove-docs/docs/about/development/testing)

### How to test

1. Access the
2. Login as a
3.

### Frontend

- [ ] There are no aXe warnings for UI.
- [ ] This works in [Supported Browsers and their phone views](https://transcom.github.io/mymove-docs/docs/about/supported-browsers) (Chrome, Firefox, Edge).
- [ ] There are no new console errors in the browser devtools.
- [ ] There are no new console errors in the test output.
- [ ] If this PR adds a new component to Storybook, it ensures the component is fully responsive, OR if it is intentionally not, a wrapping div using the `officeApp` class or custom `min-width` styling is used to hide any states the would not be visible to the user.

### Backend

- [ ] Code follows the guidelines for [Logging](https://transcom.github.io/mymove-docs/docs/about/development/logging).
- [ ] The requirements listed in [Querying the Database Safely](https://transcom.github.io/mymove-docs/docs/backend/guides/golang-guide#querying-the-database-safely) have been satisfied.

### Database

#### Any new migrations/schema changes:

- [ ] Follows our guidelines for [Zero-Downtime Deploys](https://transcom.github.io/mymove-docs/docs/backend/setup/database-migrations#zero-downtime-migrations).
- [ ] Have been communicated to #g-database.
- [ ] Secure migrations have been tested following the instructions in our [docs](https://transcom.github.io/mymove-docs/docs/backend/setup/database-migrations#secure-migrations).

## Screenshots
