### PR TITLE
B-17661 update ShipmentDetailsMain to pass null if requestedPickupDate value

### DIFF
--- a/src/components/Office/ShipmentDetails/ShipmentDetailsMain.jsx
+++ b/src/components/Office/ShipmentDetails/ShipmentDetailsMain.jsx
@@ -153,7 +153,7 @@ const ShipmentDetailsMain = ({
         />
       )}
       <ImportantShipmentDates
-        requestedPickupDate={formatDate(requestedPickupDate)}
+        requestedPickupDate={requestedPickupDate ? formatDate(requestedPickupDate) : null}
         scheduledPickupDate={scheduledPickupDate ? formatDate(scheduledPickupDate) : null}
         actualPickupDate={actualPickupDate ? formatDate(actualPickupDate) : null}
         requestedDeliveryDate={requestedDeliveryDate ? formatDate(requestedDeliveryDate) : null}


### PR DESCRIPTION
## Summary

All props being passed from ShipmentDetailsMain to ImportantShipmentDates checks if the data is present first before formatting; requestedPickupDate prop is being updated to align with that standard to avoid situations where "Invalid Date" is displayed in lieu of emDash.

### How to test

1. Access the application as an office user
2. Login as a TOO
3. Check the Move Task Order of a move without a requested pickup date and confirm it displays -