### PR TITLE
B-17993 Recalculate sit dates after edit updates

### DIFF
--- a/pkg/handlers/primeapi/mto_shipment.go
+++ b/pkg/handlers/primeapi/mto_shipment.go
@@ -351,7 +351,7 @@ func (h UpdateSITDeliveryRequestHandler) Handle(params mtoshipmentops.UpdateSITD
 			var sitCustomerContacted = (*time.Time)(params.Body.SitCustomerContacted)
 			var sitRequestedDelivery = (*time.Time)(params.Body.SitRequestedDelivery)
 
-			shipmentSITStatus, err := h.shipmentStatus.CalculateSITAllowanceRequestedDates(*shipment, sitCustomerContacted, sitRequestedDelivery, eTag)
+			shipmentSITStatus, err := h.shipmentStatus.CalculateSITAllowanceRequestedDates(appCtx, *shipment, sitCustomerContacted, sitRequestedDelivery, eTag)
 
 			if err != nil {
 				appCtx.Logger().Error("primeapi.UpdateSITDeliveryRequestHandler error - failed to update dates", zap.Error(err))

--- a/pkg/services/mocks/ShipmentSITStatus.go
+++ b/pkg/services/mocks/ShipmentSITStatus.go
@@ -18,25 +18,25 @@ type ShipmentSITStatus struct {
 	mock.Mock
 }
 
-// CalculateSITAllowanceRequestedDates provides a mock function with given fields: shipment, sitCustomerContacted, sitRequestedDelivery, eTag
-func (_m *ShipmentSITStatus) CalculateSITAllowanceRequestedDates(shipment models.MTOShipment, sitCustomerContacted *time.Time, sitRequestedDelivery *time.Time, eTag string) (*services.SITStatus, error) {
-	ret := _m.Called(shipment, sitCustomerContacted, sitRequestedDelivery, eTag)
+// CalculateSITAllowanceRequestedDates provides a mock function with given fields: appCtx, shipment, sitCustomerContacted, sitRequestedDelivery, eTag
+func (_m *ShipmentSITStatus) CalculateSITAllowanceRequestedDates(appCtx appcontext.AppContext, shipment models.MTOShipment, sitCustomerContacted *time.Time, sitRequestedDelivery *time.Time, eTag string) (*services.SITStatus, error) {
+	ret := _m.Called(appCtx, shipment, sitCustomerContacted, sitRequestedDelivery, eTag)
 
 	var r0 *services.SITStatus
 	var r1 error
-	if rf, ok := ret.Get(0).(func(models.MTOShipment, *time.Time, *time.Time, string) (*services.SITStatus, error)); ok {
-		return rf(shipment, sitCustomerContacted, sitRequestedDelivery, eTag)
+	if rf, ok := ret.Get(0).(func(appcontext.AppContext, models.MTOShipment, *time.Time, *time.Time, string) (*services.SITStatus, error)); ok {
+		return rf(appCtx, shipment, sitCustomerContacted, sitRequestedDelivery, eTag)
 	}
-	if rf, ok := ret.Get(0).(func(models.MTOShipment, *time.Time, *time.Time, string) *services.SITStatus); ok {
-		r0 = rf(shipment, sitCustomerContacted, sitRequestedDelivery, eTag)
+	if rf, ok := ret.Get(0).(func(appcontext.AppContext, models.MTOShipment, *time.Time, *time.Time, string) *services.SITStatus); ok {
+		r0 = rf(appCtx, shipment, sitCustomerContacted, sitRequestedDelivery, eTag)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*services.SITStatus)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(models.MTOShipment, *time.Time, *time.Time, string) error); ok {
-		r1 = rf(shipment, sitCustomerContacted, sitRequestedDelivery, eTag)
+	if rf, ok := ret.Get(1).(func(appcontext.AppContext, models.MTOShipment, *time.Time, *time.Time, string) error); ok {
+		r1 = rf(appCtx, shipment, sitCustomerContacted, sitRequestedDelivery, eTag)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/pkg/services/mto_shipment.go
+++ b/pkg/services/mto_shipment.go
@@ -150,6 +150,6 @@ type ShipmentSITStatus interface {
 	CalculateShipmentsSITStatuses(appCtx appcontext.AppContext, shipments []models.MTOShipment) map[string]SITStatus
 	CalculateShipmentSITStatus(appCtx appcontext.AppContext, shipment models.MTOShipment) (*SITStatus, error)
 	CalculateShipmentSITAllowance(appCtx appcontext.AppContext, shipment models.MTOShipment) (int, error)
-	CalculateSITAllowanceRequestedDates(shipment models.MTOShipment, sitCustomerContacted *time.Time,
+	CalculateSITAllowanceRequestedDates(appCtx appcontext.AppContext, shipment models.MTOShipment, sitCustomerContacted *time.Time,
 		sitRequestedDelivery *time.Time, eTag string) (*SITStatus, error)
 }

--- a/pkg/services/payment_request/payment_request_shipments_sit_balance_test.go
+++ b/pkg/services/payment_request/payment_request_shipments_sit_balance_test.go
@@ -203,7 +203,7 @@ func (suite *PaymentRequestServiceSuite) TestListShipmentPaymentSITBalance() {
 		suite.Equal(paymentEndDate.String(), pendingSITBalance.PendingBilledEndDate.String())
 		suite.Equal(120, pendingSITBalance.TotalSITDaysAuthorized)
 		suite.Equal(90, pendingSITBalance.TotalSITDaysRemaining)
-		suite.Equal(doasit.SITEntryDate.AddDate(0, 0, 120).String(), pendingSITBalance.TotalSITEndDate.String())
+		suite.Equal(doasit.SITEntryDate.AddDate(0, 0, 120).String(), pendingSITBalance.TotalSITEndDate.UTC().String())
 	})
 
 	suite.Run("calculates pending destination SIT balance when origin was invoiced previously", func() {
@@ -530,7 +530,7 @@ func (suite *PaymentRequestServiceSuite) TestListShipmentPaymentSITBalance() {
 		// 120 total authorized - 30 from origin SIT - 60 from destination SIT = 30 SIT days remaining
 		suite.Equal(30, pendingSITBalance.TotalSITDaysRemaining)
 
-		suite.Equal(ddasit.SITEntryDate.AddDate(0, 0, 90).String(), pendingSITBalance.TotalSITEndDate.String())
+		suite.Equal(ddasit.SITEntryDate.AddDate(0, 0, 90).String(), pendingSITBalance.TotalSITEndDate.UTC().String())
 	})
 
 	suite.Run("ignores including previously denied service items in SIT balance", func() {

--- a/pkg/services/sit_status/shipment_sit_status_test.go
+++ b/pkg/services/sit_status/shipment_sit_status_test.go
@@ -428,7 +428,7 @@ func (suite *SITStatusServiceSuite) TestShipmentSITStatus() {
 	suite.Run("calculates allowance end date and requested delivery date for a shipment currently in SIT", func() {
 		subtestData := makeSubtestData(true, models.ReServiceCodeDOFSIT)
 
-		sitStatus, err := sitStatusService.CalculateSITAllowanceRequestedDates(subtestData.shipment, &subtestData.sitCustomerContacted,
+		sitStatus, err := sitStatusService.CalculateSITAllowanceRequestedDates(suite.AppContextForTest(), subtestData.shipment, &subtestData.sitCustomerContacted,
 			&subtestData.sitRequestedDelivery, subtestData.eTag)
 		suite.NoError(err)
 		suite.NotNil(sitStatus)
@@ -443,7 +443,7 @@ func (suite *SITStatusServiceSuite) TestShipmentSITStatus() {
 		oldDate := time.Date(year, month, day, 0, 0, 0, 0, time.UTC)
 		subtestData.eTag = etag.GenerateEtag(oldDate)
 
-		sitStatus, err := sitStatusService.CalculateSITAllowanceRequestedDates(subtestData.shipment, &subtestData.sitCustomerContacted,
+		sitStatus, err := sitStatusService.CalculateSITAllowanceRequestedDates(suite.AppContextForTest(), subtestData.shipment, &subtestData.sitCustomerContacted,
 			&subtestData.sitRequestedDelivery, subtestData.eTag)
 
 		suite.Error(err)
@@ -453,7 +453,7 @@ func (suite *SITStatusServiceSuite) TestShipmentSITStatus() {
 
 	suite.Run("failure test for calculate allowance with no service items", func() {
 		subtestData := makeSubtestData(false, models.ReServiceCodeDOFSIT)
-		sitStatus, err := sitStatusService.CalculateSITAllowanceRequestedDates(subtestData.shipment, &subtestData.sitCustomerContacted,
+		sitStatus, err := sitStatusService.CalculateSITAllowanceRequestedDates(suite.AppContextForTest(), subtestData.shipment, &subtestData.sitCustomerContacted,
 			&subtestData.sitRequestedDelivery, subtestData.eTag)
 
 		suite.Error(err)
@@ -463,7 +463,7 @@ func (suite *SITStatusServiceSuite) TestShipmentSITStatus() {
 
 	suite.Run("failure test for calculate allowance with no current SIT", func() {
 		subtestData := makeSubtestData(false, models.ReServiceCodeCS)
-		sitStatus, err := sitStatusService.CalculateSITAllowanceRequestedDates(subtestData.shipment, &subtestData.sitCustomerContacted,
+		sitStatus, err := sitStatusService.CalculateSITAllowanceRequestedDates(suite.AppContextForTest(), subtestData.shipment, &subtestData.sitCustomerContacted,
 			&subtestData.sitRequestedDelivery, subtestData.eTag)
 
 		suite.Error(err)

--- a/src/components/Office/SubmitSITExtensionModal/SubmitSITExtensionModal.jsx
+++ b/src/components/Office/SubmitSITExtensionModal/SubmitSITExtensionModal.jsx
@@ -41,7 +41,7 @@ const SitEndDateForm = ({ onChange }) => (
 );
 
 const SitStatusTables = ({ sitStatus, shipment }) => {
-  const { totalSITDaysUsed } = sitStatus;
+  const { totalSITDaysUsed, calculatedTotalDaysInSIT } = sitStatus;
   const { daysInSIT } = sitStatus.currentSIT;
   const sitEntryDate = moment(sitStatus.currentSIT.sitEntryDate, swaggerDateFormat);
   const daysInPreviousSIT = totalSITDaysUsed - daysInSIT;
@@ -98,7 +98,9 @@ const SitStatusTables = ({ sitStatus, shipment }) => {
     // Sit days allowance
     sitAllowanceHelper.setValue(daysApproved);
     // // // Sit End date
-    const calculatedSitEndDate = formatDateForDatePicker(sitEntryDate.add(daysApproved - daysInPreviousSIT, 'days'));
+    const calculatedSitEndDate = formatDateForDatePicker(
+      sitEntryDate.add(daysApproved - (calculatedTotalDaysInSIT - daysInSIT), 'days'),
+    );
     endDateHelper.setTouched(true);
     endDateHelper.setValue(calculatedSitEndDate);
   };
@@ -162,7 +164,7 @@ const SubmitSITExtensionModal = ({ shipment, sitStatus, onClose, onSubmit }) => 
     daysApproved: String(shipment.sitDaysAllowance),
     sitEndDate: formatDateForDatePicker(moment(sitStatus.currentSIT.sitAllowanceEndDate, swaggerDateFormat)),
   };
-  const minimumDaysAllowed = sitStatus.totalSITDaysUsed - sitStatus.currentSIT.daysInSIT + 1;
+  const minimumDaysAllowed = sitStatus.calculatedTotalDaysInSIT - sitStatus.currentSIT.daysInSIT + 1;
   const sitEntryDate = moment(sitStatus.currentSIT.sitEntryDate, swaggerDateFormat);
   const reviewSITExtensionSchema = Yup.object().shape({
     requestReason: Yup.string().required('Required'),


### PR DESCRIPTION
## Summary

This PR is to check and fix any issues found when TOO edits `Total days of SIT approved` or `SIT authorized end date` in the **Edit SIT authorization** modal. While editing the fields and/or save the new dates entered, other values should reflect the change correctly.

- Edits have been made to the SIT authorized end date calculation to reflect the change to `Total days used` calculation.
- Changed UI minimum value validation for `Total days of SIT approved` have been changed to show correct number of minimum days required.
- Fixed the bug where the user was able to bypass the minimum value validation for the `Total days of SIT approved`.
- Fixed auto-date change to show correct dates when editing `Total days of SIT approved` or `SIT authorized end date`

### How to test

1. Create a HHG move with a SIT service item.
2. Login as TOO -> under "Move task order" tab -> use the 'Edit' button.
3. Make changes to the `Total days of SIT approved` or `SIT authorized end date`.
4. Verify that the changed edits are correct.

## Screenshots
### BEFORE
<img width="1118" alt="image" src="https://github.com/transcom/mymove/assets/146856854/d13c10b2-1136-47a5-b203-b84867d45ebf">

### AFTER
<img width="1138" alt="image" src="https://github.com/transcom/mymove/assets/146856854/462f01ce-e445-4e67-b7ca-3feff58e1acf">
