### PR TITLE
B-17956: Fix "Total days used" to not exceed "total days of SIT approved".

### DIFF
--- a/src/components/Office/ReviewSITExtensionModal/ReviewSITExtensionModal.jsx
+++ b/src/components/Office/ReviewSITExtensionModal/ReviewSITExtensionModal.jsx
@@ -82,7 +82,7 @@ const SitStatusTables = ({ sitStatus, sitExtension, shipment }) => {
       return daysRemaining;
     }
     // SIT in has started
-    if (sitStatus && daysRemaining > 0) {
+    if (sitStatus && daysRemaining > 1) {
       return daysRemaining - 1;
     }
     return 'Expired';

--- a/src/components/Office/ShipmentSITDisplay/ShipmentSITDisplay.jsx
+++ b/src/components/Office/ShipmentSITDisplay/ShipmentSITDisplay.jsx
@@ -102,14 +102,16 @@ const SitStatusTables = ({ shipment, sitExtensions, sitStatus, openModalButton }
     return <p key={pastSITItem.id}>{text}</p>;
   });
 
+  const clamp = (value, min, max) => Math.min(Math.max(value, min), max);
+
   // Currently active SIT
   const currentLocation =
     sitStatus.currentSIT?.location === LOCATION_TYPES.DESTINATION ? 'destination SIT' : 'origin SIT';
 
-  const totalSITDaysUsed = sitStatus.totalSITDaysUsed || 0;
+  const totalSITDaysUsed = clamp(sitStatus.totalSITDaysUsed || 0, 0, shipment.sitDaysAllowance);
   const totalDaysRemaining = () => {
     const daysRemaining = sitStatus ? sitStatus.totalDaysRemaining : shipment.sitDaysAllowance;
-    if (daysRemaining >= 0) {
+    if (daysRemaining > 0) {
       return daysRemaining;
     }
     return 'Expired';

--- a/src/components/Office/SubmitSITExtensionModal/SubmitSITExtensionModal.jsx
+++ b/src/components/Office/SubmitSITExtensionModal/SubmitSITExtensionModal.jsx
@@ -55,7 +55,7 @@ const SitStatusTables = ({ sitStatus, shipment }) => {
   const currentDateEnteredSit = <p>{formatDateForDatePicker(sitEntryDate)}</p>;
   const totalDaysRemaining = () => {
     const daysRemaining = sitStatus ? sitStatus.totalDaysRemaining : shipment.sitDaysAllowance;
-    if (daysRemaining >= 0) {
+    if (daysRemaining > 0) {
       return daysRemaining;
     }
     return 'Expired';


### PR DESCRIPTION
… and allowed days. Also, set Expired to show when at 0 days left since a negative num is no longer possible

## [Agility ticket]B-17956
https://www13.v1host.com/USTRANSCOM38/story.mvc/Summary?oidToken=Story%3a869482

## Summary

Given that I am a government user (TOO), when I review a shipment in SIT who's SIT has expired, I will see that the Total days used does not exceed the Sit approved days.

## Verification Steps for the Author

These are to be checked by the author.

- [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
- [ ] Have the Agility acceptance criteria been met for this change?

## Verification Steps for Reviewers

These are to be checked by a reviewer.

- [ ] Has the branch been pulled in and checked out?
- [ ] Have the BL acceptance criteria been met for this change?
- [ ] Was the CircleCI build successful?
- [ ] Has the code been reviewed from a standards and best practices point of view?

### Setup to Run the Code

- [Instructions for starting storybook](https://transcom.github.io/mymove-docs/docs/frontend/setup/storybook)
- [Instructions for starting the MilMove application](https://transcom.github.io/mymove-docs/docs/getting-started/application-setup/)
- [Instructions for running tests](https://transcom.github.io/mymove-docs/docs/getting-started/development/testing)

### How to test

1. Access the Office side as a TOO user
2. Find a move with SIT items on it and open it
3. You should be able to adjust the approved days which will force Days Used to match it if approved days falls below the Days Used number.
4. If the Days Left value is 0, it will show as "Expired"
Note: Days Used value and Days Left value shouldn't change until the item is saved on the modal.

### Frontend

- [ ] There are no aXe warnings for UI.
- [ ] This works in [Supported Browsers and their phone views](https://transcom.github.io/mymove-docs/docs/adrs/Browser-Support/#minimum-browser-requirements) (Chrome, Firefox, Edge).
- [ ] There are no new console errors in the browser devtools.
- [ ] There are no new console errors in the test output.
- [ ] If this PR adds a new component to Storybook, it ensures the component is fully responsive, OR if it is intentionally not, a wrapping div using the `officeApp` class or custom `min-width` styling is used to hide any states the would not be visible to the user.
- [ ] This change meets the standards for [Section 508 compliance](https://www.ssa.gov/accessibility/andi/help/install.html).

### Backend

- [ ] Code follows the guidelines for [Logging](https://transcom.github.io/mymove-docs/docs/getting-started/development/logging).
- [ ] The requirements listed in [Querying the Database Safely](https://transcom.github.io/mymove-docs/docs/backend/guides/golang-guide#querying-the-database-safely) have been satisfied.

### Database

#### Any new migrations/schema changes:

- [ ] Follows our guidelines for [Zero-Downtime Deploys](https://transcom.github.io/mymove-docs/docs/backend/setup/database-migrations#zero-downtime-migrations).
- [ ] Have been communicated to #g-database.
- [ ] Secure migrations have been tested following the instructions in our [docs](https://transcom.github.io/mymove-docs/docs/backend/setup/database-migrations#secure-migrations).

## Screenshots
![ss1](https://github.com/transcom/mymove/assets/147739091/9542b4e9-c735-4f87-ad88-f021bf57eece)
![ss2](https://github.com/transcom/mymove/assets/147739091/c679bcde-31be-427b-a609-275972883afc)

