### PR TITLE
B-17616 TOO Can Edit SIT Entry Date (formatted date with UTC)

### DIFF
--- a/src/components/Office/ServiceItemDetails/ServiceItemDetails.jsx
+++ b/src/components/Office/ServiceItemDetails/ServiceItemDetails.jsx
@@ -7,7 +7,7 @@ import { trimFileName } from '../../../utils/serviceItems';
 
 import styles from './ServiceItemDetails.module.scss';
 
-import { formatDate } from 'shared/dates';
+import { formatDate, formatDateWithUTC } from 'shared/dates';
 import { formatWeight, convertFromThousandthInchToInch } from 'utils/formatters';
 
 function generateDetailText(details, id, className) {
@@ -47,7 +47,7 @@ const generateDestinationSITDetailSection = (id, serviceRequestDocUploads, detai
           : null}
         {code === 'DDFSIT'
           ? generateDetailText({
-              'SIT entry date': details.sitEntryDate ? formatDate(details.sitEntryDate, 'DD MMM YYYY') : '-',
+              'SIT entry date': details.sitEntryDate ? formatDateWithUTC(details.sitEntryDate, 'DD MMM YYYY') : '-',
             })
           : null}
 
@@ -101,7 +101,7 @@ const ServiceItemDetails = ({ id, code, details, serviceRequestDocs }) => {
           <dl>
             {generateDetailText(
               {
-                'SIT entry date': details.sitEntryDate ? formatDate(details.sitEntryDate, 'DD MMM YYYY') : '-',
+                'SIT entry date': details.sitEntryDate ? formatDateWithUTC(details.sitEntryDate, 'DD MMM YYYY') : '-',
                 ZIP: details.SITPostalCode ? details.SITPostalCode : '-',
                 Reason: details.reason ? details.reason : '-',
               },

--- a/src/shared/dates.js
+++ b/src/shared/dates.js
@@ -33,6 +33,10 @@ export function formatDate(date, format = defaultDateFormat, locale = 'en') {
   return moment(date, allowedDateFormats, locale, true).locale(locale).format(format);
 }
 
+export function formatDateWithUTC(date, format = defaultDateFormat, locale = 'en') {
+  return moment.utc(date, allowedDateFormats, locale, true).locale(locale).format(format);
+}
+
 export function formatDateForSwagger(dateString) {
   if (dateString) {
     return formatDate(dateString, swaggerDateFormat);

--- a/src/shared/dates.test.js
+++ b/src/shared/dates.test.js
@@ -1,6 +1,13 @@
 import moment from 'moment';
 
-import { parseDate, formatDate, formatDateForSwagger, formatDateTime, formatDateForDatePicker } from './dates';
+import {
+  parseDate,
+  formatDate,
+  formatDateForSwagger,
+  formatDateTime,
+  formatDateForDatePicker,
+  formatDateWithUTC,
+} from './dates';
 
 describe('dates', () => {
   describe('parseDate', () => {
@@ -30,6 +37,24 @@ describe('dates', () => {
     });
     describe('when parsing a date that does the match allowed date formats', () => {
       const result = formatDate('8-23-2019');
+      it('should return 8/23/2019', () => {
+        expect(result).toEqual('8/23/2019');
+      });
+    });
+  });
+  describe('formatDateWithUTC', () => {
+    describe('when formatting a date that does not match the allowed date formats', () => {
+      it('should return "invalid date"', () => {
+        const result = formatDateWithUTC('8');
+        expect(result).toEqual('Invalid date');
+      });
+      it('should return "invalid date"', () => {
+        const result = formatDateWithUTC();
+        expect(result).toEqual('Invalid date');
+      });
+    });
+    describe('when parsing a date that does the match allowed date formats', () => {
+      const result = formatDateWithUTC('8-23-2019');
       it('should return 8/23/2019', () => {
         expect(result).toEqual('8/23/2019');
       });


### PR DESCRIPTION
## [B-17616 TOO Can Edit SIT Entry Date](https://www13.v1host.com/USTRANSCOM38/story.mvc/Summary?oidToken=Story%3A844136&RoomContext=TeamRoom%3A808731&concept=TeamRoom)

## Summary

Added javascript function to consider UTC when implementing date formatting. It was returning the day prior in the UI, but was correct in the database (database said `31 Oct 23` but UI would say `30 Oct 23`, for example).

Additional story to follow to update SIT panel upon SIT entry date update.