### PR TITLE
B-17900: Add weight billed field to additional serviceitems

### DIFF
--- a/src/components/PrimeUI/CreatePaymentRequestForm/CreatePaymentRequestForm.jsx
+++ b/src/components/PrimeUI/CreatePaymentRequestForm/CreatePaymentRequestForm.jsx
@@ -128,7 +128,12 @@ const CreatePaymentRequestForm = ({
                               />
                             </>
                           )}
-                          {(mtoServiceItem.reServiceCode === 'DOFSIT' ||
+                          {(mtoServiceItem.reServiceCode === 'DLH' ||
+                            mtoServiceItem.reServiceCode === 'DSH' ||
+                            mtoServiceItem.reServiceCode === 'FSC' ||
+                            mtoServiceItem.reServiceCode === 'DUPK' ||
+                            mtoServiceItem.reServiceCode === 'DNPK' ||
+                            mtoServiceItem.reServiceCode === 'DOFSIT' ||
                             mtoServiceItem.reServiceCode === 'DOPSIT' ||
                             mtoServiceItem.reServiceCode === 'DOSHUT' ||
                             mtoServiceItem.reServiceCode === 'DDFSIT' ||

--- a/src/components/PrimeUI/CreatePaymentRequestForm/CreatePaymentRequestForm.test.jsx
+++ b/src/components/PrimeUI/CreatePaymentRequestForm/CreatePaymentRequestForm.test.jsx
@@ -180,7 +180,7 @@ describe('CreatePaymentRequestForm', () => {
     );
 
     expect(
-      screen.getByRole('textbox', { name: 'Weight Billed (if different from shipment weight)' }),
-    ).toBeInTheDocument();
+      screen.getAllByRole('textbox', { name: 'Weight Billed (if different from shipment weight)' }).length,
+    ).toBeGreaterThan(0);
   });
 });


### PR DESCRIPTION
## [Agility ticket](B-17900)

## Summary

In this story I just added the weight billed field to additional serviceItems. Those are DLH, DSH, FSC, DUPK and DNPK. 

### How to test

1. Access the prime simulator
2. Create a payment request
3. Add a value to the billed weight field on the serviceItems
4. Submit Payment Request


## Screenshots
![image](https://github.com/transcom/mymove/assets/136514590/d9354680-e128-44cd-b14f-4394f0febbdf)
![image](https://github.com/transcom/mymove/assets/136514590/aa347371-e964-4f8f-b875-92870f936354)
