### PR TITLE
Trdm weekly digest

### DIFF
--- a/pkg/models/trdm_get_table_request.go
+++ b/pkg/models/trdm_get_table_request.go
@@ -5,9 +5,8 @@ import "time"
 // The first and second date time filters are used to specifically request a range of data. If not provided,
 // it will pull data with no filter. This allows us to specifically gather identified date ranges of data.
 type GetTableRequest struct {
-	PhysicalName                string     `json:"physicalName"`
-	ContentUpdatedSinceDateTime time.Time  `json:"contentUpdatedSinceDateTime"`
-	ReturnContent               bool       `json:"returnContent"`
-	FirstDateTimeFilter         *time.Time `json:"firstDateTimeFilter"`  // Optional
-	SecondDateTimeFilter        *time.Time `json:"secondDateTimeFIlter"` // Optional
+	PhysicalName                     string     `json:"physicalName"`
+	ContentUpdatedSinceDateTime      time.Time  `json:"contentUpdatedSinceDateTime"`
+	ReturnContent                    bool       `json:"returnContent"`
+	ContentUpdatedOnOrBeforeDateTime *time.Time `json:"contentUpdatedOnOrBeforeDateTime"` // Optional
 }

--- a/pkg/models/trdm_get_table_request.go
+++ b/pkg/models/trdm_get_table_request.go
@@ -2,8 +2,12 @@ package models
 
 import "time"
 
+// The first and second date time filters are used to specifically request a range of data. If not provided,
+// it will pull data with no filter. This allows us to specifically gather identified date ranges of data.
 type GetTableRequest struct {
-	PhysicalName                string    `json:"physicalName"`
-	ContentUpdatedSinceDateTime time.Time `json:"contentUpdatedSinceDateTime"`
-	ReturnContent               bool      `json:"returnContent"`
+	PhysicalName                string     `json:"physicalName"`
+	ContentUpdatedSinceDateTime time.Time  `json:"contentUpdatedSinceDateTime"`
+	ReturnContent               bool       `json:"returnContent"`
+	FirstDateTimeFilter         *time.Time `json:"firstDateTimeFilter"`  // Optional
+	SecondDateTimeFilter        *time.Time `json:"secondDateTimeFIlter"` // Optional
 }

--- a/pkg/trdm/get_table.go
+++ b/pkg/trdm/get_table.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"io"
+	"time"
 
 	"go.uber.org/zap"
 
@@ -14,43 +15,92 @@ import (
 	"github.com/transcom/mymove/pkg/parser/tac"
 )
 
-func GetTGETData(getTableRequest models.GetTableRequest, service GatewayService, appCtx appcontext.AppContext, logger *zap.Logger) error {
+func GetTGETData(getTableRequest models.GetTableRequest, lastTableUpdateResponseLastUpdate time.Time, service GatewayService, appCtx appcontext.AppContext, logger *zap.Logger) error {
 	// Setup response model
 	getTableResponse := models.GetTableResponse{}
 
-	// Forward model to getTable to gather TGET data
-	resp, err := service.gatewayGetTable(getTableRequest)
+	// See how many weeks of data we're looking to gather before firing off to getTable
+	missingWeeks, err := FetchWeeksOfMissingTime(getTableRequest.ContentUpdatedSinceDateTime, lastTableUpdateResponseLastUpdate)
 	if err != nil {
-		logger.Error("failed to call gatewayGetTable", zap.Error(err))
-		return err
-	}
-	// Read it
-	if resp.Body == nil {
-		return errors.New("received empty body response from API gateway")
-	}
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		logger.Error("failed to read response body", zap.Error(err))
-		return err
-	}
-	defer resp.Body.Close()
-
-	// Parse it into getTableResponse model
-	err = json.Unmarshal(body, &getTableResponse)
-	if err != nil {
-		logger.Error("failed to unmarshal response body into getTableResponse type", zap.Error(err))
+		logger.Error("failed to identify missing weeks of data", zap.Error(err))
 		return err
 	}
 
-	// Parse the attachment, this will also store it in the DB if all goes well
-	err = parseGetTableResponse(appCtx, getTableResponse.Attachment, getTableRequest.PhysicalName)
-	if err != nil {
-		logger.Error("failed to parseGetTableResponse and store it into the database", zap.Error(err))
-		return err
-	}
+	switch {
+	case len(missingWeeks) > 2:
+		// Since we're requesting more than 2 weeks of data, we need to split it up to not overload the response bodies.
+		for _, week := range missingWeeks {
+			weekRequest := getTableRequest
+			// Add the first and second datetime filters based on the missing week
+			// These are not provided inside of getTableRequest.
+			weekRequest.FirstDateTimeFilter = &week.StartOfWeek
+			weekRequest.SecondDateTimeFilter = &week.EndOfWeek
 
+			// Fire off this weeks request
+			resp, err := service.gatewayGetTable(weekRequest)
+			if err != nil {
+				logger.Fatal("failed to call gatewayGetTable for week", zap.Error(err), zap.Time("startOfWeek", week.StartOfWeek), zap.Time("endOfWeek", week.EndOfWeek))
+				return err
+			}
+			// Read it
+			if resp.Body == nil {
+				return errors.New("received empty body response from API gateway")
+			}
+			body, err := io.ReadAll(resp.Body)
+			if err != nil {
+				logger.Error("failed to read response body", zap.Error(err))
+				return err
+			}
+			defer resp.Body.Close()
+
+			// Parse it into getTableResponse model
+			err = json.Unmarshal(body, &getTableResponse)
+			if err != nil {
+				logger.Error("failed to unmarshal response body into getTableResponse type", zap.Error(err))
+				return err
+			}
+
+			// Parse the attachment, this will also store it in the DB if all goes well
+			err = parseGetTableResponse(appCtx, getTableResponse.Attachment, getTableRequest.PhysicalName)
+			if err != nil {
+				logger.Error("failed to parseGetTableResponse and store it into the database", zap.Error(err))
+				return err
+			}
+			logger.Info("retrieving trdm TGET data successful for week", zap.String("request physicalName", weekRequest.PhysicalName), zap.Time("startOfWeek", week.StartOfWeek), zap.Time("endOfWeek", week.EndOfWeek))
+		}
+	default:
+		// Forward model to getTable to gather TGET data
+		resp, err := service.gatewayGetTable(getTableRequest)
+		if err != nil {
+			logger.Error("failed to call gatewayGetTable", zap.Error(err))
+			return err
+		}
+		// Read it
+		if resp.Body == nil {
+			return errors.New("received empty body response from API gateway")
+		}
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			logger.Error("failed to read response body", zap.Error(err))
+			return err
+		}
+		defer resp.Body.Close()
+
+		// Parse it into getTableResponse model
+		err = json.Unmarshal(body, &getTableResponse)
+		if err != nil {
+			logger.Error("failed to unmarshal response body into getTableResponse type", zap.Error(err))
+			return err
+		}
+
+		// Parse the attachment, this will also store it in the DB if all goes well
+		err = parseGetTableResponse(appCtx, getTableResponse.Attachment, getTableRequest.PhysicalName)
+		if err != nil {
+			logger.Error("failed to parseGetTableResponse and store it into the database", zap.Error(err))
+			return err
+		}
+	}
 	logger.Info("retrieving trdm TGET data successful", zap.String("request physicalName", getTableRequest.PhysicalName))
-
 	return nil
 }
 

--- a/pkg/trdm/get_table.go
+++ b/pkg/trdm/get_table.go
@@ -33,8 +33,8 @@ func GetTGETData(getTableRequest models.GetTableRequest, lastTableUpdateResponse
 			weekRequest := getTableRequest
 			// Add the first and second datetime filters based on the missing week
 			// These are not provided inside of getTableRequest.
-			weekRequest.FirstDateTimeFilter = &week.StartOfWeek
-			weekRequest.SecondDateTimeFilter = &week.EndOfWeek
+			weekRequest.ContentUpdatedSinceDateTime = week.StartOfWeek
+			weekRequest.ContentUpdatedOnOrBeforeDateTime = &week.EndOfWeek
 
 			// Fire off this weeks request
 			resp, err := service.gatewayGetTable(weekRequest)

--- a/pkg/trdm/last_table_update.go
+++ b/pkg/trdm/last_table_update.go
@@ -100,7 +100,7 @@ func startLastTableUpdateCron(physicalName string, logger *zap.Logger, v *viper.
 						PhysicalName:                LineOfAccounting,
 						ContentUpdatedSinceDateTime: *ourLastUpdate,
 						ReturnContent:               true,
-					}, *service, appCtx, logger)
+					}, lastTableUpdateResponse.LastUpdate, *service, appCtx, logger)
 					if caseErr != nil {
 						logger.Fatal("failed to retrieve latest line of accounting TGET data", zap.Error(err))
 					} else {
@@ -125,7 +125,7 @@ func startLastTableUpdateCron(physicalName string, logger *zap.Logger, v *viper.
 						PhysicalName:                TransportationAccountingCode,
 						ContentUpdatedSinceDateTime: *ourLastUpdate,
 						ReturnContent:               true,
-					}, *service, appCtx, logger)
+					}, lastTableUpdateResponse.LastUpdate, *service, appCtx, logger)
 					if caseErr != nil {
 						logger.Fatal("failed to retrieve latest transportation accounting TGET data", zap.Error(err))
 					} else {
@@ -233,4 +233,41 @@ func TGETLOADataOutOfDate(appcontext appcontext.AppContext, timeToCheck time.Tim
 	isOutOfDate := loa.UpdatedAt.Before(timeToCheck)
 
 	return isOutOfDate, &loa.UpdatedAt, nil
+}
+
+// This type should be used as an array
+type MissingWeek struct {
+	// Matching dates should not occur because that would mean our data is up to date and the function using this type should never be called
+	StartOfWeek time.Time // Example: AUG 01 OR AUG 05 OR AUG 01 (Read these top down)
+	EndOfWeek   time.Time // Example: AUG 07 OR AUG 07 OR NOV 01 (Read these top down)
+}
+
+// This func won't inherently check from our DB but it will receive the latest update from a table within that DB to compare to TRDM
+// It will allow us to split a request that would be 1 request of 1 month+ of data into 4 requests at 1 week each
+func FetchWeeksOfMissingTime(ourLastUpdate time.Time, trdmLastUpdate time.Time) ([]MissingWeek, error) {
+	if trdmLastUpdate.Before(ourLastUpdate) {
+		return nil, errors.New("the provided parameters are out of order")
+	}
+	// Matching dates should not occur because that would mean our data is up to date and the function using this type should never be called
+	var missingWeeks []MissingWeek // Individual start and end dates of each week to be used in the TRDM filter so we can grab 1 week at a time
+
+	// Create a startOfWeek for each loop iteration.
+	// If that start of week is not after the last update in TRDM then there are still weeks or days in between ourLastUpdate and trdmLastUpdate
+	// Then set the new startOfWeek to the end of that week and run the loop again.
+	// This loop will run every time until the startOfWeek finally matches trdmLastUpdate, meaning we have found all missing weeks
+	// This loop can be modified to be startOfWeek.Before(trdmLastUpdate) to specifically find only the weeks, but we want individual days too
+	for startOfWeek := ourLastUpdate; !startOfWeek.After(trdmLastUpdate); startOfWeek = startOfWeek.AddDate(0, 0, 7) {
+		endOfWeek := startOfWeek.AddDate(0, 0, 6) // Add 6 days because it's already a day. 1 + 6 = 7, and 7 days are in a week
+		// Set endOfWeek to the last second of the last day so it is truly the end of the week
+		endOfWeek = endOfWeek.Truncate(24 * time.Hour).Add(24*time.Hour - time.Nanosecond)
+
+		if endOfWeek.After(trdmLastUpdate) {
+			// If it is the last week, set to the last second of trdmLastUpdate instead of trying to pull data that doesn't exist yet
+			endOfWeek = trdmLastUpdate.Truncate(24 * time.Hour).Add(24*time.Hour - time.Nanosecond)
+		}
+
+		missingWeeks = append(missingWeeks, MissingWeek{StartOfWeek: startOfWeek, EndOfWeek: endOfWeek}) // Not always full weeks, sometimes split in half
+	}
+
+	return missingWeeks, nil
 }

--- a/pkg/trdm/last_table_update_test.go
+++ b/pkg/trdm/last_table_update_test.go
@@ -253,3 +253,29 @@ func (suite *TRDMSuite) TestSuccessfulTRDMFlowTACsAndLOAs() {
 	// On factory build TAC, a LOA is generated alongside it.
 	suite.Equal(len(allLOAs), len(outdatedLOACodes)+len(expectedLOACodes)+len(outdatedTACCodes))
 }
+func (suite *TRDMSuite) TestFetchWeeksOfMissingTime() {
+	// These errs can be "_" because no matter what it will error out after FetchWeeksOfMissingData is called
+	// Additionally, we are providing correct parameters that will never error
+	ourLastUpdate, _ := time.Parse("Jan 02, 2006", "Aug 01, 2023")
+	trdmLastUpdate, _ := time.Parse("Jan 02, 2006", "Aug 14, 2023")
+	missingWeeks, err := trdm.FetchWeeksOfMissingTime(ourLastUpdate, trdmLastUpdate)
+	suite.NoError(err)
+
+	suite.Equal(len(missingWeeks), 2) // Assert 2 weeks are missing from the provided dates
+
+	trdmLastUpdate, _ = time.Parse("Jan 02, 2006", "Aug 15, 2023") // 2 weeks and 1 day after our last update
+
+	missingWeeks, err = trdm.FetchWeeksOfMissingTime(ourLastUpdate, trdmLastUpdate)
+	suite.NoError(err)
+
+	suite.Equal(len(missingWeeks), 3)
+}
+
+func (suite *TRDMSuite) TestIncorrectParametersForWeeksOfMissingTime() {
+	// These errs can be "_" because no matter what it will error out after FetchWeeksOfMissingData is called
+	// Additionally, we are providing correct parameters that will never error
+	ourLastUpdate, _ := time.Parse("Jan 02, 2006", "Aug 02, 2023")
+	trdmLastUpdate, _ := time.Parse("Jan 02, 2006", "Aug 01, 2023") // trdmLastUpdate is before our last update
+	_, err := trdm.FetchWeeksOfMissingTime(ourLastUpdate, trdmLastUpdate)
+	suite.Error(err)
+}


### PR DESCRIPTION
Reverted the revert off the previous getTable attempts based on TwoDateTimeValue filters. and made modifications to match the latest lambda release This will now utilize the SingleDateTimeValue twice, providing `contentUpdatedSinceDateTime` as the `IS_ON_OR_AFTER` and the `contentUpdatedOnOrBeforeDateTime` as the `IS_ON_OR_BEFORE` per the `ReturnTableV7.wsdl`.

## Reviewers

Please see the previously reviewed pull request [here](https://github.com/transcom/mymove/pull/11610). This PR was reverted, and this PR for "trdm-weekly-digest" reintroduces it with minor modifications.