### PR TITLE
B-18403: Updating An Approved Service Item Update

### DIFF
--- a/pkg/services/mto_service_item/mto_service_item_validators.go
+++ b/pkg/services/mto_service_item/mto_service_item_validators.go
@@ -268,12 +268,15 @@ func (v *updateMTOServiceItemData) checkOldServiceItemStatus(_ appcontext.AppCon
 
 			// Fields allowed to changed when status is approved
 			if serviceItemData.updatedServiceItem.SITDepartureDate != nil {
+				serviceItemData.updatedServiceItem.Status = models.MTOServiceItemStatusApproved
 				return nil
 			}
 			if serviceItemData.updatedServiceItem.SITRequestedDelivery != nil {
+				serviceItemData.updatedServiceItem.Status = models.MTOServiceItemStatusApproved
 				return nil
 			}
 			if serviceItemData.updatedServiceItem.SITCustomerContacted != nil {
+				serviceItemData.updatedServiceItem.Status = models.MTOServiceItemStatusApproved
 				return nil
 			}
 


### PR DESCRIPTION
## [B-18403](https://www13.v1host.com/USTRANSCOM38/Default.aspx?menu=StoryBoardPage&feat-nav=--m2)

## Summary

When sitDepartureDate, sitRequestedDelivery and/or sitCustomerContacted is updated on an approved DDDSIT, DOPSIT, DOASIT, or DOFSIT service item, then the service item stays in approved status.


## How to Test

Update the sitDepartureDate, sitRequestedDelivery and/or sitCustomerContacted on an approved DDDSIT, DOPSIT, DOASIT, or DOFSIT service item, then make sure the serviceItem status is still approved.

