### PR TITLE
B-18033-Fix-for-I-12339-Use--Current-Address-On-Shipment-Address-Change

### DIFF
--- a/pkg/services/shipment_address_update/shipment_address_update_requester.go
+++ b/pkg/services/shipment_address_update/shipment_address_update_requester.go
@@ -216,6 +216,9 @@ func (f *shipmentAddressUpdateRequester) RequestShipmentDeliveryAddressUpdate(ap
 		} else {
 			return nil, err
 		}
+	} else {
+		addressUpdate.OriginalAddressID = *shipment.DestinationAddressID
+		addressUpdate.OriginalAddress = *shipment.DestinationAddress
 	}
 
 	addressUpdate.Status = models.ShipmentAddressUpdateStatusApproved


### PR DESCRIPTION
## [Agility ticket](https://www13.v1host.com/USTRANSCOM38/story.mvc/Summary?oidToken=Story%3a870438)

## Summary

When updating a shipment address, the issue was that when there was a previous shipment address update in the shipment_address_updates table, the original address of the shipment was not getting updated. So if the prime changed the shipment address the first time from Address 1 to Address 2, we would compare those two. However, if the prime requested another address change from Address 2 to Address 3, we would now see Address 1 vs Address 3.

This fix will make sure that in the case of a previous shipment address update, we are updating the original address we are comparing to our newly changed address.

### How to test

1. Access the office app
3. Login as the prime
4. For a shipment with no previous address updates, request an address update from Address 1 to Address 2
5. Review as the TOO and verify that you see Address 1 as the original delivery location and Address 2 as the Requested delivery location
6. Request another address update from Address 2 to Address 3
5. Review as the TOO and verify that you see Address 2 as the original delivery location and Address 3 as the Requested delivery location