### PR TITLE
B-11810 Fixed remaining rank label

### DIFF
--- a/src/components/Customer/ServiceInfoForm/ServiceInfoForm.jsx
+++ b/src/components/Customer/ServiceInfoForm/ServiceInfoForm.jsx
@@ -72,7 +72,7 @@ const ServiceInfoForm = ({ initialValues, onSubmit, onCancel }) => {
 
               <Grid row gap>
                 <Grid mobileLg={{ col: 6 }}>
-                  <DropdownInput label="Rank" name="rank" id="rank" required options={rankOptions} />
+                  <DropdownInput label="Pay grade" name="rank" id="rank" required options={rankOptions} />
                 </Grid>
               </Grid>
 

--- a/src/components/Customer/ServiceInfoForm/ServiceInfoForm.test.jsx
+++ b/src/components/Customer/ServiceInfoForm/ServiceInfoForm.test.jsx
@@ -167,7 +167,7 @@ describe('ServiceInfoForm', () => {
     expect(dodInput).toBeInstanceOf(HTMLInputElement);
     expect(dodInput).toBeRequired();
 
-    const rankInput = await screen.findByLabelText('Rank');
+    const rankInput = await screen.findByLabelText('Pay grade');
     expect(rankInput).toBeInstanceOf(HTMLSelectElement);
     expect(rankInput).toBeRequired();
 
@@ -193,7 +193,7 @@ describe('ServiceInfoForm', () => {
     await userEvent.click(screen.getByLabelText('Last name'));
     await userEvent.click(screen.getByLabelText('Branch of service'));
     await userEvent.click(screen.getByLabelText('DoD ID number'));
-    await userEvent.click(screen.getByLabelText('Rank'));
+    await userEvent.click(screen.getByLabelText('Pay grade'));
 
     const submitBtn = screen.getByRole('button', { name: 'Save' });
     await userEvent.click(submitBtn);
@@ -217,7 +217,7 @@ describe('ServiceInfoForm', () => {
     await userEvent.type(screen.getByLabelText('Last name'), 'Spaceman');
     await userEvent.selectOptions(screen.getByLabelText('Branch of service'), ['NAVY']);
     await userEvent.type(screen.getByLabelText('DoD ID number'), '1234567890');
-    await userEvent.selectOptions(screen.getByLabelText('Rank'), ['E_5']);
+    await userEvent.selectOptions(screen.getByLabelText('Pay grade'), ['E_5']);
     fireEvent.change(screen.getByLabelText('Current duty location'), { target: { value: 'AFB' } });
     await act(() => selectEvent.select(screen.getByLabelText('Current duty location'), /Luke/));
 

--- a/src/pages/MyMove/Profile/EditServiceInfo.test.jsx
+++ b/src/pages/MyMove/Profile/EditServiceInfo.test.jsx
@@ -185,7 +185,7 @@ describe('EditServiceInfo page', () => {
       />,
     );
 
-    const rankInput = await screen.findByLabelText('Rank');
+    const rankInput = await screen.findByLabelText('Pay grade');
     await userEvent.selectOptions(rankInput, ['E_2']);
 
     const submitButton = await screen.findByText('Save');


### PR DESCRIPTION
## [B-11810](https://www13.v1host.com/USTRANSCOM38/story.mvc/Summary?oidToken=Story%3a871309)

## Summary

It was found in testing that there was a remaining "Rank" label under the "edit" view of the profile.

### Setup to Run the Code

- [Instructions for starting storybook](https://transcom.github.io/mymove-docs/docs/frontend/setup/storybook)
- [Instructions for starting the MilMove application](https://transcom.github.io/mymove-docs/docs/getting-started/application-setup/)
- [Instructions for running tests](https://transcom.github.io/mymove-docs/docs/getting-started/development/testing)

### How to test

1. Access the customer site
2. On creating a new account, edit your profile
3. See that the "edit" view does not have "Rank" and instead has "Pay grade"

## See screenshots from Happo for changes
<img width="862" alt="image" src="https://github.com/transcom/mymove/assets/136814362/f5c6ed79-9fe9-4a70-b799-cd513838952d">

<img width="862" alt="image" src="https://github.com/transcom/mymove/assets/136814362/dad55c65-5ef1-4016-8135-0dc5f06b5a3b">
