### PR TITLE
B-18193 Moved Progear Weight Ticket query from handler into the service object

### DIFF
--- a/pkg/handlers/internalapi/progear_weight_ticket.go
+++ b/pkg/handlers/internalapi/progear_weight_ticket.go
@@ -1,19 +1,15 @@
 package internalapi
 
 import (
-	"database/sql"
-
 	"github.com/go-openapi/runtime/middleware"
 	"github.com/gofrs/uuid"
 	"go.uber.org/zap"
 
 	"github.com/transcom/mymove/pkg/appcontext"
 	"github.com/transcom/mymove/pkg/apperror"
-	"github.com/transcom/mymove/pkg/db/utilities"
 	progearops "github.com/transcom/mymove/pkg/gen/internalapi/internaloperations/ppm"
 	"github.com/transcom/mymove/pkg/handlers"
 	"github.com/transcom/mymove/pkg/handlers/internalapi/internal/payloads"
-	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/services"
 )
 
@@ -159,39 +155,9 @@ func (h DeleteProGearWeightTicketHandler) Handle(params progearops.DeleteProGear
 
 			// Make sure the service member is not modifying another service member's PPM
 			ppmID := uuid.FromStringOrNil(params.PpmShipmentID.String())
-			var ppmShipment models.PPMShipment
-			err := appCtx.DB().Scope(utilities.ExcludeDeletedScope()).
-				EagerPreload(
-					"Shipment.MoveTaskOrder.Orders",
-					"ProgearWeightTickets",
-				).
-				Find(&ppmShipment, ppmID)
-			if err != nil {
-				if err == sql.ErrNoRows {
-					return progearops.NewDeleteWeightTicketNotFound(), err
-				}
-				return progearops.NewDeleteProGearWeightTicketInternalServerError(), err
-			}
-			if ppmShipment.Shipment.MoveTaskOrder.Orders.ServiceMemberID != appCtx.Session().ServiceMemberID {
-				wrongServiceMemberIDErr := apperror.NewSessionError("Attempted delete by wrong service member")
-				appCtx.Logger().Error("internalapi.DeleteProgearWeightTicketHandler", zap.Error(wrongServiceMemberIDErr))
-				return progearops.NewDeleteProGearWeightTicketForbidden(), wrongServiceMemberIDErr
-			}
-			progearWeightTicketID := uuid.FromStringOrNil(params.ProGearWeightTicketID.String())
-			found := false
-			for _, lineItem := range ppmShipment.ProgearWeightTickets {
-				if lineItem.ID == progearWeightTicketID {
-					found = true
-					break
-				}
-			}
-			if !found {
-				mismatchedPPMShipmentAndProgearWeightTicketIDErr := apperror.NewSessionError("Pro-gear weight ticket does not exist on ppm shipment")
-				appCtx.Logger().Error("internalapi.DeleteProGearWeightTicketHandler", zap.Error(mismatchedPPMShipmentAndProgearWeightTicketIDErr))
-				return progearops.NewDeleteProGearWeightTicketNotFound(), mismatchedPPMShipmentAndProgearWeightTicketIDErr
-			}
 
-			err = h.progearDeleter.DeleteProgearWeightTicket(appCtx, progearWeightTicketID)
+			progearWeightTicketID := uuid.FromStringOrNil(params.ProGearWeightTicketID.String())
+			err := h.progearDeleter.DeleteProgearWeightTicket(appCtx, ppmID, progearWeightTicketID)
 			if err != nil {
 				appCtx.Logger().Error("internalapi.DeleteProgearWeightTicketHandler", zap.Error(err))
 

--- a/pkg/handlers/internalapi/progear_weight_ticket_test.go
+++ b/pkg/handlers/internalapi/progear_weight_ticket_test.go
@@ -395,6 +395,7 @@ func (suite *HandlerSuite) TestDeleteProgearWeightTicketHandler() {
 		mockDeleter.On("DeleteProgearWeightTicket",
 			mock.AnythingOfType("*appcontext.appContext"),
 			mock.AnythingOfType("uuid.UUID"),
+			mock.AnythingOfType("uuid.UUID"),
 		).Return(err)
 
 		// Use createS3HandlerConfig for the HandlerConfig because we are required to upload a doc

--- a/pkg/services/mocks/ProgearWeightTicketDeleter.go
+++ b/pkg/services/mocks/ProgearWeightTicketDeleter.go
@@ -14,13 +14,13 @@ type ProgearWeightTicketDeleter struct {
 	mock.Mock
 }
 
-// DeleteProgearWeightTicket provides a mock function with given fields: appCtx, progearWeightTicketID
-func (_m *ProgearWeightTicketDeleter) DeleteProgearWeightTicket(appCtx appcontext.AppContext, progearWeightTicketID uuid.UUID) error {
-	ret := _m.Called(appCtx, progearWeightTicketID)
+// DeleteProgearWeightTicket provides a mock function with given fields: appCtx, ppmID, progearWeightTicketID
+func (_m *ProgearWeightTicketDeleter) DeleteProgearWeightTicket(appCtx appcontext.AppContext, ppmID uuid.UUID, progearWeightTicketID uuid.UUID) error {
+	ret := _m.Called(appCtx, ppmID, progearWeightTicketID)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(appcontext.AppContext, uuid.UUID) error); ok {
-		r0 = rf(appCtx, progearWeightTicketID)
+	if rf, ok := ret.Get(0).(func(appcontext.AppContext, uuid.UUID, uuid.UUID) error); ok {
+		r0 = rf(appCtx, ppmID, progearWeightTicketID)
 	} else {
 		r0 = ret.Error(0)
 	}

--- a/pkg/services/progear_weight_ticket.go
+++ b/pkg/services/progear_weight_ticket.go
@@ -25,5 +25,5 @@ type ProgearWeightTicketUpdater interface {
 //
 //go:generate mockery --name ProgearWeightTicketDeleter
 type ProgearWeightTicketDeleter interface {
-	DeleteProgearWeightTicket(appCtx appcontext.AppContext, progearWeightTicketID uuid.UUID) error
+	DeleteProgearWeightTicket(appCtx appcontext.AppContext, ppmID uuid.UUID, progearWeightTicketID uuid.UUID) error
 }

--- a/pkg/services/progear_weight_ticket/progear_weight_ticket_deleter.go
+++ b/pkg/services/progear_weight_ticket/progear_weight_ticket_deleter.go
@@ -1,10 +1,15 @@
 package progearweightticket
 
 import (
+	"database/sql"
+
 	"github.com/gofrs/uuid"
+	"go.uber.org/zap"
 
 	"github.com/transcom/mymove/pkg/appcontext"
+	"github.com/transcom/mymove/pkg/apperror"
 	"github.com/transcom/mymove/pkg/db/utilities"
+	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/services"
 )
 
@@ -15,7 +20,40 @@ func NewProgearWeightTicketDeleter() services.ProgearWeightTicketDeleter {
 	return &progearWeightTicketDeleter{}
 }
 
-func (d *progearWeightTicketDeleter) DeleteProgearWeightTicket(appCtx appcontext.AppContext, progearWeightTicketID uuid.UUID) error {
+func (d *progearWeightTicketDeleter) DeleteProgearWeightTicket(appCtx appcontext.AppContext, ppmID uuid.UUID, progearWeightTicketID uuid.UUID) error {
+	var ppmShipment models.PPMShipment
+	err := appCtx.DB().Scope(utilities.ExcludeDeletedScope()).
+		EagerPreload(
+			"Shipment.MoveTaskOrder.Orders",
+			"ProgearWeightTickets",
+		).
+		Find(&ppmShipment, ppmID)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return apperror.NewNotFoundError(progearWeightTicketID, "while looking for ProgearWeightTicket")
+		}
+		return apperror.NewQueryError("Progear Weight Ticket fetch original", err, "")
+	}
+
+	if ppmShipment.Shipment.MoveTaskOrder.Orders.ServiceMemberID != appCtx.Session().ServiceMemberID && !appCtx.Session().IsOfficeUser() {
+		wrongServiceMemberIDErr := apperror.NewForbiddenError("Attempted delete by wrong service member")
+		appCtx.Logger().Error("internalapi.DeleteProgearWeightTicketHandler", zap.Error(wrongServiceMemberIDErr))
+		return wrongServiceMemberIDErr
+	}
+
+	found := false
+	for _, lineItem := range ppmShipment.ProgearWeightTickets {
+		if lineItem.ID == progearWeightTicketID {
+			found = true
+			break
+		}
+	}
+	if !found {
+		mismatchedPPMShipmentAndProgearWeightTicketIDErr := apperror.NewNotFoundError(progearWeightTicketID, "Pro-gear weight ticket does not exist on ppm shipment")
+		appCtx.Logger().Error("internalapi.DeleteProGearWeightTicketHandler", zap.Error(mismatchedPPMShipmentAndProgearWeightTicketIDErr))
+		return mismatchedPPMShipmentAndProgearWeightTicketIDErr
+	}
+
 	progearWeightTicket, err := FetchProgearWeightTicketByIDExcludeDeletedUploads(appCtx, progearWeightTicketID)
 	if err != nil {
 		return err

--- a/pkg/services/progear_weight_ticket/progear_weight_ticket_deleter_test.go
+++ b/pkg/services/progear_weight_ticket/progear_weight_ticket_deleter_test.go
@@ -72,7 +72,7 @@ func (suite *ProgearWeightTicketSuite) TestDeleteProgearWeightTicket() {
 		notFoundProgearWeightTicketID := uuid.Must(uuid.NewV4())
 		deleter := NewProgearWeightTicketDeleter()
 
-		err := deleter.DeleteProgearWeightTicket(session, notFoundProgearWeightTicketID)
+		err := deleter.DeleteProgearWeightTicket(session, uuid.Nil, notFoundProgearWeightTicketID)
 
 		if suite.Error(err) {
 			suite.IsType(apperror.NotFoundError{}, err)
@@ -95,7 +95,7 @@ func (suite *ProgearWeightTicketSuite) TestDeleteProgearWeightTicket() {
 		deleter := NewProgearWeightTicketDeleter()
 
 		suite.Nil(originalProgearWeightTicket.DeletedAt)
-		err := deleter.DeleteProgearWeightTicket(session, originalProgearWeightTicket.ID)
+		err := deleter.DeleteProgearWeightTicket(session, originalProgearWeightTicket.PPMShipmentID, originalProgearWeightTicket.ID)
 		suite.NoError(err)
 
 		var progearWeightTicketInDB models.ProgearWeightTicket


### PR DESCRIPTION
## [Agility ticket](https://www13.v1host.com/USTRANSCOM38/story.mvc/Summary?oidToken=Story%3A871907&RoomContext=TeamRoom%3A848240&concept=TeamRoom)

## Summary

Relocated query out of handler 

### How to test

1. Access the mymove app
2. Login as a servicemember with a ppm at closeout
3. Delete progear weight ticket
4. Success

### Backend

- [ ] Code follows the guidelines for [Logging](https://transcom.github.io/mymove-docs/docs/getting-started/development/logging).
- [ ] The requirements listed in [Querying the Database Safely](https://transcom.github.io/mymove-docs/docs/backend/guides/golang-guide#querying-the-database-safely) have been satisfied.

