### PR TITLE
B 17787 last table update rest

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -120,8 +120,7 @@ export DB_RETRY_INTERVAL=5s
 export DB_SSL_MODE=disable
 
 # TRDM Configuration
-require TRDM_API_URL "See 'DISABLE_AWS_VAULT_WRAPPER=1 AWS_REGION=us-gov-west-1 aws-vault exec transcom-gov-dev -- chamber read app-devlocal trdm_api_url'"
-require TRDM_API_RETURN_TABLE_V7_WSDL "See 'DISABLE_AWS_VAULT_WRAPPER=1 AWS_REGION=us-gov-west-1 aws-vault exec transcom-gov-dev -- chamber read app-devlocal trdm_api_return_table_v7_wsdl'"
+require TRDM_API_GATEWAY_URL "See 'DISABLE_AWS_VAULT_WRAPPER=1 AWS_REGION=us-gov-west-1 aws-vault exec transcom-gov-dev -- chamber read app-devlocal TRDM_API_GATEWAY_URL'"
 require TRDM_USE_MOCK "See 'DISABLE_AWS_VAULT_WRAPPER=1 AWS_REGION=us-gov-west-1 aws-vault exec transcom-gov-dev -- chamber read app-devlocal trdm_use_mock'"
 require TRDM_IS_ENABLED "See 'DISABLE_AWS_VAULT_WRAPPER=1 AWS_REGION=us-gov-west-1 aws-vault exec transcom-gov-dev -- chamber read app-devlocal trdm_is_enabled'"
 

--- a/cmd/milmove/serve.go
+++ b/cmd/milmove/serve.go
@@ -813,7 +813,7 @@ func serveFunction(cmd *cobra.Command, args []string) error {
 	trdmIsEnabled := v.GetBool(cli.TRDMIsEnabledFlag)
 	if trdmIsEnabled {
 		// Call the initial SOAP call for LastTableUpdate on server start and once per day
-		err := trdm.LastTableUpdate(v, tlsConfig)
+		err := trdm.LastTableUpdate(v, tlsConfig, appCtx)
 		if err != nil {
 			return err
 		}

--- a/pkg/cli/trdm.go
+++ b/pkg/cli/trdm.go
@@ -7,10 +7,8 @@ import (
 )
 
 const (
-	// TRDMApiURLFlag is the TRDM API URL Flag
-	TRDMApiURLFlag string = "trdm-api-url"
-	// TRDMApiWSDLFlag is the TRDM API WSDL Flag for ReturnTableV7
-	TRDMApiReturnTableV7WSDLFlag string = "trdm-api-return-table-v7-wsdl"
+	// TRDMApiGatewayURLFlag is the TRDM API Gateway URL Flag
+	TRDMApiGatewayURLFlag string = "trdm-api-gateway-url"
 	// TRDMUseMockFlag is the TRDM Use Mock Flag
 	TRDMUseMockFlag string = "trdm-use-mock"
 	// FF to enable or disable TRDM soap requests
@@ -19,18 +17,16 @@ const (
 
 // InitTRDMFlags initializes Route command line flags
 func InitTRDMFlags(flag *pflag.FlagSet) {
-	flag.String(TRDMApiURLFlag, "", "URL for sending a SOAP request to TRDM")
-	flag.String(TRDMApiReturnTableV7WSDLFlag, "", "WSDL for sending a SOAP request to TRDM ReturnTable, V7")
+	flag.String(TRDMApiGatewayURLFlag, "", "URL for sending a REST request to the TRDM gateway")
 
 	flag.Bool(TRDMUseMockFlag, false, "Whether to use a mocked version of TRDM")
-	flag.Bool(TRDMIsEnabledFlag, false, "Enable TRDM SOAP requests")
+	flag.Bool(TRDMIsEnabledFlag, false, "Enable TRDM data requests")
 }
 
 // CheckRoute validates Route command line flags
 func CheckTRDM(v *viper.Viper) error {
 	urlVars := []string{
-		TRDMApiURLFlag,
-		TRDMApiReturnTableV7WSDLFlag,
+		TRDMApiGatewayURLFlag,
 		TRDMIsEnabledFlag,
 	}
 

--- a/pkg/models/trdm_last_table_update_request.go
+++ b/pkg/models/trdm_last_table_update_request.go
@@ -1,0 +1,5 @@
+package models
+
+type LastTableUpdateRequest struct {
+	PhysicalName string `json:"physicalName"`
+}

--- a/pkg/models/trdm_last_table_update_response.go
+++ b/pkg/models/trdm_last_table_update_response.go
@@ -1,0 +1,9 @@
+package models
+
+import "time"
+
+type LastTableUpdateResponse struct {
+	StatusCode string    `json:"physicalName"`
+	DateTime   time.Time `json:"dateTime"`
+	LastUpdate time.Time `json:"lastUpdate"`
+}

--- a/pkg/trdm/api_gateway.go
+++ b/pkg/trdm/api_gateway.go
@@ -18,8 +18,11 @@ import (
 	"github.com/transcom/mymove/pkg/models"
 )
 
+type HTTPClient interface {
+	Do(req *http.Request) (*http.Response, error)
+}
 type GatewayService struct {
-	httpClient  *http.Client
+	httpClient  HTTPClient
 	logger      *zap.Logger
 	region      string
 	trdmIamRole string
@@ -27,7 +30,7 @@ type GatewayService struct {
 	creds       *aws.Credentials
 }
 
-func NewGatewayService(httpClient *http.Client, logger *zap.Logger, region, trdmIamRole string, gatewayURL string, creds *aws.Credentials) *GatewayService {
+func NewGatewayService(httpClient HTTPClient, logger *zap.Logger, region, trdmIamRole string, gatewayURL string, creds *aws.Credentials) *GatewayService {
 	return &GatewayService{
 		httpClient:  httpClient,
 		logger:      logger,

--- a/pkg/trdm/api_gateway.go
+++ b/pkg/trdm/api_gateway.go
@@ -1,0 +1,115 @@
+package trdm
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/json"
+	"net/http"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	v4 "github.com/aws/aws-sdk-go-v2/aws/signer/v4"
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/credentials/stscreds"
+	"github.com/aws/aws-sdk-go-v2/service/sts"
+	"github.com/spf13/viper"
+	"go.uber.org/zap"
+
+	"github.com/transcom/mymove/pkg/models"
+)
+
+const (
+	// ! Not in use yet
+	// TODO:
+	// TrdmIamFlag is the TRDM IAM flag
+	TrdmIamFlag string = "trdm-iam"
+	// TrdmIamRoleFlag is the TRDM IAM Role flag
+	TrdmIamRoleFlag string = "trdm-iam-role"
+	// TrdmRegionFlag is the TRDM Region flag
+	TrdmRegionFlag string = "trdm-region"
+)
+
+func gatewayLastTableUpdate(request models.LastTableUpdateRequest, url string, v *viper.Viper, logger *zap.Logger) error {
+	// Obtain viper info
+	region := v.GetString(TrdmRegionFlag)
+	trdmIamRole := v.GetString(TrdmIamRoleFlag)
+
+	// Create the request body
+	requestBody, err := json.Marshal(request)
+	if err != nil {
+		logger.Error("marshalling LastTableUpdate request body", zap.Error(err))
+		return err
+	}
+	// Generate a SHA256 hash for signing
+	hash := GenerateSHA256Hash(requestBody)
+
+	// Put it into a new request
+	req, err := http.NewRequest("POST", url, bytes.NewBuffer(requestBody))
+	if err != nil {
+		logger.Error("lastTableUpdate request", zap.Error(err))
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	// Obtain creds for signing
+	creds, err := retrieveCredentials(region, trdmIamRole, logger)
+	if err != nil {
+		logger.Error("retrieving aws creds", zap.Error(err))
+		return err
+	}
+
+	// Sign request
+	err = signRequest(req, creds, string(hash), region, logger)
+	if err != nil {
+		logger.Error("signing lastTableUpdate request", zap.Error(err))
+		return err
+	}
+
+	return nil
+}
+
+func GenerateSHA256Hash(data []byte) []byte {
+	hasher := sha256.New()
+	hasher.Write(data)
+	return hasher.Sum(nil)
+}
+
+func signRequest(req *http.Request, creds aws.Credentials, hash string, region string, logger *zap.Logger) error {
+	signer := v4.NewSigner()
+
+	// Provide execute-api service as we're going through the gateway for this request
+	err := signer.SignHTTP(context.Background(), creds, req, hash, "execute-api", region, time.Now())
+	if err != nil {
+		logger.Error("error signing http request", zap.Error(err))
+		return err
+	}
+
+	return nil
+}
+
+func retrieveCredentials(region string, trdmIamRole string, logger *zap.Logger) (aws.Credentials, error) {
+	// We want to get the credentials from the logged in AWS
+	// session rather than create directly, because the session
+	// conflates the environment, shared, and container metdata
+	// config within NewSession. With stscreds, we use the Secure
+	// Token Service, to assume the given role (that has API
+	// gateway `execute-api` permissions).
+	cfg, err := config.LoadDefaultConfig(context.Background(), config.WithRegion(region))
+	if err != nil {
+		logger.Error("loading aws config", zap.Error(err))
+		return aws.Credentials{}, err
+	}
+
+	logger.Info("assuming AWS role for API gateway execution", zap.String("role", trdmIamRole))
+	stsClient := sts.NewFromConfig(cfg)
+	provider := stscreds.NewAssumeRoleProvider(stsClient, trdmIamRole)
+
+	creds, err := provider.Retrieve(context.Background())
+	if err != nil {
+		logger.Error("error retrieving aws credentials", zap.Error(err))
+		return aws.Credentials{}, err
+	}
+
+	return creds, nil
+}

--- a/pkg/trdm/last_table_update.go
+++ b/pkg/trdm/last_table_update.go
@@ -9,6 +9,9 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/credentials/stscreds"
+	"github.com/aws/aws-sdk-go-v2/service/sts"
 	"github.com/pkg/errors"
 	"github.com/spf13/viper"
 	"go.uber.org/zap"
@@ -18,10 +21,6 @@ import (
 	"github.com/transcom/mymove/pkg/cli"
 	"github.com/transcom/mymove/pkg/logging"
 	"github.com/transcom/mymove/pkg/models"
-
-	"github.com/aws/aws-sdk-go-v2/config"
-	"github.com/aws/aws-sdk-go-v2/credentials/stscreds"
-	"github.com/aws/aws-sdk-go-v2/service/sts"
 )
 
 const (

--- a/pkg/trdm/last_table_update.go
+++ b/pkg/trdm/last_table_update.go
@@ -19,7 +19,6 @@ import (
 	"github.com/transcom/mymove/pkg/models"
 )
 
-// const successfulStatusCode = "Successful"
 const (
 	// TrdmIamRoleFlag is the TRDM IAM Role flag
 	TrdmIamRoleFlag string = "trdm-iam-role"
@@ -27,6 +26,10 @@ const (
 	TrdmRegionFlag string = "trdm-region"
 	// GatewayURLFlag is the TRDM API Gateway URL flag
 	GatewayURLFlag string = "trdm-api-gateway-url"
+	// Success status code
+	successfulStatusCode string = "Successful"
+	// Failure status code
+	failureStatusCode string = "Failure"
 )
 
 // Date/time value is used in conjunction with the contentUpdatedSinceDateTime column in the getTable method.
@@ -92,7 +95,17 @@ func StartLastTableUpdateCron(physicalName string, logger *zap.Logger, v *viper.
 		if err != nil {
 			logger.Error("could not unmarshal body into lastTableUpdateResponse", zap.Error(err))
 		}
-		// TODO:
+
+		switch lastTableUpdateResponse.StatusCode {
+		case successfulStatusCode:
+			// Proceed to getTable requeest
+			// TODO:
+		case failureStatusCode:
+			logger.Error("trdm api gateway request failed, please inspect the trdm gateway logs")
+		default:
+			logger.Error("unexpected api gateway request failure response, please inspect the trdm gateway logs")
+		}
+
 	}
 
 	// Run the task immediately
@@ -116,23 +129,14 @@ func LastTableUpdate(v *viper.Viper, tlsConfig *tls.Config) error {
 	}
 	zap.ReplaceGlobals(logger)
 
-	// TODO: Turn back on when replacing with rest
+	// TODO: Turn back on when implementing getTable
 	// DB connection
 	// dbConnection, err := cli.InitDatabase(v, logger)
 	// if err != nil {
 	// 	return err
 	// }
 
-	// appCtx := appcontext.NewAppContext(dbConnection, logger, nil)
-
-	// tr := &http.Transport{TLSClientConfig: tlsConfig}
-	// httpClient := &http.Client{Transport: tr, Timeout: time.Duration(30) * time.Second}
-
-	// TODO: Replace with api gateway call
-
-	// TODO: Replace with REST
-
-	// These are likely to never err
+	// These are likely to never err. Remember, errors are logged not returned in cron
 	getLastTableUpdateTACErr := StartLastTableUpdateCron(transportationAccountingCode, logger, v, tlsConfig)
 	getLastTableUpdateLOAErr := StartLastTableUpdateCron(lineOfAccounting, logger, v, tlsConfig)
 	if getLastTableUpdateLOAErr != nil {

--- a/pkg/trdm/last_table_update.go
+++ b/pkg/trdm/last_table_update.go
@@ -68,7 +68,7 @@ func StartLastTableUpdateCron(physicalName string, logger *zap.Logger, v *viper.
 
 		// Initialize the request model with physicalName
 		request := models.LastTableUpdateRequest{
-			PhysicalName: physicalName, // assuming physicalName is available in this scope
+			PhysicalName: physicalName,
 		}
 
 		// Setup response model

--- a/pkg/trdm/last_table_update_test.go
+++ b/pkg/trdm/last_table_update_test.go
@@ -1,6 +1,7 @@
 package trdm_test
 
 import (
+	"crypto/tls"
 	"time"
 
 	"github.com/transcom/mymove/pkg/factory"
@@ -48,4 +49,9 @@ func (suite *TRDMSuite) TestFetchTACRecordsByTime() {
 	finalCodesLength := len(codes)
 
 	suite.NotEqual(finalCodesLength, initialTacCodeLength)
+}
+
+func (suite *TRDMSuite) TestLastTableUpdate() {
+	err := trdm.LastTableUpdate(suite.viper, &tls.Config{MinVersion: tls.VersionTLS13}, suite.AppContextForTest())
+	suite.NoError(err)
 }

--- a/pkg/trdm/last_table_update_test.go
+++ b/pkg/trdm/last_table_update_test.go
@@ -55,3 +55,22 @@ func (suite *TRDMSuite) TestLastTableUpdate() {
 	err := trdm.LastTableUpdate(suite.viper, &tls.Config{MinVersion: tls.VersionTLS13}, suite.AppContextForTest())
 	suite.NoError(err)
 }
+
+func (suite *TRDMSuite) TestFetchAllTACRecords() {
+	// Get initial TAC codes count
+	initialCodes, err := trdm.FetchAllTACRecords(suite.AppContextForTest())
+	initialTacCodeLength := len(initialCodes)
+	suite.NoError(err)
+
+	// Creates a test TAC code record in the DB
+	factory.BuildFullTransportationAccountingCode(suite.DB())
+
+	// Fetch All TAC Records
+	codes, err := trdm.FetchAllTACRecords(suite.AppContextForTest())
+
+	// Compare new TAC Code count to initial count
+	finalCodesLength := len(codes)
+
+	suite.NoError(err)
+	suite.NotEqual(finalCodesLength, initialTacCodeLength)
+}

--- a/pkg/trdm/trdm_test.go
+++ b/pkg/trdm/trdm_test.go
@@ -1,20 +1,67 @@
 package trdm_test
 
 import (
+	"log"
+	"os"
+	"strings"
 	"testing"
 
+	"github.com/spf13/pflag"
+	"github.com/spf13/viper"
 	"github.com/stretchr/testify/suite"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest"
 
 	"github.com/transcom/mymove/pkg/testingsuite"
 )
 
 type TRDMSuite struct {
 	*testingsuite.PopTestSuite
+	viper  *viper.Viper
+	logger *zap.Logger
+}
+
+type initFlags func(f *pflag.FlagSet)
+
+func (suite *TRDMSuite) Setup(fn initFlags, flagSet []string) {
+	suite.viper = nil
+
+	flag := pflag.NewFlagSet(os.Args[0], pflag.ExitOnError)
+	fn(flag)
+	suite.NoError(flag.Parse(flagSet))
+
+	v := viper.New()
+	err := v.BindPFlags(flag)
+	if err != nil {
+		suite.logger.Fatal("could not bind flags", zap.Error(err))
+	}
+	v.SetEnvKeyReplacer(strings.NewReplacer("-", "_"))
+	v.AutomaticEnv()
+
+	suite.SetViper(v)
+}
+
+func (suite *TRDMSuite) SetViper(v *viper.Viper) {
+	suite.viper = v
 }
 
 func TestTRDMSuite(t *testing.T) {
+	flag := pflag.CommandLine
+
+	v := viper.New()
+	bindErr := v.BindPFlags(flag)
+	if bindErr != nil {
+		log.Fatal("failed to bind flags", zap.Error(bindErr))
+	}
+	v.SetEnvKeyReplacer(strings.NewReplacer("-", "_"))
+	v.AutomaticEnv()
+
+	logger := zaptest.NewLogger(t)
+
 	hs := &TRDMSuite{
 		PopTestSuite: testingsuite.NewPopTestSuite(testingsuite.CurrentPackage(), testingsuite.WithPerTestTransaction()),
+		viper:        v,
+		logger:       logger,
 	}
 	suite.Run(t, hs)
 	hs.PopTestSuite.TearDown()


### PR DESCRIPTION
# Changes
* Removed SOAP and XML from backend
* Refactored TRDM package lastTableUpdate to form a REST call to the AWS API gateway
* Configured AWS SDK STS client for HTTP signing, allowing IAM auth over HTTP
* Added lastTableUpdate models reflecting TRDM Soap Proxy Lambda function (The java microservice)
* Added additional secrets (See terraform repository)

# How to test
Unable to conduct frontend testing until getTable has been implemented. Additionally, due to security constraints this cannot be tested locally on a dev machine, but the mock tests provide us with the expected behavior based on how the functions are used.