### PR TITLE
B-18156 Fixes

### DIFF
--- a/pkg/services/mto_shipment/mto_shipment_updater.go
+++ b/pkg/services/mto_shipment/mto_shipment_updater.go
@@ -1000,7 +1000,8 @@ func (f mtoShipmentUpdater) MTOShipmentsMTOAvailableToPrime(appCtx appcontext.Ap
 	return true, nil
 }
 
-// UpdateServiceItemsAddress updates a shipments, service items address
+// UpdateDestinationSITServiceItemsAddress updates destination SIT service items attached to a shipment
+// this updates the final_destination_address to be the same as the shipment's destination_address
 func UpdateDestinationSITServiceItemsAddress(appCtx appcontext.AppContext, shipment *models.MTOShipment) error {
 	// getting the shipment and service items with code in case they weren't passed in
 	eagerAssociations := []string{"MTOServiceItems.ReService.Code"}

--- a/pkg/services/mto_shipment/mto_shipment_updater.go
+++ b/pkg/services/mto_shipment/mto_shipment_updater.go
@@ -358,7 +358,7 @@ func (f *mtoShipmentUpdater) UpdateMTOShipment(appCtx appcontext.AppContext, mto
 	}
 	updatedShipment.MTOAgents = updatedAgents
 
-	err = UpdateServiceItemsAddress(appCtx, updatedShipment)
+	err = UpdateDestinationSITServiceItemsAddress(appCtx, updatedShipment)
 	if err != nil {
 		return nil, err
 	}
@@ -1001,9 +1001,15 @@ func (f mtoShipmentUpdater) MTOShipmentsMTOAvailableToPrime(appCtx appcontext.Ap
 }
 
 // UpdateServiceItemsAddress updates a shipments, service items address
-func UpdateServiceItemsAddress(appCtx appcontext.AppContext, shipment *models.MTOShipment) error {
+func UpdateDestinationSITServiceItemsAddress(appCtx appcontext.AppContext, shipment *models.MTOShipment) error {
+	// getting the shipment and service items with code in case they weren't passed in
+	eagerAssociations := []string{"MTOServiceItems.ReService.Code"}
+	mtoShipment, err := FindShipment(appCtx, shipment.ID, eagerAssociations...)
+	if err != nil {
+		return err
+	}
 
-	mtoServiceItems := shipment.MTOServiceItems
+	mtoServiceItems := mtoShipment.MTOServiceItems
 
 	// Only update these serviceItems address ID
 	serviceItemsToUpdate := []models.ReServiceCode{models.ReServiceCodeDDDSIT, models.ReServiceCodeDDFSIT, models.ReServiceCodeDDASIT, models.ReServiceCodeDDSFSC}

--- a/pkg/services/shipment_address_update/shipment_address_update_requester.go
+++ b/pkg/services/shipment_address_update/shipment_address_update_requester.go
@@ -324,7 +324,7 @@ func (f *shipmentAddressUpdateRequester) ReviewShipmentAddressChange(appCtx appc
 	var shipment models.MTOShipment
 	var addressUpdate models.ShipmentAddressUpdate
 
-	err := appCtx.DB().EagerPreload("Shipment", "Shipment.MoveTaskOrder", "Shipment.MTOServiceItems", "Shipment.MTOServiceItems.ReService.Code", "Shipment.MTOServiceItems.SITDestinationFinalAddressID", "Shipment.PickupAddress", "OriginalAddress", "NewAddress").Where("shipment_id = ?", shipmentID).First(&addressUpdate)
+	err := appCtx.DB().EagerPreload("Shipment", "Shipment.MoveTaskOrder", "Shipment.MTOServiceItems", "Shipment.PickupAddress", "OriginalAddress", "NewAddress").Where("shipment_id = ?", shipmentID).First(&addressUpdate)
 	if err != nil {
 		if err == sql.ErrNoRows {
 			return nil, apperror.NewNotFoundError(shipmentID, "looking for shipment address update")
@@ -406,7 +406,7 @@ func (f *shipmentAddressUpdateRequester) ReviewShipmentAddressChange(appCtx appc
 		}
 
 		if len(shipment.MTOServiceItems) > 0 {
-			err = mtoshipment.UpdateServiceItemsAddress(appCtx, &shipment)
+			err = mtoshipment.UpdateDestinationSITServiceItemsAddress(appCtx, &shipment)
 		}
 		if err != nil {
 			return err

--- a/pkg/services/shipment_address_update/shipment_address_update_requester.go
+++ b/pkg/services/shipment_address_update/shipment_address_update_requester.go
@@ -323,7 +323,7 @@ func (f *shipmentAddressUpdateRequester) ReviewShipmentAddressChange(appCtx appc
 	var shipment models.MTOShipment
 	var addressUpdate models.ShipmentAddressUpdate
 
-	err := appCtx.DB().EagerPreload("Shipment", "Shipment.MoveTaskOrder", "Shipment.MTOServiceItems", "Shipment.PickupAddress", "OriginalAddress", "NewAddress").Where("shipment_id = ?", shipmentID).First(&addressUpdate)
+	err := appCtx.DB().EagerPreload("Shipment", "Shipment.MoveTaskOrder", "Shipment.MTOServiceItems", "Shipment.MTOServiceItems.ReService.Code", "Shipment.MTOServiceItems.SITDestinationFinalAddressID", "Shipment.PickupAddress", "OriginalAddress", "NewAddress").Where("shipment_id = ?", shipmentID).First(&addressUpdate)
 	if err != nil {
 		if err == sql.ErrNoRows {
 			return nil, apperror.NewNotFoundError(shipmentID, "looking for shipment address update")
@@ -342,6 +342,37 @@ func (f *shipmentAddressUpdateRequester) ReviewShipmentAddressChange(appCtx appc
 		addressUpdate.OfficeRemarks = &tooRemarks
 		shipment.DestinationAddress = &addressUpdate.NewAddress
 		shipment.DestinationAddressID = &addressUpdate.NewAddressID
+
+		// we need to also update this final destination address for destination SIT service items
+		// if the service item's final address id is different, we'll need to update it
+		serviceItems := shipment.MTOServiceItems
+		for _, serviceItem := range serviceItems {
+			if serviceItem.SITDestinationFinalAddressID != shipment.DestinationAddressID {
+				serviceCode := serviceItem.ReService.Code
+				if serviceCode == models.ReServiceCodeDDASIT ||
+					serviceCode == models.ReServiceCodeDDFSIT ||
+					serviceCode == models.ReServiceCodeDDDSIT ||
+					serviceCode == models.ReServiceCodeDDSFSC {
+					serviceItem.SITDestinationFinalAddress = shipment.DestinationAddress
+					serviceItem.SITDestinationFinalAddressID = shipment.DestinationAddressID
+
+					transactionError := appCtx.NewTransaction(func(txnAppCtx appcontext.AppContext) error {
+						verrs, txnErr := appCtx.DB().ValidateAndSave(serviceItem)
+						if verrs.HasAny() {
+							return apperror.NewInvalidInputError(serviceItem.ID, txnErr, verrs, "unable to update service item's final destination address")
+						}
+						if txnErr != nil {
+							return apperror.NewQueryError("ServiceItemUpdate", txnErr, "error updating service items in shipment address update request")
+						}
+						return nil
+					})
+
+					if transactionError != nil {
+						return nil, transactionError
+					}
+				}
+			}
+		}
 
 		//We want to make sure the newly approved address update does not affect line haul/short haul pricing
 		haulPricingTypeHasChanged, err := f.doesDeliveryAddressUpdateChangeShipmentPricingType(*shipment.PickupAddress, addressUpdate.OriginalAddress, addressUpdate.NewAddress)


### PR DESCRIPTION
## [Agility ticket](https://www13.v1host.com/USTRANSCOM38/story.mvc/Summary?oidToken=Story%3A871785&RoomContext=TeamRoom%3A808731&concept=TeamRoom)

## Summary

This PR is to fix an issue that was found in an already complete BL item.

Addressing updating the service item's final destination address data to be the same as the shipment's when the TOO approves the shipment destination address update review request. This PR does the following:
- loops through service items in the shipment
- change final destination address data if it is a destination SIT service item
- update the database

### How to test

1. Access MM as prime
2. Request the destination address of a shipment to be updated with new ZIP that triggers review
3. Sign in as TOO
4. Review the request
5. Approve the request
6. Confirm the destination SIT service item data is the same as the shipment