### PR TITLE
added resolution for follow-redirects

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,7 +96,8 @@
     "recursive-readdir": "^2.2.3",
     "semver": "^7.5.2",
     "url-parse": "^1.5.1",
-    "y18n": "^5.0.5"
+    "y18n": "^5.0.5",
+    "follow-redirects": "^1.15.4"
   },
   "name": "client",
   "private": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -11173,10 +11173,10 @@ flow-parser@0.*:
   resolved "https://registry.yarnpkg.com/flow-parser/-/flow-parser-0.206.0.tgz#f4f794f8026535278393308e01ea72f31000bfef"
   integrity sha512-HVzoK3r6Vsg+lKvlIZzaWNBVai+FXTX1wdYhz/wVlH13tb/gOdLXmlTqy6odmTBhT5UoWUbq0k8263Qhr9d88w==
 
-follow-redirects@^1.0.0:
-  version "1.15.1"
-  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.1.tgz#0ca6a452306c9b276e4d3127483e29575e207ad5"
-  integrity sha512-yLAMQs+k0b2m7cVxpS1VKJVvoz7SS9Td1zss3XRwXj+ZDH00RJgnuLx7E44wx02kQLrdM3aOOy+FpzS7+8OizA==
+follow-redirects@^1.0.0, follow-redirects@^1.15.4:
+  version "1.15.4"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.4.tgz#cdc7d308bf6493126b17ea2191ea0ccf3e535adf"
+  integrity sha512-Cr4D/5wlrb0z9dgERpUL3LrmPKVDsETIJhaCMeDfuFYcqa5bldGV6wBsAN6X/vxlXQtFBMrXdXxdL8CbDTGniw==
 
 for-each@^0.3.3:
   version "0.3.3"


### PR DESCRIPTION
## [I-12305](https://www13.v1host.com/USTRANSCOM38/Issue.mvc/Summary?oidToken=Issue%3A885611)

## Summary

Please see [vulnerability finding](https://github.com/advisories/GHSA-jchw-25xp-jwwc)
```
Versions of the package follow-redirects before 1.15.4 are vulnerable to Improper Input Validation due to the improper handling of URLs by the url.parse() function. When new URL() throws an error, it can be manipulated to misinterpret the hostname. An attacker could exploit this weakness to redirect traffic to a malicious site, potentially leading to information disclosure, phishing attacks, or other security breaches.
```

The "http-proxy" package has not received an update to address this vulnerability yet. Please see reference in `yarn.lock` below.
```
http-proxy@^1.18.1:
  version "1.18.1"
  resolved "https://registry.yarnpkg.com/http-proxy/-/http-proxy-1.18.1.tgz#401541f0534884bbf95260334e72f88ee3976549"
  integrity sha512-7mz/721AbnJwIVbnaSv1Cz3Am0ZLT/UBwkC92VlxhXv/k/BBQfM2fXElQNC27BVGr0uwUpplYPQM9LnaBMR5NQ==
  dependencies:
    eventemitter3 "^4.0.0"
    follow-redirects "^1.0.0"
    requires-port "^1.0.0"
```

By adding `"follow-redirects": "^1.15.4"` as a resolution we can force the update of this library to address it.

[This article](https://nvd.nist.gov/vuln/detail/CVE-2023-26159) explains more about the issue.
