### PR TITLE
B-17615 Change isWeightTicket to optional

### DIFF
--- a/migrations/app/schema/20231109142950_add-weight-ticket-boolean-to-uploads-table.up.sql
+++ b/migrations/app/schema/20231109142950_add-weight-ticket-boolean-to-uploads-table.up.sql
@@ -1,7 +1,7 @@
 -- adding column to uploads table so we can determine if an upload is a weight ticket or not
 -- this will be a boolean data type
 ALTER TABLE proof_of_service_docs
-ADD COLUMN is_weight_ticket boolean DEFAULT false NOT NULL;
+ADD COLUMN is_weight_ticket boolean DEFAULT false;
 
 -- Column comments
 COMMENT ON COLUMN proof_of_service_docs.is_weight_ticket IS 'Determines if the proof of service doc is a weight ticket or not, this will be used in the UI when reviewing the requests.';

--- a/pkg/gen/primeapi/embedded_spec.go
+++ b/pkg/gen/primeapi/embedded_spec.go
@@ -1259,7 +1259,7 @@ func init() {
     },
     "/payment-requests/{paymentRequestID}/uploads": {
       "post": {
-        "description": "### Functionality\nThis endpoint **uploads** a Proof of Service document for a PaymentRequest.\n\nThe PaymentRequest should already exist.\n\nRequired field of **isWeightTicket** indicates if the document is a weight ticket or not.\nThis will be used for partial and full deliveries and makes it easier for the Transportation Invoicing Officers to locate and review service item documents.\n\nThe formdata in the body of the POST request that is sent should look like this if it IS a weight ticket being attached to an existing payment request:\n  ` + "`" + `` + "`" + `` + "`" + `json\n  {\n    \"file\": \"filePath\",\n    \"isWeightTicket\": true\n  }\n  ` + "`" + `` + "`" + `` + "`" + `\n\n  If the proof of service doc is NOT a weight ticket, it will look like this:\n  ` + "`" + `` + "`" + `` + "`" + `json\n  {\n    \"file\": \"filePath\",\n    \"isWeightTicket\": false\n  }\n  ` + "`" + `` + "`" + `` + "`" + `\n\nPaymentRequests are created with the [createPaymentRequest](#operation/createPaymentRequest) endpoint.\n",
+        "description": "### Functionality\nThis endpoint **uploads** a Proof of Service document for a PaymentRequest.\n\nThe PaymentRequest should already exist.\n\nOptional field of **isWeightTicket** indicates if the document is a weight ticket or not.\nThis will be used for partial and full deliveries and makes it easier for the Transportation Invoicing Officers to locate and review service item documents.\n\nThe formdata in the body of the POST request that is sent should look like this if it IS a weight ticket being attached to an existing payment request:\n  ` + "`" + `` + "`" + `` + "`" + `json\n  {\n    \"file\": \"filePath\",\n    \"isWeightTicket\": true\n  }\n  ` + "`" + `` + "`" + `` + "`" + `\n\n  If the proof of service doc is NOT a weight ticket, it will look like this - or you can leave it empty:\n  ` + "`" + `` + "`" + `` + "`" + `json\n  {\n    \"file\": \"filePath\",\n    \"isWeightTicket\": false\n  }\n  ` + "`" + `` + "`" + `` + "`" + `\n  ` + "`" + `` + "`" + `` + "`" + `json\n  {\n    \"file\": \"filePath\",\n  }\n  ` + "`" + `` + "`" + `` + "`" + `\n\nPaymentRequests are created with the [createPaymentRequest](#operation/createPaymentRequest) endpoint.\n",
         "consumes": [
           "multipart/form-data"
         ],
@@ -1290,8 +1290,7 @@ func init() {
             "type": "boolean",
             "description": "Indicates whether the file is a weight ticket.",
             "name": "isWeightTicket",
-            "in": "formData",
-            "required": true
+            "in": "formData"
           }
         ],
         "responses": {
@@ -6216,7 +6215,7 @@ func init() {
     },
     "/payment-requests/{paymentRequestID}/uploads": {
       "post": {
-        "description": "### Functionality\nThis endpoint **uploads** a Proof of Service document for a PaymentRequest.\n\nThe PaymentRequest should already exist.\n\nRequired field of **isWeightTicket** indicates if the document is a weight ticket or not.\nThis will be used for partial and full deliveries and makes it easier for the Transportation Invoicing Officers to locate and review service item documents.\n\nThe formdata in the body of the POST request that is sent should look like this if it IS a weight ticket being attached to an existing payment request:\n  ` + "`" + `` + "`" + `` + "`" + `json\n  {\n    \"file\": \"filePath\",\n    \"isWeightTicket\": true\n  }\n  ` + "`" + `` + "`" + `` + "`" + `\n\n  If the proof of service doc is NOT a weight ticket, it will look like this:\n  ` + "`" + `` + "`" + `` + "`" + `json\n  {\n    \"file\": \"filePath\",\n    \"isWeightTicket\": false\n  }\n  ` + "`" + `` + "`" + `` + "`" + `\n\nPaymentRequests are created with the [createPaymentRequest](#operation/createPaymentRequest) endpoint.\n",
+        "description": "### Functionality\nThis endpoint **uploads** a Proof of Service document for a PaymentRequest.\n\nThe PaymentRequest should already exist.\n\nOptional field of **isWeightTicket** indicates if the document is a weight ticket or not.\nThis will be used for partial and full deliveries and makes it easier for the Transportation Invoicing Officers to locate and review service item documents.\n\nThe formdata in the body of the POST request that is sent should look like this if it IS a weight ticket being attached to an existing payment request:\n  ` + "`" + `` + "`" + `` + "`" + `json\n  {\n    \"file\": \"filePath\",\n    \"isWeightTicket\": true\n  }\n  ` + "`" + `` + "`" + `` + "`" + `\n\n  If the proof of service doc is NOT a weight ticket, it will look like this - or you can leave it empty:\n  ` + "`" + `` + "`" + `` + "`" + `json\n  {\n    \"file\": \"filePath\",\n    \"isWeightTicket\": false\n  }\n  ` + "`" + `` + "`" + `` + "`" + `\n  ` + "`" + `` + "`" + `` + "`" + `json\n  {\n    \"file\": \"filePath\",\n  }\n  ` + "`" + `` + "`" + `` + "`" + `\n\nPaymentRequests are created with the [createPaymentRequest](#operation/createPaymentRequest) endpoint.\n",
         "consumes": [
           "multipart/form-data"
         ],
@@ -6247,8 +6246,7 @@ func init() {
             "type": "boolean",
             "description": "Indicates whether the file is a weight ticket.",
             "name": "isWeightTicket",
-            "in": "formData",
-            "required": true
+            "in": "formData"
           }
         ],
         "responses": {

--- a/pkg/gen/primeapi/primeoperations/payment_request/create_upload.go
+++ b/pkg/gen/primeapi/primeoperations/payment_request/create_upload.go
@@ -39,7 +39,7 @@ This endpoint **uploads** a Proof of Service document for a PaymentRequest.
 
 The PaymentRequest should already exist.
 
-Required field of **isWeightTicket** indicates if the document is a weight ticket or not.
+Optional field of **isWeightTicket** indicates if the document is a weight ticket or not.
 This will be used for partial and full deliveries and makes it easier for the Transportation Invoicing Officers to locate and review service item documents.
 
 The formdata in the body of the POST request that is sent should look like this if it IS a weight ticket being attached to an existing payment request:
@@ -51,11 +51,16 @@ The formdata in the body of the POST request that is sent should look like this 
 	}
 	```
 
-	If the proof of service doc is NOT a weight ticket, it will look like this:
+	If the proof of service doc is NOT a weight ticket, it will look like this - or you can leave it empty:
 	```json
 	{
 	  "file": "filePath",
 	  "isWeightTicket": false
+	}
+	```
+	```json
+	{
+	  "file": "filePath",
 	}
 	```
 

--- a/pkg/gen/primeapi/primeoperations/payment_request/create_upload_parameters.go
+++ b/pkg/gen/primeapi/primeoperations/payment_request/create_upload_parameters.go
@@ -15,7 +15,6 @@ import (
 	"github.com/go-openapi/runtime/middleware"
 	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
-	"github.com/go-openapi/validate"
 )
 
 // CreateUploadMaxParseMemory sets the maximum size in bytes for
@@ -48,10 +47,9 @@ type CreateUploadParams struct {
 	*/
 	File io.ReadCloser
 	/*Indicates whether the file is a weight ticket.
-	  Required: true
 	  In: formData
 	*/
-	IsWeightTicket bool
+	IsWeightTicket *bool
 	/*UUID of payment request to use.
 	  Required: true
 	  In: path
@@ -111,25 +109,22 @@ func (o *CreateUploadParams) bindFile(file multipart.File, header *multipart.Fil
 
 // bindIsWeightTicket binds and validates parameter IsWeightTicket from formData.
 func (o *CreateUploadParams) bindIsWeightTicket(rawData []string, hasKey bool, formats strfmt.Registry) error {
-	if !hasKey {
-		return errors.Required("isWeightTicket", "formData", rawData)
-	}
 	var raw string
 	if len(rawData) > 0 {
 		raw = rawData[len(rawData)-1]
 	}
 
-	// Required: true
+	// Required: false
 
-	if err := validate.RequiredString("isWeightTicket", "formData", raw); err != nil {
-		return err
+	if raw == "" { // empty values pass all other validations
+		return nil
 	}
 
 	value, err := swag.ConvertBool(raw)
 	if err != nil {
 		return errors.InvalidType("isWeightTicket", "formData", "bool", raw)
 	}
-	o.IsWeightTicket = value
+	o.IsWeightTicket = &value
 
 	return nil
 }

--- a/pkg/gen/primeclient/payment_request/create_upload_parameters.go
+++ b/pkg/gen/primeclient/payment_request/create_upload_parameters.go
@@ -72,7 +72,7 @@ type CreateUploadParams struct {
 
 	   Indicates whether the file is a weight ticket.
 	*/
-	IsWeightTicket bool
+	IsWeightTicket *bool
 
 	/* PaymentRequestID.
 
@@ -145,13 +145,13 @@ func (o *CreateUploadParams) SetFile(file runtime.NamedReadCloser) {
 }
 
 // WithIsWeightTicket adds the isWeightTicket to the create upload params
-func (o *CreateUploadParams) WithIsWeightTicket(isWeightTicket bool) *CreateUploadParams {
+func (o *CreateUploadParams) WithIsWeightTicket(isWeightTicket *bool) *CreateUploadParams {
 	o.SetIsWeightTicket(isWeightTicket)
 	return o
 }
 
 // SetIsWeightTicket adds the isWeightTicket to the create upload params
-func (o *CreateUploadParams) SetIsWeightTicket(isWeightTicket bool) {
+func (o *CreateUploadParams) SetIsWeightTicket(isWeightTicket *bool) {
 	o.IsWeightTicket = isWeightTicket
 }
 
@@ -178,12 +178,18 @@ func (o *CreateUploadParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.
 		return err
 	}
 
-	// form param isWeightTicket
-	frIsWeightTicket := o.IsWeightTicket
-	fIsWeightTicket := swag.FormatBool(frIsWeightTicket)
-	if fIsWeightTicket != "" {
-		if err := r.SetFormParam("isWeightTicket", fIsWeightTicket); err != nil {
-			return err
+	if o.IsWeightTicket != nil {
+
+		// form param isWeightTicket
+		var frIsWeightTicket bool
+		if o.IsWeightTicket != nil {
+			frIsWeightTicket = *o.IsWeightTicket
+		}
+		fIsWeightTicket := swag.FormatBool(frIsWeightTicket)
+		if fIsWeightTicket != "" {
+			if err := r.SetFormParam("isWeightTicket", fIsWeightTicket); err != nil {
+				return err
+			}
 		}
 	}
 

--- a/pkg/gen/primeclient/payment_request/payment_request_client.go
+++ b/pkg/gen/primeclient/payment_request/payment_request_client.go
@@ -105,7 +105,7 @@ This endpoint **uploads** a Proof of Service document for a PaymentRequest.
 
 The PaymentRequest should already exist.
 
-Required field of **isWeightTicket** indicates if the document is a weight ticket or not.
+Optional field of **isWeightTicket** indicates if the document is a weight ticket or not.
 This will be used for partial and full deliveries and makes it easier for the Transportation Invoicing Officers to locate and review service item documents.
 
 The formdata in the body of the POST request that is sent should look like this if it IS a weight ticket being attached to an existing payment request:
@@ -117,11 +117,16 @@ The formdata in the body of the POST request that is sent should look like this 
 	}
 	```
 
-	If the proof of service doc is NOT a weight ticket, it will look like this:
+	If the proof of service doc is NOT a weight ticket, it will look like this - or you can leave it empty:
 	```json
 	{
 	  "file": "filePath",
 	  "isWeightTicket": false
+	}
+	```
+	```json
+	{
+	  "file": "filePath",
 	}
 	```
 

--- a/pkg/handlers/primeapi/upload.go
+++ b/pkg/handlers/primeapi/upload.go
@@ -69,8 +69,14 @@ func (h CreateUploadHandler) Handle(params paymentrequestop.CreateUploadParams) 
 				return paymentrequestop.NewCreateUploadInternalServerError(), err
 			}
 
-			// the prime is required to provide if a doc is a weight ticket or not
-			isWeightTicketParam := params.IsWeightTicket
+			// the prime can provide optional param of isWeightTicket
+			// if it not provided, we will assume false
+			var isWeightTicketParam bool
+			if params.IsWeightTicket != nil {
+				isWeightTicketParam = *params.IsWeightTicket
+			} else {
+				isWeightTicketParam = false
+			}
 
 			createdUpload, err := h.PaymentRequestUploadCreator.CreateUpload(appCtx, file.Data, paymentRequestID, contractorID, file.Header.Filename, isWeightTicketParam)
 			if err != nil {

--- a/pkg/handlers/primeapi/upload_test.go
+++ b/pkg/handlers/primeapi/upload_test.go
@@ -43,7 +43,7 @@ func (suite *HandlerSuite) TestCreateUploadHandler() {
 			HTTPRequest:      req,
 			File:             file,
 			PaymentRequestID: paymentRequest.ID.String(),
-			IsWeightTicket:   isWeightTicketParam,
+			IsWeightTicket:   &isWeightTicketParam,
 		}
 
 		// Validate incoming payload: no body to validate

--- a/swagger-def/prime.yaml
+++ b/swagger-def/prime.yaml
@@ -1143,7 +1143,7 @@ paths:
 
         The PaymentRequest should already exist.
 
-        Required field of **isWeightTicket** indicates if the document is a weight ticket or not.
+        Optional field of **isWeightTicket** indicates if the document is a weight ticket or not.
         This will be used for partial and full deliveries and makes it easier for the Transportation Invoicing Officers to locate and review service item documents.
 
         The formdata in the body of the POST request that is sent should look like this if it IS a weight ticket being attached to an existing payment request:
@@ -1154,11 +1154,16 @@ paths:
           }
           ```
 
-          If the proof of service doc is NOT a weight ticket, it will look like this:
+          If the proof of service doc is NOT a weight ticket, it will look like this - or you can leave it empty:
           ```json
           {
             "file": "filePath",
             "isWeightTicket": false
+          }
+          ```
+          ```json
+          {
+            "file": "filePath",
           }
           ```
 
@@ -1186,7 +1191,6 @@ paths:
           name: isWeightTicket
           type: boolean
           description: Indicates whether the file is a weight ticket.
-          required: true
       responses:
         '201':
           description: Successfully created upload of digital file.

--- a/swagger/prime.yaml
+++ b/swagger/prime.yaml
@@ -1352,7 +1352,7 @@ paths:
         The PaymentRequest should already exist.
 
 
-        Required field of **isWeightTicket** indicates if the document is a
+        Optional field of **isWeightTicket** indicates if the document is a
         weight ticket or not.
 
         This will be used for partial and full deliveries and makes it easier
@@ -1370,11 +1370,16 @@ paths:
           }
           ```
 
-          If the proof of service doc is NOT a weight ticket, it will look like this:
+          If the proof of service doc is NOT a weight ticket, it will look like this - or you can leave it empty:
           ```json
           {
             "file": "filePath",
             "isWeightTicket": false
+          }
+          ```
+          ```json
+          {
+            "file": "filePath",
           }
           ```
 
@@ -1402,7 +1407,6 @@ paths:
           name: isWeightTicket
           type: boolean
           description: Indicates whether the file is a weight ticket.
-          required: true
       responses:
         '201':
           description: Successfully created upload of digital file.


### PR DESCRIPTION
## [Agility ticket](https://www13.v1host.com/USTRANSCOM38/story.mvc/Summary?oidToken=Story%3A844121&RoomContext=TeamRoom%3A808731&concept=TeamRoom)

## Summary

You can check out the previous PR [HERE](https://github.com/transcom/mymove/pull/11547) - the functionality remains the same but the parameter `isWeightTicket` is now optional. If it is not provided in the `POST` request to `createUpload` endpoint as the Prime, then it is assumed to be false.
