### PR TITLE
Increasing TRDM timeout

### DIFF
--- a/cmd/milmove/serve.go
+++ b/cmd/milmove/serve.go
@@ -838,7 +838,7 @@ func serveFunction(cmd *cobra.Command, args []string) error {
 
 		// Setup client
 		tr := &http.Transport{TLSClientConfig: tlsConfig}
-		httpClient := &http.Client{Transport: tr, Timeout: time.Duration(30) * time.Second}
+		httpClient := &http.Client{Transport: tr, Timeout: time.Duration(10) * time.Minute}
 
 		// Begin the TRDM cron job now (Referred to as the TGET flow as well). This will
 		// send a REST call to the lastTableUpdate endpoint within the trdm soap proxy api gateway,


### PR DESCRIPTION
Increasing HTTP client timeout for TRDM. This will allow the gateway and lambda function to properly parse and return before the client gives out.