### PR TITLE
B-17678 Update DocumentViewer to return to zeroth index when files change

### DIFF
--- a/src/components/DocumentViewer/DocumentViewer.jsx
+++ b/src/components/DocumentViewer/DocumentViewer.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { bool } from 'prop-types';
 import { Button } from '@trussworks/react-uswds';
 import moment from 'moment';
@@ -24,8 +24,11 @@ const DocumentViewer = ({ files, allowDownload }) => {
   const [menuIsOpen, setMenuOpen] = useState(false);
 
   const sortedFiles = files.sort((a, b) => moment(b.createdAt) - moment(a.createdAt));
-
   const selectedFile = sortedFiles[parseInt(selectedFileIndex, 10)];
+
+  useEffect(() => {
+    selectFile(0);
+  }, [files]);
 
   if (!selectedFile) {
     return <h2>File Not Found</h2>;


### PR DESCRIPTION
## [Agility ticket](https://www13.v1host.com/USTRANSCOM38/story.mvc/Summary?oidToken=Story%3a847106)

## Summary

Currently when office users are reviewing documents, they run occasionally run into a "File not found" error when documents have multiple receipts to be viewed. This is a result of us not "resetting" the DocumentViewer component to a default state displaying the first document when we advance pages. I added a useEffect hook to monitor the files prop for changes, and to set the state of the selectedFileIndex back to 0.

I considered using an approach that didn't utilize useEffect, but felt the use of useEffect was more semantic; lets watch the files for changes, and when they change, lets return to first element. I also considered updating the setter for the selectedFileIndex to follow useState naming conventions, but not sure if that is a hard and fast rule for us.

## Verification Steps for the Author

These are to be checked by the author.

- [x] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
- [x] Have the Agility acceptance criteria been met for this change?

## Verification Steps for Reviewers

These are to be checked by a reviewer.

- [ ] Has the branch been pulled in and checked out?
- [ ] Have the BL acceptance criteria been met for this change?
- [ ] Was the CircleCI build successful?
- [ ] Has the code been reviewed from a standards and best practices point of view?

### How to test

1. Access the office application
2. Login as a services counselor and view a move in the document review stage
3. Click "Review Documents"
4. Click the document menu in the upper left corner of the document review screen and select a different document; if the move you selected does not have multiple documents available, try a different move
5. Accept or reject the review, and continue to the next step
6. Note that the "File Not Found" screen does not appear
