### PR TITLE
B-17809 Ability To Submit Empty Pro Gear

### DIFF
--- a/src/components/Office/ShipmentForm/ShipmentForm.jsx
+++ b/src/components/Office/ShipmentForm/ShipmentForm.jsx
@@ -243,6 +243,19 @@ const ShipmentForm = (props) => {
     //* PPM Shipment *//
     if (isPPM) {
       const ppmShipmentBody = formatPpmShipmentForAPI(formValues);
+
+      // Allow blank values to be entered into Pro Gear input fields
+      if (
+        ppmShipmentBody.ppmShipment.hasProGear &&
+        ppmShipmentBody.ppmShipment.spouseProGearWeight >= 0 &&
+        ppmShipmentBody.ppmShipment.proGearWeight === undefined
+      ) {
+        ppmShipmentBody.ppmShipment.proGearWeight = 0;
+      }
+      if (ppmShipmentBody.ppmShipment.hasProGear && ppmShipmentBody.ppmShipment.spouseProGearWeight === undefined) {
+        ppmShipmentBody.ppmShipment.spouseProGearWeight = 0;
+      }
+
       // Add a PPM shipment
       if (isCreatePage) {
         const body = { ...ppmShipmentBody, moveTaskOrderID };
@@ -470,6 +483,7 @@ const ShipmentForm = (props) => {
     >
       {({ values, isValid, isSubmitting, setValues, handleSubmit, errors }) => {
         const { hasDeliveryAddress, hasSecondaryPickup, hasSecondaryDelivery } = values;
+
         const handleUseCurrentResidenceChange = (e) => {
           const { checked } = e.target;
           if (checked) {


### PR DESCRIPTION
## [Agility ticket](https://www13.v1host.com/USTRANSCOM38/TeamRoom.mvc/Show/848240)

## Summary

When editing a ppm shipment either through the office api or the prime api, we can’t blank out the "Pro Gear Weight" and "Spouse Pro Gear Weight" fields.

### How to test

1. Access officelocal
2. Login as a TOO
3. Select a PPM
4. Click edit shipment
5. Clear spouse pro gear input field
6. Save and continue
7. '0' should be saved as spouse pro gear amount

### Frontend

- [ ] There are no aXe warnings for UI.
- [ ] This works in [Supported Browsers and their phone views](https://transcom.github.io/mymove-docs/docs/adrs/Browser-Support/#minimum-browser-requirements) (Chrome, Firefox, Edge).
- [ ] There are no new console errors in the browser devtools.
- [ ] There are no new console errors in the test output.
- [ ] If this PR adds a new component to Storybook, it ensures the component is fully responsive, OR if it is intentionally not, a wrapping div using the `officeApp` class or custom `min-width` styling is used to hide any states the would not be visible to the user.
- [ ] This change meets the standards for [Section 508 compliance](https://www.ssa.gov/accessibility/andi/help/install.html).


