### PR TITLE
B-18069- sitDepartureDate stays nil when updating servItems

### DIFF
--- a/pkg/handlers/primeapi/payloads/payload_to_model.go
+++ b/pkg/handlers/primeapi/payloads/payload_to_model.go
@@ -562,12 +562,16 @@ func MTOServiceItemModelFromUpdate(mtoServiceItemID string, mtoServiceItem prime
 	switch mtoServiceItem.ModelType() {
 	case primemessages.UpdateMTOServiceItemModelTypeUpdateMTOServiceItemSIT:
 		sit := mtoServiceItem.(*primemessages.UpdateMTOServiceItemSIT)
-		model.SITDepartureDate = models.TimePointer(time.Time(sit.SitDepartureDate))
 		model.ReService.Code = models.ReServiceCode(sit.ReServiceCode)
 		model.SITDestinationFinalAddress = AddressModel(sit.SitDestinationFinalAddress)
 		model.SITRequestedDelivery = (*time.Time)(sit.SitRequestedDelivery)
 		model.Status = models.MTOServiceItemStatusSubmitted
 		model.Reason = sit.UpdateReason
+
+		var zeroDate strfmt.Date
+		if sit.SitDepartureDate != zeroDate {
+			model.SITDepartureDate = models.TimePointer(time.Time(sit.SitDepartureDate))
+		}
 
 		if sit.SitEntryDate != nil {
 			model.SITEntryDate = (*time.Time)(sit.SitEntryDate)

--- a/pkg/services/mto_service_item/mto_service_item_validators.go
+++ b/pkg/services/mto_service_item/mto_service_item_validators.go
@@ -410,8 +410,10 @@ func (v *updateMTOServiceItemData) setNewMTOServiceItem() *models.MTOServiceItem
 	newMTOServiceItem.SITEntryDate = services.SetOptionalDateTimeField(
 		v.updatedServiceItem.SITEntryDate, newMTOServiceItem.SITEntryDate)
 
-	newMTOServiceItem.SITDepartureDate = services.SetOptionalDateTimeField(
-		v.updatedServiceItem.SITDepartureDate, newMTOServiceItem.SITDepartureDate)
+	if v.updatedServiceItem.SITDepartureDate != nil {
+		newMTOServiceItem.SITDepartureDate = services.SetOptionalDateTimeField(
+			v.updatedServiceItem.SITDepartureDate, newMTOServiceItem.SITDepartureDate)
+	}
 
 	newMTOServiceItem.SITCustomerContacted = services.SetOptionalDateTimeField(v.updatedServiceItem.SITCustomerContacted, newMTOServiceItem.SITCustomerContacted)
 	newMTOServiceItem.SITRequestedDelivery = services.SetOptionalDateTimeField(v.updatedServiceItem.SITRequestedDelivery, newMTOServiceItem.SITRequestedDelivery)


### PR DESCRIPTION
## [B-18069](https://www13.v1host.com/USTRANSCOM38/story.mvc/Summary?oidToken=Story%3a870739)

## Summary

When updating a sit serviceItem the sitDepartureDate nil value was not being handled properly. If sitDepartureDate did not have a value it was be nil in the reques tbut then turned to golangs zero value for its datatype. This no longer happens. If sitDepartureDate is nil in the request then it will keep a nil value through implementation.

Test:

Update a serviceItem and do not include sitDepartureDate in the body. sitDepartureDate should stay nil and the not able to manually update sitDepartureDate rejection message will not be returned in the api call response.
