### PR TITLE
INT-B-18180 Removed PPM Estimated Weight

### DIFF
--- a/migrations/app/migrations_manifest.txt
+++ b/migrations/app/migrations_manifest.txt
@@ -889,3 +889,4 @@
 20231226174935_create_ppm_documents_triggers.up.sql
 20240103174317_add_customer_expense.up.sql
 20240109200110_add_address_columns_to_ppmshipments4.up.sql
+20240123193627_remove_ppm_estimated_weight.up.sql

--- a/migrations/app/schema/20240123193627_remove_ppm_estimated_weight.up.sql
+++ b/migrations/app/schema/20240123193627_remove_ppm_estimated_weight.up.sql
@@ -1,0 +1,1 @@
+alter table moves drop column ppm_estimated_weight;

--- a/pkg/handlers/ghcapi/internal/payloads/model_to_payload.go
+++ b/pkg/handlers/ghcapi/internal/payloads/model_to_payload.go
@@ -87,10 +87,6 @@ func ListMove(move *models.Move) *ghcmessages.ListPrimeMove {
 		ETag:               etag.GenerateEtag(move.UpdatedAt),
 	}
 
-	if move.PPMEstimatedWeight != nil {
-		payload.PpmEstimatedWeight = int64(*move.PPMEstimatedWeight)
-	}
-
 	if move.PPMType != nil {
 		payload.PpmType = *move.PPMType
 	}

--- a/pkg/handlers/primeapi/move_task_order_test.go
+++ b/pkg/handlers/primeapi/move_task_order_test.go
@@ -574,7 +574,6 @@ func (suite *HandlerSuite) TestGetMoveTaskOrder() {
 			{
 				Model: models.Move{
 					PrimeCounselingCompletedAt: &aWeekAgo,
-					PPMEstimatedWeight:         models.PoundPointer(1000),
 					ExcessWeightQualifiedAt:    &aWeekAgo,
 					ExcessWeightAcknowledgedAt: &now,
 					ExcessWeightUploadID:       &upload.ID,
@@ -605,7 +604,6 @@ func (suite *HandlerSuite) TestGetMoveTaskOrder() {
 		suite.Equal(successMove.AvailableToPrimeAt.Format(time.RFC3339), handlers.FmtDateTimePtrToPop(movePayload.AvailableToPrimeAt).Format(time.RFC3339))
 		suite.Equal(successMove.PrimeCounselingCompletedAt.Format(time.RFC3339), handlers.FmtDateTimePtrToPop(movePayload.PrimeCounselingCompletedAt).Format(time.RFC3339))
 		suite.Equal(*successMove.PPMType, movePayload.PpmType)
-		suite.Equal(*handlers.FmtPoundPtr(successMove.PPMEstimatedWeight), movePayload.PpmEstimatedWeight)
 		suite.Equal(successMove.ExcessWeightQualifiedAt.Format(time.RFC3339), handlers.FmtDateTimePtrToPop(movePayload.ExcessWeightQualifiedAt).Format(time.RFC3339))
 		suite.Equal(successMove.ExcessWeightAcknowledgedAt.Format(time.RFC3339), handlers.FmtDateTimePtrToPop(movePayload.ExcessWeightAcknowledgedAt).Format(time.RFC3339))
 		suite.Equal(successMove.ExcessWeightUploadID.String(), movePayload.ExcessWeightUploadID.String())

--- a/pkg/handlers/primeapi/payloads/model_to_payload.go
+++ b/pkg/handlers/primeapi/payloads/model_to_payload.go
@@ -45,10 +45,6 @@ func MoveTaskOrder(moveTaskOrder *models.Move) *primemessages.MoveTaskOrder {
 		ETag:                       etag.GenerateEtag(moveTaskOrder.UpdatedAt),
 	}
 
-	if moveTaskOrder.PPMEstimatedWeight != nil {
-		payload.PpmEstimatedWeight = int64(*moveTaskOrder.PPMEstimatedWeight)
-	}
-
 	if moveTaskOrder.PPMType != nil {
 		payload.PpmType = *moveTaskOrder.PPMType
 	}
@@ -73,10 +69,6 @@ func ListMove(move *models.Move) *primemessages.ListMove {
 		ReferenceID:        *move.ReferenceID,
 		UpdatedAt:          strfmt.DateTime(move.UpdatedAt),
 		ETag:               etag.GenerateEtag(move.UpdatedAt),
-	}
-
-	if move.PPMEstimatedWeight != nil {
-		payload.PpmEstimatedWeight = int64(*move.PPMEstimatedWeight)
 	}
 
 	if move.PPMType != nil {

--- a/pkg/handlers/primeapiv2/move_task_order_test.go
+++ b/pkg/handlers/primeapiv2/move_task_order_test.go
@@ -523,7 +523,6 @@ func (suite *HandlerSuite) TestGetMoveTaskOrder() {
 			{
 				Model: models.Move{
 					PrimeCounselingCompletedAt: &aWeekAgo,
-					PPMEstimatedWeight:         models.PoundPointer(1000),
 					ExcessWeightQualifiedAt:    &aWeekAgo,
 					ExcessWeightAcknowledgedAt: &now,
 					ExcessWeightUploadID:       &upload.ID,
@@ -554,7 +553,6 @@ func (suite *HandlerSuite) TestGetMoveTaskOrder() {
 		suite.Equal(successMove.AvailableToPrimeAt.Format(time.RFC3339), handlers.FmtDateTimePtrToPop(movePayload.AvailableToPrimeAt).Format(time.RFC3339))
 		suite.Equal(successMove.PrimeCounselingCompletedAt.Format(time.RFC3339), handlers.FmtDateTimePtrToPop(movePayload.PrimeCounselingCompletedAt).Format(time.RFC3339))
 		suite.Equal(*successMove.PPMType, movePayload.PpmType)
-		suite.Equal(*handlers.FmtPoundPtr(successMove.PPMEstimatedWeight), movePayload.PpmEstimatedWeight)
 		suite.Equal(successMove.ExcessWeightQualifiedAt.Format(time.RFC3339), handlers.FmtDateTimePtrToPop(movePayload.ExcessWeightQualifiedAt).Format(time.RFC3339))
 		suite.Equal(successMove.ExcessWeightAcknowledgedAt.Format(time.RFC3339), handlers.FmtDateTimePtrToPop(movePayload.ExcessWeightAcknowledgedAt).Format(time.RFC3339))
 		suite.Equal(successMove.ExcessWeightUploadID.String(), movePayload.ExcessWeightUploadID.String())

--- a/pkg/handlers/primeapiv2/payloads/model_to_payload.go
+++ b/pkg/handlers/primeapiv2/payloads/model_to_payload.go
@@ -42,10 +42,6 @@ func MoveTaskOrder(moveTaskOrder *models.Move) *primev2messages.MoveTaskOrder {
 		ETag:                       etag.GenerateEtag(moveTaskOrder.UpdatedAt),
 	}
 
-	if moveTaskOrder.PPMEstimatedWeight != nil {
-		payload.PpmEstimatedWeight = int64(*moveTaskOrder.PPMEstimatedWeight)
-	}
-
 	if moveTaskOrder.PPMType != nil {
 		payload.PpmType = *moveTaskOrder.PPMType
 	}

--- a/pkg/handlers/supportapi/internal/payloads/model_to_payload.go
+++ b/pkg/handlers/supportapi/internal/payloads/model_to_payload.go
@@ -48,10 +48,6 @@ func MoveTaskOrder(moveTaskOrder *models.Move) *supportmessages.MoveTaskOrder {
 		MoveCode:           moveTaskOrder.Locator,
 	}
 
-	if moveTaskOrder.PPMEstimatedWeight != nil {
-		payload.PpmEstimatedWeight = int64(*moveTaskOrder.PPMEstimatedWeight)
-	}
-
 	if moveTaskOrder.PPMType != nil {
 		payload.PpmType = *moveTaskOrder.PPMType
 	}

--- a/pkg/handlers/supportapi/internal/payloads/payload_to_model.go
+++ b/pkg/handlers/supportapi/internal/payloads/payload_to_model.go
@@ -10,7 +10,6 @@ import (
 	"github.com/transcom/mymove/pkg/handlers"
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/services/event"
-	"github.com/transcom/mymove/pkg/unit"
 )
 
 // CustomerModel converts payload to model - currently does not tackle addresses
@@ -99,13 +98,12 @@ func MoveTaskOrderModel(mtoPayload *supportmessages.MoveTaskOrder) *models.Move 
 	if mtoPayload == nil {
 		return nil
 	}
-	ppmEstimatedWeight := unit.Pound(mtoPayload.PpmEstimatedWeight)
+
 	contractorID := uuid.FromStringOrNil(mtoPayload.ContractorID.String())
 	model := &models.Move{
-		ReferenceID:        &mtoPayload.ReferenceID,
-		PPMEstimatedWeight: &ppmEstimatedWeight,
-		PPMType:            &mtoPayload.PpmType,
-		ContractorID:       &contractorID,
+		ReferenceID:  &mtoPayload.ReferenceID,
+		PPMType:      &mtoPayload.PpmType,
+		ContractorID: &contractorID,
 	}
 
 	if mtoPayload.AvailableToPrimeAt != nil {

--- a/pkg/models/move.go
+++ b/pkg/models/move.go
@@ -67,7 +67,6 @@ type Move struct {
 	AvailableToPrimeAt           *time.Time              `db:"available_to_prime_at"`
 	ContractorID                 *uuid.UUID              `db:"contractor_id"`
 	Contractor                   *Contractor             `belongs_to:"contractors" fk_id:"contractor_id"`
-	PPMEstimatedWeight           *unit.Pound             `db:"ppm_estimated_weight"`
 	PPMType                      *string                 `db:"ppm_type"`
 	MTOServiceItems              MTOServiceItems         `has_many:"mto_service_items" fk_id:"move_id"`
 	PaymentRequests              PaymentRequests         `has_many:"payment_requests" fk_id:"move_id"`

--- a/pkg/services/event/notification_payloads.go
+++ b/pkg/services/event/notification_payloads.go
@@ -71,10 +71,6 @@ func MoveTaskOrderModelToPayload(moveTaskOrder *models.Move) *MoveTaskOrder {
 		ETag:               etag.GenerateEtag(moveTaskOrder.UpdatedAt),
 	}
 
-	if moveTaskOrder.PPMEstimatedWeight != nil {
-		payload.PpmEstimatedWeight = int64(*moveTaskOrder.PPMEstimatedWeight)
-	}
-
 	if moveTaskOrder.PPMType != nil {
 		payload.PpmType = *moveTaskOrder.PPMType
 	}

--- a/pkg/services/support/move_task_order/move_task_order_creator.go
+++ b/pkg/services/support/move_task_order/move_task_order_creator.go
@@ -17,7 +17,6 @@ import (
 	"github.com/transcom/mymove/pkg/services"
 	"github.com/transcom/mymove/pkg/services/office_user/customer"
 	"github.com/transcom/mymove/pkg/services/support"
-	"github.com/transcom/mymove/pkg/unit"
 )
 
 type moveTaskOrderCreator struct {
@@ -385,15 +384,14 @@ func MoveTaskOrderModel(mtoPayload *supportmessages.MoveTaskOrder) *models.Move 
 	if mtoPayload == nil {
 		return nil
 	}
-	ppmEstimatedWeight := unit.Pound(mtoPayload.PpmEstimatedWeight)
+
 	contractorID := uuid.FromStringOrNil(mtoPayload.ContractorID.String())
 	model := &models.Move{
-		ReferenceID:        &mtoPayload.ReferenceID,
-		Locator:            mtoPayload.MoveCode,
-		PPMEstimatedWeight: &ppmEstimatedWeight,
-		PPMType:            &mtoPayload.PpmType,
-		ContractorID:       &contractorID,
-		Status:             (models.MoveStatus)(mtoPayload.Status),
+		ReferenceID:  &mtoPayload.ReferenceID,
+		Locator:      mtoPayload.MoveCode,
+		PPMType:      &mtoPayload.PpmType,
+		ContractorID: &contractorID,
+		Status:       (models.MoveStatus)(mtoPayload.Status),
 	}
 
 	if mtoPayload.AvailableToPrimeAt != nil {


### PR DESCRIPTION
## [Agility ticket](https://www13.v1host.com/USTRANSCOM38/story.mvc/Summary?oidToken=Story%3A871874)

## Summary

Removed PPM specific fields in the moves model that aren't used.
Functionality of the app should not be effected.

### How to test

1. Login as a service member and create a ppm and hhg
2. Login as a service counselor and approve shipments
3. Everything should be working with no noticeable changes

### Backend

- [ ] Code follows the guidelines for [Logging](https://transcom.github.io/mymove-docs/docs/getting-started/development/logging).
- [ ] The requirements listed in [Querying the Database Safely](https://transcom.github.io/mymove-docs/docs/backend/guides/golang-guide#querying-the-database-safely) have been satisfied.

### Database

#### Any new migrations/schema changes:

- [ ] Follows our guidelines for [Zero-Downtime Deploys](https://transcom.github.io/mymove-docs/docs/backend/setup/database-migrations#zero-downtime-migrations).
- [ ] Have been communicated to #g-database.
- [ ] Secure migrations have been tested following the instructions in our [docs](https://transcom.github.io/mymove-docs/docs/backend/setup/database-migrations#secure-migrations).
