### PR TITLE
reverting trdm tls to default

### DIFF
--- a/cmd/milmove/serve.go
+++ b/cmd/milmove/serve.go
@@ -837,7 +837,7 @@ func serveFunction(cmd *cobra.Command, args []string) error {
 		stsProvider := stscreds.NewAssumeRoleProvider(stsClient, trdmIamRole)
 
 		// Setup client
-		tr := &http.Transport{TLSClientConfig: tlsConfig}
+		tr := &http.Transport{}
 		httpClient := &http.Client{Transport: tr, Timeout: time.Duration(10) * time.Minute}
 
 		// Begin the TRDM cron job now (Referred to as the TGET flow as well). This will


### PR DESCRIPTION
Reverting TLS config to default. I suspect that using the MilMove TLS configuration is forcing DoD CA expectation while we are looking to interface with Amazon, not DoD.