### PR TITLE
B17814 Update orders table to reference renamed duty locations before deleting old base names from duty_locations table

### DIFF
--- a/migrations/app/schema/20231128203410_update_addresses_and_duty_locations_for_base_renames.up.sql
+++ b/migrations/app/schema/20231128203410_update_addresses_and_duty_locations_for_base_renames.up.sql
@@ -11,6 +11,24 @@ UPDATE addresses SET city = 'Fort Eisenhower' WHERE city = 'Fort Gordon' AND pos
 UPDATE duty_locations SET name = 'Fort Barfoot' WHERE name = 'Blackstone, VA 23824';
 
 -- postal codes 31905 and 31995 should have name of fort moore, ga rather than fort walker, ga
+-- update the orders table to use the correct duty_locations for origin_duty_location_id and new_duty_location_id
+UPDATE orders
+SET origin_duty_location_id = (SELECT id FROM duty_locations WHERE name = 'Fort Moore, GA 31905')
+WHERE origin_duty_location_id = (SELECT id FROM duty_locations WHERE name = 'Fort Walker, GA 31905');
+
+UPDATE orders
+SET new_duty_location_id = (SELECT id FROM duty_locations WHERE name = 'Fort Moore, GA 31905')
+WHERE new_duty_location_id = (SELECT id FROM duty_locations WHERE name = 'Fort Walker, GA 31905');
+
+UPDATE orders
+SET origin_duty_location_id = (SELECT id FROM duty_locations WHERE name = 'Fort Moore, GA 31995')
+WHERE origin_duty_location_id = (SELECT id FROM duty_locations WHERE name = 'Fort Walker, GA 31995');
+
+UPDATE orders
+SET new_duty_location_id = (SELECT id FROM duty_locations WHERE name = 'Fort Moore, GA 31995')
+WHERE new_duty_location_id = (SELECT id FROM duty_locations WHERE name = 'Fort Walker, GA 31995');
+
+-- postal codes 31905 and 31995 should have name of fort moore, ga rather than fort walker, ga
 -- a valid entry already exists for Fort Moore, GA 31905 so delete Fort Walker, GA 31905
 -- a valid entry already exists for Fort Moore, GA 31995 so delete Fort Walker, GA 31995
 DELETE FROM duty_locations WHERE name = 'Fort Walker, GA 31905';


### PR DESCRIPTION
New: When trying to delete an incorrect location from the duty_locations table, staging ran into issues because some entries in the orders table referenced the duty_location I wanted to delete. Updating the duty_locations referenced to be the correct renamed base values instead of the incorrect old base name values, then deleting the incorrect values from duty_locations table.


Removing references to Fort Benning and removing incorrect link between Fort Walker and Fort Benning

## [Agility ticket](https://www13.v1host.com/USTRANSCOM38/TeamRoom.mvc/Show/808731)

## Summary

PR description copied over from previous PR. This PR reverts changes made to an older migration file and instead applies them to a new migration file which will make the changes correctly apply to staging.


This PR addresses issues I-12142 and I-12141, written up against B 17814.

Fort Benning was renamed to Fort Moore. Fort A.P. Hill was renamed to Fort Walker. There was a link in the database between Fort Benning and Fort Walker, which is incorrect. The zip codes of 31905 and 31995 should be associated with Fort Moore, GA, instead of Fort Walker, GA.

This also contains a rename of Blackstone, VA in the duty locations table to Fort Barfoot so that when users type in Fort Barfoot, they can see Fort Barfoot in the search results with the address of Blackstone, VA populated under the duty location bar.

## Verification Steps for the Author

- [x] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
- [x] Have the Agility acceptance criteria been met for this change?

## Verification Steps for Reviewers

These are to be checked by a reviewer.

- [ ] Has the branch been pulled in and checked out?
- [ ] Have the BL acceptance criteria been met for this change?
- [ ] Was the CircleCI build successful?
- [ ] Has the code been reviewed from a standards and best practices point of view?

### Setup to Run the Code

- [Instructions for starting storybook](https://transcom.github.io/mymove-docs/docs/frontend/setup/storybook)
- [Instructions for starting the MilMove application](https://transcom.github.io/mymove-docs/docs/getting-started/application-setup/)
- [Instructions for running tests](https://transcom.github.io/mymove-docs/docs/getting-started/development/testing)

### How to test

1. Access the milmove application
2. Login as a customer starting a new move.
3. Type in Fort Barfoot and you should see Fort Barfoot in the duty location line and underneath it, Blackstone, VA 23824.
4. Type in Ft Benning and no Fort Benning values should display.
5. Type in Ft Walker and it should display Fort Walker, VA 22427.

### Database

#### Any new migrations/schema changes:

- [ ] Follows our guidelines for [Zero-Downtime Deploys](https://transcom.github.io/mymove-docs/docs/backend/setup/database-migrations#zero-downtime-migrations).
- [ ] Have been communicated to #g-database.
- [ ] Secure migrations have been tested following the instructions in our [docs](https://transcom.github.io/mymove-docs/docs/backend/setup/database-migrations#secure-migrations).

## Screenshots
