### PR TITLE
Attempt to fix SIT destination address postal codes behavior.

### DIFF
--- a/pkg/services/mto_service_item/mto_service_item_updater_test.go
+++ b/pkg/services/mto_service_item/mto_service_item_updater_test.go
@@ -700,12 +700,12 @@ func (suite *MTOServiceItemServiceSuite) TestUpdateMTOServiceItemStatus() {
 		suite.Nil(updatedServiceItem.RejectionReason)
 		suite.Nil(updatedServiceItem.RejectedAt)
 		suite.NotNil(updatedServiceItem)
-		suite.Equal(sitDestinationFinalAddress.ID, *updatedServiceItem.SITDestinationOriginalAddressID)
-		suite.Equal(sitDestinationFinalAddress.ID, updatedServiceItem.SITDestinationOriginalAddress.ID)
-		suite.Equal(sitDestinationFinalAddress.StreetAddress1, updatedServiceItem.SITDestinationOriginalAddress.StreetAddress1)
-		suite.Equal(sitDestinationFinalAddress.City, updatedServiceItem.SITDestinationOriginalAddress.City)
-		suite.Equal(sitDestinationFinalAddress.State, updatedServiceItem.SITDestinationOriginalAddress.State)
-		suite.Equal(sitDestinationFinalAddress.PostalCode, updatedServiceItem.SITDestinationOriginalAddress.PostalCode)
+
+		destinationAddress := serviceItem.MTOShipment.DestinationAddress
+		suite.Equal(destinationAddress.StreetAddress1, updatedServiceItem.SITDestinationOriginalAddress.StreetAddress1)
+		suite.Equal(destinationAddress.City, updatedServiceItem.SITDestinationOriginalAddress.City)
+		suite.Equal(destinationAddress.State, updatedServiceItem.SITDestinationOriginalAddress.State)
+		suite.Equal(destinationAddress.PostalCode, updatedServiceItem.SITDestinationOriginalAddress.PostalCode)
 	})
 
 	suite.Run("When TOO approves a DDDSIT service item without a SITDestinationFinalAddress", func() {
@@ -756,12 +756,6 @@ func (suite *MTOServiceItemServiceSuite) TestUpdateMTOServiceItemStatus() {
 		suite.Equal(shipment.DestinationAddress.City, updatedServiceItem.SITDestinationOriginalAddress.City)
 		suite.Equal(shipment.DestinationAddress.State, updatedServiceItem.SITDestinationOriginalAddress.State)
 		suite.Equal(shipment.DestinationAddress.PostalCode, updatedServiceItem.SITDestinationOriginalAddress.PostalCode)
-		suite.NotEqual(shipment.DestinationAddressID, *updatedServiceItem.SITDestinationFinalAddressID)
-		suite.NotEqual(shipment.DestinationAddress.ID, *updatedServiceItem.SITDestinationFinalAddressID)
-		suite.Equal(shipment.DestinationAddress.StreetAddress1, updatedServiceItem.SITDestinationFinalAddress.StreetAddress1)
-		suite.Equal(shipment.DestinationAddress.City, updatedServiceItem.SITDestinationFinalAddress.City)
-		suite.Equal(shipment.DestinationAddress.State, updatedServiceItem.SITDestinationFinalAddress.State)
-		suite.Equal(shipment.DestinationAddress.PostalCode, updatedServiceItem.SITDestinationFinalAddress.PostalCode)
 	})
 
 	suite.Run("When TOO approves a DDSFSC service item with an existing SITDestinationFinalAddress", func() {
@@ -806,12 +800,11 @@ func (suite *MTOServiceItemServiceSuite) TestUpdateMTOServiceItemStatus() {
 		suite.Nil(updatedServiceItem.RejectionReason)
 		suite.Nil(updatedServiceItem.RejectedAt)
 		suite.NotNil(updatedServiceItem)
-		suite.Equal(sitDestinationFinalAddress.ID, *updatedServiceItem.SITDestinationOriginalAddressID)
-		suite.Equal(sitDestinationFinalAddress.ID, updatedServiceItem.SITDestinationOriginalAddress.ID)
-		suite.Equal(sitDestinationFinalAddress.StreetAddress1, updatedServiceItem.SITDestinationOriginalAddress.StreetAddress1)
-		suite.Equal(sitDestinationFinalAddress.City, updatedServiceItem.SITDestinationOriginalAddress.City)
-		suite.Equal(sitDestinationFinalAddress.State, updatedServiceItem.SITDestinationOriginalAddress.State)
-		suite.Equal(sitDestinationFinalAddress.PostalCode, updatedServiceItem.SITDestinationOriginalAddress.PostalCode)
+		destinationAddress := serviceItem.MTOShipment.DestinationAddress
+		suite.Equal(destinationAddress.StreetAddress1, updatedServiceItem.SITDestinationOriginalAddress.StreetAddress1)
+		suite.Equal(destinationAddress.City, updatedServiceItem.SITDestinationOriginalAddress.City)
+		suite.Equal(destinationAddress.State, updatedServiceItem.SITDestinationOriginalAddress.State)
+		suite.Equal(destinationAddress.PostalCode, updatedServiceItem.SITDestinationOriginalAddress.PostalCode)
 	})
 
 	suite.Run("When TOO approves a DDSFSC service item without a SITDestinationFinalAddress", func() {
@@ -862,12 +855,6 @@ func (suite *MTOServiceItemServiceSuite) TestUpdateMTOServiceItemStatus() {
 		suite.Equal(shipment.DestinationAddress.City, updatedServiceItem.SITDestinationOriginalAddress.City)
 		suite.Equal(shipment.DestinationAddress.State, updatedServiceItem.SITDestinationOriginalAddress.State)
 		suite.Equal(shipment.DestinationAddress.PostalCode, updatedServiceItem.SITDestinationOriginalAddress.PostalCode)
-		suite.NotEqual(shipment.DestinationAddressID, *updatedServiceItem.SITDestinationFinalAddressID)
-		suite.NotEqual(shipment.DestinationAddress.ID, *updatedServiceItem.SITDestinationFinalAddressID)
-		suite.Equal(shipment.DestinationAddress.StreetAddress1, updatedServiceItem.SITDestinationFinalAddress.StreetAddress1)
-		suite.Equal(shipment.DestinationAddress.City, updatedServiceItem.SITDestinationFinalAddress.City)
-		suite.Equal(shipment.DestinationAddress.State, updatedServiceItem.SITDestinationFinalAddress.State)
-		suite.Equal(shipment.DestinationAddress.PostalCode, updatedServiceItem.SITDestinationFinalAddress.PostalCode)
 	})
 
 	// Test that the move's status changes to Approvals Requested if any of its service

--- a/pkg/testdatagen/scenario/shared.go
+++ b/pkg/testdatagen/scenario/shared.go
@@ -4718,7 +4718,7 @@ func createHHGWithPaymentServiceItems(
 	planner.On("ZipTransitDistance", mock.AnythingOfType("*appcontext.appContext"), "90210", "94535").Return(348, nil).Once()
 
 	// called for domestic destination SIT delivery service item
-	planner.On("ZipTransitDistance", mock.AnythingOfType("*appcontext.appContext"), "94535", "90210").Return(348, nil).Once()
+	planner.On("ZipTransitDistance", mock.AnythingOfType("*appcontext.appContext"), "94535", "90210").Return(348, nil).Times(2)
 
 	for _, shipment := range []models.MTOShipment{longhaulShipment, shorthaulShipment, shipmentWithOriginalWeight, shipmentWithOriginalAndReweighWeight, shipmentWithOriginalAndReweighWeightReweihBolded, shipmentWithOriginalReweighAndAdjustedWeight, shipmentWithOriginalAndAdjustedWeight} {
 		shipmentUpdater := mtoshipment.NewMTOShipmentStatusUpdater(queryBuilder, serviceItemCreator, planner)

--- a/src/pages/Office/MoveTaskOrder/MoveTaskOrder.jsx
+++ b/src/pages/Office/MoveTaskOrder/MoveTaskOrder.jsx
@@ -876,7 +876,8 @@ export const MoveTaskOrder = (props) => {
    * @returns {AddressShape}
    */
   const getSitAddressInitialValues = () => {
-    const address = selectedServiceItem.sitDestinationOriginalAddress || selectedServiceItem.destinationAddress;
+    const address = selectedServiceItem.sitDestinationFinalAddress || selectedServiceItem.sitDestinationOriginalAddress;
+
     const blankAddress = {
       city: '',
       state: '',


### PR DESCRIPTION
## Summary

Previously we were setting the original destination address to be the same as the final destination address for SIT destination service items. This gets rid of that part of the logic and instead goes to setting it to the shipment destination address. 

[this article](tbd) explains more about the approach used.

## Verification Steps for the Author

These are to be checked by the author.

- [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
- [ ] Have the Jira acceptance criteria been met for this change?

## Verification Steps for Reviewers

These are to be checked by a reviewer.

### Setup to Run the Code

- [Instructions for starting storybook](https://transcom.github.io/mymove-docs/docs/frontend/setup/run-storybook)
- [Instructions for starting the MilMove application](https://transcom.github.io/mymove-docs/docs/about/application-setup/milmove-local-client/)
- [Instructions for running tests](https://transcom.github.io/mymove-docs/docs/about/development/testing)

### How to test

1. Access the
2. Login as a
3.

### Frontend

- [ ] There are no aXe warnings for UI.
- [ ] This works in [Supported Browsers and their phone views](https://transcom.github.io/mymove-docs/docs/about/supported-browsers) (Chrome, Firefox, Edge).
- [ ] There are no new console errors in the browser devtools.
- [ ] There are no new console errors in the test output.
- [ ] If this PR adds a new component to Storybook, it ensures the component is fully responsive, OR if it is intentionally not, a wrapping div using the `officeApp` class or custom `min-width` styling is used to hide any states the would not be visible to the user.

### Backend

- [ ] Code follows the guidelines for [Logging](https://transcom.github.io/mymove-docs/docs/about/development/logging).
- [ ] The requirements listed in [Querying the Database Safely](https://transcom.github.io/mymove-docs/docs/backend/guides/golang-guide#querying-the-database-safely) have been satisfied.

### Database

#### Any new migrations/schema changes:

- [ ] Follows our guidelines for [Zero-Downtime Deploys](https://transcom.github.io/mymove-docs/docs/backend/setup/database-migrations#zero-downtime-migrations).
- [ ] Have been communicated to #g-database.
- [ ] Secure migrations have been tested following the instructions in our [docs](https://transcom.github.io/mymove-docs/docs/backend/setup/database-migrations#secure-migrations).

## Screenshots
