### PR TITLE
B17951 - rename "Office remarks" label and underlying code.

### DIFF
--- a/src/components/Office/ConvertSITToCustomerExpenseModal/ConvertSITToCustomerExpenseModal.jsx
+++ b/src/components/Office/ConvertSITToCustomerExpenseModal/ConvertSITToCustomerExpenseModal.jsx
@@ -77,11 +77,11 @@ const ConvertSITToCustomerExpenseModal = ({ shipment, sitStatus, onClose, onSubm
   }
 
   const initialValues = {
-    officeRemarks: '',
+    remarks: '',
     convertToCustomersExpense: true,
   };
   const convertSITToCustomerExpenseSchema = Yup.object().shape({
-    officeRemarks: Yup.string().required('Required'),
+    remarks: Yup.string().required('Required'),
     convertToCustomersExpense: Yup.boolean().required('Required'),
   });
 
@@ -106,15 +106,8 @@ const ConvertSITToCustomerExpenseModal = ({ shipment, sitStatus, onClose, onSubm
                   <DataTableWrapper className={classnames('maxw-tablet', styles.sitDisplayForm)} testID="sitExtensions">
                     <SitStatusTables sitStatus={sitStatus} shipment={shipment} />
                   </DataTableWrapper>
-                  <Label htmlFor="officeRemarks">Office remarks</Label>
-                  <Field
-                    as={Textarea}
-                    data-testid="officeRemarks"
-                    label="No"
-                    name="officeRemarks"
-                    id="officeRemarks"
-                    required
-                  />
+                  <Label htmlFor="remarks">Remarks</Label>
+                  <Field as={Textarea} data-testid="remarks" label="No" name="remarks" id="remarks" required />
                   <ModalActions>
                     <Button type="submit" disabled={!isValid}>
                       Save

--- a/src/components/Office/ConvertSITToCustomerExpenseModal/ConvertSITToCustomerExpenseModal.test.jsx
+++ b/src/components/Office/ConvertSITToCustomerExpenseModal/ConvertSITToCustomerExpenseModal.test.jsx
@@ -25,17 +25,17 @@ describe('ConvertSITToCustomerExpenseModal', () => {
   it('calls onSubmit prop on approval with form values when validations pass', async () => {
     const mockOnSubmit = jest.fn();
     await render(<ConvertSITToCustomerExpenseModal onSubmit={mockOnSubmit} onClose={() => {}} {...defaultValues} />);
-    const officeRemarksInput = screen.getByLabelText('Office remarks');
+    const remarksInput = screen.getByLabelText('Remarks');
     const submitBtn = screen.getByRole('button', { name: 'Save' });
 
-    await act(() => userEvent.type(officeRemarksInput, 'Approved!'));
+    await act(() => userEvent.type(remarksInput, 'Approved!'));
     await act(() => userEvent.click(submitBtn));
 
     await waitFor(() => {
       expect(mockOnSubmit).toHaveBeenCalled();
       expect(mockOnSubmit).toHaveBeenCalledWith({
         convertToCustomersExpense: true,
-        officeRemarks: 'Approved!',
+        remarks: 'Approved!',
       });
     });
   });
@@ -43,10 +43,10 @@ describe('ConvertSITToCustomerExpenseModal', () => {
   it('does not allow submission when office remarks is empty', async () => {
     const mockOnSubmit = jest.fn();
     await render(<ConvertSITToCustomerExpenseModal onSubmit={mockOnSubmit} onClose={() => {}} {...defaultValues} />);
-    const officeRemarksInput = screen.getByLabelText('Office remarks');
+    const remarksInput = screen.getByLabelText('Remarks');
     const submitBtn = screen.getByRole('button', { name: 'Save' });
 
-    await act(() => userEvent.clear(officeRemarksInput));
+    await act(() => userEvent.clear(remarksInput));
     await waitFor(() => {
       expect(submitBtn).toBeDisabled();
     });


### PR DESCRIPTION
## [Agility ticket](https://www13.v1host.com/USTRANSCOM38/story.mvc/Summary?oidToken=Story%3A869456)

## Summary

In the "Convert to Customer Expense" modal (location: logged in as TOO, under "Move Task Order"), the "Office Remarks" label was changed to "Remarks".

### How to test

How to test
* create a new move
* add an HHG shipment
* submit move
* login as counselor and approve the move.
* login as too and approve the move.
* login as prime and add an origin SIT service item to move.
* login as too and "accept" all origin SIT service items
* Click "Edit" and change "Total days of SIT approved" so that "Total days remaining" is 30 or less.  Click "save".
* Click "Convert to customer expense" button.  The modal "Convert SIT to Customer Expense" appears.
* Confirm the label for the text area is "Remarks".

Testing complete.

## Screenshots
![Screenshot 2023-12-29 at 10 44 04 AM](https://github.com/transcom/mymove/assets/146897935/15dedf22-089c-424e-a5e0-d7b0431db842)
