### PR TITLE
B 17788 get table rest

### DIFF
--- a/cmd/milmove/serve.go
+++ b/cmd/milmove/serve.go
@@ -836,7 +836,7 @@ func serveFunction(cmd *cobra.Command, args []string) error {
 		httpClient := &http.Client{Transport: tr, Timeout: time.Duration(30) * time.Second}
 
 		// Initial REST call for LastTableUpdate on server start and once per day
-		err = trdm.LastTableUpdate(v, appCtx, stsProvider, httpClient)
+		err = trdm.BeginTGETFlow(v, appCtx, stsProvider, httpClient)
 		if err != nil {
 			logger.Fatal("unable to retrieve latest TGET data from TRDM", zap.Error(err))
 			return err

--- a/cmd/milmove/serve.go
+++ b/cmd/milmove/serve.go
@@ -838,7 +838,10 @@ func serveFunction(cmd *cobra.Command, args []string) error {
 		tr := &http.Transport{TLSClientConfig: tlsConfig}
 		httpClient := &http.Client{Transport: tr, Timeout: time.Duration(30) * time.Second}
 
-		// Initial REST call for LastTableUpdate on server start and once per day
+		// Begin the TRDM cron job now (Referred to as the TGET flow as well). This will
+		// send a REST call to the lastTableUpdate endpoint within the trdm soap proxy api gateway,
+		// then if new data is discovered it will call getTable to retreive, parse, and store within the database.
+		// This will run immediately when the server turns on as well as every day at midnight.
 		err = trdm.BeginTGETFlow(v, appCtx, stsProvider, httpClient)
 		if err != nil {
 			logger.Fatal("unable to retrieve latest TGET data from TRDM", zap.Error(err))

--- a/cmd/milmove/serve.go
+++ b/cmd/milmove/serve.go
@@ -813,8 +813,11 @@ func serveFunction(cmd *cobra.Command, args []string) error {
 	}
 
 	// Gather TRDM TGET data
-	trdmIsEnabled := v.GetBool(cli.TRDMIsEnabledFlag)
-	if trdmIsEnabled {
+	trdmEnabledEnvironments := []string{
+		cli.EnvironmentTest,
+		cli.EnvironmentPrd,
+	}
+	if environment := v.GetString(cli.EnvironmentFlag); stringSliceContains(trdmEnabledEnvironments, environment) {
 		// Get the AWS configuration so we can build a session
 		cfg, err := config.LoadDefaultConfig(context.Background(),
 			config.WithRegion(v.GetString(cli.AWSRegionFlag)),

--- a/pkg/models/trdm_get_table_request.go
+++ b/pkg/models/trdm_get_table_request.go
@@ -1,7 +1,9 @@
 package models
 
+import "time"
+
 type GetTableRequest struct {
-	PhysicalName                string `json:"physicalName"`
-	ContentUpdatedSinceDateTime string `json:"contentUpdatedSinceDateTime"`
-	ReturnContent               bool   `json:"returnContent"`
+	PhysicalName                string    `json:"physicalName"`
+	ContentUpdatedSinceDateTime time.Time `json:"contentUpdatedSinceDateTime"`
+	ReturnContent               bool      `json:"returnContent"`
 }

--- a/pkg/models/trdm_get_table_request.go
+++ b/pkg/models/trdm_get_table_request.go
@@ -1,0 +1,7 @@
+package models
+
+type GetTableRequest struct {
+	PhysicalName                string `json:"physicalName"`
+	ContentUpdatedSinceDateTime string `json:"contentUpdatedSinceDateTime"`
+	ReturnContent               bool   `json:"returnContent"`
+}

--- a/pkg/models/trdm_get_table_response.go
+++ b/pkg/models/trdm_get_table_response.go
@@ -1,12 +1,11 @@
 package models
 
 import (
-	"math/big"
 	"time"
 )
 
 type GetTableResponse struct {
-	RowCount   big.Int   `json:"rowCount"`
+	RowCount   int64     `json:"rowCount"`
 	StatusCode string    `json:"statusCode"`
 	DateTime   time.Time `json:"dateTime"`
 	Attachment []byte    `json:"attachment"`

--- a/pkg/models/trdm_get_table_response.go
+++ b/pkg/models/trdm_get_table_response.go
@@ -1,0 +1,13 @@
+package models
+
+import (
+	"math/big"
+	"time"
+)
+
+type GetTableResponse struct {
+	RowCount   big.Int   `json:"rowCount"`
+	StatusCode string    `json:"statusCode"`
+	DateTime   time.Time `json:"dateTime"`
+	Attachment []byte    `json:"attachment"`
+}

--- a/pkg/models/trdm_last_table_update_response.go
+++ b/pkg/models/trdm_last_table_update_response.go
@@ -3,7 +3,7 @@ package models
 import "time"
 
 type LastTableUpdateResponse struct {
-	StatusCode string    `json:"physicalName"`
+	StatusCode string    `json:"statusCode"`
 	DateTime   time.Time `json:"dateTime"`
 	LastUpdate time.Time `json:"lastUpdate"`
 }

--- a/pkg/trdm/api_gateway.go
+++ b/pkg/trdm/api_gateway.go
@@ -15,8 +15,8 @@ import (
 )
 
 const (
-	lastTableUpdateEndpoint      string = "/api/v1/lastTableUpdate"
-	getTableEndpoint             string = "/api/v1/getTable"
+	LastTableUpdateEndpoint      string = "/api/v1/lastTableUpdate"
+	GetTableEndpoint             string = "/api/v1/getTable"
 	LineOfAccounting             string = "LN_OF_ACCT"
 	TransportationAccountingCode string = "TRNSPRTN_ACNT"
 )
@@ -56,7 +56,7 @@ func (gs GatewayService) gatewayLastTableUpdate(request models.LastTableUpdateRe
 	hash := generateSHA256Hash(requestBody)
 
 	// Put it into a new request
-	req, err := http.NewRequest("POST", gs.gatewayURL+lastTableUpdateEndpoint, bytes.NewBuffer(requestBody))
+	req, err := http.NewRequest("POST", gs.gatewayURL+LastTableUpdateEndpoint, bytes.NewBuffer(requestBody))
 	if err != nil {
 		gs.logger.Error("lastTableUpdate request", zap.Error(err))
 		return nil, err
@@ -93,7 +93,7 @@ func (gs GatewayService) gatewayGetTable(request models.GetTableRequest) (*http.
 	hash := generateSHA256Hash(requestBody)
 
 	// Put it into a new request
-	req, err := http.NewRequest("POST", gs.gatewayURL+getTableEndpoint, bytes.NewBuffer(requestBody))
+	req, err := http.NewRequest("POST", gs.gatewayURL+GetTableEndpoint, bytes.NewBuffer(requestBody))
 	if err != nil {
 		gs.logger.Error("getTable request", zap.Error(err))
 		return nil, err

--- a/pkg/trdm/api_gateway.go
+++ b/pkg/trdm/api_gateway.go
@@ -113,7 +113,9 @@ func (gs GatewayService) gatewayGetTable(request models.GetTableRequest) (*http.
 		gs.logger.Error("error sending request to API Gateway", zap.Error(err))
 		return nil, err
 	}
-	defer resp.Body.Close()
+	if resp.Body != nil {
+		defer resp.Body.Close()
+	}
 
 	return resp, nil
 }

--- a/pkg/trdm/api_gateway.go
+++ b/pkg/trdm/api_gateway.go
@@ -15,8 +15,10 @@ import (
 )
 
 const (
-	lastTableUpdateEndpoint string = "/api/v1/lastTableUpdate"
-	// getTableEndpoint        string = "/api/v1/getTable"
+	lastTableUpdateEndpoint      string = "/api/v1/lastTableUpdate"
+	getTableEndpoint             string = "/api/v1/getTable"
+	lineOfAccounting             string = "LN_OF_ACCT"
+	transportationAccountingCode string = "TRNSPRTN_ACNT"
 )
 
 type HTTPClient interface {
@@ -51,7 +53,7 @@ func (gs GatewayService) gatewayLastTableUpdate(request models.LastTableUpdateRe
 	}
 
 	// Generate a SHA256 hash for signing
-	hash := GenerateSHA256Hash(requestBody)
+	hash := generateSHA256Hash(requestBody)
 
 	// Put it into a new request
 	req, err := http.NewRequest("POST", gs.gatewayURL+lastTableUpdateEndpoint, bytes.NewBuffer(requestBody))
@@ -79,7 +81,44 @@ func (gs GatewayService) gatewayLastTableUpdate(request models.LastTableUpdateRe
 	return resp, nil
 }
 
-func GenerateSHA256Hash(data []byte) []byte {
+func (gs GatewayService) gatewayGetTable(request models.GetTableRequest) (*http.Response, error) {
+	// Create the request body
+	requestBody, err := json.Marshal(request)
+	if err != nil {
+		gs.logger.Error("marshalling GetTable request body", zap.Error(err))
+		return nil, err
+	}
+
+	// Generate a SHA256 hash for signing
+	hash := generateSHA256Hash(requestBody)
+
+	// Put it into a new request
+	req, err := http.NewRequest("POST", gs.gatewayURL+getTableEndpoint, bytes.NewBuffer(requestBody))
+	if err != nil {
+		gs.logger.Error("getTable request", zap.Error(err))
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	// Sign request, this will update req in place
+	err = signRequest(req, gs.stsCreds, string(hash), gs.region, gs.logger)
+	if err != nil {
+		gs.logger.Error("signing getTable request", zap.Error(err))
+		return nil, err
+	}
+
+	// Send the request
+	resp, err := gs.httpClient.Do(req)
+	if err != nil {
+		gs.logger.Error("error sending request to API Gateway", zap.Error(err))
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	return resp, nil
+}
+
+func generateSHA256Hash(data []byte) []byte {
 	hasher := sha256.New()
 	hasher.Write(data)
 	return hasher.Sum(nil)

--- a/pkg/trdm/api_gateway.go
+++ b/pkg/trdm/api_gateway.go
@@ -17,8 +17,8 @@ import (
 const (
 	lastTableUpdateEndpoint      string = "/api/v1/lastTableUpdate"
 	getTableEndpoint             string = "/api/v1/getTable"
-	lineOfAccounting             string = "LN_OF_ACCT"
-	transportationAccountingCode string = "TRNSPRTN_ACNT"
+	LineOfAccounting             string = "LN_OF_ACCT"
+	TransportationAccountingCode string = "TRNSPRTN_ACNT"
 )
 
 type HTTPClient interface {

--- a/pkg/trdm/get_table.go
+++ b/pkg/trdm/get_table.go
@@ -59,6 +59,7 @@ func parseGetTableResponse(appcontext appcontext.AppContext, attachment []byte, 
 		}
 	case TransportationAccountingCode:
 		tacCodes, err := tac.Parse(reader)
+		// Consolidate duplicates
 		consolidatedTacs := tac.ConsolidateDuplicateTACsDesiredFromTRDM(tacCodes)
 		if err != nil {
 			return err

--- a/pkg/trdm/get_table.go
+++ b/pkg/trdm/get_table.go
@@ -3,6 +3,7 @@ package trdm
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"io"
 
 	"github.com/transcom/mymove/pkg/appcontext"
@@ -21,6 +22,9 @@ func GetTGETData(getTableRequest models.GetTableRequest, service GatewayService,
 		return err
 	}
 	// Read it
+	if resp.Body == nil {
+		return errors.New("a body must be provided for TGET data gathering")
+	}
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return err

--- a/pkg/trdm/get_table.go
+++ b/pkg/trdm/get_table.go
@@ -11,7 +11,7 @@ import (
 	"github.com/transcom/mymove/pkg/parser/tac"
 )
 
-func getTGETData(getTableRequest models.GetTableRequest, service GatewayService, appCtx appcontext.AppContext) error {
+func GetTGETData(getTableRequest models.GetTableRequest, service GatewayService, appCtx appcontext.AppContext) error {
 	// Setup response model
 	getTableResponse := models.GetTableResponse{}
 
@@ -48,22 +48,22 @@ func getTGETData(getTableRequest models.GetTableRequest, service GatewayService,
 func parseGetTableResponse(appcontext appcontext.AppContext, attachment []byte, physicalName string) error {
 	reader := bytes.NewReader(attachment)
 	switch physicalName {
-	case lineOfAccounting:
+	case LineOfAccounting:
 		loaCodes, err := loa.Parse(reader)
 		if err != nil {
 			return err
 		}
-		err = saveLoaCodes(appcontext, loaCodes)
+		err = createLoaCodes(appcontext, loaCodes)
 		if err != nil {
 			return err
 		}
-	case transportationAccountingCode:
+	case TransportationAccountingCode:
 		tacCodes, err := tac.Parse(reader)
 		consolidatedTacs := tac.ConsolidateDuplicateTACsDesiredFromTRDM(tacCodes)
 		if err != nil {
 			return err
 		}
-		if err = saveTacCodes(appcontext, consolidatedTacs); err != nil {
+		if err = createTacCodes(appcontext, consolidatedTacs); err != nil {
 			return err
 		}
 	default:
@@ -72,18 +72,18 @@ func parseGetTableResponse(appcontext appcontext.AppContext, attachment []byte, 
 	return nil
 }
 
-// Saves TAC Code slice to DB and updates records
-func saveTacCodes(appcontext appcontext.AppContext, tacCodes []models.TransportationAccountingCode) error {
-	saveErr := appcontext.DB().Update(tacCodes)
+// Saves new TAC Code slice to DB
+func createTacCodes(appcontext appcontext.AppContext, tacCodes []models.TransportationAccountingCode) error {
+	saveErr := appcontext.DB().Create(tacCodes)
 	if saveErr != nil {
 		return saveErr
 	}
 	return nil
 }
 
-// Saves LOA Code slice to DB and updates records
-func saveLoaCodes(appcontext appcontext.AppContext, loa []models.LineOfAccounting) error {
-	saveErr := appcontext.DB().Update(loa)
+// Saves new LOA Code slice to DB
+func createLoaCodes(appcontext appcontext.AppContext, loa []models.LineOfAccounting) error {
+	saveErr := appcontext.DB().Create(loa)
 	if saveErr != nil {
 		return saveErr
 	}

--- a/pkg/trdm/get_table.go
+++ b/pkg/trdm/get_table.go
@@ -72,7 +72,7 @@ func parseGetTableResponse(appcontext appcontext.AppContext, attachment []byte, 
 			return err
 		}
 	default:
-		return nil
+		return errors.New("provided physical name is not valid for TGET data")
 	}
 	return nil
 }

--- a/pkg/trdm/get_table.go
+++ b/pkg/trdm/get_table.go
@@ -1,109 +1,61 @@
 package trdm
 
 import (
-	"time"
-
-	"github.com/pkg/errors"
+	"bytes"
+	"encoding/json"
+	"io"
 
 	"github.com/transcom/mymove/pkg/appcontext"
 	"github.com/transcom/mymove/pkg/models"
+	"github.com/transcom/mymove/pkg/parser/loa"
+	"github.com/transcom/mymove/pkg/parser/tac"
 )
 
-// const successResponseString = "Successful"
-const lineOfAccounting = "LN_OF_ACCT"
-const transportationAccountingCode = "TRNSPRTN_ACNT"
+func getTGETData(getTableRequest models.GetTableRequest, service GatewayService, appCtx appcontext.AppContext) error {
+	// Setup response model
+	getTableResponse := models.GetTableResponse{}
 
-// Fetch Transportation Accounting Codes from DB and return the list of records if the updated_at field is < the returned LastTableUpdate updated time.
-// Ex:
-//
-//	LastTableUpdate : 2023-08-30 15:24:13.19931
-//	updated_at: 2023-08-29 15:24:13.19931
-//
-// Because updated_at is before LastTableUpdate the DB will return records that match this case.
-//
-//	returns []models.TransportationAccountingCode, error
-func FetchTACRecordsByTime(appcontext appcontext.AppContext, time time.Time) ([]models.TransportationAccountingCode, error) {
-	var tacCodes []models.TransportationAccountingCode
-	err := appcontext.DB().Select("*").Where("updated_at < $1", time).All(&tacCodes)
-
+	// Forward model to getTable to gather TGET data
+	resp, err := service.gatewayGetTable(getTableRequest)
 	if err != nil {
-		return tacCodes, errors.Wrap(err, "Fetch line items query failed")
+		return err
+	}
+	// Read it
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	// Parse it into getTableResponse model
+	err = json.Unmarshal(body, &getTableResponse)
+	if err != nil {
+		return err
 	}
 
-	return tacCodes, nil
-}
-
-// Fetch Line Of Accounting records from DB and return the list of records if the updated_at field is < the returned LastTableUpdate updated time.
-// Ex:
-//
-//	LastTableUpdate : 2023-08-30 15:24:13.19931
-//	updated_at: 2023-08-29 15:24:13.19931
-//
-// Because updated_at is before LastTableUpdate the DB will return records that match this case.
-//
-//	returns []models.LineOfAccounting, error
-func FetchLOARecordsByTime(appcontext appcontext.AppContext, time time.Time) ([]models.LineOfAccounting, error) {
-	var loa []models.LineOfAccounting
-	err := appcontext.DB().Select("*").Where("updated_at < $1", time).All(&loa)
+	// Parse the attachment, this will also store it in the DB if all goes well
+	err = parseGetTableResponse(appCtx, getTableResponse.Attachment, getTableRequest.PhysicalName)
 	if err != nil {
-		return loa, errors.Wrap(err, "Fetch line items query failed")
+		return err
 	}
-	return loa, nil
+
+	return nil
 }
-
-// Determines if call is needed to be made
-// If the DB does not return any records we do not need make a call to GetTable and update our local mapping
-//   - appCtx: Application Context
-//   - physicalName: Table Name (Will be either TAC or LOA)
-//   - lastUpdate: Returned date time from LastTableUpdate Soap Request
-//
-// returns error
-
-//TODO: Next story
-// func GetTable(appCtx appcontext.AppContext, physicalName string, lastUpdate time.Time) error {
-
-// 	switch physicalName {
-// 	case lineOfAccounting:
-// 		loaRecords, loaFetchErr := FetchLOARecordsByTime(appCtx, lastUpdate)
-
-// 		if loaFetchErr != nil {
-// 			return loaFetchErr
-// 		}
-
-// 		if len(loaRecords) > 0 {
-// 			// TODO: Send off the call
-// 			return loaFetchErr // Remove me
-// 		}
-// 	case transportationAccountingCode:
-// 		tacRecords, fetchErr := FetchTACRecordsByTime(appCtx, lastUpdate)
-// 		if fetchErr != nil {
-// 			return fetchErr
-// 		}
-// 		if len(tacRecords) > 0 {
-// 			// TODO: Send off the call
-// 			return fetchErr // Remove me
-// 		}
-// 	}
-
-// 	return nil
-// }
 
 // Parses pipedelimited file attachment from GetTable webservice and saves records to database
 //
 //	returns error
-// TODO: Impelement again
-/*
-func parseGetTableResponse(appcontext appcontext.AppContext, response *gosoap.Response, physicalName string) error {
-	reader := bytes.NewReader(response.Payload)
+func parseGetTableResponse(appcontext appcontext.AppContext, attachment []byte, physicalName string) error {
+	reader := bytes.NewReader(attachment)
 	switch physicalName {
 	case lineOfAccounting:
 		loaCodes, err := loa.Parse(reader)
 		if err != nil {
 			return err
 		}
-		saveErr := saveLoaCodes(appcontext, loaCodes)
-		if saveErr != nil {
-			return saveErr
+		err = saveLoaCodes(appcontext, loaCodes)
+		if err != nil {
+			return err
 		}
 	case transportationAccountingCode:
 		tacCodes, err := tac.Parse(reader)
@@ -111,19 +63,16 @@ func parseGetTableResponse(appcontext appcontext.AppContext, response *gosoap.Re
 		if err != nil {
 			return err
 		}
-		if saveErr := saveTacCodes(appcontext, consolidatedTacs); saveErr != nil {
-			return saveErr
+		if err = saveTacCodes(appcontext, consolidatedTacs); err != nil {
+			return err
 		}
 	default:
 		return nil
 	}
 	return nil
 }
-*/
 
 // Saves TAC Code slice to DB and updates records
-// TODO: Implement again
-/*
 func saveTacCodes(appcontext appcontext.AppContext, tacCodes []models.TransportationAccountingCode) error {
 	saveErr := appcontext.DB().Update(tacCodes)
 	if saveErr != nil {
@@ -140,4 +89,3 @@ func saveLoaCodes(appcontext appcontext.AppContext, loa []models.LineOfAccountin
 	}
 	return nil
 }
-*/

--- a/pkg/trdm/get_table_test.go
+++ b/pkg/trdm/get_table_test.go
@@ -127,3 +127,26 @@ func (suite *TRDMSuite) TestSuccessfulGetTGETDataTAC() {
 	// just checking to see if the values are now present, not 1:1 matches
 	suite.Equal(len(expectedTACCodes), len(tacCodes))
 }
+
+func (suite *TRDMSuite) TestGetTGETDataBadPhysicalName() {
+	mockClient := &MockHTTPClient{
+		DoFunc: func(req *http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: http.StatusBadRequest,
+				Body:       nil,
+			}, nil
+		}}
+
+	mockProvider := &mockAssumeRoleProvider{creds: suite.creds}
+
+	service := trdm.NewGatewayService(mockClient, suite.logger, "us-gov-west-1", "mockRole", "https://test.gateway.url.amazon.com", mockProvider)
+
+	getTableRequest := models.GetTableRequest{
+		PhysicalName:                "null",
+		ContentUpdatedSinceDateTime: time.Now().Add(time.Hour * 24 * 365 * 5),
+		ReturnContent:               true,
+	}
+
+	err := trdm.GetTGETData(getTableRequest, *service, suite.AppContextForTest())
+	suite.Error(err)
+}

--- a/pkg/trdm/get_table_test.go
+++ b/pkg/trdm/get_table_test.go
@@ -1,9 +1,70 @@
 package trdm_test
 
-// func getTextFile(filePath string) ([]byte, error) {
-// 	text, err := os.ReadFile(filePath)
-// 	if err != nil {
-// 		return nil, err
-// 	}
-// 	return text, nil
-// }
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"os"
+	"time"
+
+	"github.com/transcom/mymove/pkg/models"
+	"github.com/transcom/mymove/pkg/parser/loa"
+	"github.com/transcom/mymove/pkg/trdm"
+)
+
+func (suite *TRDMSuite) TestGetTGETDataLOA() {
+	getTableRequest := models.GetTableRequest{
+		PhysicalName:                trdm.LineOfAccounting,
+		ContentUpdatedSinceDateTime: time.Now().Add(time.Hour * 24 * 365 * 5),
+		ReturnContent:               true,
+	}
+
+	// Mock a successful attachment return from GetTable
+	// Use parser fixtures for LOA
+	loaFile, err := os.ReadFile("../parser/loa/fixtures/Line Of Accounting.txt")
+	suite.NoError(err)
+
+	getTableResponse := models.GetTableResponse{
+		RowCount:   2,
+		StatusCode: trdm.SuccessfulStatusCode,
+		DateTime:   time.Now(),
+		Attachment: loaFile,
+	}
+
+	responseBody, err := json.Marshal(getTableResponse)
+	suite.NoError(err)
+
+	mockClient := &MockHTTPClient{
+		DoFunc: func(req *http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(bytes.NewReader(responseBody)),
+			}, nil
+		}}
+
+	mockProvider := &mockAssumeRoleProvider{creds: suite.creds}
+
+	service := trdm.NewGatewayService(mockClient, suite.logger, "us-gov-west-1", "mockRole", "https://test.gateway.url.amazon.com", mockProvider)
+
+	// GetTable for Line of Accounting, parse it, and then store it in the database
+	err = trdm.GetTGETData(getTableRequest, *service, suite.AppContextForTest())
+	suite.NoError(err)
+
+	// Load our test file
+	reader := bytes.NewReader(loaFile)
+	expectedLOACodes, err := loa.Parse(reader)
+	suite.NoError(err)
+
+	// Load our loa codes from the DB
+	var loaCodes []models.LineOfAccounting
+
+	err = suite.AppContextForTest().DB().All(&loaCodes)
+	suite.NoError(err)
+
+	// Only compare len. Remember, the attachment does not
+	// have the same automatically populated values we do in the DB
+	// Such as UUID, Created, Updated, that sort. That's why we're
+	// just checking to see if the values are now present, not 1:1 matches
+	suite.Equal(len(expectedLOACodes), len(loaCodes))
+}

--- a/pkg/trdm/get_table_test.go
+++ b/pkg/trdm/get_table_test.go
@@ -128,7 +128,7 @@ func (suite *TRDMSuite) TestSuccessfulGetTGETDataTAC() {
 	suite.Equal(len(expectedTACCodes), len(tacCodes))
 }
 
-func (suite *TRDMSuite) TestGetTGETDataBadPhysicalName() {
+func (suite *TRDMSuite) TestGetTGETDataNilResponseBody() {
 	mockClient := &MockHTTPClient{
 		DoFunc: func(req *http.Request) (*http.Response, error) {
 			return &http.Response{
@@ -148,5 +148,57 @@ func (suite *TRDMSuite) TestGetTGETDataBadPhysicalName() {
 	}
 
 	err := trdm.GetTGETData(getTableRequest, *service, suite.AppContextForTest())
+	suite.Error(err)
+}
+
+func (suite *TRDMSuite) TestGetTGETDataNilRequestBody() {
+	mockClient := &MockHTTPClient{
+		DoFunc: func(req *http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: http.StatusBadRequest,
+				Body:       nil,
+			}, nil
+		}}
+
+	mockProvider := &mockAssumeRoleProvider{creds: suite.creds}
+
+	service := trdm.NewGatewayService(mockClient, suite.logger, "us-gov-west-1", "mockRole", "https://test.gateway.url.amazon.com", mockProvider)
+
+	getTableRequest := models.GetTableRequest{}
+
+	err := trdm.GetTGETData(getTableRequest, *service, suite.AppContextForTest())
+	suite.Error(err)
+}
+
+func (suite *TRDMSuite) TestGetTGETDataBadPhysicalName() {
+	getTableResponse := models.GetTableResponse{
+		RowCount:   2,
+		StatusCode: trdm.SuccessfulStatusCode,
+		DateTime:   time.Now(),
+		Attachment: nil,
+	}
+
+	responseBody, err := json.Marshal(getTableResponse)
+	suite.NoError(err)
+
+	mockClient := &MockHTTPClient{
+		DoFunc: func(req *http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(bytes.NewReader(responseBody)),
+			}, nil
+		}}
+
+	mockProvider := &mockAssumeRoleProvider{creds: suite.creds}
+
+	service := trdm.NewGatewayService(mockClient, suite.logger, "us-gov-west-1", "mockRole", "https://test.gateway.url.amazon.com", mockProvider)
+
+	getTableRequest := models.GetTableRequest{
+		PhysicalName:                "badName",
+		ContentUpdatedSinceDateTime: time.Now().Add(time.Hour * 24 * 365 * 5),
+		ReturnContent:               true,
+	}
+
+	err = trdm.GetTGETData(getTableRequest, *service, suite.AppContextForTest())
 	suite.Error(err)
 }

--- a/pkg/trdm/get_table_test.go
+++ b/pkg/trdm/get_table_test.go
@@ -10,10 +10,11 @@ import (
 
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/parser/loa"
+	"github.com/transcom/mymove/pkg/parser/tac"
 	"github.com/transcom/mymove/pkg/trdm"
 )
 
-func (suite *TRDMSuite) TestGetTGETDataLOA() {
+func (suite *TRDMSuite) TestSuccessfulGetTGETDataLOA() {
 	getTableRequest := models.GetTableRequest{
 		PhysicalName:                trdm.LineOfAccounting,
 		ContentUpdatedSinceDateTime: time.Now().Add(time.Hour * 24 * 365 * 5),
@@ -26,7 +27,7 @@ func (suite *TRDMSuite) TestGetTGETDataLOA() {
 	suite.NoError(err)
 
 	getTableResponse := models.GetTableResponse{
-		RowCount:   2,
+		RowCount:   7,
 		StatusCode: trdm.SuccessfulStatusCode,
 		DateTime:   time.Now(),
 		Attachment: loaFile,
@@ -67,4 +68,62 @@ func (suite *TRDMSuite) TestGetTGETDataLOA() {
 	// Such as UUID, Created, Updated, that sort. That's why we're
 	// just checking to see if the values are now present, not 1:1 matches
 	suite.Equal(len(expectedLOACodes), len(loaCodes))
+}
+
+func (suite *TRDMSuite) TestSuccessfulGetTGETDataTAC() {
+	getTableRequest := models.GetTableRequest{
+		PhysicalName:                trdm.TransportationAccountingCode,
+		ContentUpdatedSinceDateTime: time.Now().Add(time.Hour * 24 * 365 * 5),
+		ReturnContent:               true,
+	}
+
+	// Mock a successful attachment return from GetTable
+	// Use parser fixtures for TAC
+	tacFile, err := os.ReadFile("../parser/tac/fixtures/Transportation Account.txt")
+	suite.NoError(err)
+
+	getTableResponse := models.GetTableResponse{
+		RowCount:   2,
+		StatusCode: trdm.SuccessfulStatusCode,
+		DateTime:   time.Now(),
+		Attachment: tacFile,
+	}
+
+	responseBody, err := json.Marshal(getTableResponse)
+	suite.NoError(err)
+
+	mockClient := &MockHTTPClient{
+		DoFunc: func(req *http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(bytes.NewReader(responseBody)),
+			}, nil
+		}}
+
+	mockProvider := &mockAssumeRoleProvider{creds: suite.creds}
+
+	service := trdm.NewGatewayService(mockClient, suite.logger, "us-gov-west-1", "mockRole", "https://test.gateway.url.amazon.com", mockProvider)
+
+	// GetTable for Line of Accounting, parse it, and then store it in the database
+	err = trdm.GetTGETData(getTableRequest, *service, suite.AppContextForTest())
+	suite.NoError(err)
+
+	// Load our test file
+	reader := bytes.NewReader(tacFile)
+	expectedTACCodes, err := tac.Parse(reader)
+	suite.NoError(err)
+	// Consolidate duplicates
+	expectedTACCodes = tac.ConsolidateDuplicateTACsDesiredFromTRDM(expectedTACCodes)
+
+	// Load our tac codes from the DB
+	var tacCodes []models.TransportationAccountingCode
+
+	err = suite.AppContextForTest().DB().All(&tacCodes)
+	suite.NoError(err)
+
+	// Only compare len. Remember, the attachment does not
+	// have the same automatically populated values we do in the DB
+	// Such as UUID, Created, Updated, that sort. That's why we're
+	// just checking to see if the values are now present, not 1:1 matches
+	suite.Equal(len(expectedTACCodes), len(tacCodes))
 }

--- a/pkg/trdm/last_table_update.go
+++ b/pkg/trdm/last_table_update.go
@@ -110,9 +110,9 @@ func startLastTableUpdateCron(physicalName string, logger *zap.Logger, v *viper.
 						ReturnContent:               true,
 					}, *service, appCtx)
 					if err != nil {
-						logger.Info("successfully retrieved latest line of accounting TGET data")
-					} else {
 						logger.Fatal("failed to retrieve latest line of accounting TGET data")
+					} else {
+						logger.Info("successfully retrieved latest line of accounting TGET data")
 					}
 					return
 				}

--- a/pkg/trdm/last_table_update.go
+++ b/pkg/trdm/last_table_update.go
@@ -132,9 +132,9 @@ func startLastTableUpdateCron(physicalName string, logger *zap.Logger, v *viper.
 						ReturnContent:               true,
 					}, *service, appCtx)
 					if err != nil {
-						logger.Info("successfully retrieved latest transportation accounting TGET data")
-					} else {
 						logger.Fatal("failed to retrieve latest transportation accounting TGET data")
+					} else {
+						logger.Info("successfully retrieved latest transportation accounting TGET data")
 					}
 					return
 				}

--- a/pkg/trdm/last_table_update.go
+++ b/pkg/trdm/last_table_update.go
@@ -94,7 +94,7 @@ func startLastTableUpdateCron(physicalName string, logger *zap.Logger, v *viper.
 		switch lastTableUpdateResponse.StatusCode {
 		case SuccessfulStatusCode:
 			switch physicalName {
-			case lineOfAccounting:
+			case LineOfAccounting:
 				loas, err := FetchLOARecordsByTime(appCtx, lastTableUpdateResponse.LastUpdate)
 				if err != nil {
 					logger.Error("fetching loa records by time", zap.Error(err))
@@ -104,8 +104,8 @@ func startLastTableUpdateCron(physicalName string, logger *zap.Logger, v *viper.
 				if len(loas) > 0 {
 					// Since loas were returned, we are in fact out of date
 					// Trigger Get TGET data and GetTable call
-					err := getTGETData(models.GetTableRequest{
-						PhysicalName:                lineOfAccounting,
+					err := GetTGETData(models.GetTableRequest{
+						PhysicalName:                LineOfAccounting,
 						ContentUpdatedSinceDateTime: lastTableUpdateResponse.LastUpdate,
 						ReturnContent:               true,
 					}, *service, appCtx)
@@ -116,7 +116,7 @@ func startLastTableUpdateCron(physicalName string, logger *zap.Logger, v *viper.
 					}
 					return
 				}
-			case transportationAccountingCode:
+			case TransportationAccountingCode:
 				tacs, err := FetchTACRecordsByTime(appCtx, lastTableUpdateResponse.LastUpdate)
 				if err != nil {
 					logger.Error("fetching tac records by time", zap.Error(err))
@@ -126,8 +126,8 @@ func startLastTableUpdateCron(physicalName string, logger *zap.Logger, v *viper.
 				if len(tacs) > 0 {
 					// Since tacs were returned, we are in fact out of date
 					// Trigger Get TGET data and GetTable call
-					err := getTGETData(models.GetTableRequest{
-						PhysicalName:                transportationAccountingCode,
+					err := GetTGETData(models.GetTableRequest{
+						PhysicalName:                TransportationAccountingCode,
 						ContentUpdatedSinceDateTime: lastTableUpdateResponse.LastUpdate,
 						ReturnContent:               true,
 					}, *service, appCtx)

--- a/pkg/trdm/last_table_update_test.go
+++ b/pkg/trdm/last_table_update_test.go
@@ -80,14 +80,8 @@ func (m *MockHTTPClient) Do(req *http.Request) (*http.Response, error) {
 }
 
 func (suite *TRDMSuite) TestLastTableUpdate() {
-	// Setup mock creds
-	mockCreds := aws.Credentials{
-		AccessKeyID:     "mockAccessKeyID",
-		SecretAccessKey: "mockSecretAccessKey",
-		SessionToken:    "mockSessionToken",
-		Source:          "mockProvider",
-	}
-	mockProvider := &mockAssumeRoleProvider{creds: mockCreds}
+
+	mockProvider := &mockAssumeRoleProvider{creds: suite.creds}
 
 	lastUpdateResponse := models.LastTableUpdateResponse{
 		StatusCode: trdm.SuccessfulStatusCode,

--- a/pkg/trdm/last_table_update_test.go
+++ b/pkg/trdm/last_table_update_test.go
@@ -111,7 +111,7 @@ func (suite *TRDMSuite) TestLastTableUpdate() {
 	suite.viper.Set(trdm.TrdmGatewayRegionFlag, "us-gov-west-1") // TODO: Possibly switch to var that itself is pulled from viper
 	suite.viper.Set(trdm.GatewayURLFlag, "https://test.gateway.url.amazon.com")
 
-	err = trdm.LastTableUpdate(suite.viper, suite.AppContextForTest(), mockProvider, mockHTTPClient)
+	err = trdm.BeginTGETFlow(suite.viper, suite.AppContextForTest(), mockProvider, mockHTTPClient)
 	suite.NoError(err)
 }
 

--- a/pkg/trdm/last_table_update_test.go
+++ b/pkg/trdm/last_table_update_test.go
@@ -6,13 +6,20 @@ import (
 	"encoding/json"
 	"io"
 	"net/http"
+	"os"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 
 	"github.com/transcom/mymove/pkg/factory"
 	"github.com/transcom/mymove/pkg/models"
+	"github.com/transcom/mymove/pkg/parser/loa"
+	"github.com/transcom/mymove/pkg/parser/tac"
 	"github.com/transcom/mymove/pkg/trdm"
+)
+
+const (
+	gatewayURL string = "https://test.gateway.url.amazon.com"
 )
 
 func (suite *TRDMSuite) TestFetchLOARecordsByTime() {
@@ -103,10 +110,179 @@ func (suite *TRDMSuite) TestLastTableUpdate() {
 	// Set the configuration for the test
 	suite.viper.Set(trdm.TrdmIamRoleFlag, "mockRole")
 	suite.viper.Set(trdm.TrdmGatewayRegionFlag, "us-gov-west-1") // TODO: Possibly switch to var that itself is pulled from viper
-	suite.viper.Set(trdm.GatewayURLFlag, "https://test.gateway.url.amazon.com")
+	suite.viper.Set(trdm.GatewayURLFlag, gatewayURL)
 
 	err = trdm.BeginTGETFlow(suite.viper, suite.AppContextForTest(), mockProvider, mockHTTPClient)
 	suite.NoError(err)
+}
+
+// This is a rather large test. It will test lastTableUpdate triggering the need to retrieve
+// additional TGET data for both TAC and LOA tables. It will then test a full
+// successful TRDM cron flow
+func (suite *TRDMSuite) TestSuccessfulTRDMFlowTACsAndLOAs() {
+	// Factory customizations for TAC generation
+	tacCustoms := []factory.Customization{
+		{
+			Model: models.TransportationAccountingCode{
+				CreatedAt: time.Now().Add(time.Hour * 24 * 365 * -1),
+				UpdatedAt: time.Now().Add(time.Hour * 24 * 365 * -1),
+			},
+		},
+	}
+
+	// Factory customizations for LOA generation
+	loaCustoms := []factory.Customization{
+		{
+			Model: models.LineOfAccounting{
+				CreatedAt: time.Now().Add(time.Hour * 24 * 365 * -1),
+				UpdatedAt: time.Now().Add(time.Hour * 24 * 365 * -1),
+			},
+		},
+	}
+
+	// Create multiple old TACs in the DB
+	outdatedTACCodes := make([]models.TransportationAccountingCode, 4)
+	for i := range outdatedTACCodes {
+		outdatedTACCodes[i] = factory.BuildTransportationAccountingCode(suite.DB(), tacCustoms, nil)
+	}
+
+	// Create multiple old LOAs in the DB
+	outdatedLOACodes := make([]models.LineOfAccounting, 4)
+	for i := range outdatedLOACodes {
+		outdatedLOACodes[i] = factory.BuildLineOfAccounting(suite.DB(), loaCustoms, nil)
+	}
+
+	// Now pull the fixtures for testing
+	tacFile, err := os.ReadFile("../parser/tac/fixtures/Transportation Account.txt")
+	suite.NoError(err)
+	loaFile, err := os.ReadFile("../parser/loa/fixtures/Line Of Accounting.txt")
+	suite.NoError(err)
+
+	// Mock creds provider
+	mockProvider := &mockAssumeRoleProvider{creds: suite.creds}
+
+	// Mock response from LastTableUpdate
+	// We'll use the same response for both
+	lastUpdateResponse := models.LastTableUpdateResponse{
+		StatusCode: trdm.SuccessfulStatusCode,
+		DateTime:   time.Now(),
+		LastUpdate: time.Now(),
+	}
+	lastTableUpdateResponseBody, err := json.Marshal(lastUpdateResponse)
+	suite.NoError(err)
+
+	// Mock response from GetTable TAC
+	getTableResponseTAC := models.GetTableResponse{
+		RowCount:   1,
+		StatusCode: trdm.SuccessfulStatusCode,
+		DateTime:   time.Now(),
+		Attachment: tacFile, // We're going to return our fixtureTACs to be added to the DB
+	}
+
+	getTableResponseBodyTAC, err := json.Marshal(getTableResponseTAC)
+	suite.NoError(err)
+
+	// Mock response from GetTable LOA
+	getTableResponseLOA := models.GetTableResponse{
+		RowCount:   1,
+		StatusCode: trdm.SuccessfulStatusCode,
+		DateTime:   time.Now(),
+		Attachment: loaFile, // We're going to return our fixtureTACs to be added to the DB
+	}
+
+	getTableResponseBodyLOA, err := json.Marshal(getTableResponseLOA)
+	suite.NoError(err)
+
+	// Mock client and simulate the 2 different getTable responses and the reused lastTableUpdate response
+	mockHTTPClient := &MockHTTPClient{
+		DoFunc: func(req *http.Request) (*http.Response, error) {
+			switch req.URL.String() {
+			// Simulate lastTablUpdate response
+			case gatewayURL + trdm.LastTableUpdateEndpoint:
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(bytes.NewReader(lastTableUpdateResponseBody)),
+				}, nil
+				// Simulate getTable response
+			case gatewayURL + trdm.GetTableEndpoint:
+				// Parse the incoming request to determine if it's
+				// trying to get LOA or TAC data from getTable
+				var getTableRequest models.GetTableRequest
+				// getTableErr used to avoid err shadowing
+				reqBody, getTableErr := io.ReadAll(req.Body)
+				suite.NoError(getTableErr)
+				getTableErr = json.Unmarshal(reqBody, &getTableRequest)
+				suite.NoError(getTableErr)
+
+				// Give two different responses for LOA and TAC
+				switch getTableRequest.PhysicalName {
+				case trdm.LineOfAccounting:
+					return &http.Response{
+						StatusCode: http.StatusOK,
+						Body:       io.NopCloser(bytes.NewReader(getTableResponseBodyLOA)),
+					}, nil
+				case trdm.TransportationAccountingCode:
+					return &http.Response{
+						StatusCode: http.StatusOK,
+						Body:       io.NopCloser(bytes.NewReader(getTableResponseBodyTAC)),
+					}, nil
+					// If unable to determine LOA or TAC for getTable then error
+				default:
+					return &http.Response{
+						StatusCode: http.StatusBadRequest,
+						Body:       nil,
+					}, nil
+				}
+
+			default:
+				return &http.Response{
+					StatusCode: http.StatusBadRequest,
+					Body:       nil,
+				}, nil
+			}
+		},
+	}
+
+	// Set the configuration for the test
+	suite.viper.Set(trdm.TrdmIamRoleFlag, "mockRole")
+	suite.viper.Set(trdm.TrdmGatewayRegionFlag, "us-gov-west-1") // TODO: Possibly switch to var that itself is pulled from viper
+	suite.viper.Set(trdm.GatewayURLFlag, gatewayURL)
+
+	// Now our flow will run and it will detect we have outdated TACs and LOAs.
+	// When it finds these outdated TACs/LOAs it should trigger the `getTable` part of the flow
+	// and attempt to store the new data found
+	err = trdm.BeginTGETFlow(suite.viper, suite.AppContextForTest(), mockProvider, mockHTTPClient)
+	suite.NoError(err)
+
+	// Pull the TAC and LOA entries, they should have both the old and new ones
+	var allTACs []models.TransportationAccountingCode
+	err = suite.DB().All(&allTACs)
+	suite.NoError(err)
+	var allLOAs []models.LineOfAccounting
+	err = suite.DB().All(&allLOAs)
+	suite.NoError(err)
+
+	/*
+	**** Parse our fixture files ****
+	 */
+
+	// TAC
+	reader := bytes.NewReader(tacFile)
+	expectedTACCodes, err := tac.Parse(reader)
+	suite.NoError(err)
+	// Consolidate duplicates
+	expectedTACCodes = tac.ConsolidateDuplicateTACsDesiredFromTRDM(expectedTACCodes)
+
+	// LOA
+	reader = bytes.NewReader(loaFile)
+	expectedLOACodes, err := loa.Parse(reader)
+	suite.NoError(err)
+
+	// Now lets see if our new TACs and LOAs were stored
+	suite.Equal(len(allTACs), len(outdatedTACCodes)+len(expectedTACCodes))
+	// Also include the TAC length in the LOA calculation.
+	// On factory build TAC, a LOA is generated alongside it.
+	suite.Equal(len(allLOAs), len(outdatedLOACodes)+len(expectedLOACodes)+len(outdatedTACCodes))
 }
 
 func (suite *TRDMSuite) TestFetchAllTACRecords() {

--- a/pkg/trdm/trdm.go
+++ b/pkg/trdm/trdm.go
@@ -1,0 +1,38 @@
+package trdm
+
+import (
+	"github.com/spf13/viper"
+	"go.uber.org/zap"
+
+	"github.com/transcom/mymove/pkg/appcontext"
+	"github.com/transcom/mymove/pkg/cli"
+	"github.com/transcom/mymove/pkg/logging"
+)
+
+func BeginTGETFlow(v *viper.Viper, appCtx appcontext.AppContext, provider AssumeRoleProvider, client HTTPClient) error {
+	dbEnv := v.GetString(cli.DbEnvFlag)
+	logger, _, err := logging.Config(logging.WithEnvironment(dbEnv), logging.WithLoggingLevel(v.GetString(cli.LoggingLevelFlag)))
+	if err != nil {
+		return err
+	}
+	zap.ReplaceGlobals(logger)
+
+	// TODO: Turn back on when implementing getTable
+	// DB connection
+	// dbConnection, err := cli.InitDatabase(v, logger)
+	// if err != nil {
+	// 	return err
+	// }
+
+	// These are likely to never err. Remember, errors are logged not returned in cron
+	getLastTableUpdateTACErr := startLastTableUpdateCron(transportationAccountingCode, logger, v, appCtx, provider, client)
+	getLastTableUpdateLOAErr := startLastTableUpdateCron(lineOfAccounting, logger, v, appCtx, provider, client)
+	if getLastTableUpdateLOAErr != nil {
+		return getLastTableUpdateLOAErr
+	}
+	if getLastTableUpdateTACErr != nil {
+		return getLastTableUpdateTACErr
+	}
+
+	return nil
+}

--- a/pkg/trdm/trdm.go
+++ b/pkg/trdm/trdm.go
@@ -17,16 +17,9 @@ func BeginTGETFlow(v *viper.Viper, appCtx appcontext.AppContext, provider Assume
 	}
 	zap.ReplaceGlobals(logger)
 
-	// TODO: Turn back on when implementing getTable
-	// DB connection
-	// dbConnection, err := cli.InitDatabase(v, logger)
-	// if err != nil {
-	// 	return err
-	// }
-
 	// These are likely to never err. Remember, errors are logged not returned in cron
-	getLastTableUpdateTACErr := startLastTableUpdateCron(transportationAccountingCode, logger, v, appCtx, provider, client)
-	getLastTableUpdateLOAErr := startLastTableUpdateCron(lineOfAccounting, logger, v, appCtx, provider, client)
+	getLastTableUpdateTACErr := startLastTableUpdateCron(TransportationAccountingCode, logger, v, appCtx, provider, client)
+	getLastTableUpdateLOAErr := startLastTableUpdateCron(LineOfAccounting, logger, v, appCtx, provider, client)
 	if getLastTableUpdateLOAErr != nil {
 		return getLastTableUpdateLOAErr
 	}

--- a/pkg/trdm/trdm_test.go
+++ b/pkg/trdm/trdm_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/suite"
@@ -19,6 +20,7 @@ type TRDMSuite struct {
 	*testingsuite.PopTestSuite
 	viper  *viper.Viper
 	logger *zap.Logger
+	creds  aws.Credentials
 }
 
 type initFlags func(f *pflag.FlagSet)
@@ -58,10 +60,19 @@ func TestTRDMSuite(t *testing.T) {
 
 	logger := zaptest.NewLogger(t)
 
+	// Setup mock creds
+	mockCreds := aws.Credentials{
+		AccessKeyID:     "mockAccessKeyID",
+		SecretAccessKey: "mockSecretAccessKey",
+		SessionToken:    "mockSessionToken",
+		Source:          "mockProvider",
+	}
+
 	hs := &TRDMSuite{
 		PopTestSuite: testingsuite.NewPopTestSuite(testingsuite.CurrentPackage(), testingsuite.WithPerTestTransaction()),
 		viper:        v,
 		logger:       logger,
+		creds:        mockCreds,
 	}
 	suite.Run(t, hs)
 	hs.PopTestSuite.TearDown()


### PR DESCRIPTION
[Ticket](https://www13.v1host.com/USTRANSCOM38/story.mvc/Summary?oidToken=Story%3a857401)

# Discussion
Please see the testing section as I have pointed out an area for conversation within this PR.

# Changes
* Refactored GetTable section of the code to form new REST calls based on the `GatewayService`.
* Changed TRDM package file structure and organization to try and improve readability. Such as moving the flow start to a `trdm.go` file and instead of the function being called `LastTableUpdate` it's now called `BeginTGETFlow` that creates the cron job which calls lastTableUpdate.
* Made some minor touch ups to lastTableUpdate such as logger locations, variables, and the calling and handling of getTable.

# Review
Please see documentation [here](https://aws.github.io/aws-sdk-go-v2/docs/) and [here](https://pkg.go.dev/github.com/aws/aws-sdk-go-v2) to provide better feedback.

# Testing
The code is now at a point of testing - though interestingly I've encountered a little hiccup when attempting to do so manually. In theory, as long as the server boots up with staging credentials it should attempt to call `BeginTGETFlow`. As of right now, I'm encountering a little issue with the AWS credentials provided, this may be due to the server automatically using dev creds and not being able to get overwritten with stg creds.  It is failing on my end due to having an empty `'roleArn'`. I would encourage this as a topic of discussion within the PR.

If we can't test it properly within local, we may push it up to staging for it to just fail there. What should happen is on the local side you should be able to provide staging credentials (Such as using `aws-vault`), turn on the server, and it should be able to create a proper provider, form a good request, sign that request, and then attempt to send it to the gateway. However, right now it's failing due to creds before even sending it off.

**NOTE**
It **_should_** fail. But, we should get denied at gateway entry not on credential signage. See security reasons why it would fail locally [here](https://dp3.atlassian.net/wiki/spaces/MT/pages/2275573761/TRDM+Soap+Proxy+API+Gateway+Lambda+Function).

- To wrap your server in the staging credentials run this command: `aws-vault exec ${AWS_PROFILE} -- make server_run`

# Steps for Reviewers

- [ ] Ensure the server runs normally during local development
- [ ] Ensure the server can turn on normally when wrapped in staging credentials, and that it can sign its request and send off to the API gateway. It should receive a failing response in return, but it should still be able to send off properly.