### PR TITLE
Break trdm into week based requests

### DIFF
--- a/pkg/models/trdm_get_table_request.go
+++ b/pkg/models/trdm_get_table_request.go
@@ -2,8 +2,12 @@ package models
 
 import "time"
 
+// The first and second date time filters are used to specifically request a range of data. If not provided,
+// it will pull data with no filter. This allows us to specifically gather identified date ranges of data.
 type GetTableRequest struct {
-	PhysicalName                string    `json:"physicalName"`
-	ContentUpdatedSinceDateTime time.Time `json:"contentUpdatedSinceDateTime"`
-	ReturnContent               bool      `json:"returnContent"`
+	PhysicalName                string     `json:"physicalName"`
+	ContentUpdatedSinceDateTime time.Time  `json:"contentUpdatedSinceDateTime"`
+	ReturnContent               bool       `json:"returnContent"`
+	FirstDateTimeFilter         *time.Time `json:"firstDateTimeFilter"`  // Optional
+	SecondDateTimeFilter        *time.Time `json:"secondDateTimeFIlter"` // Optional
 }

--- a/pkg/trdm/get_table.go
+++ b/pkg/trdm/get_table.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"io"
+	"time"
 
 	"go.uber.org/zap"
 
@@ -14,43 +15,92 @@ import (
 	"github.com/transcom/mymove/pkg/parser/tac"
 )
 
-func GetTGETData(getTableRequest models.GetTableRequest, service GatewayService, appCtx appcontext.AppContext, logger *zap.Logger) error {
+func GetTGETData(getTableRequest models.GetTableRequest, lastTableUpdateResponseLastUpdate time.Time, service GatewayService, appCtx appcontext.AppContext, logger *zap.Logger) error {
 	// Setup response model
 	getTableResponse := models.GetTableResponse{}
 
-	// Forward model to getTable to gather TGET data
-	resp, err := service.gatewayGetTable(getTableRequest)
+	// See how many weeks of data we're looking to gather before firing off to getTable
+	missingWeeks, err := FetchWeeksOfMissingTime(getTableRequest.ContentUpdatedSinceDateTime, lastTableUpdateResponseLastUpdate)
 	if err != nil {
-		logger.Error("failed to call gatewayGetTable", zap.Error(err))
-		return err
-	}
-	// Read it
-	if resp.Body == nil {
-		return errors.New("received empty body response from API gateway")
-	}
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		logger.Error("failed to read response body", zap.Error(err))
-		return err
-	}
-	defer resp.Body.Close()
-
-	// Parse it into getTableResponse model
-	err = json.Unmarshal(body, &getTableResponse)
-	if err != nil {
-		logger.Error("failed to unmarshal response body into getTableResponse type", zap.Error(err))
+		logger.Error("failed to identify missing weeks of data", zap.Error(err))
 		return err
 	}
 
-	// Parse the attachment, this will also store it in the DB if all goes well
-	err = parseGetTableResponse(appCtx, getTableResponse.Attachment, getTableRequest.PhysicalName)
-	if err != nil {
-		logger.Error("failed to parseGetTableResponse and store it into the database", zap.Error(err))
-		return err
-	}
+	switch {
+	case len(missingWeeks) > 2:
+		// Since we're requesting more than 2 weeks of data, we need to split it up to not overload the response bodies.
+		for _, week := range missingWeeks {
+			weekRequest := getTableRequest
+			// Add the first and second datetime filters based on the missing week
+			// These are not provided inside of getTableRequest.
+			weekRequest.FirstDateTimeFilter = &week.StartOfWeek
+			weekRequest.SecondDateTimeFilter = &week.EndOfWeek
 
+			// Fire off this weeks request
+			resp, err := service.gatewayGetTable(weekRequest)
+			if err != nil {
+				logger.Fatal("failed to call gatewayGetTable for week", zap.Error(err), zap.Time("startOfWeek", week.StartOfWeek), zap.Time("endOfWeek", week.EndOfWeek))
+				return err
+			}
+			// Read it
+			if resp.Body == nil {
+				return errors.New("received empty body response from API gateway")
+			}
+			body, err := io.ReadAll(resp.Body)
+			if err != nil {
+				logger.Error("failed to read response body", zap.Error(err))
+				return err
+			}
+			defer resp.Body.Close()
+
+			// Parse it into getTableResponse model
+			err = json.Unmarshal(body, &getTableResponse)
+			if err != nil {
+				logger.Error("failed to unmarshal response body into getTableResponse type", zap.Error(err))
+				return err
+			}
+
+			// Parse the attachment, this will also store it in the DB if all goes well
+			err = parseGetTableResponse(appCtx, getTableResponse.Attachment, getTableRequest.PhysicalName)
+			if err != nil {
+				logger.Error("failed to parseGetTableResponse and store it into the database", zap.Error(err))
+				return err
+			}
+			logger.Info("retrieving trdm TGET data successful for week", zap.String("request physicalName", weekRequest.PhysicalName), zap.Time("startOfWeek", week.StartOfWeek), zap.Time("endOfWeek", week.EndOfWeek))
+		}
+	default:
+		// Forward model to getTable to gather TGET data
+		resp, err := service.gatewayGetTable(getTableRequest)
+		if err != nil {
+			logger.Error("failed to call gatewayGetTable", zap.Error(err))
+			return err
+		}
+		// Read it
+		if resp.Body == nil {
+			return errors.New("received empty body response from API gateway")
+		}
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			logger.Error("failed to read response body", zap.Error(err))
+			return err
+		}
+		defer resp.Body.Close()
+
+		// Parse it into getTableResponse model
+		err = json.Unmarshal(body, &getTableResponse)
+		if err != nil {
+			logger.Error("failed to unmarshal response body into getTableResponse type", zap.Error(err))
+			return err
+		}
+
+		// Parse the attachment, this will also store it in the DB if all goes well
+		err = parseGetTableResponse(appCtx, getTableResponse.Attachment, getTableRequest.PhysicalName)
+		if err != nil {
+			logger.Error("failed to parseGetTableResponse and store it into the database", zap.Error(err))
+			return err
+		}
+	}
 	logger.Info("retrieving trdm TGET data successful", zap.String("request physicalName", getTableRequest.PhysicalName))
-
 	return nil
 }
 

--- a/pkg/trdm/get_table_test.go
+++ b/pkg/trdm/get_table_test.go
@@ -235,3 +235,42 @@ func (suite *TRDMSuite) TestGetTGETDataBadAttachmentResponse() {
 	err = trdm.GetTGETData(getTableRequest, getTableRequest.ContentUpdatedSinceDateTime.AddDate(0, 0, 7), *service, suite.AppContextForTest(), suite.logger)
 	suite.Error(err)
 }
+
+func (suite *TRDMSuite) TestGetTGETDataOver2Weeks() {
+
+	// Mock a successful attachment return from GetTable
+	file, err := os.ReadFile("../parser/loa/fixtures/Line Of Accounting.txt")
+	suite.NoError(err)
+
+	getTableResponse := models.GetTableResponse{
+		RowCount:   7,
+		StatusCode: trdm.SuccessfulStatusCode,
+		DateTime:   time.Now(),
+		Attachment: file,
+	}
+
+	responseBody, err := json.Marshal(getTableResponse)
+	suite.NoError(err)
+
+	mockClient := &MockHTTPClient{
+		DoFunc: func(req *http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(bytes.NewReader(responseBody)),
+			}, nil
+		}}
+
+	mockProvider := &mockAssumeRoleProvider{creds: suite.creds}
+
+	service := trdm.NewGatewayService(mockClient, suite.logger, "us-gov-west-1", "mockRole", "https://test.gateway.url.amazon.com", mockProvider)
+
+	getTableRequest := models.GetTableRequest{
+		PhysicalName:                trdm.LineOfAccounting,
+		ContentUpdatedSinceDateTime: time.Now(),
+		ReturnContent:               true,
+	}
+
+	// GetTable for Line of Accounting data that is over 2 weeks worth of data, parse it, and then store it in the database
+	err = trdm.GetTGETData(getTableRequest, getTableRequest.ContentUpdatedSinceDateTime.AddDate(0, 0, 15), *service, suite.AppContextForTest(), suite.logger)
+	suite.NoError(err)
+}

--- a/pkg/trdm/get_table_test.go
+++ b/pkg/trdm/get_table_test.go
@@ -49,7 +49,7 @@ func (suite *TRDMSuite) TestSuccessfulGetTGETDataLOA() {
 	service := trdm.NewGatewayService(mockClient, suite.logger, "us-gov-west-1", "mockRole", "https://test.gateway.url.amazon.com", mockProvider)
 
 	// GetTable for Line of Accounting, parse it, and then store it in the database
-	err = trdm.GetTGETData(getTableRequest, *service, suite.AppContextForTest(), suite.logger)
+	err = trdm.GetTGETData(getTableRequest, getTableRequest.ContentUpdatedSinceDateTime.AddDate(0, 0, 7), *service, suite.AppContextForTest(), suite.logger)
 	suite.NoError(err)
 
 	// Load our test file
@@ -105,7 +105,7 @@ func (suite *TRDMSuite) TestSuccessfulGetTGETDataTAC() {
 	service := trdm.NewGatewayService(mockClient, suite.logger, "us-gov-west-1", "mockRole", "https://test.gateway.url.amazon.com", mockProvider)
 
 	// GetTable for Line of Accounting, parse it, and then store it in the database
-	err = trdm.GetTGETData(getTableRequest, *service, suite.AppContextForTest(), suite.logger)
+	err = trdm.GetTGETData(getTableRequest, getTableRequest.ContentUpdatedSinceDateTime.AddDate(0, 0, 7), *service, suite.AppContextForTest(), suite.logger)
 	suite.NoError(err)
 
 	// Load our test file
@@ -147,7 +147,7 @@ func (suite *TRDMSuite) TestGetTGETDataNilResponseBody() {
 		ReturnContent:               true,
 	}
 
-	err := trdm.GetTGETData(getTableRequest, *service, suite.AppContextForTest(), suite.logger)
+	err := trdm.GetTGETData(getTableRequest, time.Now(), *service, suite.AppContextForTest(), suite.logger)
 	suite.Error(err)
 }
 
@@ -166,7 +166,7 @@ func (suite *TRDMSuite) TestGetTGETDataNilRequestBody() {
 
 	getTableRequest := models.GetTableRequest{}
 
-	err := trdm.GetTGETData(getTableRequest, *service, suite.AppContextForTest(), suite.logger)
+	err := trdm.GetTGETData(getTableRequest, getTableRequest.ContentUpdatedSinceDateTime.AddDate(0, 0, 7), *service, suite.AppContextForTest(), suite.logger)
 	suite.Error(err)
 }
 
@@ -199,7 +199,7 @@ func (suite *TRDMSuite) TestGetTGETDataBadPhysicalName() {
 		ReturnContent:               true,
 	}
 
-	err = trdm.GetTGETData(getTableRequest, *service, suite.AppContextForTest(), suite.logger)
+	err = trdm.GetTGETData(getTableRequest, getTableRequest.ContentUpdatedSinceDateTime.AddDate(0, 0, 7), *service, suite.AppContextForTest(), suite.logger)
 	suite.Error(err)
 }
 
@@ -232,6 +232,6 @@ func (suite *TRDMSuite) TestGetTGETDataBadAttachmentResponse() {
 		ReturnContent:               true,
 	}
 
-	err = trdm.GetTGETData(getTableRequest, *service, suite.AppContextForTest(), suite.logger)
+	err = trdm.GetTGETData(getTableRequest, getTableRequest.ContentUpdatedSinceDateTime.AddDate(0, 0, 7), *service, suite.AppContextForTest(), suite.logger)
 	suite.Error(err)
 }

--- a/pkg/trdm/last_table_update.go
+++ b/pkg/trdm/last_table_update.go
@@ -100,7 +100,7 @@ func startLastTableUpdateCron(physicalName string, logger *zap.Logger, v *viper.
 						PhysicalName:                LineOfAccounting,
 						ContentUpdatedSinceDateTime: *ourLastUpdate,
 						ReturnContent:               true,
-					}, *service, appCtx, logger)
+					}, lastTableUpdateResponse.LastUpdate, *service, appCtx, logger)
 					if caseErr != nil {
 						logger.Fatal("failed to retrieve latest line of accounting TGET data", zap.Error(err))
 					} else {
@@ -125,7 +125,7 @@ func startLastTableUpdateCron(physicalName string, logger *zap.Logger, v *viper.
 						PhysicalName:                TransportationAccountingCode,
 						ContentUpdatedSinceDateTime: *ourLastUpdate,
 						ReturnContent:               true,
-					}, *service, appCtx, logger)
+					}, lastTableUpdateResponse.LastUpdate, *service, appCtx, logger)
 					if caseErr != nil {
 						logger.Fatal("failed to retrieve latest transportation accounting TGET data", zap.Error(err))
 					} else {

--- a/pkg/trdm/last_table_update.go
+++ b/pkg/trdm/last_table_update.go
@@ -234,3 +234,40 @@ func TGETLOADataOutOfDate(appcontext appcontext.AppContext, timeToCheck time.Tim
 
 	return isOutOfDate, &loa.UpdatedAt, nil
 }
+
+// This type should be used as an array
+type MissingWeek struct {
+	// Matching dates should not occur because that would mean our data is up to date and the function using this type should never be called
+	StartOfWeek time.Time // Example: AUG 01 OR AUG 05 OR AUG 01 (Read these top down)
+	EndOfWeek   time.Time // Example: AUG 07 OR AUG 07 OR NOV 01 (Read these top down)
+}
+
+// This func won't inherently check from our DB but it will receive the latest update from a table within that DB to compare to TRDM
+// It will allow us to split a request that would be 1 request of 1 month+ of data into 4 requests at 1 week each
+func FetchWeeksOfMissingData(ourLastUpdate time.Time, trdmLastUpdate time.Time) ([]MissingWeek, error) {
+	if trdmLastUpdate.Before(ourLastUpdate) {
+		return nil, errors.New("the provided parameters are out of order")
+	}
+	// Matching dates should not occur because that would mean our data is up to date and the function using this type should never be called
+	var missingWeeks []MissingWeek // Individual start and end dates of each week to be used in the TRDM filter so we can grab 1 week at a time
+
+	// Create a startOfWeek for each loop iteration.
+	// If that start of week is not after the last update in TRDM then there are still weeks or days in between ourLastUpdate and trdmLastUpdate
+	// Then set the new startOfWeek to the end of that week and run the loop again.
+	// This loop will run every time until the startOfWeek finally matches trdmLastUpdate, meaning we have found all missing weeks
+	// This loop can be modified to be startOfWeek.Before(trdmLastUpdate) to specifically find only the weeks, but we want individual days too
+	for startOfWeek := ourLastUpdate; !startOfWeek.After(trdmLastUpdate); startOfWeek = startOfWeek.AddDate(0, 0, 7) {
+		endOfWeek := startOfWeek.AddDate(0, 0, 6) // Add 6 days because it's already a day. 1 + 6 = 7, and 7 days are in a week
+		// Set endOfWeek to the last second of the last day so it is truly the end of the week
+		endOfWeek = endOfWeek.Truncate(24 * time.Hour).Add(24*time.Hour - time.Nanosecond)
+
+		if endOfWeek.After(trdmLastUpdate) {
+			// If it is the last week, set to the last second of trdmLastUpdate instead of trying to pull data that doesn't exist yet
+			endOfWeek = trdmLastUpdate.Truncate(24 * time.Hour).Add(24*time.Hour - time.Nanosecond)
+		}
+
+		missingWeeks = append(missingWeeks, MissingWeek{StartOfWeek: startOfWeek, EndOfWeek: endOfWeek}) // Not always full weeks, sometimes split in half
+	}
+
+	return missingWeeks, nil
+}

--- a/pkg/trdm/last_table_update.go
+++ b/pkg/trdm/last_table_update.go
@@ -244,7 +244,7 @@ type MissingWeek struct {
 
 // This func won't inherently check from our DB but it will receive the latest update from a table within that DB to compare to TRDM
 // It will allow us to split a request that would be 1 request of 1 month+ of data into 4 requests at 1 week each
-func FetchWeeksOfMissingData(ourLastUpdate time.Time, trdmLastUpdate time.Time) ([]MissingWeek, error) {
+func FetchWeeksOfMissingTime(ourLastUpdate time.Time, trdmLastUpdate time.Time) ([]MissingWeek, error) {
 	if trdmLastUpdate.Before(ourLastUpdate) {
 		return nil, errors.New("the provided parameters are out of order")
 	}

--- a/pkg/trdm/last_table_update_test.go
+++ b/pkg/trdm/last_table_update_test.go
@@ -253,3 +253,29 @@ func (suite *TRDMSuite) TestSuccessfulTRDMFlowTACsAndLOAs() {
 	// On factory build TAC, a LOA is generated alongside it.
 	suite.Equal(len(allLOAs), len(outdatedLOACodes)+len(expectedLOACodes)+len(outdatedTACCodes))
 }
+func (suite *TRDMSuite) TestFetchWeeksOfMissingData() {
+	// These errs can be "_" because no matter what it will error out after FetchWeeksOfMissingData is called
+	// Additionally, we are providing correct parameters that will never error
+	ourLastUpdate, _ := time.Parse("Jan 02, 2006", "Aug 01, 2023")
+	trdmLastUpdate, _ := time.Parse("Jan 02, 2006", "Aug 14, 2023")
+	missingWeeks, err := trdm.FetchWeeksOfMissingData(ourLastUpdate, trdmLastUpdate)
+	suite.NoError(err)
+
+	suite.Equal(len(missingWeeks), 2) // Assert 2 weeks are missing from the provided dates
+
+	trdmLastUpdate, _ = time.Parse("Jan 02, 2006", "Aug 15, 2023") // 2 weeks and 1 day after our last update
+
+	missingWeeks, err = trdm.FetchWeeksOfMissingData(ourLastUpdate, trdmLastUpdate)
+	suite.NoError(err)
+
+	suite.Equal(len(missingWeeks), 3)
+}
+
+func (suite *TRDMSuite) TestIncorrectParametersForWeeksOfMissingData() {
+	// These errs can be "_" because no matter what it will error out after FetchWeeksOfMissingData is called
+	// Additionally, we are providing correct parameters that will never error
+	ourLastUpdate, _ := time.Parse("Jan 02, 2006", "Aug 02, 2023")
+	trdmLastUpdate, _ := time.Parse("Jan 02, 2006", "Aug 01, 2023") // trdmLastUpdate is before our last update
+	_, err := trdm.FetchWeeksOfMissingData(ourLastUpdate, trdmLastUpdate)
+	suite.Error(err)
+}

--- a/pkg/trdm/last_table_update_test.go
+++ b/pkg/trdm/last_table_update_test.go
@@ -253,29 +253,29 @@ func (suite *TRDMSuite) TestSuccessfulTRDMFlowTACsAndLOAs() {
 	// On factory build TAC, a LOA is generated alongside it.
 	suite.Equal(len(allLOAs), len(outdatedLOACodes)+len(expectedLOACodes)+len(outdatedTACCodes))
 }
-func (suite *TRDMSuite) TestFetchWeeksOfMissingData() {
+func (suite *TRDMSuite) TestFetchWeeksOfMissingTime() {
 	// These errs can be "_" because no matter what it will error out after FetchWeeksOfMissingData is called
 	// Additionally, we are providing correct parameters that will never error
 	ourLastUpdate, _ := time.Parse("Jan 02, 2006", "Aug 01, 2023")
 	trdmLastUpdate, _ := time.Parse("Jan 02, 2006", "Aug 14, 2023")
-	missingWeeks, err := trdm.FetchWeeksOfMissingData(ourLastUpdate, trdmLastUpdate)
+	missingWeeks, err := trdm.FetchWeeksOfMissingTime(ourLastUpdate, trdmLastUpdate)
 	suite.NoError(err)
 
 	suite.Equal(len(missingWeeks), 2) // Assert 2 weeks are missing from the provided dates
 
 	trdmLastUpdate, _ = time.Parse("Jan 02, 2006", "Aug 15, 2023") // 2 weeks and 1 day after our last update
 
-	missingWeeks, err = trdm.FetchWeeksOfMissingData(ourLastUpdate, trdmLastUpdate)
+	missingWeeks, err = trdm.FetchWeeksOfMissingTime(ourLastUpdate, trdmLastUpdate)
 	suite.NoError(err)
 
 	suite.Equal(len(missingWeeks), 3)
 }
 
-func (suite *TRDMSuite) TestIncorrectParametersForWeeksOfMissingData() {
+func (suite *TRDMSuite) TestIncorrectParametersForWeeksOfMissingTime() {
 	// These errs can be "_" because no matter what it will error out after FetchWeeksOfMissingData is called
 	// Additionally, we are providing correct parameters that will never error
 	ourLastUpdate, _ := time.Parse("Jan 02, 2006", "Aug 02, 2023")
 	trdmLastUpdate, _ := time.Parse("Jan 02, 2006", "Aug 01, 2023") // trdmLastUpdate is before our last update
-	_, err := trdm.FetchWeeksOfMissingData(ourLastUpdate, trdmLastUpdate)
+	_, err := trdm.FetchWeeksOfMissingTime(ourLastUpdate, trdmLastUpdate)
 	suite.Error(err)
 }


### PR DESCRIPTION
## [Epic](https://www13.v1host.com/USTRANSCOM38/Epic.mvc/Summary?oidToken=Epic%3a810602)


## This PR merge is dependent upon the new lambda update being reviewed [here](https://github.com/transcom/trdm-lambda/pull/2).

# Changes
MilMove will now automatically compare our last update to TRDM's last update. If there are more than 2 weeks of missing data, it will break apart the TGET data gathering into week based requests. One request for each week of missing data. This is to circumvent the API request data handling limit.