### PR TITLE
B-17477 Add and update weight fields in MTO Shipment Weight

### DIFF
--- a/src/components/Office/ShipmentDetails/ShipmentDetailsMain.jsx
+++ b/src/components/Office/ShipmentDetails/ShipmentDetailsMain.jsx
@@ -57,6 +57,7 @@ const ShipmentDetailsMain = ({
     requiredDeliveryDate,
     pickupAddress,
     destinationAddress,
+    calculatedBillableWeight,
     primeEstimatedWeight,
     primeActualWeight,
     counselorRemarks,
@@ -176,7 +177,8 @@ const ShipmentDetailsMain = ({
       />
       <ShipmentWeightDetails
         estimatedWeight={primeEstimatedWeight}
-        actualWeight={primeActualWeight}
+        initialWeight={primeActualWeight}
+        actualWeight={calculatedBillableWeight}
         shipmentInfo={{
           shipmentID: shipment.id,
           ifMatchEtag: shipment.eTag,

--- a/src/components/Office/ShipmentWeightDetails/ShipmentWeightDetails.jsx
+++ b/src/components/Office/ShipmentWeightDetails/ShipmentWeightDetails.jsx
@@ -8,18 +8,24 @@ import DataTable from '../../DataTable/index';
 
 import styles from './ShipmentWeightDetails.module.scss';
 
-import returnLowestValue from 'utils/returnLowestValue';
 import { formatWeight } from 'utils/formatters';
 import { SHIPMENT_OPTIONS } from 'shared/constants';
 import { ShipmentOptionsOneOf } from 'types/shipment';
 import Restricted from 'components/Restricted/Restricted';
 import { permissionTypes } from 'constants/permissions';
 
-const ShipmentWeightDetails = ({ estimatedWeight, actualWeight, shipmentInfo, handleRequestReweighModal }) => {
-  const lowestWeight = returnLowestValue(actualWeight, shipmentInfo.reweighWeight);
+const ShipmentWeightDetails = ({
+  estimatedWeight,
+  initialWeight,
+  actualWeight,
+  shipmentInfo,
+  handleRequestReweighModal,
+}) => {
+  const emDash = '\u2014';
+
   const reweighHeader = (
     <div className={styles.shipmentWeight}>
-      <span>Shipment weight</span>
+      <span>Reweigh weight</span>
       {!shipmentInfo.reweighID && (
         <div className={styles.rightAlignButtonWrapper}>
           <Restricted to={permissionTypes.createReweighRequest}>
@@ -33,22 +39,26 @@ const ShipmentWeightDetails = ({ estimatedWeight, actualWeight, shipmentInfo, ha
       {shipmentInfo.reweighWeight && <Tag>reweighed</Tag>}
     </div>
   );
+
   return (
     <div className={classnames('maxw-tablet', styles.ShipmentWeightDetails)}>
-      {shipmentInfo.shipmentType !== SHIPMENT_OPTIONS.NTSR && (
-        <DataTableWrapper className={classnames('maxw-mobile', 'table--data-point-group')}>
-          <DataTable
-            columnHeaders={['Estimated weight']}
-            dataRow={estimatedWeight ? [formatWeight(estimatedWeight)] : ['']}
-          />
-        </DataTableWrapper>
-      )}
-      <DataTableWrapper
-        className={classnames('table--data-point-group', {
-          'maxw-mobile': shipmentInfo.shipmentType !== SHIPMENT_OPTIONS.NTSR,
-        })}
-      >
-        <DataTable columnHeaders={[reweighHeader]} dataRow={lowestWeight ? [formatWeight(lowestWeight)] : ['']} />
+      <DataTableWrapper className={classnames('table--data-point-group')}>
+        <DataTable
+          columnHeaders={['Estimated weight', 'Initial weight']}
+          dataRow={[
+            estimatedWeight && shipmentInfo.shipmentType !== SHIPMENT_OPTIONS.NTSR
+              ? formatWeight(estimatedWeight)
+              : emDash,
+            initialWeight ? formatWeight(initialWeight) : emDash,
+          ]}
+        />
+        <DataTable
+          columnHeaders={[reweighHeader, 'Actual shipment weight']}
+          dataRow={[
+            shipmentInfo.reweighWeight ? formatWeight(shipmentInfo.reweighWeight) : emDash,
+            actualWeight ? formatWeight(actualWeight) : emDash,
+          ]}
+        />
       </DataTableWrapper>
     </div>
   );

--- a/src/components/Office/ShipmentWeightDetails/ShipmentWeightDetails.test.jsx
+++ b/src/components/Office/ShipmentWeightDetails/ShipmentWeightDetails.test.jsx
@@ -1,11 +1,14 @@
 import React from 'react';
 import { fireEvent, render, screen } from '@testing-library/react';
+import { mount } from 'enzyme';
 
 import ShipmentWeightDetails from './ShipmentWeightDetails';
 
 import { SHIPMENT_OPTIONS } from 'shared/constants';
 import { MockProviders } from 'testUtils';
 import { permissionTypes } from 'constants/permissions';
+
+const emDash = '\u2014';
 
 const shipmentInfoReweighRequested = {
   shipmentID: 'shipment1',
@@ -36,6 +39,7 @@ describe('ShipmentWeightDetails', () => {
       <MockProviders permissions={[permissionTypes.createReweighRequest]}>
         <ShipmentWeightDetails
           estimatedWeight={4500}
+          initialWeight={5000}
           actualWeight={5000}
           shipmentInfo={shipmentInfoNoReweigh}
           handleRequestReweighModal={handleRequestReweighModal}
@@ -43,14 +47,17 @@ describe('ShipmentWeightDetails', () => {
       </MockProviders>,
     );
 
-    const estWeight = await screen.findByText('Estimated weight');
-    expect(estWeight).toBeTruthy();
+    const estimatedWeight = await screen.findByText('Estimated weight');
+    expect(estimatedWeight).toBeTruthy();
 
-    const shipWeight = await screen.findByText('Shipment weight');
-    expect(shipWeight).toBeTruthy();
+    const initialWeight = await screen.findByText('Initial weight');
+    expect(initialWeight).toBeTruthy();
 
     const reweighButton = await screen.findByText('Request reweigh');
     expect(reweighButton).toBeTruthy();
+
+    const actualWeight = await screen.findByText('Actual shipment weight');
+    expect(actualWeight).toBeTruthy();
   });
 
   it('renders with estimated weight if not an NTSR', async () => {
@@ -68,7 +75,7 @@ describe('ShipmentWeightDetails', () => {
   });
 
   it('renders without estimated weight if an NTSR', async () => {
-    render(
+    const wrapper = mount(
       <ShipmentWeightDetails
         estimatedWeight={null}
         actualWeight={12000}
@@ -77,7 +84,7 @@ describe('ShipmentWeightDetails', () => {
       />,
     );
 
-    expect(screen.queryByText('Estimated weight')).not.toBeInTheDocument();
+    expect(wrapper.find('td').at(0).text()).toEqual(emDash);
   });
 
   it('renders with shipment weight', async () => {


### PR DESCRIPTION
## [B-17477](https://www13.v1host.com/USTRANSCOM38/story.mvc/Summary?oidToken=Story%3a842007)

## Summary

When viewing the weight details of a MTO, counselors were not able to see all the weight data points. This update fixes that, displaying the estimated weight, initial weight, a reweigh weight (if requested), and the actual shipment weight (the lesser of two values between the initial weight and the reweigh). Because the api returns a value (calculatedBillableWeight) for the actual shipment weight that is calculated more thoroughly than the front end previously did (see: shipment_billable_weight.go > CalculateShipmentBillableWeight), so I removed the front end code to determine that.

Also, the front end had logic for not displaying the Estimated Weight if the shipment was a shipment coming out of NTS, as the prime would not need to estimate that. Per my conversation with DS, we updated that to have an emDash to keep in line with the other UI elements.

Note: naming of data points may be somewhat confusing when viewing the code. The values are mapped as follows:

primeEstimatedWeight => Estimated weight
primeActualWeight => Initial weight
shipmentInfo.reweighWeight => Reweigh weight
calculatedBillableWeight => Actual shipment weight

## Verification Steps for the Author

These are to be checked by the author.

- [x] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
- [x] Have the Agility acceptance criteria been met for this change?

## Verification Steps for Reviewers

These are to be checked by a reviewer.

- [ ] Has the branch been pulled in and checked out?
- [ ] Have the BL acceptance criteria been met for this change?
- [ ] Was the CircleCI build successful?
- [ ] Has the code been reviewed from a standards and best practices point of view?

### How to test

1. Login as a new or existing customer and create a new HHG shipment
2. Login as a services counselor, access the newly created HHG, and fill out necessary information, then click Submit move details
3. Login as a TOO, access the new move; select the move and approve the Move management service item. Confirm that all weight fields in the shipment appear and don't have values
4. Login in a prime simulator role and access the new move; Update the shipment and include values for estimated weight and actual weight
5. Login as a TOO, access the move; confirm estimated weight, initial weight, and actual shipment weight are populated with values. Request a reweigh
6. Login in a prime simulator role and access the move; respond to the reweigh request and enter a number
7. Login as a TOO, access the move, and confirm that a reweigh value appears, and the Actual shipment weight displays the lower of the two values between Initial weight and Reweigh weight
