### PR TITLE
kickback - B-17965 Send Email - Gov't Counselor Submission (Before TOO Approval)

### DIFF
--- a/pkg/assets/notifications/templates/move_counseled_template.html
+++ b/pkg/assets/notifications/templates/move_counseled_template.html
@@ -1,6 +1,6 @@
 <p>*** DO NOT REPLY directly to this email ***</p>
 
-<p>This is a confirmation that your counselor has approved move details for the <strong>assigned move code{{if or (not .Locator) (not .OriginDutyLocation) (not .DestinationDutyLocation)}}</strong>{{end}}{{if and .Locator .OriginDutyLocation .DestinationDutyLocation}} {{.Locator}}</strong> from {{.OriginDutyLocation}} to {{.DestinationDutyLocation}} in the MilMove system{{end}}.</p>
+<p>This is a confirmation that your counselor has approved move details for the <strong>assigned move code{{if not .Locator}}</strong>{{end}}{{if .Locator}} {{.Locator}}</strong>{{end}} {{if .OriginDutyLocation}}from {{.OriginDutyLocation}}{{end}}{{if not .OriginDutyLocation}}{{if .DestinationDutyLocation}} going to {{.DestinationDutyLocation}}{{end}}{{end}} in the MilMove system{{end}}.</p>
 
 <p>What this means to you:</br>
 If you are doing a Personally Procured Move (PPM), you can start moving your personal property.</p>

--- a/pkg/assets/notifications/templates/move_counseled_template.txt
+++ b/pkg/assets/notifications/templates/move_counseled_template.txt
@@ -1,6 +1,6 @@
 *** DO NOT REPLY directly to this email ***
 
-This is a confirmation that your counselor has approved move details for the assigned move code{{if and .Locator .OriginDutyLocation .DestinationDutyLocation}} {{.Locator}} from {{.OriginDutyLocation}} to {{.DestinationDutyLocation}} in the MilMove system{{end}}.
+This is a confirmation that your counselor has approved move details for the assigned move code {{if .Locator}} {{if .OriginDutyLocation}}from {{.OriginDutyLocation}}{{end}}{{if not .OriginDutyLocation}}{{if .DestinationDutyLocation}} going to {{.DestinationDutyLocation}}{{end}}{{end}} in the MilMove system{{end}}.
 
 What this means to you:
 If you are doing a Personally Procured Move (PPM), you can start moving your personal property.

--- a/pkg/handlers/ghcapi/move_task_order.go
+++ b/pkg/handlers/ghcapi/move_task_order.go
@@ -191,6 +191,12 @@ func (h UpdateMTOStatusServiceCounselingCompletedHandlerFunc) Handle(params move
 			eTag := params.IfMatch
 			moveTaskOrderID := uuid.FromStringOrNil(params.MoveTaskOrderID)
 
+			errNotif := h.NotificationSender().SendNotification(appCtx, notifications.NewMoveCounseled(moveTaskOrderID))
+			if errNotif != nil {
+				appCtx.Logger().Error("problem sending email to user", zap.Error(errNotif))
+				return handlers.ResponseForError(appCtx.Logger(), errNotif), errNotif
+			}
+
 			mto, err := h.moveTaskOrderStatusUpdater.UpdateStatusServiceCounselingCompleted(appCtx, moveTaskOrderID, eTag)
 
 			if err != nil {

--- a/pkg/notifications/move_counseled_test.go
+++ b/pkg/notifications/move_counseled_test.go
@@ -122,7 +122,7 @@ The information contained in this email may contain Privacy Act information and 
 	suite.Equal(trimExtraSpaces(expectedTextContent), trimExtraSpaces(textContent))
 }
 
-func (suite *NotificationSuite) TestMoveCounseledTextTemplateRenderWithMissingMoveInfo() {
+func (suite *NotificationSuite) TestMoveCounseledTextTemplateRenderWithMissingAllMoveInfo() {
 
 	approver := factory.BuildUser(nil, nil, nil)
 	move := factory.BuildMove(suite.DB(), nil, nil)
@@ -140,6 +140,52 @@ func (suite *NotificationSuite) TestMoveCounseledTextTemplateRenderWithMissingMo
 	expectedTextContent := `*** DO NOT REPLY directly to this email ***
 
 This is a confirmation that your counselor has approved move details for the assigned move code.
+
+What this means to you:
+If you are doing a Personally Procured Move (PPM), you can start moving your personal property.
+
+Next steps for a PPM:
+	* Remember to get legible certified weight tickets for both the empty and full weights for every trip you perform. If you do not upload legible certified weight tickets, your PPM incentive could be affected.
+	* If your counselor approved an Advance Operating Allowance (AOA, or cash advance) for a PPM, log into MilMove <https://my.move.mil/> to download your AOA Packet, and submit it to finance according to the instructions provided by your counselor. If you have been directed to use your government travel charge card (GTCC) for expenses no further action is required.
+	* Once you complete your PPM, log into MilMove <https://my.move.mil/>, upload your receipts and weight tickets, and submit your PPM for review.
+
+Next steps for government arranged shipments:
+	* Your move request will be reviewed by the responsible personal property shipping office and a move task order for services will be placed with HomeSafe Alliance.
+	* Once this order is placed, you will receive an e-mail invitation to create an account in HomeSafe Connect (check your spam or junk folder). This is the system you will use to schedule your pre-move survey.
+	* HomeSafe is required to contact you within 24 hours of receiving your move task order. Once contact has been established, HomeSafe is your primary point of contact. If any information about your move changes at any point during the move, immediately notify your HomeSafe Customer Care Representative of the changes. Remember to keep your contact information updated in MilMove.
+
+Thank you,
+USTRANSCOM MilMove Team
+
+The information contained in this email may contain Privacy Act information and is therefore protected under the Privacy Act of 1974. Failure to protect Privacy Act information could result in a $5,000 fine.
+`
+
+	textContent, err := notification.RenderText(suite.AppContextWithSessionForTest(&auth.Session{
+		UserID:          approver.ID,
+		ApplicationName: auth.OfficeApp,
+	}), s)
+
+	suite.NoError(err)
+	suite.Equal(trimExtraSpaces(expectedTextContent), trimExtraSpaces(textContent))
+}
+
+func (suite *NotificationSuite) TestMoveCounseledTextTemplateRenderWithMissingOriginLocationMoveInfo() {
+
+	approver := factory.BuildUser(nil, nil, nil)
+	move := factory.BuildMove(suite.DB(), nil, nil)
+	notification := NewMoveCounseled(move.ID)
+
+	originDutyLocation := ""
+
+	s := MoveCounseledEmailData{
+		OriginDutyLocation:      &originDutyLocation,
+		DestinationDutyLocation: "destDutyLocation",
+		Locator:                 "abc123",
+	}
+
+	expectedTextContent := `*** DO NOT REPLY directly to this email ***
+
+This is a confirmation that your counselor has approved move details for the assigned move code abc123 going to destDutyLocation in the MilMove system.
 
 What this means to you:
 If you are doing a Personally Procured Move (PPM), you can start moving your personal property.


### PR DESCRIPTION
## This PR was made from an already merged PR located [HERE](https://github.com/transcom/mymove/pull/11785)

## [B-17965](https://www13.v1host.com/USTRANSCOM38/story.mvc/Summary?oidToken=Story%3a869537)

## Summary

Was kicked back from testing due to the email not populating with the moveID, origin location, or destination location. I changed the logic inside both (txt and html) templates so that it will still send moveID and destination location even if the origin location is missing. I also added testing to account for that possibility.

## How to test
1. In terminal run ```EMAIL_BACKEND=ses AWS_REGION=us-gov-west-1  aws-vault exec transcom-gov-dev -- make server_run```
2. On a separate terminal tab run ```make client_run```
3. As a standard user, create a move. During the move creation process, make sure you enter the email address as something you have access to check.
4. You should receive an initial email for creating the move.
5. Log into the Office side as a Services Counselor.
6. Find the move and update the Orders section per standard procedure.
7. After the Orders section has been updated, click the Submit move button.
8. You should receive a confirmation about the change in status for your move. 

### Sidenote
The only commit that is associated directly with this issue is all the way at the bottom 14557bf754f42898d8b3ed9117dc3b676ab16970

### Screenshots
![Screenshot 2024-01-17 at 12 09 32 PM](https://github.com/transcom/mymove/assets/147739091/dc8a6ed5-2a78-45b9-ab0c-938f6cd8886f)