### PR TITLE
B 18329 remove na from address

### DIFF
--- a/src/components/Office/ShipmentAddresses/ShipmentAddresses.jsx
+++ b/src/components/Office/ShipmentAddresses/ShipmentAddresses.jsx
@@ -5,7 +5,7 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { Button } from '@trussworks/react-uswds';
 
 import { AddressShape } from '../../../types/address';
-import { formatCityStateAndPostalCode } from '../../../utils/shipmentDisplay';
+import { formatAddress, formatCityStateAndPostalCode } from '../../../utils/shipmentDisplay';
 import DataTableWrapper from '../../DataTableWrapper/index';
 import DataTable from '../../DataTable/index';
 
@@ -69,8 +69,8 @@ const ShipmentAddresses = ({
       <DataTable
         columnHeaders={[pickupHeader, destinationHeader]}
         dataRow={[
-          pickupAddress ? formatCityStateAndPostalCode(pickupAddress) : '—',
-          destinationAddress ? formatCityStateAndPostalCode(destinationAddress) : '—',
+          pickupAddress ? formatAddress(pickupAddress, shipmentInfo.shipmentType) : '—',
+          destinationAddress ? formatAddress(destinationAddress, shipmentInfo.shipmentType) : '—',
         ]}
         icon={<FontAwesomeIcon icon="arrow-right" />}
         data-testid="pickupDestinationAddress"

--- a/src/components/Office/ShipmentAddresses/ShipmentAddresses.jsx
+++ b/src/components/Office/ShipmentAddresses/ShipmentAddresses.jsx
@@ -5,7 +5,7 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { Button } from '@trussworks/react-uswds';
 
 import { AddressShape } from '../../../types/address';
-import { formatAddress, formatCityStateAndPostalCode } from '../../../utils/shipmentDisplay';
+import { formatCityStateAndPostalCode } from '../../../utils/shipmentDisplay';
 import DataTableWrapper from '../../DataTableWrapper/index';
 import DataTable from '../../DataTable/index';
 
@@ -69,8 +69,8 @@ const ShipmentAddresses = ({
       <DataTable
         columnHeaders={[pickupHeader, destinationHeader]}
         dataRow={[
-          pickupAddress ? formatAddress(pickupAddress) : '—',
-          destinationAddress ? formatAddress(destinationAddress) : '—',
+          pickupAddress ? formatCityStateAndPostalCode(pickupAddress) : '—',
+          destinationAddress ? formatCityStateAndPostalCode(destinationAddress) : '—',
         ]}
         icon={<FontAwesomeIcon icon="arrow-right" />}
         data-testid="pickupDestinationAddress"

--- a/src/utils/shipmentDisplay.jsx
+++ b/src/utils/shipmentDisplay.jsx
@@ -10,7 +10,7 @@ export function formatAddress(address) {
   if (address.streetAddress1 != null && address.streetAddress1 !== 'n/a') {
     return `${address.streetAddress1}, ${address.city}, ${address.state} ${address.postalCode}`;
   }
-  if (address.city != null && address.state != null && address.zip != null) {
+  if (address.city != null || address.state != null || address.zip != null) {
     return `${address.city}, ${address.state} ${address.postalCode}`;
   }
   return '';

--- a/src/utils/shipmentDisplay.jsx
+++ b/src/utils/shipmentDisplay.jsx
@@ -6,6 +6,17 @@ import { LOA_TYPE, shipmentOptionLabels } from 'shared/constants';
 import { shipmentStatuses, shipmentModificationTypes } from 'constants/shipments';
 import affiliations from 'content/serviceMemberAgencies';
 
+export function formatAddress(address) {
+  const { streetAddress1, streetAddress2, city, state, postalCode } = address;
+  return (
+    <>
+      {streetAddress1 && <>{streetAddress1},&nbsp;</>}
+      {streetAddress2 && <>{streetAddress2},&nbsp;</>}
+      {city ? `${city}, ${state} ${postalCode}` : postalCode}
+    </>
+  );
+}
+
 export function formatTwoLineAddress(address) {
   const { streetAddress1, streetAddress2, city, state, postalCode } = address;
 

--- a/src/utils/shipmentDisplay.jsx
+++ b/src/utils/shipmentDisplay.jsx
@@ -6,13 +6,6 @@ import { LOA_TYPE, shipmentOptionLabels } from 'shared/constants';
 import { shipmentStatuses, shipmentModificationTypes } from 'constants/shipments';
 import affiliations from 'content/serviceMemberAgencies';
 
-export function formatAddress(address) {
-  if (address.city != null || address.state != null || address.zip != null) {
-    return `${address.city}, ${address.state} ${address.postalCode}`;
-  }
-  return '';
-}
-
 export function formatTwoLineAddress(address) {
   const { streetAddress1, streetAddress2, city, state, postalCode } = address;
 

--- a/src/utils/shipmentDisplay.jsx
+++ b/src/utils/shipmentDisplay.jsx
@@ -2,12 +2,16 @@
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import React from 'react';
 
-import { LOA_TYPE, shipmentOptionLabels } from 'shared/constants';
+import { SHIPMENT_OPTIONS, LOA_TYPE, shipmentOptionLabels } from 'shared/constants';
 import { shipmentStatuses, shipmentModificationTypes } from 'constants/shipments';
 import affiliations from 'content/serviceMemberAgencies';
 
-export function formatAddress(address) {
+export function formatAddress(address, shipmentType) {
   const { streetAddress1, streetAddress2, city, state, postalCode } = address;
+
+  if (shipmentType === SHIPMENT_OPTIONS.PPM) {
+    return city ? `${city}, ${state} ${postalCode}` : postalCode;
+  }
   return (
     <>
       {streetAddress1 && <>{streetAddress1},&nbsp;</>}
@@ -149,10 +153,7 @@ export function formatPaymentRequestAddressString(pickupAddress, destinationAddr
  * It displays only the city, state and postal code.
  * */
 export function formatCityStateAndPostalCode(address) {
-  if (
-    address != null &&
-    (address.city !== undefined || address.state !== undefined || address.postalCode !== undefined)
-  ) {
+  if (address) {
     return `${address.city}, ${address.state} ${address.postalCode}`;
   }
   return '';

--- a/src/utils/shipmentDisplay.jsx
+++ b/src/utils/shipmentDisplay.jsx
@@ -149,7 +149,7 @@ export function formatPaymentRequestAddressString(pickupAddress, destinationAddr
  * It displays only the city, state and postal code.
  * */
 export function formatCityStateAndPostalCode(address) {
-  if (address !== undefined && address !== null) {
+  if (address != null && address.city !== undefined) {
     return `${address.city}, ${address.state} ${address.postalCode}`;
   }
   return '';

--- a/src/utils/shipmentDisplay.jsx
+++ b/src/utils/shipmentDisplay.jsx
@@ -149,7 +149,10 @@ export function formatPaymentRequestAddressString(pickupAddress, destinationAddr
  * It displays only the city, state and postal code.
  * */
 export function formatCityStateAndPostalCode(address) {
-  if (address != null && address.city !== undefined) {
+  if (
+    address != null &&
+    (address.city !== undefined || address.state !== undefined || address.postalCode !== undefined)
+  ) {
     return `${address.city}, ${address.state} ${address.postalCode}`;
   }
   return '';

--- a/src/utils/shipmentDisplay.jsx
+++ b/src/utils/shipmentDisplay.jsx
@@ -149,7 +149,7 @@ export function formatPaymentRequestAddressString(pickupAddress, destinationAddr
  * It displays only the city, state and postal code.
  * */
 export function formatCityStateAndPostalCode(address) {
-  if (address) {
+  if (address !== undefined && address !== null) {
     return `${address.city}, ${address.state} ${address.postalCode}`;
   }
   return '';

--- a/src/utils/shipmentDisplay.jsx
+++ b/src/utils/shipmentDisplay.jsx
@@ -7,9 +7,6 @@ import { shipmentStatuses, shipmentModificationTypes } from 'constants/shipments
 import affiliations from 'content/serviceMemberAgencies';
 
 export function formatAddress(address) {
-  if (address.streetAddress1 != null && address.streetAddress1 !== 'n/a') {
-    return `${address.streetAddress1}, ${address.city}, ${address.state} ${address.postalCode}`;
-  }
   if (address.city != null || address.state != null || address.zip != null) {
     return `${address.city}, ${address.state} ${address.postalCode}`;
   }

--- a/src/utils/shipmentDisplay.jsx
+++ b/src/utils/shipmentDisplay.jsx
@@ -7,14 +7,13 @@ import { shipmentStatuses, shipmentModificationTypes } from 'constants/shipments
 import affiliations from 'content/serviceMemberAgencies';
 
 export function formatAddress(address) {
-  const { streetAddress1, streetAddress2, city, state, postalCode } = address;
-  return (
-    <>
-      {streetAddress1 && <>{streetAddress1},&nbsp;</>}
-      {streetAddress2 && <>{streetAddress2},&nbsp;</>}
-      {city ? `${city}, ${state} ${postalCode}` : postalCode}
-    </>
-  );
+  if (address.streetAddress1 != null && address.streetAddress1 !== 'n/a') {
+    return `${address.streetAddress1}, ${address.city}, ${address.state} ${address.postalCode}`;
+  }
+  if (address.city != null && address.state != null && address.zip != null) {
+    return `${address.city}, ${address.state} ${address.postalCode}`;
+  }
+  return '';
 }
 
 export function formatTwoLineAddress(address) {


### PR DESCRIPTION
## [Agility ticket] B-18329

## Summary

When viewing the customer's address as a TOO, the street address is present and would show as "n/a".
This PR removes that "n/a" and only shows city, state, zip for origin and dest location.

### How to test

1. Log in office as TOO
2. select a PPM move
3. Click "Move task order" tab
4. Confirm "customer's addresses" only shows city, state, zip

## Verification Steps for Reviewers

These are to be checked by a reviewer.

- [ ] Has the branch been pulled in and checked out?
- [ ] Have the BL acceptance criteria been met for this change?
- [ ] Was the CircleCI build successful?
- [ ] Has the code been reviewed from a standards and best practices point of view?

## Screenshots
## Before:
<img width="1709" alt="Screenshot 2024-01-22 at 3 49 40 AM" src="https://github.com/transcom/mymove/assets/146969726/f01acb9f-9e5e-4d15-8b77-75c56919dbbb">

## Updated:
<img width="1663" alt="Screenshot 2024-01-22 at 3 50 12 AM" src="https://github.com/transcom/mymove/assets/146969726/aa76bcde-0417-4ca9-96e8-231c280d3109">