### PR TITLE
INT B-18475-shipment-dest-address-update-with-sit-updates

### DIFF
--- a/migrations/app/migrations_manifest.txt
+++ b/migrations/app/migrations_manifest.txt
@@ -889,3 +889,4 @@
 20231226174935_create_ppm_documents_triggers.up.sql
 20240103174317_add_customer_expense.up.sql
 20240109200110_add_address_columns_to_ppmshipments4.up.sql
+20240123213917_update_shipment_address_update_table_sit_and_distance_columns.up.sql

--- a/migrations/app/schema/20240123213917_update_shipment_address_update_table_sit_and_distance_columns.up.sql
+++ b/migrations/app/schema/20240123213917_update_shipment_address_update_table_sit_and_distance_columns.up.sql
@@ -1,0 +1,15 @@
+-- Adds new columns to shipment address update table
+ALTER TABLE shipment_address_updates
+ADD COLUMN sit_original_address_id uuid DEFAULT NULL,
+ADD COLUMN old_sit_distance_between INTEGER DEFAULT NULL,
+ADD COLUMN new_sit_distance_between INTEGER DEFAULT NULL;
+
+-- Add foreign key constraint
+ALTER TABLE shipment_address_updates
+ADD CONSTRAINT fk_sit_original_address
+FOREIGN KEY (sit_original_address_id) REFERENCES addresses(id);
+
+-- Comments on new columns
+COMMENT on COLUMN shipment_address_updates.sit_original_address_id IS 'SIT address at the original time of SIT approval';
+COMMENT on COLUMN shipment_address_updates.old_sit_distance_between IS 'Distance between original SIT address and previous shipment destination address';
+COMMENT on COLUMN shipment_address_updates.new_sit_distance_between IS 'Distance between original SIT address and new shipment destination address';

--- a/pkg/gen/ghcapi/embedded_spec.go
+++ b/pkg/gen/ghcapi/embedded_spec.go
@@ -9076,12 +9076,22 @@ func init() {
         "newAddress": {
           "$ref": "#/definitions/Address"
         },
+        "newSitDistanceBetween": {
+          "description": "The distance between the original SIT address and requested new destination address of shipment",
+          "type": "integer",
+          "example": 88
+        },
         "officeRemarks": {
           "description": "The TOO comment on approval or rejection.",
           "type": "string",
           "title": "Office Remarks",
           "x-nullable": true,
           "example": "This is an office remark"
+        },
+        "oldSitDistanceBetween": {
+          "description": "The distance between the original SIT address and the previous/old destination address of shipment",
+          "type": "integer",
+          "example": 50
         },
         "originalAddress": {
           "$ref": "#/definitions/Address"
@@ -9091,6 +9101,9 @@ func init() {
           "format": "uuid",
           "readOnly": true,
           "example": "c56a4180-65aa-42ec-a945-5fd21dec0538"
+        },
+        "sitOriginalAddress": {
+          "$ref": "#/definitions/Address"
         },
         "status": {
           "$ref": "#/definitions/ShipmentAddressUpdateStatus"
@@ -20687,12 +20700,24 @@ func init() {
         "newAddress": {
           "$ref": "#/definitions/Address"
         },
+        "newSitDistanceBetween": {
+          "description": "The distance between the original SIT address and requested new destination address of shipment",
+          "type": "integer",
+          "minimum": 0,
+          "example": 88
+        },
         "officeRemarks": {
           "description": "The TOO comment on approval or rejection.",
           "type": "string",
           "title": "Office Remarks",
           "x-nullable": true,
           "example": "This is an office remark"
+        },
+        "oldSitDistanceBetween": {
+          "description": "The distance between the original SIT address and the previous/old destination address of shipment",
+          "type": "integer",
+          "minimum": 0,
+          "example": 50
         },
         "originalAddress": {
           "$ref": "#/definitions/Address"
@@ -20702,6 +20727,9 @@ func init() {
           "format": "uuid",
           "readOnly": true,
           "example": "c56a4180-65aa-42ec-a945-5fd21dec0538"
+        },
+        "sitOriginalAddress": {
+          "$ref": "#/definitions/Address"
         },
         "status": {
           "$ref": "#/definitions/ShipmentAddressUpdateStatus"

--- a/pkg/gen/ghcmessages/shipment_address_update.go
+++ b/pkg/gen/ghcmessages/shipment_address_update.go
@@ -38,11 +38,21 @@ type ShipmentAddressUpdate struct {
 	// Required: true
 	NewAddress *Address `json:"newAddress"`
 
+	// The distance between the original SIT address and requested new destination address of shipment
+	// Example: 88
+	// Minimum: 0
+	NewSitDistanceBetween *int64 `json:"newSitDistanceBetween,omitempty"`
+
 	// Office Remarks
 	//
 	// The TOO comment on approval or rejection.
 	// Example: This is an office remark
 	OfficeRemarks *string `json:"officeRemarks,omitempty"`
+
+	// The distance between the original SIT address and the previous/old destination address of shipment
+	// Example: 50
+	// Minimum: 0
+	OldSitDistanceBetween *int64 `json:"oldSitDistanceBetween,omitempty"`
 
 	// original address
 	// Required: true
@@ -54,6 +64,9 @@ type ShipmentAddressUpdate struct {
 	// Read Only: true
 	// Format: uuid
 	ShipmentID strfmt.UUID `json:"shipmentID"`
+
+	// sit original address
+	SitOriginalAddress *Address `json:"sitOriginalAddress,omitempty"`
 
 	// status
 	// Required: true
@@ -76,11 +89,23 @@ func (m *ShipmentAddressUpdate) Validate(formats strfmt.Registry) error {
 		res = append(res, err)
 	}
 
+	if err := m.validateNewSitDistanceBetween(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateOldSitDistanceBetween(formats); err != nil {
+		res = append(res, err)
+	}
+
 	if err := m.validateOriginalAddress(formats); err != nil {
 		res = append(res, err)
 	}
 
 	if err := m.validateShipmentID(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateSitOriginalAddress(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -136,6 +161,30 @@ func (m *ShipmentAddressUpdate) validateNewAddress(formats strfmt.Registry) erro
 	return nil
 }
 
+func (m *ShipmentAddressUpdate) validateNewSitDistanceBetween(formats strfmt.Registry) error {
+	if swag.IsZero(m.NewSitDistanceBetween) { // not required
+		return nil
+	}
+
+	if err := validate.MinimumInt("newSitDistanceBetween", "body", *m.NewSitDistanceBetween, 0, false); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (m *ShipmentAddressUpdate) validateOldSitDistanceBetween(formats strfmt.Registry) error {
+	if swag.IsZero(m.OldSitDistanceBetween) { // not required
+		return nil
+	}
+
+	if err := validate.MinimumInt("oldSitDistanceBetween", "body", *m.OldSitDistanceBetween, 0, false); err != nil {
+		return err
+	}
+
+	return nil
+}
+
 func (m *ShipmentAddressUpdate) validateOriginalAddress(formats strfmt.Registry) error {
 
 	if err := validate.Required("originalAddress", "body", m.OriginalAddress); err != nil {
@@ -164,6 +213,25 @@ func (m *ShipmentAddressUpdate) validateShipmentID(formats strfmt.Registry) erro
 
 	if err := validate.FormatOf("shipmentID", "body", "uuid", m.ShipmentID.String(), formats); err != nil {
 		return err
+	}
+
+	return nil
+}
+
+func (m *ShipmentAddressUpdate) validateSitOriginalAddress(formats strfmt.Registry) error {
+	if swag.IsZero(m.SitOriginalAddress) { // not required
+		return nil
+	}
+
+	if m.SitOriginalAddress != nil {
+		if err := m.SitOriginalAddress.Validate(formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("sitOriginalAddress")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("sitOriginalAddress")
+			}
+			return err
+		}
 	}
 
 	return nil
@@ -208,6 +276,10 @@ func (m *ShipmentAddressUpdate) ContextValidate(ctx context.Context, formats str
 	}
 
 	if err := m.contextValidateShipmentID(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.contextValidateSitOriginalAddress(ctx, formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -277,6 +349,27 @@ func (m *ShipmentAddressUpdate) contextValidateShipmentID(ctx context.Context, f
 
 	if err := validate.ReadOnly(ctx, "shipmentID", "body", strfmt.UUID(m.ShipmentID)); err != nil {
 		return err
+	}
+
+	return nil
+}
+
+func (m *ShipmentAddressUpdate) contextValidateSitOriginalAddress(ctx context.Context, formats strfmt.Registry) error {
+
+	if m.SitOriginalAddress != nil {
+
+		if swag.IsZero(m.SitOriginalAddress) { // not required
+			return nil
+		}
+
+		if err := m.SitOriginalAddress.ContextValidate(ctx, formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("sitOriginalAddress")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("sitOriginalAddress")
+			}
+			return err
+		}
 	}
 
 	return nil

--- a/pkg/gen/primeapi/embedded_spec.go
+++ b/pkg/gen/primeapi/embedded_spec.go
@@ -4018,12 +4018,22 @@ func init() {
         "newAddress": {
           "$ref": "#/definitions/Address"
         },
+        "newSitDistanceBetween": {
+          "description": "The distance between the original SIT address and requested new destination address of shipment",
+          "type": "integer",
+          "example": 88
+        },
         "officeRemarks": {
           "description": "The TOO comment on approval or rejection.",
           "type": "string",
           "title": "Office Remarks",
           "x-nullable": true,
           "example": "This is an office remark"
+        },
+        "oldSitDistanceBetween": {
+          "description": "The distance between the original SIT address and the previous/old destination address of shipment",
+          "type": "integer",
+          "example": 50
         },
         "originalAddress": {
           "$ref": "#/definitions/Address"
@@ -4033,6 +4043,9 @@ func init() {
           "format": "uuid",
           "readOnly": true,
           "example": "c56a4180-65aa-42ec-a945-5fd21dec0538"
+        },
+        "sitOriginalAddress": {
+          "$ref": "#/definitions/Address"
         },
         "status": {
           "$ref": "#/definitions/ShipmentAddressUpdateStatus"
@@ -9284,12 +9297,24 @@ func init() {
         "newAddress": {
           "$ref": "#/definitions/Address"
         },
+        "newSitDistanceBetween": {
+          "description": "The distance between the original SIT address and requested new destination address of shipment",
+          "type": "integer",
+          "minimum": 0,
+          "example": 88
+        },
         "officeRemarks": {
           "description": "The TOO comment on approval or rejection.",
           "type": "string",
           "title": "Office Remarks",
           "x-nullable": true,
           "example": "This is an office remark"
+        },
+        "oldSitDistanceBetween": {
+          "description": "The distance between the original SIT address and the previous/old destination address of shipment",
+          "type": "integer",
+          "minimum": 0,
+          "example": 50
         },
         "originalAddress": {
           "$ref": "#/definitions/Address"
@@ -9299,6 +9324,9 @@ func init() {
           "format": "uuid",
           "readOnly": true,
           "example": "c56a4180-65aa-42ec-a945-5fd21dec0538"
+        },
+        "sitOriginalAddress": {
+          "$ref": "#/definitions/Address"
         },
         "status": {
           "$ref": "#/definitions/ShipmentAddressUpdateStatus"

--- a/pkg/gen/primemessages/shipment_address_update.go
+++ b/pkg/gen/primemessages/shipment_address_update.go
@@ -38,11 +38,21 @@ type ShipmentAddressUpdate struct {
 	// Required: true
 	NewAddress *Address `json:"newAddress"`
 
+	// The distance between the original SIT address and requested new destination address of shipment
+	// Example: 88
+	// Minimum: 0
+	NewSitDistanceBetween *int64 `json:"newSitDistanceBetween,omitempty"`
+
 	// Office Remarks
 	//
 	// The TOO comment on approval or rejection.
 	// Example: This is an office remark
 	OfficeRemarks *string `json:"officeRemarks,omitempty"`
+
+	// The distance between the original SIT address and the previous/old destination address of shipment
+	// Example: 50
+	// Minimum: 0
+	OldSitDistanceBetween *int64 `json:"oldSitDistanceBetween,omitempty"`
 
 	// original address
 	// Required: true
@@ -54,6 +64,9 @@ type ShipmentAddressUpdate struct {
 	// Read Only: true
 	// Format: uuid
 	ShipmentID strfmt.UUID `json:"shipmentID"`
+
+	// sit original address
+	SitOriginalAddress *Address `json:"sitOriginalAddress,omitempty"`
 
 	// status
 	// Required: true
@@ -76,11 +89,23 @@ func (m *ShipmentAddressUpdate) Validate(formats strfmt.Registry) error {
 		res = append(res, err)
 	}
 
+	if err := m.validateNewSitDistanceBetween(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateOldSitDistanceBetween(formats); err != nil {
+		res = append(res, err)
+	}
+
 	if err := m.validateOriginalAddress(formats); err != nil {
 		res = append(res, err)
 	}
 
 	if err := m.validateShipmentID(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateSitOriginalAddress(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -136,6 +161,30 @@ func (m *ShipmentAddressUpdate) validateNewAddress(formats strfmt.Registry) erro
 	return nil
 }
 
+func (m *ShipmentAddressUpdate) validateNewSitDistanceBetween(formats strfmt.Registry) error {
+	if swag.IsZero(m.NewSitDistanceBetween) { // not required
+		return nil
+	}
+
+	if err := validate.MinimumInt("newSitDistanceBetween", "body", *m.NewSitDistanceBetween, 0, false); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (m *ShipmentAddressUpdate) validateOldSitDistanceBetween(formats strfmt.Registry) error {
+	if swag.IsZero(m.OldSitDistanceBetween) { // not required
+		return nil
+	}
+
+	if err := validate.MinimumInt("oldSitDistanceBetween", "body", *m.OldSitDistanceBetween, 0, false); err != nil {
+		return err
+	}
+
+	return nil
+}
+
 func (m *ShipmentAddressUpdate) validateOriginalAddress(formats strfmt.Registry) error {
 
 	if err := validate.Required("originalAddress", "body", m.OriginalAddress); err != nil {
@@ -164,6 +213,25 @@ func (m *ShipmentAddressUpdate) validateShipmentID(formats strfmt.Registry) erro
 
 	if err := validate.FormatOf("shipmentID", "body", "uuid", m.ShipmentID.String(), formats); err != nil {
 		return err
+	}
+
+	return nil
+}
+
+func (m *ShipmentAddressUpdate) validateSitOriginalAddress(formats strfmt.Registry) error {
+	if swag.IsZero(m.SitOriginalAddress) { // not required
+		return nil
+	}
+
+	if m.SitOriginalAddress != nil {
+		if err := m.SitOriginalAddress.Validate(formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("sitOriginalAddress")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("sitOriginalAddress")
+			}
+			return err
+		}
 	}
 
 	return nil
@@ -208,6 +276,10 @@ func (m *ShipmentAddressUpdate) ContextValidate(ctx context.Context, formats str
 	}
 
 	if err := m.contextValidateShipmentID(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.contextValidateSitOriginalAddress(ctx, formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -277,6 +349,27 @@ func (m *ShipmentAddressUpdate) contextValidateShipmentID(ctx context.Context, f
 
 	if err := validate.ReadOnly(ctx, "shipmentID", "body", strfmt.UUID(m.ShipmentID)); err != nil {
 		return err
+	}
+
+	return nil
+}
+
+func (m *ShipmentAddressUpdate) contextValidateSitOriginalAddress(ctx context.Context, formats strfmt.Registry) error {
+
+	if m.SitOriginalAddress != nil {
+
+		if swag.IsZero(m.SitOriginalAddress) { // not required
+			return nil
+		}
+
+		if err := m.SitOriginalAddress.ContextValidate(ctx, formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("sitOriginalAddress")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("sitOriginalAddress")
+			}
+			return err
+		}
 	}
 
 	return nil

--- a/pkg/gen/primev2api/embedded_spec.go
+++ b/pkg/gen/primev2api/embedded_spec.go
@@ -2528,12 +2528,22 @@ func init() {
         "newAddress": {
           "$ref": "#/definitions/Address"
         },
+        "newSitDistanceBetween": {
+          "description": "The distance between the original SIT address and requested new destination address of shipment",
+          "type": "integer",
+          "example": 88
+        },
         "officeRemarks": {
           "description": "The TOO comment on approval or rejection.",
           "type": "string",
           "title": "Office Remarks",
           "x-nullable": true,
           "example": "This is an office remark"
+        },
+        "oldSitDistanceBetween": {
+          "description": "The distance between the original SIT address and the previous/old destination address of shipment",
+          "type": "integer",
+          "example": 50
         },
         "originalAddress": {
           "$ref": "#/definitions/Address"
@@ -2543,6 +2553,9 @@ func init() {
           "format": "uuid",
           "readOnly": true,
           "example": "c56a4180-65aa-42ec-a945-5fd21dec0538"
+        },
+        "sitOriginalAddress": {
+          "$ref": "#/definitions/Address"
         },
         "status": {
           "$ref": "#/definitions/ShipmentAddressUpdateStatus"
@@ -5791,12 +5804,24 @@ func init() {
         "newAddress": {
           "$ref": "#/definitions/Address"
         },
+        "newSitDistanceBetween": {
+          "description": "The distance between the original SIT address and requested new destination address of shipment",
+          "type": "integer",
+          "minimum": 0,
+          "example": 88
+        },
         "officeRemarks": {
           "description": "The TOO comment on approval or rejection.",
           "type": "string",
           "title": "Office Remarks",
           "x-nullable": true,
           "example": "This is an office remark"
+        },
+        "oldSitDistanceBetween": {
+          "description": "The distance between the original SIT address and the previous/old destination address of shipment",
+          "type": "integer",
+          "minimum": 0,
+          "example": 50
         },
         "originalAddress": {
           "$ref": "#/definitions/Address"
@@ -5806,6 +5831,9 @@ func init() {
           "format": "uuid",
           "readOnly": true,
           "example": "c56a4180-65aa-42ec-a945-5fd21dec0538"
+        },
+        "sitOriginalAddress": {
+          "$ref": "#/definitions/Address"
         },
         "status": {
           "$ref": "#/definitions/ShipmentAddressUpdateStatus"

--- a/pkg/gen/primev2messages/shipment_address_update.go
+++ b/pkg/gen/primev2messages/shipment_address_update.go
@@ -38,11 +38,21 @@ type ShipmentAddressUpdate struct {
 	// Required: true
 	NewAddress *Address `json:"newAddress"`
 
+	// The distance between the original SIT address and requested new destination address of shipment
+	// Example: 88
+	// Minimum: 0
+	NewSitDistanceBetween *int64 `json:"newSitDistanceBetween,omitempty"`
+
 	// Office Remarks
 	//
 	// The TOO comment on approval or rejection.
 	// Example: This is an office remark
 	OfficeRemarks *string `json:"officeRemarks,omitempty"`
+
+	// The distance between the original SIT address and the previous/old destination address of shipment
+	// Example: 50
+	// Minimum: 0
+	OldSitDistanceBetween *int64 `json:"oldSitDistanceBetween,omitempty"`
 
 	// original address
 	// Required: true
@@ -54,6 +64,9 @@ type ShipmentAddressUpdate struct {
 	// Read Only: true
 	// Format: uuid
 	ShipmentID strfmt.UUID `json:"shipmentID"`
+
+	// sit original address
+	SitOriginalAddress *Address `json:"sitOriginalAddress,omitempty"`
 
 	// status
 	// Required: true
@@ -76,11 +89,23 @@ func (m *ShipmentAddressUpdate) Validate(formats strfmt.Registry) error {
 		res = append(res, err)
 	}
 
+	if err := m.validateNewSitDistanceBetween(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateOldSitDistanceBetween(formats); err != nil {
+		res = append(res, err)
+	}
+
 	if err := m.validateOriginalAddress(formats); err != nil {
 		res = append(res, err)
 	}
 
 	if err := m.validateShipmentID(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateSitOriginalAddress(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -136,6 +161,30 @@ func (m *ShipmentAddressUpdate) validateNewAddress(formats strfmt.Registry) erro
 	return nil
 }
 
+func (m *ShipmentAddressUpdate) validateNewSitDistanceBetween(formats strfmt.Registry) error {
+	if swag.IsZero(m.NewSitDistanceBetween) { // not required
+		return nil
+	}
+
+	if err := validate.MinimumInt("newSitDistanceBetween", "body", *m.NewSitDistanceBetween, 0, false); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (m *ShipmentAddressUpdate) validateOldSitDistanceBetween(formats strfmt.Registry) error {
+	if swag.IsZero(m.OldSitDistanceBetween) { // not required
+		return nil
+	}
+
+	if err := validate.MinimumInt("oldSitDistanceBetween", "body", *m.OldSitDistanceBetween, 0, false); err != nil {
+		return err
+	}
+
+	return nil
+}
+
 func (m *ShipmentAddressUpdate) validateOriginalAddress(formats strfmt.Registry) error {
 
 	if err := validate.Required("originalAddress", "body", m.OriginalAddress); err != nil {
@@ -164,6 +213,25 @@ func (m *ShipmentAddressUpdate) validateShipmentID(formats strfmt.Registry) erro
 
 	if err := validate.FormatOf("shipmentID", "body", "uuid", m.ShipmentID.String(), formats); err != nil {
 		return err
+	}
+
+	return nil
+}
+
+func (m *ShipmentAddressUpdate) validateSitOriginalAddress(formats strfmt.Registry) error {
+	if swag.IsZero(m.SitOriginalAddress) { // not required
+		return nil
+	}
+
+	if m.SitOriginalAddress != nil {
+		if err := m.SitOriginalAddress.Validate(formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("sitOriginalAddress")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("sitOriginalAddress")
+			}
+			return err
+		}
 	}
 
 	return nil
@@ -208,6 +276,10 @@ func (m *ShipmentAddressUpdate) ContextValidate(ctx context.Context, formats str
 	}
 
 	if err := m.contextValidateShipmentID(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.contextValidateSitOriginalAddress(ctx, formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -277,6 +349,27 @@ func (m *ShipmentAddressUpdate) contextValidateShipmentID(ctx context.Context, f
 
 	if err := validate.ReadOnly(ctx, "shipmentID", "body", strfmt.UUID(m.ShipmentID)); err != nil {
 		return err
+	}
+
+	return nil
+}
+
+func (m *ShipmentAddressUpdate) contextValidateSitOriginalAddress(ctx context.Context, formats strfmt.Registry) error {
+
+	if m.SitOriginalAddress != nil {
+
+		if swag.IsZero(m.SitOriginalAddress) { // not required
+			return nil
+		}
+
+		if err := m.SitOriginalAddress.ContextValidate(ctx, formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("sitOriginalAddress")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("sitOriginalAddress")
+			}
+			return err
+		}
 	}
 
 	return nil

--- a/pkg/handlers/ghcapi/internal/payloads/model_to_payload.go
+++ b/pkg/handlers/ghcapi/internal/payloads/model_to_payload.go
@@ -1032,13 +1032,16 @@ func ShipmentAddressUpdate(shipmentAddressUpdate *models.ShipmentAddressUpdate) 
 	}
 
 	payload := &ghcmessages.ShipmentAddressUpdate{
-		ID:                strfmt.UUID(shipmentAddressUpdate.ID.String()),
-		ShipmentID:        strfmt.UUID(shipmentAddressUpdate.ShipmentID.String()),
-		NewAddress:        Address(&shipmentAddressUpdate.NewAddress),
-		OriginalAddress:   Address(&shipmentAddressUpdate.OriginalAddress),
-		ContractorRemarks: shipmentAddressUpdate.ContractorRemarks,
-		OfficeRemarks:     shipmentAddressUpdate.OfficeRemarks,
-		Status:            ghcmessages.ShipmentAddressUpdateStatus(shipmentAddressUpdate.Status),
+		ID:                    strfmt.UUID(shipmentAddressUpdate.ID.String()),
+		ShipmentID:            strfmt.UUID(shipmentAddressUpdate.ShipmentID.String()),
+		NewAddress:            Address(&shipmentAddressUpdate.NewAddress),
+		OriginalAddress:       Address(&shipmentAddressUpdate.OriginalAddress),
+		SitOriginalAddress:    Address(shipmentAddressUpdate.SitOriginalAddress),
+		ContractorRemarks:     shipmentAddressUpdate.ContractorRemarks,
+		OfficeRemarks:         shipmentAddressUpdate.OfficeRemarks,
+		Status:                ghcmessages.ShipmentAddressUpdateStatus(shipmentAddressUpdate.Status),
+		NewSitDistanceBetween: handlers.FmtIntPtrToInt64(shipmentAddressUpdate.NewSitDistanceBetween),
+		OldSitDistanceBetween: handlers.FmtIntPtrToInt64(shipmentAddressUpdate.OldSitDistanceBetween),
 	}
 
 	return payload

--- a/pkg/models/shipment_address_updates.go
+++ b/pkg/models/shipment_address_updates.go
@@ -36,12 +36,16 @@ type ShipmentAddressUpdate struct {
 	UpdatedAt         time.Time                   `db:"updated_at"`
 
 	// Associations
-	Shipment          MTOShipment `belongs_to:"mto_shipments" fk_id:"shipment_id"`
-	ShipmentID        uuid.UUID   `db:"shipment_id"`
-	OriginalAddress   Address     `belongs_to:"addresses" fk_id:"original_address_id"`
-	OriginalAddressID uuid.UUID   `db:"original_address_id"`
-	NewAddress        Address     `belongs_to:"addresses" fk_id:"new_address_id"`
-	NewAddressID      uuid.UUID   `db:"new_address_id"`
+	Shipment              MTOShipment `belongs_to:"mto_shipments" fk_id:"shipment_id"`
+	ShipmentID            uuid.UUID   `db:"shipment_id"`
+	OriginalAddress       Address     `belongs_to:"addresses" fk_id:"original_address_id"`
+	OriginalAddressID     uuid.UUID   `db:"original_address_id"`
+	NewAddress            Address     `belongs_to:"addresses" fk_id:"new_address_id"`
+	NewAddressID          uuid.UUID   `db:"new_address_id"`
+	SitOriginalAddressID  *uuid.UUID  `db:"sit_original_address_id"`
+	SitOriginalAddress    *Address    `belongs_to:"addresses" fk_id:"sit_original_address_id"`
+	OldSitDistanceBetween *int        `db:"old_sit_distance_between"`
+	NewSitDistanceBetween *int        `db:"new_sit_distance_between"`
 }
 
 // Validate gets run every time you call a "pop.Validate*" (pop.ValidateAndSave, pop.ValidateAndCreate,

--- a/pkg/services/mto_shipment/mto_shipment_fetcher.go
+++ b/pkg/services/mto_shipment/mto_shipment_fetcher.go
@@ -124,7 +124,7 @@ func (f mtoShipmentFetcher) ListMTOShipments(appCtx appcontext.AppContext, moveI
 		if shipments[i].DeliveryAddressUpdate != nil {
 			// Cannot EagerPreload the address update `NewAddress` due to POP bug
 			// See: https://transcom.github.io/mymove-docs/docs/backend/setup/using-eagerpreload-in-pop#eager-vs-eagerpreload-inconsistency
-			loadErr := appCtx.DB().Load(shipments[i].DeliveryAddressUpdate, "NewAddress")
+			loadErr := appCtx.DB().Load(shipments[i].DeliveryAddressUpdate, "NewAddress", "SitOriginalAddress")
 			if loadErr != nil {
 				return nil, apperror.NewQueryError("DeliveryAddressUpdate", loadErr, "")
 			}

--- a/pkg/services/shipment_address_update/shipment_address_update_requester.go
+++ b/pkg/services/shipment_address_update/shipment_address_update_requester.go
@@ -138,6 +138,20 @@ func (f *shipmentAddressUpdateRequester) doesDeliveryAddressUpdateChangeShipment
 	return true, nil
 }
 
+func (f *shipmentAddressUpdateRequester) doesShipmentContainDestinationSIT(shipment models.MTOShipment) bool {
+	if len(shipment.MTOServiceItems) > 0 {
+		serviceItems := shipment.MTOServiceItems
+
+		for _, serviceItem := range serviceItems {
+			serviceCode := serviceItem.ReService.Code
+			if serviceCode == models.ReServiceCodeDDASIT || serviceCode == models.ReServiceCodeDDDSIT || serviceCode == models.ReServiceCodeDDFSIT || serviceCode == models.ReServiceCodeDDSFSC {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 func (f *shipmentAddressUpdateRequester) mapServiceItemWithUpdatedPriceRequirements(originalServiceItem models.MTOServiceItem) models.MTOServiceItem {
 	var reService models.ReService
 
@@ -187,7 +201,7 @@ func (f *shipmentAddressUpdateRequester) mapServiceItemWithUpdatedPriceRequireme
 func (f *shipmentAddressUpdateRequester) RequestShipmentDeliveryAddressUpdate(appCtx appcontext.AppContext, shipmentID uuid.UUID, newAddress models.Address, contractorRemarks string, eTag string) (*models.ShipmentAddressUpdate, error) {
 	var addressUpdate models.ShipmentAddressUpdate
 	var shipment models.MTOShipment
-	err := appCtx.DB().EagerPreload("MoveTaskOrder", "PickupAddress", "MTOServiceItems.ReService", "DestinationAddress").Find(&shipment, shipmentID)
+	err := appCtx.DB().EagerPreload("MoveTaskOrder", "PickupAddress", "MTOServiceItems.ReService", "DestinationAddress", "MTOServiceItems.SITDestinationOriginalAddress").Find(&shipment, shipmentID)
 	if err != nil {
 		if err == sql.ErrNoRows {
 			return nil, apperror.NewNotFoundError(shipmentID, "looking for shipment")
@@ -204,6 +218,8 @@ func (f *shipmentAddressUpdateRequester) RequestShipmentDeliveryAddressUpdate(ap
 	if eTag != etag.GenerateEtag(shipment.UpdatedAt) {
 		return nil, apperror.NewPreconditionFailedError(shipmentID, nil)
 	}
+
+	shipmentHasDestSIT := f.doesShipmentContainDestinationSIT(shipment)
 
 	err = appCtx.DB().EagerPreload("OriginalAddress", "NewAddress").Where("shipment_id = ?", shipmentID).First(&addressUpdate)
 	if err != nil {
@@ -229,6 +245,44 @@ func (f *shipmentAddressUpdateRequester) RequestShipmentDeliveryAddressUpdate(ap
 	}
 	addressUpdate.NewAddressID = address.ID
 	addressUpdate.NewAddress = *address
+
+	// if the shipment contains destination SIT service items, we need to update the addressUpdate data
+	// with the SIT original address and calculate the distances between the old & new shipment addresses
+	if shipmentHasDestSIT {
+		serviceItems := shipment.MTOServiceItems
+		for _, serviceItem := range serviceItems {
+			serviceCode := serviceItem.ReService.Code
+			if serviceCode == models.ReServiceCodeDDASIT || serviceCode == models.ReServiceCodeDDDSIT || serviceCode == models.ReServiceCodeDDFSIT || serviceCode == models.ReServiceCodeDDSFSC {
+				if serviceItem.SITDestinationOriginalAddressID != nil {
+					addressUpdate.SitOriginalAddressID = serviceItem.SITDestinationOriginalAddressID
+				}
+				if serviceItem.SITDestinationOriginalAddress != nil {
+					addressUpdate.SitOriginalAddress = serviceItem.SITDestinationOriginalAddress
+				}
+			}
+			// if we have updated the values we need, no need to keep looping through the service items
+			if addressUpdate.SitOriginalAddress != nil && addressUpdate.SitOriginalAddressID != nil {
+				break
+			}
+		}
+		var distanceBetweenNew int
+		var distanceBetweenOld int
+		distanceBetweenNew, err = f.planner.ZipTransitDistance(appCtx, addressUpdate.SitOriginalAddress.PostalCode, addressUpdate.NewAddress.PostalCode)
+		if err != nil {
+			return nil, err
+		}
+		distanceBetweenOld, err = f.planner.ZipTransitDistance(appCtx, addressUpdate.SitOriginalAddress.PostalCode, addressUpdate.OriginalAddress.PostalCode)
+		if err != nil {
+			return nil, err
+		}
+		addressUpdate.NewSitDistanceBetween = &distanceBetweenNew
+		addressUpdate.OldSitDistanceBetween = &distanceBetweenOld
+	} else {
+		addressUpdate.SitOriginalAddressID = nil
+		addressUpdate.SitOriginalAddress = nil
+		addressUpdate.NewSitDistanceBetween = nil
+		addressUpdate.OldSitDistanceBetween = nil
+	}
 
 	contract, err := serviceparamvaluelookups.FetchContract(appCtx, *shipment.MoveTaskOrder.AvailableToPrimeAt)
 	if err != nil {

--- a/pkg/services/shipment_address_update/shipment_address_update_requester_test.go
+++ b/pkg/services/shipment_address_update/shipment_address_update_requester_test.go
@@ -148,7 +148,7 @@ func (suite *ShipmentAddressUpdateServiceSuite) TestCreateApprovedShipmentAddres
 		suite.Nil(update)
 	})
 
-	suite.Run("Should be able to use this service to update a shipment with SIT", func() {
+	suite.Run("Should be able to use this service to update a shipment with origin SIT", func() {
 		move := setupTestData()
 		newAddress := models.Address{
 			StreetAddress1: "123 Any St",
@@ -180,7 +180,7 @@ func (suite *ShipmentAddressUpdateServiceSuite) TestCreateApprovedShipmentAddres
 			},
 			{
 				Model: models.ReService{
-					Code: models.ReServiceCodeDOPSIT,
+					Code: models.ReServiceCodeDOASIT,
 				},
 			},
 		}, nil)
@@ -480,6 +480,71 @@ func (suite *ShipmentAddressUpdateServiceSuite) TestCreateApprovedShipmentAddres
 		suite.NoError(err)
 		suite.Equal(models.MoveStatusAPPROVALSREQUESTED, updatedMove.Status)
 	})
+	suite.Run("destination address request succeeds when containing destination SIT", func() {
+		move := setupTestData()
+		newAddress := models.Address{
+			StreetAddress1: "123 Any St",
+			City:           "Beverly Hills",
+			State:          "CA",
+			PostalCode:     "90210",
+			Country:        models.StringPointer("United States"),
+		}
+
+		shipment := factory.BuildMTOShipmentWithMove(&move, suite.DB(), nil, nil)
+
+		// building DDASIT service item to get dest SIT checks
+		serviceItemDDASIT := factory.BuildMTOServiceItem(suite.DB(), []factory.Customization{
+			{
+				Model: models.MTOServiceItem{
+					Status:                          models.MTOServiceItemStatusApproved,
+					SITDestinationOriginalAddressID: shipment.DestinationAddressID,
+				},
+			},
+			{
+				Model:    move,
+				LinkOnly: true,
+			},
+			{
+				Model:    shipment,
+				LinkOnly: true,
+			},
+			{
+				Model: models.ReService{
+					Code: models.ReServiceCodeDDASIT,
+				},
+			},
+		}, nil)
+
+		// mock ZipTransitDistance function
+		mockPlanner.On("ZipTransitDistance",
+			mock.AnythingOfType("*appcontext.appContext"),
+			"94535",
+			"94535",
+		).Return(0, nil).Once()
+		mockPlanner.On("ZipTransitDistance",
+			mock.AnythingOfType("*appcontext.appContext"),
+			"94523",
+			"90210",
+		).Return(500, nil).Once()
+		mockPlanner.On("ZipTransitDistance",
+			mock.AnythingOfType("*appcontext.appContext"),
+			"94535",
+			"90210",
+		).Return(501, nil).Once()
+
+		// request the update
+		update, err := addressUpdateRequester.RequestShipmentDeliveryAddressUpdate(suite.AppContextForTest(), shipment.ID, newAddress, "we really need to change the address", etag.GenerateEtag(shipment.UpdatedAt))
+		suite.NoError(err)
+		suite.NotNil(update)
+
+		// querying the address update to make sure that SIT data was populated
+		var addressUpdate models.ShipmentAddressUpdate
+		err = suite.DB().Find(&addressUpdate, update.ID)
+		suite.NoError(err)
+		suite.Equal(*addressUpdate.NewSitDistanceBetween, 501)
+		suite.Equal(*addressUpdate.OldSitDistanceBetween, 0)
+		suite.Equal(*addressUpdate.SitOriginalAddressID, *serviceItemDDASIT.SITDestinationOriginalAddressID)
+	})
 }
 
 func (suite *ShipmentAddressUpdateServiceSuite) TestTOOApprovedShipmentAddressUpdateRequest() {
@@ -554,6 +619,72 @@ func (suite *ShipmentAddressUpdateServiceSuite) TestTOOApprovedShipmentAddressUp
 		suite.NotNil(update)
 		suite.Equal(models.MoveStatusAPPROVED, updatedMove.Status)
 
+	})
+
+	suite.Run("TOO approves address change and service items final destination address changes", func() {
+
+		// creating an address change that shares the same address to avoid hitting lineHaulChange check
+		addressChange := factory.BuildShipmentAddressUpdate(suite.DB(), []factory.Customization{
+			{
+				Model: models.Address{
+					StreetAddress1: "123 Main St",
+					StreetAddress2: models.StringPointer("Apt 2"),
+					StreetAddress3: models.StringPointer("Suite 200"),
+					City:           "New York",
+					State:          "NY",
+					PostalCode:     "10001",
+					Country:        models.StringPointer("US"),
+				},
+				Type: &factory.Addresses.OriginalAddress,
+			},
+			{
+				Model: models.Address{
+					StreetAddress1: "123 Main St",
+					StreetAddress2: models.StringPointer("Apt 2"),
+					StreetAddress3: models.StringPointer("Suite 200"),
+					City:           "New York",
+					State:          "NY",
+					PostalCode:     "10001",
+					Country:        models.StringPointer("US"),
+				},
+				Type: &factory.Addresses.NewAddress,
+			},
+		}, nil)
+		shipment := addressChange.Shipment
+		reService := factory.BuildDDFSITReService(suite.DB())
+		factory.BuildMTOServiceItem(suite.DB(), []factory.Customization{
+			{
+				Model: models.Move{
+					ID: shipment.MoveTaskOrderID,
+				},
+			},
+			{
+				Model:    shipment,
+				LinkOnly: true,
+			},
+			{
+				Model:    reService,
+				LinkOnly: true,
+			},
+		}, nil)
+		officeRemarks := "This is a TOO remark"
+
+		update, err := addressUpdateRequester.ReviewShipmentAddressChange(suite.AppContextForTest(), addressChange.Shipment.ID, "APPROVED", officeRemarks)
+
+		suite.NoError(err)
+		suite.NotNil(update)
+		suite.Equal(models.ShipmentAddressUpdateStatusApproved, update.Status)
+		suite.Equal("This is a TOO remark", *update.OfficeRemarks)
+
+		// Make sure the destination address on the shipment was updated
+		var updatedShipment models.MTOShipment
+		err = suite.DB().EagerPreload("DestinationAddress", "MTOServiceItems").Find(&updatedShipment, update.ShipmentID)
+		suite.NoError(err)
+
+		// service item status should be changed to submitted
+		suite.Equal(models.MTOServiceItemStatusSubmitted, updatedShipment.MTOServiceItems[0].Status)
+		// delivery and final destination addresses should be the same
+		suite.Equal(updatedShipment.DestinationAddressID, updatedShipment.MTOServiceItems[0].SITDestinationFinalAddressID)
 	})
 
 }
@@ -901,7 +1032,7 @@ func (suite *ShipmentAddressUpdateServiceSuite) TestTOOApprovedShipmentAddressUp
 		shipment := factory.BuildMTOShipmentWithMove(&move, suite.DB(), nil, nil)
 
 		//Generate a couple of service items to test their status changes upon approval
-		serviceItem1 := factory.BuildRealMTOServiceItemWithAllDeps(suite.DB(), models.ReServiceCodeDDDSIT, move, shipment, nil, nil)
+		serviceItem1 := factory.BuildRealMTOServiceItemWithAllDeps(suite.DB(), models.ReServiceCodeDOASIT, move, shipment, nil, nil)
 
 		var serviceItems models.MTOServiceItems
 		shipment.MTOServiceItems = append(serviceItems, serviceItem1)

--- a/swagger-def/definitions/ShipmentAddressUpdate.yaml
+++ b/swagger-def/definitions/ShipmentAddressUpdate.yaml
@@ -30,6 +30,18 @@ properties:
     $ref: 'Address.yaml'
   newAddress:
     $ref: 'Address.yaml'
+  sitOriginalAddress:
+    $ref: 'Address.yaml'
+  oldSitDistanceBetween:
+    description: The distance between the original SIT address and the previous/old destination address of shipment
+    example: 50
+    minimum: 0
+    type: integer
+  newSitDistanceBetween:
+    description: The distance between the original SIT address and requested new destination address of shipment
+    example: 88
+    minimum: 0
+    type: integer
 required:
   - id
   - status

--- a/swagger/ghc.yaml
+++ b/swagger/ghc.yaml
@@ -7223,6 +7223,22 @@ definitions:
         $ref: '#/definitions/Address'
       newAddress:
         $ref: '#/definitions/Address'
+      sitOriginalAddress:
+        $ref: '#/definitions/Address'
+      oldSitDistanceBetween:
+        description: >-
+          The distance between the original SIT address and the previous/old
+          destination address of shipment
+        example: 50
+        minimum: 0
+        type: integer
+      newSitDistanceBetween:
+        description: >-
+          The distance between the original SIT address and requested new
+          destination address of shipment
+        example: 88
+        minimum: 0
+        type: integer
     required:
       - id
       - status

--- a/swagger/prime.yaml
+++ b/swagger/prime.yaml
@@ -4134,6 +4134,22 @@ definitions:
         $ref: '#/definitions/Address'
       newAddress:
         $ref: '#/definitions/Address'
+      sitOriginalAddress:
+        $ref: '#/definitions/Address'
+      oldSitDistanceBetween:
+        description: >-
+          The distance between the original SIT address and the previous/old
+          destination address of shipment
+        example: 50
+        minimum: 0
+        type: integer
+      newSitDistanceBetween:
+        description: >-
+          The distance between the original SIT address and requested new
+          destination address of shipment
+        example: 88
+        minimum: 0
+        type: integer
     required:
       - id
       - status

--- a/swagger/prime_v2.yaml
+++ b/swagger/prime_v2.yaml
@@ -2390,6 +2390,22 @@ definitions:
         $ref: '#/definitions/Address'
       newAddress:
         $ref: '#/definitions/Address'
+      sitOriginalAddress:
+        $ref: '#/definitions/Address'
+      oldSitDistanceBetween:
+        description: >-
+          The distance between the original SIT address and the previous/old
+          destination address of shipment
+        example: 50
+        minimum: 0
+        type: integer
+      newSitDistanceBetween:
+        description: >-
+          The distance between the original SIT address and requested new
+          destination address of shipment
+        example: 88
+        minimum: 0
+        type: integer
     required:
       - id
       - status


### PR DESCRIPTION
INTEGRATION BRANCH

## [Agility ticket](https://www13.v1host.com/USTRANSCOM38/story.mvc/Summary?oidToken=Story%3A888121&RoomContext=TeamRoom%3A808731&concept=TeamRoom)

## Summary

In order to notify the TOO when a shipment address change request contains destination SIT items, we required additions of columns to the `shipment_address_update` table to store the data that will be needed in the UI. In addition to those database changes, backend logic was required to populate those columns with the appropriate data.

This PR does the following:
- adds the columns `sit_original_address_id`, `old_sit_distance_between`, & `new_sit_distance_between` to the `shipment_address_updates` table
- updated Go Struct for the model `ShipmentAddressUpdate`
- updated `swagger-def` for GHC API to return new data variables that will be used in the UI
- updated `mtoShipmentFetcher` to include additional data for `ShipmentAddressUpdate`
- added logic checks in `shipment_address_update_requester.go` to find, calculate, and populate data in db
- added tests to support new functionality

### How to test

1. Access MM as the prime
2. Request a shipment destination address change for a shipment that contains destination SIT
3. Load up the db and see new columns and data in `shipment_address_updates` table