### PR TITLE
B-17965 Send Email - Gov't Counselor Submission (Before TOO Approval)

### DIFF
--- a/pkg/assets/notifications/templates/move_counseled_template.html
+++ b/pkg/assets/notifications/templates/move_counseled_template.html
@@ -1,0 +1,24 @@
+<p>*** DO NOT REPLY directly to this email ***</p>
+
+<p>This is a confirmation that your counselor has approved move details for the <strong>assigned move code{{if or (not .Locator) (not .OriginDutyLocation) (not .DestinationDutyLocation)}}</strong>{{end}}{{if and .Locator .OriginDutyLocation .DestinationDutyLocation}} {{.Locator}}</strong> from {{.OriginDutyLocation}} to {{.DestinationDutyLocation}} in the MilMove system{{end}}.</p>
+
+<p>What this means to you:</br>
+If you are doing a Personally Procured Move (PPM), you can start moving your personal property.</p>
+
+<p><strong>Next steps for a PPM:</strong>
+<ul>
+  <li>Remember to get legible certified weight tickets for both the empty and full weights for every trip you perform. If you do not upload legible certified weight tickets, your PPM incentive could be affected.</li>
+  <li>If your counselor approved an Advance Operating Allowance (AOA, or cash advance) for a PPM, log into <a href="https://my.move.mil">MilMove</a> to download your AOA Packet, and submit it to finance according to the instructions provided by your counselor. If you have been directed to use your government travel charge card (GTCC) for expenses no further action is required.</li>
+  <li>Once you complete your PPM, log into <a href="https://my.move.mil">MilMove</a>, upload your receipts and weight tickets, and submit your PPM for review.</li>
+</ul>
+
+<p><strong>Next steps for government arranged shipments:</strong></br>
+<ul>
+  <li>Your move request will be reviewed by the responsible personal property shipping office and a move task order for services will be placed with HomeSafe Alliance.</li>
+  <li>Once this order is placed, you will receive an e-mail invitation to create an account in HomeSafe Connect (check your spam or junk folder). This is the system you will use to schedule your pre-move survey.</li>
+  <li>HomeSafe is required to contact you within 24 hours of receiving your move task order. Once contact has been established, HomeSafe is your primary point of contact. If any information about your move changes at any point during the move, immediately notify your HomeSafe Customer Care Representative of the changes. Remember to keep your contact information updated in MilMove.</li>
+</ul>
+<p>Thank you,<br>
+USTRANSCOM MilMove Team</p>
+
+<p>The information contained in this email may contain Privacy Act information and is therefore protected under the Privacy Act of 1974. Failure to protect Privacy Act information could result in a $5,000 fine.</p>

--- a/pkg/assets/notifications/templates/move_counseled_template.txt
+++ b/pkg/assets/notifications/templates/move_counseled_template.txt
@@ -1,0 +1,21 @@
+*** DO NOT REPLY directly to this email ***
+
+This is a confirmation that your counselor has approved move details for the assigned move code{{if and .Locator .OriginDutyLocation .DestinationDutyLocation}} {{.Locator}} from {{.OriginDutyLocation}} to {{.DestinationDutyLocation}} in the MilMove system{{end}}.
+
+What this means to you:
+If you are doing a Personally Procured Move (PPM), you can start moving your personal property.
+
+Next steps for a PPM:
+    * Remember to get legible certified weight tickets for both the empty and full weights for every trip you perform. If you do not upload legible certified weight tickets, your PPM incentive could be affected.
+    * If your counselor approved an Advance Operating Allowance (AOA, or cash advance) for a PPM, log into MilMove <https://my.move.mil/> to download your AOA Packet, and submit it to finance according to the instructions provided by your counselor. If you have been directed to use your government travel charge card (GTCC) for expenses no further action is required.
+    * Once you complete your PPM, log into MilMove <https://my.move.mil/>, upload your receipts and weight tickets, and submit your PPM for review.
+
+Next steps for government arranged shipments:
+    * Your move request will be reviewed by the responsible personal property shipping office and a move task order for services will be placed with HomeSafe Alliance.
+    * Once this order is placed, you will receive an e-mail invitation to create an account in HomeSafe Connect (check your spam or junk folder). This is the system you will use to schedule your pre-move survey.
+    * HomeSafe is required to contact you within 24 hours of receiving your move task order. Once contact has been established, HomeSafe is your primary point of contact. If any information about your move changes at any point during the move, immediately notify your HomeSafe Customer Care Representative of the changes. Remember to keep your contact information updated in MilMove.
+
+Thank you,
+USTRANSCOM MilMove Team
+
+The information contained in this email may contain Privacy Act information and is therefore protected under the Privacy Act of 1974. Failure to protect Privacy Act information could result in a $5,000 fine.

--- a/pkg/handlers/ghcapi/move_task_order.go
+++ b/pkg/handlers/ghcapi/move_task_order.go
@@ -190,6 +190,7 @@ func (h UpdateMTOStatusServiceCounselingCompletedHandlerFunc) Handle(params move
 
 			eTag := params.IfMatch
 			moveTaskOrderID := uuid.FromStringOrNil(params.MoveTaskOrderID)
+
 			mto, err := h.moveTaskOrderStatusUpdater.UpdateStatusServiceCounselingCompleted(appCtx, moveTaskOrderID, eTag)
 
 			if err != nil {
@@ -215,6 +216,11 @@ func (h UpdateMTOStatusServiceCounselingCompletedHandlerFunc) Handle(params move
 			})
 			if err != nil {
 				appCtx.Logger().Error("ghcapi.UpdateMTOStatusServiceCounselingCompletedHandlerFunc could not generate the event")
+			}
+
+			err = h.NotificationSender().SendNotification(appCtx, notifications.NewMoveCounseled(moveTaskOrderID))
+			if err != nil {
+				appCtx.Logger().Error("problem sending email to user", zap.Error(err))
 			}
 
 			return movetaskorderops.NewUpdateMTOStatusServiceCounselingCompletedOK().WithPayload(moveTaskOrderPayload), nil

--- a/pkg/handlers/ghcapi/move_task_order_test.go
+++ b/pkg/handlers/ghcapi/move_task_order_test.go
@@ -257,6 +257,7 @@ func (suite *HandlerSuite) TestUpdateMoveTaskOrderHandlerIntegrationWithIncomple
 func (suite *HandlerSuite) TestUpdateMTOStatusServiceCounselingCompletedHandler() {
 	setupTestData := func() UpdateMTOStatusServiceCounselingCompletedHandlerFunc {
 		handlerConfig := suite.HandlerConfig()
+		handlerConfig.SetNotificationSender(notifications.NewStubNotificationSender("milmovelocal"))
 		queryBuilder := query.NewQueryBuilder()
 		moveRouter := moverouter.NewMoveRouter()
 		siCreator := mtoserviceitem.NewMTOServiceItemCreator(queryBuilder, moveRouter)

--- a/pkg/notifications/move_counseled.go
+++ b/pkg/notifications/move_counseled.go
@@ -1,0 +1,132 @@
+package notifications
+
+import (
+	"bytes"
+	"fmt"
+	html "html/template"
+	text "text/template"
+
+	"github.com/gofrs/uuid"
+	"go.uber.org/zap"
+
+	"github.com/transcom/mymove/pkg/appcontext"
+	"github.com/transcom/mymove/pkg/assets"
+	"github.com/transcom/mymove/pkg/models"
+)
+
+var (
+	moveCounseledRawTextTemplate = string(assets.MustAsset("notifications/templates/move_counseled_template.txt"))
+	moveCounseledTextTemplate    = text.Must(text.New("text_template").Parse(moveCounseledRawTextTemplate))
+	moveCounseledRawHTMLTemplate = string(assets.MustAsset("notifications/templates/move_counseled_template.html"))
+	moveCounseledHTMLTemplate    = html.Must(html.New("text_template").Parse(moveCounseledRawHTMLTemplate))
+)
+
+// MoveCounseled has notification content for counseled moves (before TOO approval)
+type MoveCounseled struct {
+	moveID       uuid.UUID
+	htmlTemplate *html.Template
+	textTemplate *text.Template
+}
+
+// NewMoveCounseled returns a new move counseled notification (before TOO approval)
+func NewMoveCounseled(moveID uuid.UUID) *MoveCounseled {
+
+	return &MoveCounseled{
+		moveID:       moveID,
+		htmlTemplate: moveCounseledHTMLTemplate,
+		textTemplate: moveCounseledTextTemplate,
+	}
+}
+
+func (m MoveCounseled) emails(appCtx appcontext.AppContext) ([]emailContent, error) {
+	var emails []emailContent
+
+	move, err := models.FetchMove(appCtx.DB(), appCtx.Session(), m.moveID)
+	if err != nil {
+		return emails, err
+	}
+
+	orders, err := models.FetchOrderForUser(appCtx.DB(), appCtx.Session(), move.OrdersID)
+	if err != nil {
+		return emails, err
+	}
+
+	serviceMember, err := models.FetchServiceMemberForUser(appCtx.DB(), appCtx.Session(), orders.ServiceMemberID)
+	if err != nil {
+		return emails, err
+	}
+
+	originDSTransportInfo, err := models.FetchDLContactInfo(appCtx.DB(), serviceMember.DutyLocationID)
+	if err != nil {
+		return emails, err
+	}
+
+	var originDutyLocationName *string
+	if originDSTransportInfo != nil {
+		originDutyLocationName = &originDSTransportInfo.Name
+	}
+
+	if serviceMember.PersonalEmail == nil {
+		return emails, fmt.Errorf("no email found for service member")
+	}
+
+	htmlBody, textBody, err := m.renderTemplates(appCtx, MoveCounseledEmailData{
+		OriginDutyLocation:      originDutyLocationName,
+		DestinationDutyLocation: orders.NewDutyLocation.Name,
+		Locator:                 move.Locator,
+	})
+
+	if err != nil {
+		appCtx.Logger().Error("error rendering template", zap.Error(err))
+	}
+
+	smEmail := emailContent{
+		recipientEmail: *serviceMember.PersonalEmail,
+		subject:        "Your counselor has approved your move details",
+		htmlBody:       htmlBody,
+		textBody:       textBody,
+	}
+
+	appCtx.Logger().Info("Generated move counseled email",
+		zap.String("moveLocator", move.Locator))
+
+	// TODO: Send email to trusted contacts when that's supported
+	return append(emails, smEmail), nil
+}
+
+func (m MoveCounseled) renderTemplates(appCtx appcontext.AppContext, data MoveCounseledEmailData) (string, string, error) {
+	htmlBody, err := m.RenderHTML(appCtx, data)
+	if err != nil {
+		return "", "", fmt.Errorf("error rendering html template using %#v", data)
+	}
+	textBody, err := m.RenderText(appCtx, data)
+	if err != nil {
+		return "", "", fmt.Errorf("error rendering text template using %#v", data)
+	}
+	return htmlBody, textBody, nil
+}
+
+type MoveCounseledEmailData struct {
+	OriginDutyLocation      *string
+	DestinationDutyLocation string
+	Locator                 string
+}
+
+// RenderHTML renders the html for the email
+func (m MoveCounseled) RenderHTML(appCtx appcontext.AppContext, data MoveCounseledEmailData) (string, error) {
+	var htmlBuffer bytes.Buffer
+	if err := m.htmlTemplate.Execute(&htmlBuffer, data); err != nil {
+		appCtx.Logger().Error("cant render html template ", zap.Error(err))
+	}
+	return htmlBuffer.String(), nil
+}
+
+// RenderText renders the text for the email
+func (m MoveCounseled) RenderText(appCtx appcontext.AppContext, data MoveCounseledEmailData) (string, error) {
+	var textBuffer bytes.Buffer
+	if err := m.textTemplate.Execute(&textBuffer, data); err != nil {
+		appCtx.Logger().Error("cant render text template ", zap.Error(err))
+		return "", err
+	}
+	return textBuffer.String(), nil
+}

--- a/pkg/notifications/move_counseled_test.go
+++ b/pkg/notifications/move_counseled_test.go
@@ -1,0 +1,177 @@
+package notifications
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/transcom/mymove/pkg/auth"
+	"github.com/transcom/mymove/pkg/factory"
+)
+
+func (suite *NotificationSuite) TestMoveCounseled() {
+	move := factory.BuildMove(suite.DB(), nil, nil)
+	notification := NewMoveCounseled(move.ID)
+
+	emails, err := notification.emails(suite.AppContextWithSessionForTest(&auth.Session{
+		ServiceMemberID: move.Orders.ServiceMember.ID,
+		ApplicationName: auth.MilApp,
+	}))
+	subject := "Your counselor has approved your move details"
+
+	suite.NoError(err)
+	suite.Equal(len(emails), 1)
+
+	email := emails[0]
+	sm := move.Orders.ServiceMember
+	suite.Equal(email.recipientEmail, *sm.PersonalEmail)
+	suite.Equal(email.subject, subject)
+	suite.NotEmpty(email.htmlBody)
+	suite.NotEmpty(email.textBody)
+}
+
+func (suite *NotificationSuite) TestMoveCounseledHTMLTemplateRender() {
+	approver := factory.BuildUser(nil, nil, nil)
+	move := factory.BuildMove(suite.DB(), nil, nil)
+	notification := NewMoveCounseled(move.ID)
+
+	originDutyLocation := "origDutyLocation"
+
+	s := MoveCounseledEmailData{
+		OriginDutyLocation:      &originDutyLocation,
+		DestinationDutyLocation: "destDutyLocation",
+		Locator:                 "abc123",
+	}
+	expectedHTMLContent := `<p>*** DO NOT REPLY directly to this email ***</p>
+
+<p>This is a confirmation that your counselor has approved move details for the <strong>assigned move code abc123</strong> from origDutyLocation to destDutyLocation in the MilMove system.</p>
+
+<p>What this means to you:</br>
+If you are doing a Personally Procured Move (PPM), you can start moving your personal property.</p>
+
+<p><strong>Next steps for a PPM:</strong>
+<ul>
+	<li>Remember to get legible certified weight tickets for both the empty and full weights for every trip you perform. If you do not upload legible certified weight tickets, your PPM incentive could be affected.</li>
+	<li>If your counselor approved an Advance Operating Allowance (AOA, or cash advance) for a PPM, log into <a href="https://my.move.mil">MilMove</a> to download your AOA Packet, and submit it to finance according to the instructions provided by your counselor. If you have been directed to use your government travel charge card (GTCC) for expenses no further action is required.</li>
+	<li>Once you complete your PPM, log into <a href="https://my.move.mil">MilMove</a>, upload your receipts and weight tickets, and submit your PPM for review.</li>
+</ul>
+
+<p><strong>Next steps for government arranged shipments:</strong></br>
+<ul>
+	<li>Your move request will be reviewed by the responsible personal property shipping office and a move task order for services will be placed with HomeSafe Alliance.</li>
+	<li>Once this order is placed, you will receive an e-mail invitation to create an account in HomeSafe Connect (check your spam or junk folder). This is the system you will use to schedule your pre-move survey.</li>
+	<li>HomeSafe is required to contact you within 24 hours of receiving your move task order. Once contact has been established, HomeSafe is your primary point of contact. If any information about your move changes at any point during the move, immediately notify your HomeSafe Customer Care Representative of the changes. Remember to keep your contact information updated in MilMove.</li>
+</ul>
+<p>Thank you,<br>
+USTRANSCOM MilMove Team</p>
+
+<p>The information contained in this email may contain Privacy Act information and is therefore protected under the Privacy Act of 1974. Failure to protect Privacy Act information could result in a $5,000 fine.</p>
+`
+
+	htmlContent, err := notification.RenderHTML(suite.AppContextWithSessionForTest(&auth.Session{
+		UserID:          approver.ID,
+		ApplicationName: auth.OfficeApp,
+	}), s)
+
+	suite.NoError(err)
+	suite.Equal(trimExtraSpaces(expectedHTMLContent), trimExtraSpaces(htmlContent))
+}
+
+func (suite *NotificationSuite) TestMoveCounseledTextTemplateRender() {
+
+	approver := factory.BuildUser(nil, nil, nil)
+	move := factory.BuildMove(suite.DB(), nil, nil)
+	notification := NewMoveCounseled(move.ID)
+
+	originDutyLocation := "origDutyLocation"
+
+	s := MoveCounseledEmailData{
+		OriginDutyLocation:      &originDutyLocation,
+		DestinationDutyLocation: "destDutyLocation",
+		Locator:                 "abc123",
+	}
+
+	expectedTextContent := `*** DO NOT REPLY directly to this email ***
+
+This is a confirmation that your counselor has approved move details for the assigned move code abc123 from origDutyLocation to destDutyLocation in the MilMove system.
+
+What this means to you:
+If you are doing a Personally Procured Move (PPM), you can start moving your personal property.
+
+Next steps for a PPM:
+	* Remember to get legible certified weight tickets for both the empty and full weights for every trip you perform. If you do not upload legible certified weight tickets, your PPM incentive could be affected.
+	* If your counselor approved an Advance Operating Allowance (AOA, or cash advance) for a PPM, log into MilMove <https://my.move.mil/> to download your AOA Packet, and submit it to finance according to the instructions provided by your counselor. If you have been directed to use your government travel charge card (GTCC) for expenses no further action is required.
+	* Once you complete your PPM, log into MilMove <https://my.move.mil/>, upload your receipts and weight tickets, and submit your PPM for review.
+
+Next steps for government arranged shipments:
+	* Your move request will be reviewed by the responsible personal property shipping office and a move task order for services will be placed with HomeSafe Alliance.
+	* Once this order is placed, you will receive an e-mail invitation to create an account in HomeSafe Connect (check your spam or junk folder). This is the system you will use to schedule your pre-move survey.
+	* HomeSafe is required to contact you within 24 hours of receiving your move task order. Once contact has been established, HomeSafe is your primary point of contact. If any information about your move changes at any point during the move, immediately notify your HomeSafe Customer Care Representative of the changes. Remember to keep your contact information updated in MilMove.
+
+Thank you,
+USTRANSCOM MilMove Team
+
+The information contained in this email may contain Privacy Act information and is therefore protected under the Privacy Act of 1974. Failure to protect Privacy Act information could result in a $5,000 fine.
+`
+
+	textContent, err := notification.RenderText(suite.AppContextWithSessionForTest(&auth.Session{
+		UserID:          approver.ID,
+		ApplicationName: auth.OfficeApp,
+	}), s)
+
+	suite.NoError(err)
+	suite.Equal(trimExtraSpaces(expectedTextContent), trimExtraSpaces(textContent))
+}
+
+func (suite *NotificationSuite) TestMoveCounseledTextTemplateRenderWithMissingMoveInfo() {
+
+	approver := factory.BuildUser(nil, nil, nil)
+	move := factory.BuildMove(suite.DB(), nil, nil)
+	notification := NewMoveCounseled(move.ID)
+
+	var originDutyLocation string
+	var locator string
+
+	s := MoveCounseledEmailData{
+		OriginDutyLocation:      &originDutyLocation,
+		DestinationDutyLocation: "",
+		Locator:                 locator,
+	}
+
+	expectedTextContent := `*** DO NOT REPLY directly to this email ***
+
+This is a confirmation that your counselor has approved move details for the assigned move code.
+
+What this means to you:
+If you are doing a Personally Procured Move (PPM), you can start moving your personal property.
+
+Next steps for a PPM:
+	* Remember to get legible certified weight tickets for both the empty and full weights for every trip you perform. If you do not upload legible certified weight tickets, your PPM incentive could be affected.
+	* If your counselor approved an Advance Operating Allowance (AOA, or cash advance) for a PPM, log into MilMove <https://my.move.mil/> to download your AOA Packet, and submit it to finance according to the instructions provided by your counselor. If you have been directed to use your government travel charge card (GTCC) for expenses no further action is required.
+	* Once you complete your PPM, log into MilMove <https://my.move.mil/>, upload your receipts and weight tickets, and submit your PPM for review.
+
+Next steps for government arranged shipments:
+	* Your move request will be reviewed by the responsible personal property shipping office and a move task order for services will be placed with HomeSafe Alliance.
+	* Once this order is placed, you will receive an e-mail invitation to create an account in HomeSafe Connect (check your spam or junk folder). This is the system you will use to schedule your pre-move survey.
+	* HomeSafe is required to contact you within 24 hours of receiving your move task order. Once contact has been established, HomeSafe is your primary point of contact. If any information about your move changes at any point during the move, immediately notify your HomeSafe Customer Care Representative of the changes. Remember to keep your contact information updated in MilMove.
+
+Thank you,
+USTRANSCOM MilMove Team
+
+The information contained in this email may contain Privacy Act information and is therefore protected under the Privacy Act of 1974. Failure to protect Privacy Act information could result in a $5,000 fine.
+`
+
+	textContent, err := notification.RenderText(suite.AppContextWithSessionForTest(&auth.Session{
+		UserID:          approver.ID,
+		ApplicationName: auth.OfficeApp,
+	}), s)
+
+	suite.NoError(err)
+	suite.Equal(trimExtraSpaces(expectedTextContent), trimExtraSpaces(textContent))
+}
+
+func trimExtraSpaces(input string) string {
+	// Replace consecutive white spaces with a single space
+	re := regexp.MustCompile(`\s+`)
+	// return the result without leading or trailing spaces
+	return strings.TrimSpace(re.ReplaceAllString(input, " "))
+}


### PR DESCRIPTION
## [Agility ticket B-17965](https://www13.v1host.com/USTRANSCOM38/story.mvc/Summary?oidToken=Story%3a869537)

## Summary

The automated test that I implemented just confirms that the correct email body is presented.

## Verification Steps for the Author
### Setup to Run the Code

- [Instructions for starting storybook](https://transcom.github.io/mymove-docs/docs/frontend/setup/storybook)
- [Instructions for starting the MilMove application](https://transcom.github.io/mymove-docs/docs/getting-started/application-setup/)
- [Instructions for running tests](https://transcom.github.io/mymove-docs/docs/getting-started/development/testing)

### How to test
1. In terminal run ```EMAIL_BACKEND=ses AWS_REGION=us-gov-west-1  aws-vault exec transcom-gov-dev -- make server_run```
2. On a separate terminal tab run ```make client_run```
3. As a standard user, create a move. During the move creation process, make sure you enter the email address as something you have access to check.
4. You should receive an initial email for creating the move.
5. Log into the Office side as a Services Counselor.
6. Find the move and update the Orders section per standard procedure.
7. After the Orders section has been updated, click the Submit move button.
8. You should receive a confirmation about the change in status for your move. 

### Screenshots
![Screenshot 2024-01-17 at 12 09 32 PM](https://github.com/transcom/mymove/assets/147739091/dc8a6ed5-2a78-45b9-ab0c-938f6cd8886f)
