### PR TITLE
B-17490 Add Partial Delivery Column to mto_shipments table

### DIFF
--- a/migrations/app/migrations_manifest.txt
+++ b/migrations/app/migrations_manifest.txt
@@ -871,3 +871,4 @@
 20231006173747_add_approval_requested_to_mto_service_items.up.sql
 20231023144545_add_column_for_partial_payments.up.sql
 20231026172313_update_services_counseling_mayport_false.up.sql
+20231027204028_add_partial_delivery_column_to_shipments_table.up.sql

--- a/migrations/app/schema/20231027204028_add_partial_delivery_column_to_shipments_table.up.sql
+++ b/migrations/app/schema/20231027204028_add_partial_delivery_column_to_shipments_table.up.sql
@@ -1,7 +1,7 @@
 -- adding column for partial delivery
--- this is stored as an array of integers defining weight to account for potential multiple deliveries out of SIT
+-- this is stored as jsonb data type, which stores JSON data in binary format
 ALTER TABLE mto_shipments
-ADD COLUMN partial_deliveries_weight integer[];
+ADD COLUMN partial_deliveries_weight jsonb;
 
 -- Column comments
-COMMENT ON COLUMN mto_shipments.partial_deliveries_weight IS 'Partial deliveries defined by weight, stored as an array of integers';
+COMMENT ON COLUMN mto_shipments.partial_deliveries_weight IS 'Partial deliveries defined by weight, stored as JSON';

--- a/migrations/app/schema/20231027204028_add_partial_delivery_column_to_shipments_table.up.sql
+++ b/migrations/app/schema/20231027204028_add_partial_delivery_column_to_shipments_table.up.sql
@@ -1,0 +1,7 @@
+-- adding column for partial delivery
+-- this is stored as an array of integers defining weight to account for potential multiple deliveries out of SIT
+ALTER TABLE mto_shipments
+ADD COLUMN partial_deliveries_weight integer[];
+
+-- Column comments
+COMMENT ON COLUMN mto_shipments.partial_deliveries_weight IS 'Partial deliveries defined by weight, stored as an array of integers';

--- a/pkg/models/mto_shipments.go
+++ b/pkg/models/mto_shipments.go
@@ -8,6 +8,7 @@ import (
 	"github.com/gobuffalo/validate/v3"
 	"github.com/gobuffalo/validate/v3/validators"
 	"github.com/gofrs/uuid"
+	"github.com/lib/pq"
 
 	"github.com/transcom/mymove/pkg/unit"
 )
@@ -127,6 +128,7 @@ type MTOShipment struct {
 	PrimeActualWeight                *unit.Pound            `db:"prime_actual_weight"`
 	BillableWeightCap                *unit.Pound            `db:"billable_weight_cap"`
 	BillableWeightJustification      *string                `db:"billable_weight_justification"`
+	PartialDeliveries                pq.Int32Array          `db:"partial_deliveries_weight"`
 	NTSRecordedWeight                *unit.Pound            `db:"nts_recorded_weight"`
 	ShipmentType                     MTOShipmentType        `db:"shipment_type"`
 	Status                           MTOShipmentStatus      `db:"status"`

--- a/pkg/models/mto_shipments.go
+++ b/pkg/models/mto_shipments.go
@@ -1,6 +1,7 @@
 package models
 
 import (
+	"encoding/json"
 	"fmt"
 	"time"
 
@@ -8,7 +9,6 @@ import (
 	"github.com/gobuffalo/validate/v3"
 	"github.com/gobuffalo/validate/v3/validators"
 	"github.com/gofrs/uuid"
-	"github.com/lib/pq"
 
 	"github.com/transcom/mymove/pkg/unit"
 )
@@ -128,7 +128,7 @@ type MTOShipment struct {
 	PrimeActualWeight                *unit.Pound            `db:"prime_actual_weight"`
 	BillableWeightCap                *unit.Pound            `db:"billable_weight_cap"`
 	BillableWeightJustification      *string                `db:"billable_weight_justification"`
-	PartialDeliveries                pq.Int32Array          `db:"partial_deliveries_weight"`
+	PartialDeliveries                *json.RawMessage       `db:"partial_deliveries_weight"`
 	NTSRecordedWeight                *unit.Pound            `db:"nts_recorded_weight"`
 	ShipmentType                     MTOShipmentType        `db:"shipment_type"`
 	Status                           MTOShipmentStatus      `db:"status"`


### PR DESCRIPTION
## [DB - Add Partial Delivery Weight Column to MTO Shipments Table](https://www13.v1host.com/USTRANSCOM38/story.mvc/Summary?oidToken=Story%3A842079&RoomContext=TeamRoom%3A808731&concept=TeamRoom)

## Summary

Added a column of integers to the `mto_shipments` table in the database that will be used in future stories to handle partial deliveries out of SIT. The goal of this column is to store the multiple deliveries into an array, calculate those numbers, and subtract them from the `actual_weight` value. It is likely that there will be multiple deliveries so an array of integers was the most practical solution.