### PR TITLE
B-18326 Update the Estimated Weight - B-18327 Remove Fields

### DIFF
--- a/src/components/Office/ImportantShipmentDates/ImportantShipmentDates.jsx
+++ b/src/components/Office/ImportantShipmentDates/ImportantShipmentDates.jsx
@@ -15,20 +15,24 @@ const ImportantShipmentDates = ({
   requestedDeliveryDate,
   scheduledDeliveryDate,
   actualDeliveryDate,
+  isPPM,
 }) => {
   const emDash = '\u2014';
   return (
     <div className={classnames('maxw-tablet', styles.shipmentDatesContainer)}>
       <DataTableWrapper className="table--data-point-group">
-        <DataTable columnHeaders={['Required Delivery Date']} dataRow={[requiredDeliveryDate || emDash]} />
+        {!isPPM && <DataTable columnHeaders={['Required Delivery Date']} dataRow={[requiredDeliveryDate || emDash]} />};
         <DataTable
           columnHeaders={['Requested pick up date', 'Scheduled pick up date', 'Actual pick up date']}
           dataRow={[requestedPickupDate || emDash, scheduledPickupDate || emDash, actualPickupDate || emDash]}
         />
-        <DataTable
-          columnHeaders={['Requested delivery date', 'Scheduled delivery date', 'Actual delivery date']}
-          dataRow={[requestedDeliveryDate || emDash, scheduledDeliveryDate || emDash, actualDeliveryDate || emDash]}
-        />
+        {!isPPM && (
+          <DataTable
+            columnHeaders={['Requested delivery date', 'Scheduled delivery date', 'Actual delivery date']}
+            dataRow={[requestedDeliveryDate || emDash, scheduledDeliveryDate || emDash, actualDeliveryDate || emDash]}
+          />
+        )}
+        ;
       </DataTableWrapper>
     </div>
   );
@@ -42,6 +46,7 @@ ImportantShipmentDates.defaultProps = {
   requestedDeliveryDate: '',
   scheduledDeliveryDate: '',
   actualDeliveryDate: '',
+  isPPM: false,
 };
 
 ImportantShipmentDates.propTypes = {
@@ -52,6 +57,7 @@ ImportantShipmentDates.propTypes = {
   requestedDeliveryDate: PropTypes.string,
   scheduledDeliveryDate: PropTypes.string,
   actualDeliveryDate: PropTypes.string,
+  isPPM: PropTypes.bool,
 };
 
 export default ImportantShipmentDates;

--- a/src/components/Office/ImportantShipmentDates/ImportantShipmentDates.test.jsx
+++ b/src/components/Office/ImportantShipmentDates/ImportantShipmentDates.test.jsx
@@ -22,6 +22,7 @@ describe('ImportantShipmentDates', () => {
         scheduledDeliveryDate={scheduledDeliveryDate}
         actualDeliveryDate={actualDeliveryDate}
         requiredDeliveryDate={requiredDeliveryDate}
+        isPPM={false}
       />,
     );
     expect(wrapper.find('td').at(0).text()).toEqual(requiredDeliveryDate);
@@ -43,5 +44,23 @@ describe('ImportantShipmentDates', () => {
     expect(wrapper.find('td').at(4).text()).toEqual(emDash);
     expect(wrapper.find('td').at(5).text()).toEqual(emDash);
     expect(wrapper.find('td').at(6).text()).toEqual(emDash);
+  });
+
+  it('should not show irrelevant fields when it is a PPM', () => {
+    const wrapper = mount(
+      <ImportantShipmentDates
+        requestedPickupDate={requestedPickupDate}
+        scheduledPickupDate={scheduledPickupDate}
+        actualPickupDate={actualPickupDate}
+        requestedDeliveryDate={requestedDeliveryDate}
+        scheduledDeliveryDate={scheduledDeliveryDate}
+        actualDeliveryDate={actualDeliveryDate}
+        requiredDeliveryDate={requiredDeliveryDate}
+        isPPM
+      />,
+    );
+    expect(wrapper.find('td').at(0).text()).toEqual(requestedPickupDate);
+    expect(wrapper.find('td').at(1).text()).toEqual(scheduledPickupDate);
+    expect(wrapper.find('td').at(2).text()).toEqual(actualPickupDate);
   });
 });

--- a/src/components/Office/ShipmentDetails/ShipmentDetailsMain.jsx
+++ b/src/components/Office/ShipmentDetails/ShipmentDetailsMain.jsx
@@ -202,6 +202,7 @@ const ShipmentDetailsMain = ({
         scheduledDeliveryDate={scheduledDeliveryDate ? formatDateWithUTC(scheduledDeliveryDate) : null}
         actualDeliveryDate={actualDeliveryDate ? formatDateWithUTC(actualDeliveryDate) : null}
         requiredDeliveryDate={requiredDeliveryDate ? formatDateWithUTC(requiredDeliveryDate) : null}
+        isPPM={shipmentType === SHIPMENT_OPTIONS.PPM}
       />
       <ShipmentAddresses
         pickupAddress={displayedPickupAddress}

--- a/src/components/Office/ShipmentDetails/ShipmentDetailsMain.jsx
+++ b/src/components/Office/ShipmentDetails/ShipmentDetailsMain.jsx
@@ -56,6 +56,7 @@ const ShipmentDetailsMain = ({
     requiredDeliveryDate,
     pickupAddress,
     destinationAddress,
+    ppmShipment,
     primeEstimatedWeight,
     primeActualWeight,
     counselorRemarks,
@@ -124,23 +125,34 @@ const ShipmentDetailsMain = ({
 
   let displayedPickupAddress;
   let displayedDeliveryAddress;
+  let weightResult;
 
   switch (shipmentType) {
     case SHIPMENT_OPTIONS.HHG:
+      weightResult = primeEstimatedWeight;
       displayedPickupAddress = pickupAddress;
       displayedDeliveryAddress = destinationAddress || destinationDutyLocationAddress;
       break;
     case SHIPMENT_OPTIONS.NTS:
+      weightResult = primeEstimatedWeight;
       displayedPickupAddress = pickupAddress;
       displayedDeliveryAddress = storageFacility ? storageFacility.address : null;
       break;
     case SHIPMENT_OPTIONS.NTSR:
+      weightResult = primeEstimatedWeight;
       displayedPickupAddress = storageFacility ? storageFacility.address : null;
       displayedDeliveryAddress = destinationAddress;
       break;
-    default:
+    case SHIPMENT_OPTIONS.PPM:
+      weightResult = ppmShipment.estimatedWeight;
       displayedPickupAddress = pickupAddress;
       displayedDeliveryAddress = destinationAddress || destinationDutyLocationAddress;
+      break;
+    default:
+      weightResult = primeEstimatedWeight;
+      displayedPickupAddress = pickupAddress;
+      displayedDeliveryAddress = destinationAddress || destinationDutyLocationAddress;
+      break;
   }
 
   return (
@@ -205,7 +217,7 @@ const ShipmentDetailsMain = ({
         handleDivertShipment={handleDivertShipment}
       />
       <ShipmentWeightDetails
-        estimatedWeight={primeEstimatedWeight}
+        estimatedWeight={weightResult}
         initialWeight={primeActualWeight}
         shipmentInfo={{
           shipmentID: shipment.id,


### PR DESCRIPTION
### [B-18326 Update the Estimated Weight](https://www13.v1host.com/USTRANSCOM38/story.mvc/Summary?oidToken=Story%3a873997)

### [B-18327 Remove fields -"Requested delivery date", "Scheduled delivery date",  "Actual delivery date", and "Required Delivery Date"](https://www13.v1host.com/USTRANSCOM38/story.mvc/Summary?oidToken=Story%3a874041)

## Summary

When the details are displayed for a PPM shipment on the MTO tab, it should display the estimated weight entered by the customer in stead of the Prime estimated weight (B-18326). It should also not show Requested Delivery Date, Scheduled Delivery Date, Actual Delivery Date, or Required Delivery Date (B-18327).

The reason I thought appropriate to combine these 2 tickets into a singular PR is that it will cut down on technical overhead since the spot that needs to be changed/edited is the same for both tickets.

## Verification Steps for the Author

These are to be checked by the author.

- [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
- [ ] Have the Agility acceptance criteria been met for this change?

## Verification Steps for Reviewers

These are to be checked by a reviewer.

- [ ] Has the branch been pulled in and checked out?
- [ ] Have the BL acceptance criteria been met for this change?
- [ ] Was the CircleCI build successful?
- [ ] Has the code been reviewed from a standards and best practices point of view?

### Setup to Run the Code

- [Instructions for starting storybook](https://transcom.github.io/mymove-docs/docs/frontend/setup/storybook)
- [Instructions for starting the MilMove application](https://transcom.github.io/mymove-docs/docs/getting-started/application-setup/)
- [Instructions for running tests](https://transcom.github.io/mymove-docs/docs/getting-started/development/testing)

### How to test

1. Make a PPM and note what is entered for the estimated weight during shipment creation.
2. Open the PPM shipment on the MTO tab as a TOO user.
3. Observe that the estimated weight entered matches that entered by the customer.
4. Observer that none of the follow fields show up:
    -Requested Delivery Date
    -Scheduled Delivery Date
    -Actual Delivery Date
    -Required Delivery Date 

### Frontend

- [ ] There are no aXe warnings for UI.
- [ ] This works in [Supported Browsers and their phone views](https://transcom.github.io/mymove-docs/docs/adrs/Browser-Support/#minimum-browser-requirements) (Chrome, Firefox, Edge).
- [ ] There are no new console errors in the browser devtools.
- [ ] There are no new console errors in the test output.
- [ ] If this PR adds a new component to Storybook, it ensures the component is fully responsive, OR if it is intentionally not, a wrapping div using the `officeApp` class or custom `min-width` styling is used to hide any states the would not be visible to the user.
- [ ] This change meets the standards for [Section 508 compliance](https://www.ssa.gov/accessibility/andi/help/install.html).

### Backend

- [ ] Code follows the guidelines for [Logging](https://transcom.github.io/mymove-docs/docs/getting-started/development/logging).
- [ ] The requirements listed in [Querying the Database Safely](https://transcom.github.io/mymove-docs/docs/backend/guides/golang-guide#querying-the-database-safely) have been satisfied.

### Database

#### Any new migrations/schema changes:

- [ ] Follows our guidelines for [Zero-Downtime Deploys](https://transcom.github.io/mymove-docs/docs/backend/setup/database-migrations#zero-downtime-migrations).
- [ ] Have been communicated to #g-database.
- [ ] Secure migrations have been tested following the instructions in our [docs](https://transcom.github.io/mymove-docs/docs/backend/setup/database-migrations#secure-migrations).

## Screenshots (B-18326)

## Screenshots (B-18327)
![Screenshot 2024-01-16 at 2 36 42 PM](https://github.com/transcom/mymove/assets/147739091/89533ef5-409b-4c00-9352-a14ae9502ecf)