### PR TITLE
Amw b17954 b17956 fix sit status display days

### DIFF
--- a/pkg/services/mto_shipment/shipment_sit_status.go
+++ b/pkg/services/mto_shipment/shipment_sit_status.go
@@ -122,8 +122,6 @@ func (f shipmentSITStatus) CalculateShipmentSITStatus(appCtx appcontext.AppConte
 		}
 	}
 
-	// clamp total SIT days used between 0 and the totalSITAllowance
-
 	return &shipmentSITStatus, nil
 }
 

--- a/pkg/services/mto_shipment/shipment_sit_status.go
+++ b/pkg/services/mto_shipment/shipment_sit_status.go
@@ -57,6 +57,16 @@ func SortShipmentSITs(shipment models.MTOShipment, today time.Time) SortedShipme
 	return shipmentSITs
 }
 
+// Private function for clamping inclusively between 2 ints
+func clamp(input int, min int, max int) int {
+	if input < min {
+		return min
+	} else if input > max {
+		return max
+	}
+	return input
+}
+
 // CalculateShipmentSITStatus creates a SIT Status for payload to be used in
 // multiple handlers in the `ghcapi` package for the MTOShipment handlers.
 func (f shipmentSITStatus) CalculateShipmentSITStatus(appCtx appcontext.AppContext, shipment models.MTOShipment) (*services.SITStatus, error) {
@@ -83,7 +93,8 @@ func (f shipmentSITStatus) CalculateShipmentSITStatus(appCtx appcontext.AppConte
 	if err != nil {
 		return nil, err
 	}
-	shipmentSITStatus.TotalSITDaysUsed = CalculateTotalDaysInSIT(shipmentSITs, today)
+
+	shipmentSITStatus.TotalSITDaysUsed = clamp(CalculateTotalDaysInSIT(shipmentSITs, today), 0, totalSITAllowance)
 	shipmentSITStatus.TotalDaysRemaining = totalSITAllowance - shipmentSITStatus.TotalSITDaysUsed
 	shipmentSITStatus.PastSITs = shipmentSITs.pastSITs
 
@@ -110,6 +121,8 @@ func (f shipmentSITStatus) CalculateShipmentSITStatus(appCtx appcontext.AppConte
 			SITRequestedDelivery: sitRequestedDelivery,
 		}
 	}
+
+	// clamp total SIT days used between 0 and the totalSITAllowance
 
 	return &shipmentSITStatus, nil
 }


### PR DESCRIPTION
## [Agility ticket] B-17956
(https://www13.v1host.com/USTRANSCOM38/story.mvc/Summary?oidToken=Story%3a869482)

## Summary

Is there anything you would like reviewers to give additional scrutiny?
Make sure that when approved days in the SIT is lower than SIT days used, the "SIT days used" number lowers to reflect that change.
Also, when there are no days left in the SIT, the number should not display a '0'.. it should display an 'Expired'.

[this article](tbd) explains more about the approach used.

## Verification Steps for the Author

These are to be checked by the author.

- [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
- [ ] Have the Agility acceptance criteria been met for this change?

## Verification Steps for Reviewers

These are to be checked by a reviewer.

- [ ] Has the branch been pulled in and checked out?
- [ ] Have the BL acceptance criteria been met for this change?
- [ ] Was the CircleCI build successful?
- [ ] Has the code been reviewed from a standards and best practices point of view?

### Setup to Run the Code

- [Instructions for starting storybook](https://transcom.github.io/mymove-docs/docs/frontend/setup/storybook)
- [Instructions for starting the MilMove application](https://transcom.github.io/mymove-docs/docs/getting-started/application-setup/)
- [Instructions for running tests](https://transcom.github.io/mymove-docs/docs/getting-started/development/testing)

### How to test

1. Access Office MilMove as a TOO
2. View a Move Task Order tab which contains a SIT
3. Note the values of Days Approved, Days Used, and Days Left.
4. Click the "Edit" link and make changes to the Days Allowed and/or SIT End date.
    a. When lowering the Days Allowed number to below the Days Used number, the Days Used number should change to match the Days Allowed.
    b. After you have lowered the Days Allowed to lower than Days Used and observed that the Days Used number has changed to match the Days Allowed, you should then be able to adjust the Days Allowed again and observer Days Used goes up as high as it can go while still reflecting Days Used but also not exceeding Days Allowed.
    c. Also, whenever the Days Left number should read a number less than 1, it showed "Expired" in stead.

### Frontend

- [ ] There are no aXe warnings for UI.
- [ ] This works in [Supported Browsers and their phone views](https://transcom.github.io/mymove-docs/docs/adrs/Browser-Support/#minimum-browser-requirements) (Chrome, Firefox, Edge).
- [ ] There are no new console errors in the browser devtools.
- [ ] There are no new console errors in the test output.
- [ ] If this PR adds a new component to Storybook, it ensures the component is fully responsive, OR if it is intentionally not, a wrapping div using the `officeApp` class or custom `min-width` styling is used to hide any states the would not be visible to the user.
- [ ] This change meets the standards for [Section 508 compliance](https://www.ssa.gov/accessibility/andi/help/install.html).

### Backend

- [ ] Code follows the guidelines for [Logging](https://transcom.github.io/mymove-docs/docs/getting-started/development/logging).
- [ ] The requirements listed in [Querying the Database Safely](https://transcom.github.io/mymove-docs/docs/backend/guides/golang-guide#querying-the-database-safely) have been satisfied.

### Database
No DB changes were made and the code changes do not affect the data in the DB in any way moving forward or retroactively.

#### Any new migrations/schema changes:

- [ ] Follows our guidelines for [Zero-Downtime Deploys](https://transcom.github.io/mymove-docs/docs/backend/setup/database-migrations#zero-downtime-migrations).
- [ ] Have been communicated to #g-database.
- [ ] Secure migrations have been tested following the instructions in our [docs](https://transcom.github.io/mymove-docs/docs/backend/setup/database-migrations#secure-migrations).

## Screenshots![Screenshot 2023-12-09 at 10 24 10 AM](https://github.com/transcom/mymove/assets/147739091/3064d833-c12c-4109-970a-47af4cb4a361)