### PR TITLE
B 18477 integration

### DIFF
--- a/src/components/Customer/Home/Step/Step.stories.jsx
+++ b/src/components/Customer/Home/Step/Step.stories.jsx
@@ -110,7 +110,15 @@ Shipments.args = {
       shipments={[
         { id: '0001', shipmentType: SHIPMENT_OPTIONS.HHG },
         { id: '0002', shipmentType: SHIPMENT_OPTIONS.NTS },
-        { id: '0003', shipmentType: SHIPMENT_OPTIONS.PPM },
+        {
+          id: '0003',
+          shipmentType: SHIPMENT_OPTIONS.PPM,
+          ppmShipment: {
+            id: 'incompletePPM',
+            hasRequestedAdvance: false,
+            weightTickets: [],
+          },
+        },
       ]}
       onShipmentClick={action('shipment edit icon clicked')}
       moveSubmitted={false}

--- a/src/components/ShipmentList/ShipmentList.jsx
+++ b/src/components/ShipmentList/ShipmentList.jsx
@@ -35,6 +35,15 @@ export const ShipmentListItem = ({
   const isPPM = shipment.shipmentType === SHIPMENT_OPTIONS.PPM;
   const estimated = 'Estimated';
   const actual = 'Actual';
+  let requestedWeightPPM = 0;
+  if (shipment.shipmentType === SHIPMENT_OPTIONS.PPM) {
+    if (shipment.ppmShipment.weightTickets !== undefined) {
+      const wt = shipment.ppmShipment.weightTickets;
+      for (let i = 0; i < wt.length; i += 1) {
+        requestedWeightPPM += wt[i].fullWeight - wt[i].emptyWeight;
+      }
+    }
+  }
   return (
     <div
       className={`${styles['shipment-list-item-container']} ${shipmentClassName} ${
@@ -64,7 +73,7 @@ export const ShipmentListItem = ({
                   <strong>{formatWeight(shipment.ppmShipment.estimatedWeight)}</strong>
                 </h6>
                 <h6>
-                  <strong>{formatWeight(shipment.calculatedBillableWeight)}</strong>
+                  <strong>{formatWeight(requestedWeightPPM)}</strong>
                 </h6>
               </div>
             </div>

--- a/src/components/ShipmentList/ShipmentList.stories.jsx
+++ b/src/components/ShipmentList/ShipmentList.stories.jsx
@@ -46,7 +46,15 @@ BasicMultiple.args = {
   shipments: [
     { id: '0001', shipmentType: SHIPMENT_OPTIONS.HHG },
     { id: '0002', shipmentType: SHIPMENT_OPTIONS.NTS },
-    { id: '0003', shipmentType: SHIPMENT_OPTIONS.PPM },
+    {
+      id: '0003',
+      shipmentType: SHIPMENT_OPTIONS.PPM,
+      ppmShipment: {
+        id: 'completePPM',
+        hasRequestedAdvance: false,
+        weightTickets: [],
+      },
+    },
     { id: '0004', shipmentType: SHIPMENT_OPTIONS.NTSR },
   ],
 };
@@ -95,6 +103,7 @@ WithPpms.args = {
       ppmShipment: {
         id: 'completePPM',
         hasRequestedAdvance: false,
+        weightTickets: [],
       },
     },
     {

--- a/src/components/ShipmentList/ShipmentList.test.jsx
+++ b/src/components/ShipmentList/ShipmentList.test.jsx
@@ -229,4 +229,32 @@ describe('Shipment List with PPM', () => {
     expect(screen.getByText('Estimated')).toBeInTheDocument();
     expect(screen.getByText('Actual')).toBeInTheDocument();
   });
+  it('should contain actual weight as full weight minus empty weight', () => {
+    const shipments = [
+      {
+        id: '0001',
+        shipmentType: SHIPMENT_OPTIONS.PPM,
+        ppmShipment: {
+          id: '1234',
+          hasRequestedAdvance: null,
+          primeEstimatedWeight: '1000',
+          weightTickets: [
+            {
+              id: '1',
+              fullWeight: '25000',
+              emptyWeight: '22500',
+            },
+          ],
+        },
+      },
+    ];
+    const defaultProps = {
+      shipments,
+      moveSubmitted: true,
+      showShipmentWeight: true,
+    };
+    render(<ShipmentList {...defaultProps} />);
+
+    expect(screen.getByText('2,500 lbs')).toBeInTheDocument();
+  });
 });

--- a/src/pages/Office/MovePaymentRequests/MovePaymentRequests.test.jsx
+++ b/src/pages/Office/MovePaymentRequests/MovePaymentRequests.test.jsx
@@ -153,6 +153,7 @@ const multiplePaymentRequests = {
         id: 'reweighID1',
         weight: 100,
       },
+
       mtoServiceItems: [
         {
           id: '5',
@@ -185,6 +186,7 @@ const multiplePaymentRequests = {
         id: 'reweighID2',
         weight: 600,
       },
+
       mtoServiceItems: [
         {
           id: '9',
@@ -217,6 +219,7 @@ const multiplePaymentRequests = {
         id: 'reweighID3',
         weight: 900,
       },
+
       mtoServiceItems: [
         {
           id: '12',
@@ -283,6 +286,7 @@ const singleReviewedPaymentRequest = {
         id: 'reweighID',
         weight: 900,
       },
+
       mtoServiceItems: [
         {
           id: '3',
@@ -312,6 +316,7 @@ const emptyPaymentRequests = {
         id: 'reweighID',
         weight: 900,
       },
+
       mtoServiceItems: [
         {
           id: '3',
@@ -338,6 +343,7 @@ const moveShipmentOverweight = {
       calculatedBillableWeight: 5000,
       primeActualWeight: 7000,
       primeEstimatedWeight: 3000,
+
       mtoServiceItems: [
         {
           id: '3',
@@ -367,6 +373,7 @@ const moveShipmentMissingReweighWeight = {
       reweigh: {
         id: '123',
       },
+
       mtoServiceItems: [
         {
           id: '3',
@@ -393,6 +400,7 @@ const returnWithBillableWeightsReviewed = {
       calculatedBillableWeight: 2000,
       primeActualWeight: 8000,
       primeEstimatedWeight: 3000,
+
       reweigh: {
         id: '123',
       },


### PR DESCRIPTION
## [B-18477](https://www13.v1host.com/USTRANSCOM38/story.mvc/Summary?oidToken=Story%3A888485)

## Summary

The Estimated and Actual fields are displaying on the Payment Requests, but the Actual is not populating.
"Actual Weight" is not populated for ppm shipments in the ppm workflow, but rather the weight used for payment and costing is the weight of the truck used full minus the empty weight

## Verification Steps for the Author

These are to be checked by the author.

- [ ] Have the Agility acceptance criteria been met for this change?

## Verification Steps for Reviewers

These are to be checked by a reviewer.

- [ ] Has the branch been pulled in and checked out?
- [ ] Have the BL acceptance criteria been met for this change?
- [ ] Was the CircleCI build successful?
- [ ] Has the code been reviewed from a standards and best practices point of view?

### Setup to Run the Code

- [Instructions for starting storybook](https://transcom.github.io/mymove-docs/docs/frontend/setup/storybook)
- [Instructions for starting the MilMove application](https://transcom.github.io/mymove-docs/docs/getting-started/application-setup/)
- [Instructions for running tests](https://transcom.github.io/mymove-docs/docs/getting-started/development/testing)

### How to test

1. Access the Office app
3. Login as a TIO
4. Find PPM in close out status with a payment request
5. verify the actual weight matches the weight that is the full weight of the truck minus the empty weight
6.   if there are multiple weight tickets, it will be the sum of the weights  


### Frontend

- [ ] There are no aXe warnings for UI.
- [ ] This works in [Supported Browsers and their phone views](https://transcom.github.io/mymove-docs/docs/adrs/Browser-Support/#minimum-browser-requirements) (Chrome, Firefox, Edge).
- [ ] There are no new console errors in the browser devtools.
- [ ] There are no new console errors in the test output.
- [ ] If this PR adds a new component to Storybook, it ensures the component is fully responsive, OR if it is intentionally not, a wrapping div using the `officeApp` class or custom `min-width` styling is used to hide any states the would not be visible to the user.
- [ ] This change meets the standards for [Section 508 compliance](https://www.ssa.gov/accessibility/andi/help/install.html).


## Screenshots
![image](https://github.com/transcom/mymove/assets/136509766/b47deec5-44c5-4f51-959a-af581c0b5bc0)
