### PR TITLE
B-17720 Travel Order PDF Copy/Paste

### DIFF
--- a/playwright/tests/office/servicescounseling/servicesCounselingFlows.spec.js
+++ b/playwright/tests/office/servicescounseling/servicesCounselingFlows.spec.js
@@ -107,6 +107,9 @@ test.describe('Services counselor user', () => {
       await page.getByRole('link', { name: 'View and edit orders' }).click();
       await page.getByTestId('openMenu').click();
       await expect(page.getByTestId('DocViewerMenu').getByTestId('button')).toHaveCount(3);
+
+      // Check for link that allows TIO to download the PDF for copy/paste functionality
+      await expect(page.locator('p[class*="DocumentViewer_downloadLink"] > a > span')).toHaveText('Download file');
     });
   });
 

--- a/playwright/tests/office/servicescounseling/servicesCounselingFlows.spec.js
+++ b/playwright/tests/office/servicescounseling/servicesCounselingFlows.spec.js
@@ -108,7 +108,7 @@ test.describe('Services counselor user', () => {
       await page.getByTestId('openMenu').click();
       await expect(page.getByTestId('DocViewerMenu').getByTestId('button')).toHaveCount(3);
 
-      // Check for link that allows TIO to download the PDF for copy/paste functionality
+      // Check for link that allows counselor to download the PDF for copy/paste functionality
       await expect(page.locator('p[class*="DocumentViewer_downloadLink"] > a > span')).toHaveText('Download file');
     });
   });

--- a/playwright/tests/office/txo/tioFlows.spec.js
+++ b/playwright/tests/office/txo/tioFlows.spec.js
@@ -193,6 +193,10 @@ test.describe('TIO user', () => {
 
       await form.getByRole('link', { name: 'View orders' }).click();
       await tioFlowPage.waitForLoading();
+
+      // Check for link that allows TIO to download the PDF for copy/paste functionality
+      await expect(page.locator('p[class*="DocumentViewer_downloadLink"] > a > span')).toHaveText('Download file');
+
       // Edit orders page | Make edits
       await form.locator('input[name="tac"]').clear();
       await form.locator('input[name="tac"]').type('E15A');

--- a/playwright/tests/office/txo/tooFlows.spec.js
+++ b/playwright/tests/office/txo/tooFlows.spec.js
@@ -207,6 +207,9 @@ test.describe('TOO user', () => {
       await tooFlowPage.waitForLoading();
       expect(page.url()).toContain(`/moves/${tooFlowPage.moveLocator}/orders`);
 
+      // Check for link that allows TIO to download the PDF for copy/paste functionality
+      await expect(page.locator('p[class*="DocumentViewer_downloadLink"] > a > span')).toHaveText('Download file');
+
       // Edit orders fields
 
       await tooFlowPage.selectDutyLocation('Fort Irwin', 'originDutyLocation');

--- a/src/pages/Office/MoveDocumentWrapper/MoveDocumentWrapper.jsx
+++ b/src/pages/Office/MoveDocumentWrapper/MoveDocumentWrapper.jsx
@@ -32,7 +32,7 @@ const MoveDocumentWrapper = () => {
     <div className={styles.DocumentWrapper}>
       {documentsForViewer && (
         <div className={styles.embed}>
-          <DocumentViewer files={documentsForViewer} />
+          <DocumentViewer files={documentsForViewer} allowDownload />
         </div>
       )}
       {showOrders ? <Orders moveCode={moveCode} /> : <MoveAllowances moveCode={moveCode} />}

--- a/src/pages/Office/MoveDocumentWrapper/MoveDocumentWrapper.test.jsx
+++ b/src/pages/Office/MoveDocumentWrapper/MoveDocumentWrapper.test.jsx
@@ -184,7 +184,7 @@ describe('MoveDocumentWrapper', () => {
 
       const wrapper = shallow(<MoveDocumentWrapper />);
       expect(wrapper.find('DocumentViewer').props('files')).toEqual({
-        allowDownload: false,
+        allowDownload: true,
         files: [
           {
             contentType: 'application/pdf',

--- a/src/pages/Office/ServicesCounselingMoveDocumentWrapper/ServicesCounselingMoveDocumentWrapper.jsx
+++ b/src/pages/Office/ServicesCounselingMoveDocumentWrapper/ServicesCounselingMoveDocumentWrapper.jsx
@@ -33,7 +33,7 @@ const ServicesCounselingMoveDocumentWrapper = () => {
     <div className={styles.DocumentWrapper}>
       {documentsForViewer && (
         <div className={styles.embed}>
-          <DocumentViewer files={documentsForViewer} />
+          <DocumentViewer files={documentsForViewer} allowDownload />
         </div>
       )}
       {showOrders ? (

--- a/src/pages/Office/ServicesCounselingMoveDocumentWrapper/ServicesCounselingMoveDocumentWrapper.test.jsx
+++ b/src/pages/Office/ServicesCounselingMoveDocumentWrapper/ServicesCounselingMoveDocumentWrapper.test.jsx
@@ -176,7 +176,7 @@ describe('ServicesCounselingMoveDocumentWrapper', () => {
 
       const wrapper = shallow(<ServicesCounselingMoveDocumentWrapper />);
       expect(wrapper.find('DocumentViewer').props('files')).toEqual({
-        allowDownload: false,
+        allowDownload: true,
         files: [
           {
             contentType: 'application/pdf',


### PR DESCRIPTION
## [B-17720 Travel Order PDF Copy/Paste](https://www13.v1host.com/USTRANSCOM38/story.mvc/Summary?oidToken=Story%3A850750)

## Summary

Passed `allowDownload` to `DocumentViewer` to enable already existing download feature in the component.


### Setup to Run the Code

- [Instructions for starting the MilMove application](https://transcom.github.io/mymove-docs/docs/getting-started/application-setup/)
- [Instructions for running tests](https://transcom.github.io/mymove-docs/docs/getting-started/development/testing/)

### How to test

1. Login as TOO, TIO, or Services Counselor  
2. Go to any customer's order edit page to preview their uploaded document.
3. Click on the `Download File` link.

### Frontend

- Uses existing component `DocumentViewer`.
