### PR TITLE
B-18325-INT Update duty_location_names to remove references to old names

### DIFF
--- a/migrations/app/migrations_manifest.txt
+++ b/migrations/app/migrations_manifest.txt
@@ -894,3 +894,4 @@
 20240123213917_update_shipment_address_update_table_sit_and_distance_columns.up.sql
 20240124153121_remove_ppmid_from_signedcertification_table.up.sql
 20240124155759_20240124-homesafeconnect-cert.up.sql
+20240201201343_update_duty_location_names.up.sql

--- a/migrations/app/schema/20240201201343_update_duty_location_names.up.sql
+++ b/migrations/app/schema/20240201201343_update_duty_location_names.up.sql
@@ -1,0 +1,7 @@
+-- update the duty_location_names values to properly associate with the value on the duty_locations table
+UPDATE duty_location_names SET name = 'Ft Novosel' WHERE name = 'Ft Rucker';
+UPDATE duty_location_names SET name = 'Ft Gregg-Adams' WHERE name = 'Ft Lee';
+UPDATE duty_location_names SET name = 'Ft Cavazos' WHERE name = 'Ft Hood';
+UPDATE duty_location_names SET name = 'Ft Liberty' WHERE name = 'Ft Bragg';
+UPDATE duty_location_names SET name = 'Ft Johnson' WHERE name = 'Ft Polk';
+UPDATE duty_location_names SET name = 'Ft Eisenhower' WHERE name = 'Ft Gordon';


### PR DESCRIPTION
## [Agility ticket](https://www13.v1host.com/USTRANSCOM38/story.mvc/Summary?oidToken=Story%3a874026)

## Summary

For a few bases, when you typed in the old base names, the new base names would appear. This functionality was requested to be removed.

### How to test

1. Login as a new customer and create a new move
2. Fill out your required info
3. When you get to the step of entering your orders, scroll down to the Current Duty Location input
confirm it behaves as follows:
(addressed in this PR)
 - type in "rucker" and confirm neither fort rucker or fort novosel appear as options
 - type in "lee" and confirm neither fort lee or fort gregg-adams appear as options
 - type in "hood" and confirm neither fort hood or fort cavazos appear as options
 - type in "bragg" and confirm neither fort bragg (NC) or fort liberty appear as options (fort Bragg CA should still appear)
 - type in "polk" and confirm neither fort Polk or fort gordon appear as options
 - type in "gordon" and confirm neither fort gordon or fort eisenhower appear as options
 (addressed in prior PRs but part of the acceptance criteria)
 - type in "pickett" and confirm neither fort pickett or fort barfoot appear
 - type in "a.p. hill" and confirm neither fort A.P. Hill or fort walker appear (Hill AFB should still appear)