### PR TITLE
B-17955 Create new field 'Calculated total SIT days' in sit display

### DIFF
--- a/pkg/gen/ghcapi/embedded_spec.go
+++ b/pkg/gen/ghcapi/embedded_spec.go
@@ -8801,6 +8801,9 @@ func init() {
     },
     "SITStatus": {
       "properties": {
+        "calculatedTotalDaysInSIT": {
+          "type": "integer"
+        },
         "currentSIT": {
           "type": "object",
           "properties": {
@@ -20377,6 +20380,10 @@ func init() {
     },
     "SITStatus": {
       "properties": {
+        "calculatedTotalDaysInSIT": {
+          "type": "integer",
+          "minimum": 0
+        },
         "currentSIT": {
           "type": "object",
           "properties": {

--- a/pkg/gen/ghcmessages/s_i_t_status.go
+++ b/pkg/gen/ghcmessages/s_i_t_status.go
@@ -19,6 +19,10 @@ import (
 // swagger:model SITStatus
 type SITStatus struct {
 
+	// calculated total days in s i t
+	// Minimum: 0
+	CalculatedTotalDaysInSIT *int64 `json:"calculatedTotalDaysInSIT,omitempty"`
+
 	// current s i t
 	CurrentSIT *SITStatusCurrentSIT `json:"currentSIT,omitempty"`
 
@@ -37,6 +41,10 @@ type SITStatus struct {
 // Validate validates this s i t status
 func (m *SITStatus) Validate(formats strfmt.Registry) error {
 	var res []error
+
+	if err := m.validateCalculatedTotalDaysInSIT(formats); err != nil {
+		res = append(res, err)
+	}
 
 	if err := m.validateCurrentSIT(formats); err != nil {
 		res = append(res, err)
@@ -57,6 +65,18 @@ func (m *SITStatus) Validate(formats strfmt.Registry) error {
 	if len(res) > 0 {
 		return errors.CompositeValidationError(res...)
 	}
+	return nil
+}
+
+func (m *SITStatus) validateCalculatedTotalDaysInSIT(formats strfmt.Registry) error {
+	if swag.IsZero(m.CalculatedTotalDaysInSIT) { // not required
+		return nil
+	}
+
+	if err := validate.MinimumInt("calculatedTotalDaysInSIT", "body", *m.CalculatedTotalDaysInSIT, 0, false); err != nil {
+		return err
+	}
+
 	return nil
 }
 

--- a/pkg/handlers/ghcapi/internal/payloads/model_to_payload.go
+++ b/pkg/handlers/ghcapi/internal/payloads/model_to_payload.go
@@ -728,10 +728,11 @@ func SITStatus(shipmentSITStatuses *services.SITStatus, storer storage.FileStore
 		return nil
 	}
 	payload := &ghcmessages.SITStatus{
-		PastSITServiceItems: MTOServiceItemModels(shipmentSITStatuses.PastSITs, storer),
-		TotalSITDaysUsed:    handlers.FmtIntPtrToInt64(&shipmentSITStatuses.TotalSITDaysUsed),
-		TotalDaysRemaining:  handlers.FmtIntPtrToInt64(&shipmentSITStatuses.TotalDaysRemaining),
-		CurrentSIT:          currentSIT(shipmentSITStatuses.CurrentSIT),
+		PastSITServiceItems:      MTOServiceItemModels(shipmentSITStatuses.PastSITs, storer),
+		TotalSITDaysUsed:         handlers.FmtIntPtrToInt64(&shipmentSITStatuses.TotalSITDaysUsed),
+		TotalDaysRemaining:       handlers.FmtIntPtrToInt64(&shipmentSITStatuses.TotalDaysRemaining),
+		CalculatedTotalDaysInSIT: handlers.FmtIntPtrToInt64(&shipmentSITStatuses.CalculatedTotalDaysInSIT),
+		CurrentSIT:               currentSIT(shipmentSITStatuses.CurrentSIT),
 	}
 
 	return payload

--- a/pkg/handlers/ghcapi/mto_shipment_test.go
+++ b/pkg/handlers/ghcapi/mto_shipment_test.go
@@ -242,6 +242,7 @@ func (suite *HandlerSuite) TestListMTOShipmentsHandler() {
 		suite.Equal(int64(7), *payloadShipment.SitStatus.CurrentSIT.DaysInSIT)
 		suite.Equal(int64(176), *payloadShipment.SitStatus.TotalDaysRemaining)
 		suite.Equal(int64(14), *payloadShipment.SitStatus.TotalSITDaysUsed) // 7 from the previous SIT and 7 from the current
+		suite.Equal(int64(14), *payloadShipment.SitStatus.CalculatedTotalDaysInSIT)
 		suite.Equal(subtestData.sit.SITEntryDate.Format("2006-01-02"), payloadShipment.SitStatus.CurrentSIT.SitEntryDate.String())
 		suite.Equal(subtestData.sit.SITDepartureDate.Format("2006-01-02"), payloadShipment.SitStatus.CurrentSIT.SitDepartureDate.String())
 

--- a/pkg/services/mto_shipment.go
+++ b/pkg/services/mto_shipment.go
@@ -124,11 +124,12 @@ type ShipmentRouter interface {
 
 // SITStatus is the summary of the current SIT service item days in storage remaining balance and dates
 type SITStatus struct {
-	ShipmentID         uuid.UUID
-	TotalSITDaysUsed   int
-	TotalDaysRemaining int
-	CurrentSIT         *CurrentSIT
-	PastSITs           []models.MTOServiceItem
+	ShipmentID               uuid.UUID
+	TotalSITDaysUsed         int
+	TotalDaysRemaining       int
+	CalculatedTotalDaysInSIT int
+	CurrentSIT               *CurrentSIT
+	PastSITs                 []models.MTOServiceItem
 }
 
 type CurrentSIT struct {

--- a/pkg/services/mto_shipment/shipment_sit_status.go
+++ b/pkg/services/mto_shipment/shipment_sit_status.go
@@ -84,6 +84,7 @@ func (f shipmentSITStatus) CalculateShipmentSITStatus(appCtx appcontext.AppConte
 		return nil, err
 	}
 	shipmentSITStatus.TotalSITDaysUsed = CalculateTotalDaysInSIT(shipmentSITs, today)
+	shipmentSITStatus.CalculatedTotalDaysInSIT = CalculateTotalDaysInSIT(shipmentSITs, today)
 	shipmentSITStatus.TotalDaysRemaining = totalSITAllowance - shipmentSITStatus.TotalSITDaysUsed
 	shipmentSITStatus.PastSITs = shipmentSITs.pastSITs
 

--- a/pkg/services/mto_shipment/shipment_sit_status_test.go
+++ b/pkg/services/mto_shipment/shipment_sit_status_test.go
@@ -111,6 +111,7 @@ func (suite *MTOShipmentServiceSuite) TestShipmentSITStatus() {
 		suite.Equal(dofsit.ID.String(), sitStatus.PastSITs[0].ID.String())
 
 		suite.Equal(15, sitStatus.TotalSITDaysUsed)
+		suite.Equal(15, sitStatus.CalculatedTotalDaysInSIT)
 		suite.Equal(75, sitStatus.TotalDaysRemaining)
 		suite.Nil(sitStatus.CurrentSIT) // No current SIT since all SIT items have departed status
 	})
@@ -154,6 +155,7 @@ func (suite *MTOShipmentServiceSuite) TestShipmentSITStatus() {
 
 		suite.Equal(OriginSITLocation, sitStatus.CurrentSIT.Location)
 		suite.Equal(30, sitStatus.TotalSITDaysUsed)
+		suite.Equal(30, sitStatus.CalculatedTotalDaysInSIT)
 		suite.Equal(60, sitStatus.TotalDaysRemaining)
 		suite.Equal(30, sitStatus.CurrentSIT.DaysInSIT)
 		suite.Equal(aMonthAgo.String(), sitStatus.CurrentSIT.SITEntryDate.String())
@@ -224,6 +226,7 @@ func (suite *MTOShipmentServiceSuite) TestShipmentSITStatus() {
 
 		suite.Equal(OriginSITLocation, sitStatus.CurrentSIT.Location)
 		suite.Equal(22, sitStatus.TotalSITDaysUsed) // 15 days from previous SIT, 7 days from the current
+		suite.Equal(22, sitStatus.CalculatedTotalDaysInSIT)
 		suite.Equal(68, sitStatus.TotalDaysRemaining)
 		suite.Equal(7, sitStatus.CurrentSIT.DaysInSIT)
 		suite.Equal(aWeekAgo.String(), sitStatus.CurrentSIT.SITEntryDate.String())
@@ -296,6 +299,7 @@ func (suite *MTOShipmentServiceSuite) TestShipmentSITStatus() {
 
 		suite.Equal(DestinationSITLocation, sitStatus.CurrentSIT.Location)
 		suite.Equal(22, sitStatus.TotalSITDaysUsed) // 15 days from previous SIT, 7 days from the current
+		suite.Equal(22, sitStatus.CalculatedTotalDaysInSIT)
 		suite.Equal(68, sitStatus.TotalDaysRemaining)
 		suite.Equal(7, sitStatus.CurrentSIT.DaysInSIT)
 		suite.Equal(aWeekAgo.String(), sitStatus.CurrentSIT.SITEntryDate.String())
@@ -368,6 +372,7 @@ func (suite *MTOShipmentServiceSuite) TestShipmentSITStatus() {
 
 		suite.Equal(DestinationSITLocation, sitStatus.CurrentSIT.Location)
 		suite.Equal(97, sitStatus.TotalSITDaysUsed) // 15 days from previous SIT, 7 days from the current
+		suite.Equal(97, sitStatus.CalculatedTotalDaysInSIT)
 		suite.Equal(-7, sitStatus.TotalDaysRemaining)
 		suite.Equal(7, sitStatus.CurrentSIT.DaysInSIT)
 		suite.Equal(aWeekAgo.String(), sitStatus.CurrentSIT.SITEntryDate.String())

--- a/playwright/tests/office/txo/sitUpdates.spec.js
+++ b/playwright/tests/office/txo/sitUpdates.spec.js
@@ -127,6 +127,18 @@ test.describe('TOO user', () => {
       await expect(page.getByText('Additional days requested')).toBeHidden();
       await expect(page.getByTestId('sitStatusTable').getByText('90', { exact: true }).first()).toBeVisible();
     });
+    test('is showing correct labels', async ({ page }) => {
+      // navigate to MTO tab
+      await page.getByTestId('MoveTaskOrder-Tab').click();
+      await tooFlowPage.waitForPage.moveTaskOrder();
+
+      await expect(page.getByText('Total days of SIT approved')).toBeVisible();
+      await expect(page.getByText('Total days used')).toBeVisible();
+      await expect(page.getByText('Total days remaining')).toBeVisible();
+      await expect(page.getByText('SIT start date')).toBeVisible();
+      await expect(page.getByText('	SIT authorized end date')).toBeVisible();
+      await expect(page.getByText('Calculated total SIT days')).toBeVisible();
+    });
   });
 });
 

--- a/src/components/Office/ReviewSITExtensionModal/ReviewSITExtensionModal.jsx
+++ b/src/components/Office/ReviewSITExtensionModal/ReviewSITExtensionModal.jsx
@@ -167,13 +167,14 @@ const SitStatusTables = ({ sitStatus, sitExtension, shipment }) => {
           ]}
         />
       </div>
-      <div className={styles.tableContainer}>
+      <div className={styles.tableContainer} data-testid="sitStartAndEndTable">
         {/* Sit Start and End table */}
         <p className={styles.sitHeader}>Current location: {currentLocation}</p>
         <DataTable
           columnHeaders={[
             `SIT start date`,
             <SITHistoryItemHeader title="SIT authorized end date" value={approvedAndRequestedDatesCombined} />,
+            'Calculated total SIT days',
           ]}
           dataRow={[
             currentDateEnteredSit,
@@ -182,6 +183,7 @@ const SitStatusTables = ({ sitStatus, sitExtension, shipment }) => {
                 handleSitEndDateChange(value);
               }}
             />,
+            sitStatus.calculatedTotalDaysInSIT,
           ]}
           custClass={styles.currentLocation}
         />

--- a/src/components/Office/ReviewSITExtensionModal/ReviewSITExtensionModal.stories.jsx
+++ b/src/components/Office/ReviewSITExtensionModal/ReviewSITExtensionModal.stories.jsx
@@ -32,6 +32,7 @@ const sitExtension = {
 const sitStatus = {
   totalDaysRemaining: 30,
   totalSITDaysUsed: 15,
+  calculatedTotalDaysInSIT: 15,
   currentSIT: {
     daysInSIT: 15,
     sitEntryDate: new Date('22 Aug 2023'),

--- a/src/components/Office/ReviewSITExtensionModal/ReviewSITExtensionModal.test.jsx
+++ b/src/components/Office/ReviewSITExtensionModal/ReviewSITExtensionModal.test.jsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import moment from 'moment';
 import React from 'react';
@@ -18,6 +18,7 @@ describe('ReviewSITExtensionModal', () => {
   const sitStatus = {
     totalDaysRemaining: 30,
     totalSITDaysUsed: 15,
+    calculatedTotalDaysInSIT: 15,
     currentSIT: {
       daysInSIT: 15,
       sitEntryDate: moment().subtract(15, 'days').format(swaggerDateFormat),
@@ -204,5 +205,9 @@ describe('ReviewSITExtensionModal', () => {
     await waitFor(() => {
       expect(screen.getByText('SIT (STORAGE IN TRANSIT)')).toBeInTheDocument();
     });
+    const sitStartAndEndTable = await screen.findByTestId('sitStartAndEndTable');
+    expect(sitStartAndEndTable).toBeInTheDocument();
+    expect(within(sitStartAndEndTable).getByText('Calculated total SIT days')).toBeInTheDocument();
+    expect(within(sitStartAndEndTable).getByText('15')).toBeInTheDocument();
   });
 });

--- a/src/components/Office/ShipmentSITDisplay/ShipmentSITDisplay.jsx
+++ b/src/components/Office/ShipmentSITDisplay/ShipmentSITDisplay.jsx
@@ -144,8 +144,8 @@ const SitStatusTables = ({ shipment, sitExtensions, sitStatus, openModalButton }
             {/* Sit Start and End table */}
             {currentDaysInSIT > 0 && <p className={styles.sitHeader}>Current location: {currentLocation}</p>}
             <DataTable
-              columnHeaders={[`SIT start date`, 'SIT authorized end date']}
-              dataRow={[sitStartDateElement, sitEndDateString]}
+              columnHeaders={[`SIT start date`, 'SIT authorized end date', 'Calculated total SIT days']}
+              dataRow={[sitStartDateElement, sitEndDateString, sitStatus.calculatedTotalDaysInSIT]}
               custClass={styles.currentLocation}
             />
           </div>

--- a/src/components/Office/ShipmentSITDisplay/ShipmentSITDisplay.test.jsx
+++ b/src/components/Office/ShipmentSITDisplay/ShipmentSITDisplay.test.jsx
@@ -58,6 +58,10 @@ describe('ShipmentSITDisplay', () => {
     expect(screen.getByText('Current location: destination SIT')).toBeInTheDocument();
     expect(screen.getByText('Total days in destination SIT')).toBeInTheDocument();
     expect(screen.getByText('15')).toBeInTheDocument();
+    const sitStartAndEndTable = await screen.findByTestId('sitStartAndEndTable');
+    expect(sitStartAndEndTable).toBeInTheDocument();
+    expect(within(sitStartAndEndTable).getByText('Calculated total SIT days')).toBeInTheDocument();
+    expect(within(sitStartAndEndTable).getByText('45')).toBeInTheDocument();
   });
 
   it('renders the Shipment SIT at Destination, with customer delivery info', async () => {
@@ -122,6 +126,7 @@ describe('ShipmentSITDisplay', () => {
     expect(screen.queryByText('Current location')).not.toBeInTheDocument();
     expect(screen.queryByText('SIT start date')).not.toBeInTheDocument();
     expect(screen.queryByText('SIT authorized end date')).not.toBeInTheDocument();
+    expect(screen.queryByText('Calculated total SIT days')).not.toBeInTheDocument();
 
     expect(screen.getByText('Previously used SIT')).toBeInTheDocument();
     expect(screen.getByText(`30 days at origin (24 Jul 2021 - 23 Aug 2021)`)).toBeInTheDocument();
@@ -208,6 +213,8 @@ describe('ShipmentSITDisplay', () => {
     expect(within(sitStartAndEndTable).queryByText('Current location')).not.toBeInTheDocument();
     expect(within(sitStartAndEndTable).getByText('SIT start date')).toBeInTheDocument();
     expect(within(sitStartAndEndTable).getByText('SIT authorized end date')).toBeInTheDocument();
+    expect(within(sitStartAndEndTable).getByText('Calculated total SIT days')).toBeInTheDocument();
+    expect(within(sitStartAndEndTable).getByText('0')).toBeInTheDocument();
     const sitDaysAtCurrentLocation = await screen.findByTestId('sitDaysAtCurrentLocation');
     expect(sitDaysAtCurrentLocation).toBeInTheDocument();
     expect(within(sitDaysAtCurrentLocation).getByText('Total days in origin SIT')).toBeInTheDocument();

--- a/src/components/Office/ShipmentSITDisplay/ShipmentSITDisplayTestParams.js
+++ b/src/components/Office/ShipmentSITDisplay/ShipmentSITDisplayTestParams.js
@@ -62,6 +62,7 @@ export const SITExtensionDenied = [
 export const SITStatusOrigin = {
   totalSITDaysUsed: 45,
   totalDaysRemaining: 60,
+  calculatedTotalDaysInSIT: 45,
   currentSIT: {
     location: LOCATION_VALUES.ORIGIN,
     daysInSIT: 15,
@@ -73,6 +74,7 @@ export const SITStatusOrigin = {
 export const SITStatusDestination = {
   totalSITDaysUsed: 45,
   totalDaysRemaining: 60,
+  calculatedTotalDaysInSIT: 45,
   currentSIT: {
     location: LOCATION_VALUES.DESTINATION,
     daysInSIT: 15,
@@ -86,6 +88,7 @@ export const SITStatusDestination = {
 export const SITStatusDestinationWithoutCustomerDeliveryInfo = {
   totalSITDaysUsed: 45,
   totalDaysRemaining: 60,
+  calculatedTotalDaysInSIT: 45,
   currentSIT: {
     location: LOCATION_VALUES.DESTINATION,
     daysInSIT: 15,
@@ -97,6 +100,7 @@ export const SITStatusDestinationWithoutCustomerDeliveryInfo = {
 export const futureSITStatus = {
   totalDaysRemaining: 365,
   totalSITDaysUsed: 0,
+  calculatedTotalDaysInSIT: 0,
   currentSIT: {
     location: LOCATION_VALUES.ORIGIN,
     daysInSIT: 0,
@@ -111,6 +115,7 @@ export const SITStatusWithPastSITOriginServiceItem = {
   sitEntryDate: '2021-08-23',
   totalDaysRemaining: 210,
   totalSITDaysUsed: 60,
+  calculatedTotalDaysInSIT: 60,
   pastSITServiceItems: [
     {
       SITPostalCode: '90210',
@@ -141,6 +146,7 @@ export const SITStatusWithPastSITServiceItems = {
   sitEntryDate: '2021-08-23',
   totalDaysRemaining: 210,
   totalSITDaysUsed: 60,
+  calculatedTotalDaysInSIT: 60,
   pastSITServiceItems: [
     {
       SITPostalCode: '90210',
@@ -188,6 +194,7 @@ export const SITStatusWithPastSITServiceItems = {
 export const SITStatusWithPastSITServiceItemsDeparted = {
   totalDaysRemaining: 210,
   totalSITDaysUsed: 60,
+  calculatedTotalDaysInSIT: 60,
   pastSITServiceItems: [
     {
       SITPostalCode: '90210',
@@ -389,6 +396,7 @@ export const SITShipment = {
     sitEntryDate: '2023-04-24',
     totalDaysRemaining: 210,
     totalSITDaysUsed: 270,
+    calculatedTotalDaysInSIT: 270,
   },
   sitDaysAllowance: 270,
   mtoServiceItems: mtoServiceItemsWithSIT,
@@ -404,6 +412,7 @@ export const futureSITShipment = {
 export const SITStatusExpired = {
   totalSITDaysUsed: 270,
   totalDaysRemaining: -2,
+  calculatedTotalDaysInSIT: 270,
   currentSIT: {
     location: LOCATION_VALUES.DESTINATION,
     daysInSIT: 15,

--- a/src/components/Office/SubmitSITExtensionModal/SubmitSITExtensionModal.jsx
+++ b/src/components/Office/SubmitSITExtensionModal/SubmitSITExtensionModal.jsx
@@ -120,11 +120,11 @@ const SitStatusTables = ({ sitStatus, shipment }) => {
           ]}
         />
       </div>
-      <div className={styles.tableContainer}>
+      <div className={styles.tableContainer} data-testid="sitStartAndEndTable">
         {/* Sit Start and End table */}
         <p className={styles.sitHeader}>Current location: {currentLocation}</p>
         <DataTable
-          columnHeaders={[`SIT start date`, 'SIT authorized end date']}
+          columnHeaders={[`SIT start date`, 'SIT authorized end date', 'Calculated total SIT days']}
           dataRow={[
             currentDateEnteredSit,
             <SitEndDateForm
@@ -132,6 +132,7 @@ const SitStatusTables = ({ sitStatus, shipment }) => {
                 handleSitEndDateChange(value);
               }}
             />,
+            sitStatus.calculatedTotalDaysInSIT,
           ]}
           custClass={styles.currentLocation}
         />

--- a/src/components/Office/SubmitSITExtensionModal/SubmitSITExtensionModal.stories.jsx
+++ b/src/components/Office/SubmitSITExtensionModal/SubmitSITExtensionModal.stories.jsx
@@ -30,6 +30,7 @@ export default {
 const sitStatus = {
   totalDaysRemaining: 210,
   totalSITDaysUsed: 60,
+  calculatedTotalDaysInSIT: 60,
   currentSIT: {
     location: 'DESTINATION',
     daysInSIT: 30,

--- a/src/components/Office/SubmitSITExtensionModal/SubmitSITExtensionModal.test.jsx
+++ b/src/components/Office/SubmitSITExtensionModal/SubmitSITExtensionModal.test.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, waitFor, screen, act, fireEvent } from '@testing-library/react';
+import { render, waitFor, screen, act, fireEvent, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import moment from 'moment';
 
@@ -11,6 +11,7 @@ const defaultValues = {
   sitStatus: {
     totalDaysRemaining: 210,
     totalSITDaysUsed: 60,
+    calculatedTotalDaysInSIT: 60,
     currentSIT: {
       location: 'DESTINATION',
       daysInSIT: 60,
@@ -109,5 +110,9 @@ describe('SubmitSITExtensionModal', () => {
     await waitFor(() => {
       expect(screen.getByText('SIT (STORAGE IN TRANSIT)')).toBeInTheDocument();
     });
+    const sitStartAndEndTable = await screen.findByTestId('sitStartAndEndTable');
+    expect(sitStartAndEndTable).toBeInTheDocument();
+    expect(within(sitStartAndEndTable).getByText('Calculated total SIT days')).toBeInTheDocument();
+    expect(within(sitStartAndEndTable).getByText('60')).toBeInTheDocument();
   });
 });

--- a/src/types/sitStatusShape.js
+++ b/src/types/sitStatusShape.js
@@ -67,6 +67,7 @@ const PastServiceItemsShape = PropTypes.shape({
 export const SitStatusShape = PropTypes.shape({
   totalSITDaysUsed: PropTypes.number.isRequired,
   totalDaysRemaining: PropTypes.number.isRequired,
+  calculatedTotalDaysInSIT: PropTypes.number.isRequired,
   currentSIT: PropTypes.shape({
     location: LOCATION_TYPES_ONE_OF,
     daysInSIT: PropTypes.number,

--- a/swagger-def/definitions/SITStatus.yaml
+++ b/swagger-def/definitions/SITStatus.yaml
@@ -5,6 +5,9 @@ properties:
   totalDaysRemaining:
     type: integer
     minimum: 0
+  calculatedTotalDaysInSIT:
+    type: integer
+    minimum: 0
   currentSIT:
     type: object
     properties:

--- a/swagger/ghc.yaml
+++ b/swagger/ghc.yaml
@@ -6448,6 +6448,9 @@ definitions:
       totalDaysRemaining:
         type: integer
         minimum: 0
+      calculatedTotalDaysInSIT:
+        type: integer
+        minimum: 0
       currentSIT:
         type: object
         properties:


### PR DESCRIPTION
## Summary

This is adding a new field in SIT information display under "Move task order" tab.
The new label is "Calculated total SIT days" and it displays value representing calculated total SIT days for that shipment.

`calculatedTotalDaysInSIT` is created in the backend to represent this data and is added under `sitStatus` object.
This new field is not stored in DB and is calculated upon GET request.
http://officelocal:3000/swagger-ui/ghc.html#/mtoShipment/listMTOShipments

### How to test

1. Create a move with a HHG shipment and follow the normal flow to create a SIT service item.
2. Once approved as a TOO, label and the value should be visible under Move task order tab. (See image below for placement.
3. Also added in review/edit modals.

## Screenshots
<img width="1077" alt="image" src="https://github.com/transcom/mymove/assets/146856854/a1f72544-0ef6-4bde-ba94-ed87abff6ab5">
<img width="660" alt="image" src="https://github.com/transcom/mymove/assets/146856854/f3cf9384-b85b-4efc-a6ec-bd692712ef8a">
<img width="575" alt="image" src="https://github.com/transcom/mymove/assets/146856854/1f2618aa-6a6e-45fc-9aac-2c2557ec3db8">
