### PR TITLE
B 18491 update endpoint for updateMTOServiceItem MAIN

### DIFF
--- a/pkg/gen/primeapi/embedded_spec.go
+++ b/pkg/gen/primeapi/embedded_spec.go
@@ -343,7 +343,7 @@ func init() {
     },
     "/mto-service-items/{mtoServiceItemID}": {
       "patch": {
-        "description": "Updates MTOServiceItems after creation. Not all service items or fields may be updated, please see details below.\n\nThis endpoint supports different body definitions. In the modelType field below, select the modelType corresponding\n to the service item you wish to update and the documentation will update with the new definition.\n\n* Addresses: You can add a new SIT Destination final address using this endpoint (and must use this endpoint to do so), but you cannot update an existing one.\nPlease use [createSITAddressUpdateRequest](#operation/createSITAddressUpdateRequest) instead.\n\nTo create a service item, please use [createMTOServiceItem](#operation/createMTOServiceItem)) endpoint.\n",
+        "description": "Updates MTOServiceItems after creation. Not all service items or fields may be updated, please see details below.\n\nThis endpoint supports different body definitions. In the modelType field below, select the modelType corresponding\n to the service item you wish to update and the documentation will update with the new definition.\n\n* Addresses: To update a destination service item's SIT destination final address, update the shipment destination address.\n\nTo create a service item, please use [createMTOServiceItem](#operation/createMTOServiceItem)) endpoint.\n",
         "consumes": [
           "application/json"
         ],
@@ -5211,7 +5211,7 @@ func init() {
     },
     "/mto-service-items/{mtoServiceItemID}": {
       "patch": {
-        "description": "Updates MTOServiceItems after creation. Not all service items or fields may be updated, please see details below.\n\nThis endpoint supports different body definitions. In the modelType field below, select the modelType corresponding\n to the service item you wish to update and the documentation will update with the new definition.\n\n* Addresses: You can add a new SIT Destination final address using this endpoint (and must use this endpoint to do so), but you cannot update an existing one.\nPlease use [createSITAddressUpdateRequest](#operation/createSITAddressUpdateRequest) instead.\n\nTo create a service item, please use [createMTOServiceItem](#operation/createMTOServiceItem)) endpoint.\n",
+        "description": "Updates MTOServiceItems after creation. Not all service items or fields may be updated, please see details below.\n\nThis endpoint supports different body definitions. In the modelType field below, select the modelType corresponding\n to the service item you wish to update and the documentation will update with the new definition.\n\n* Addresses: To update a destination service item's SIT destination final address, update the shipment destination address.\n\nTo create a service item, please use [createMTOServiceItem](#operation/createMTOServiceItem)) endpoint.\n",
         "consumes": [
           "application/json"
         ],

--- a/pkg/gen/primeapi/primeoperations/mto_service_item/update_m_t_o_service_item.go
+++ b/pkg/gen/primeapi/primeoperations/mto_service_item/update_m_t_o_service_item.go
@@ -40,8 +40,7 @@ This endpoint supports different body definitions. In the modelType field below,
 
 	to the service item you wish to update and the documentation will update with the new definition.
 
-* Addresses: You can add a new SIT Destination final address using this endpoint (and must use this endpoint to do so), but you cannot update an existing one.
-Please use [createSITAddressUpdateRequest](#operation/createSITAddressUpdateRequest) instead.
+* Addresses: To update a destination service item's SIT destination final address, update the shipment destination address.
 
 To create a service item, please use [createMTOServiceItem](#operation/createMTOServiceItem)) endpoint.
 */

--- a/pkg/gen/primeclient/mto_service_item/mto_service_item_client.go
+++ b/pkg/gen/primeclient/mto_service_item/mto_service_item_client.go
@@ -220,8 +220,7 @@ This endpoint supports different body definitions. In the modelType field below,
 
 	to the service item you wish to update and the documentation will update with the new definition.
 
-* Addresses: You can add a new SIT Destination final address using this endpoint (and must use this endpoint to do so), but you cannot update an existing one.
-Please use [createSITAddressUpdateRequest](#operation/createSITAddressUpdateRequest) instead.
+* Addresses: To update a destination service item's SIT destination final address, update the shipment destination address.
 
 To create a service item, please use [createMTOServiceItem](#operation/createMTOServiceItem)) endpoint.
 */

--- a/pkg/services/mto_service_item/mto_service_item_validators.go
+++ b/pkg/services/mto_service_item/mto_service_item_validators.go
@@ -377,15 +377,16 @@ func (v *updateMTOServiceItemData) checkSITDestinationFinalAddress(_ appcontext.
 		return nil // the SITDestinationFinalAddress is being created, so we're fine here
 	}
 
-	if v.oldServiceItem.ReService.Code != models.ReServiceCodeDDDSIT {
-		return apperror.NewConflictError(v.updatedServiceItem.ID,
-			fmt.Sprintf("- SIT Destination Final Address may only be manually created for %s service items.", models.ReServiceCodeDDDSIT))
+	reServiceCodesDestination := []models.ReServiceCode{models.ReServiceCodeDDDSIT, models.ReServiceCodeDDASIT, models.ReServiceCodeDDFSIT, models.ReServiceCodeDDSFSC}
+	if slices.Contains(reServiceCodesDestination, v.oldServiceItem.ReService.Code) {
+		v.verrs.Add("SITDestinationFinalAddress", "Update the shipment destination address to update the service item's SIT final destination address.")
+		return nil
 	}
 
 	if *v.oldServiceItem.SITDestinationFinalAddressID != uuid.Nil &&
 		v.updatedServiceItem.SITDestinationFinalAddress != nil &&
 		v.updatedServiceItem.SITDestinationFinalAddress.ID != *v.oldServiceItem.SITDestinationFinalAddressID {
-		v.verrs.Add("SITDestinationFinalAddress", "cannot be updated")
+		v.verrs.Add("SITDestinationFinalAddress", "Update the shipment destination address to update the service item's SIT final destination address.")
 	}
 
 	return nil

--- a/pkg/services/mto_service_item/mto_service_item_validators_test.go
+++ b/pkg/services/mto_service_item/mto_service_item_validators_test.go
@@ -613,7 +613,7 @@ func (suite *MTOServiceItemServiceSuite) TestUpdateMTOServiceItemData() {
 		}
 	})
 
-	suite.Run("checkSITDestinationFinalAddress - adding SITDestinationFinalAddress", func() {
+	suite.Run("checkSITDestinationFinalAddress - adding SITDestinationFinalAddress for origin SIT service item", func() {
 		oldServiceItemPrime := factory.BuildMTOServiceItem(suite.DB(), []factory.Customization{
 			{
 				Model:    factory.BuildAvailableToPrimeMove(suite.DB(), nil, nil),
@@ -621,7 +621,7 @@ func (suite *MTOServiceItemServiceSuite) TestUpdateMTOServiceItemData() {
 			},
 			{
 				Model: models.ReService{
-					Code: models.ReServiceCodeDDDSIT,
+					Code: models.ReServiceCodeDOPSIT,
 				},
 			},
 		}, nil)
@@ -642,7 +642,7 @@ func (suite *MTOServiceItemServiceSuite) TestUpdateMTOServiceItemData() {
 		suite.NoError(err)
 	})
 
-	suite.Run("checkSITDestinationFinalAddress - invalid input failure: SITDestinationFinalAddress", func() {
+	suite.Run("checkSITDestinationFinalAddress - invalid input failure: updating SITDestinationFinalAddress for DDASIT", func() {
 		oldServiceItemPrime := factory.BuildMTOServiceItem(suite.DB(), []factory.Customization{
 			{
 				Model:    factory.BuildAvailableToPrimeMove(suite.DB(), nil, nil),
@@ -672,12 +672,12 @@ func (suite *MTOServiceItemServiceSuite) TestUpdateMTOServiceItemData() {
 		}
 		err := serviceItemData.checkSITDestinationFinalAddress(suite.AppContextForTest())
 
-		suite.Error(err)
-		conflictError := apperror.ConflictError{}
-		suite.IsType(conflictError, err)
+		suite.NoError(err)
+		suite.True(serviceItemData.verrs.HasAny())
+		suite.Contains(serviceItemData.verrs.Keys(), "SITDestinationFinalAddress")
 	})
 
-	suite.Run("checkSITDestinationFinalAddress - invalid input failure: SITDestinationFinalAddress", func() {
+	suite.Run("checkSITDestinationFinalAddress - invalid input failure: updating SITDestinationFinalAddress for DDDSIT ", func() {
 		oldServiceItemPrime := factory.BuildMTOServiceItem(suite.DB(), []factory.Customization{
 			{
 				Model:    factory.BuildAvailableToPrimeMove(suite.DB(), nil, nil),
@@ -690,6 +690,76 @@ func (suite *MTOServiceItemServiceSuite) TestUpdateMTOServiceItemData() {
 			{
 				Model: models.ReService{
 					Code: models.ReServiceCodeDDDSIT,
+				},
+			},
+		}, nil)
+		newServiceItemPrime := oldServiceItemPrime
+
+		// Try to update SITDestinationFinalAddress
+		newAddress := factory.BuildAddress(suite.DB(), nil, []factory.Trait{factory.GetTraitAddress3})
+		newServiceItemPrime.SITDestinationFinalAddress = &newAddress
+
+		serviceItemData := updateMTOServiceItemData{
+			updatedServiceItem:  newServiceItemPrime,
+			oldServiceItem:      oldServiceItemPrime,
+			verrs:               validate.NewErrors(),
+			availabilityChecker: checker,
+		}
+		err := serviceItemData.checkSITDestinationFinalAddress(suite.AppContextForTest())
+
+		suite.NoError(err)
+		suite.True(serviceItemData.verrs.HasAny())
+		suite.Contains(serviceItemData.verrs.Keys(), "SITDestinationFinalAddress")
+	})
+
+	suite.Run("checkSITDestinationFinalAddress - invalid input failure: updating SITDestinationFinalAddress for DDFSIT ", func() {
+		oldServiceItemPrime := factory.BuildMTOServiceItem(suite.DB(), []factory.Customization{
+			{
+				Model:    factory.BuildAvailableToPrimeMove(suite.DB(), nil, nil),
+				LinkOnly: true,
+			},
+			{
+				Model: models.Address{},
+				Type:  &factory.Addresses.SITDestinationFinalAddress,
+			},
+			{
+				Model: models.ReService{
+					Code: models.ReServiceCodeDDFSIT,
+				},
+			},
+		}, nil)
+		newServiceItemPrime := oldServiceItemPrime
+
+		// Try to update SITDestinationFinalAddress
+		newAddress := factory.BuildAddress(suite.DB(), nil, []factory.Trait{factory.GetTraitAddress3})
+		newServiceItemPrime.SITDestinationFinalAddress = &newAddress
+
+		serviceItemData := updateMTOServiceItemData{
+			updatedServiceItem:  newServiceItemPrime,
+			oldServiceItem:      oldServiceItemPrime,
+			verrs:               validate.NewErrors(),
+			availabilityChecker: checker,
+		}
+		err := serviceItemData.checkSITDestinationFinalAddress(suite.AppContextForTest())
+
+		suite.NoError(err)
+		suite.True(serviceItemData.verrs.HasAny())
+		suite.Contains(serviceItemData.verrs.Keys(), "SITDestinationFinalAddress")
+	})
+
+	suite.Run("checkSITDestinationFinalAddress - invalid input failure: updating SITDestinationFinalAddress for DDSFSC ", func() {
+		oldServiceItemPrime := factory.BuildMTOServiceItem(suite.DB(), []factory.Customization{
+			{
+				Model:    factory.BuildAvailableToPrimeMove(suite.DB(), nil, nil),
+				LinkOnly: true,
+			},
+			{
+				Model: models.Address{},
+				Type:  &factory.Addresses.SITDestinationFinalAddress,
+			},
+			{
+				Model: models.ReService{
+					Code: models.ReServiceCodeDDSFSC,
 				},
 			},
 		}, nil)

--- a/swagger-def/prime.yaml
+++ b/swagger-def/prime.yaml
@@ -1036,8 +1036,7 @@ paths:
         This endpoint supports different body definitions. In the modelType field below, select the modelType corresponding
          to the service item you wish to update and the documentation will update with the new definition.
 
-        * Addresses: You can add a new SIT Destination final address using this endpoint (and must use this endpoint to do so), but you cannot update an existing one.
-        Please use [createSITAddressUpdateRequest](#operation/createSITAddressUpdateRequest) instead.
+        * Addresses: To update a destination service item's SIT destination final address, update the shipment destination address.
 
         To create a service item, please use [createMTOServiceItem](#operation/createMTOServiceItem)) endpoint.
       operationId: updateMTOServiceItem

--- a/swagger/prime.yaml
+++ b/swagger/prime.yaml
@@ -1235,13 +1235,8 @@ paths:
         field below, select the modelType corresponding
          to the service item you wish to update and the documentation will update with the new definition.
 
-        * Addresses: You can add a new SIT Destination final address using this
-        endpoint (and must use this endpoint to do so), but you cannot update an
-        existing one.
-
-        Please use
-        [createSITAddressUpdateRequest](#operation/createSITAddressUpdateRequest)
-        instead.
+        * Addresses: To update a destination service item's SIT destination
+        final address, update the shipment destination address.
 
 
         To create a service item, please use


### PR DESCRIPTION
## [Agility ticket](https://www13.v1host.com/USTRANSCOM38/story.mvc/Summary?oidToken=Story%3a889877)

## Summary

The updateMTOServiceItem only allows a service item without a SITDestinationFinalAddress field value to be created. It does not allow updates of the SITDestinationFinalAddress value if it already exists. 

Since we populate the SITDestinationFinalAddress for destination SIT service items DDASIT, DDDSIT, DDFSIT, and DDSFSC at the time of destination SIT request/creation, there will never be a case where a destination SIT service item has an empty SITDestinationFinalAddress field, so this endpoint can never update that SITDestinationFinalAddress field.

Based on those findings, a new v2 endpoint was not needed. Instead, I added the four destination service codes as an explicit check that ensures the final destination address field cannot be update. The added check does not break any functionality, it just clearly documents what was already happening based on the current logic in place.

I updated the error message to be more informative and to direct end users to update the shipment destination address if they want to update the destination SIT service item's final destination address.

I also expanded tests to reflect this functionality and updated the documentation for the endpoint to.

The updateMTOServiceItem **_does_** allow the SITDestinationFinalAddress field value to be created for origin SIT service items, however, that column being populated for origin SIT service items is not relevant to SIT calculations. Instead, we are focusing on the destination SIT service items and their SITDestinationFinalAddress value.

### How to test

1. Access the office application.
2. Login as a prime user.
3. Request destination SIT, which creates the 4 destination service items: DDASIT, DDDSIT, DDFSIT, and DDSFSC.
4. Using swagger or postman, use the updateMTOServiceItem endpoint to try updating the SITDestinationFinalAddress for any of the four destination SIT service items. Example request body:
{
  "modelType": "UpdateMTOServiceItemSIT",
  "SITDestinationFinalAddress": {
    "ID": "62e795f4-61a8-4cca-b59d-028345c07b89",
    "StreetAddress1": "Maria Street Address 1",
    "City": "Herington",
    "State": "KS",
    "PostalCode": "66667",
    "Country": "United States"
  }
}
5. Check that you receive a 422 with an error message directing you to update the shipment destination address:
![image](https://github.com/transcom/mymove/assets/147537467/7e7e04f0-93e0-4f6f-8470-67925dae8fdb)
6. Check that the database value for SITDestinationFinalAddress was not changed for the service item, and make sure that the SITDestinationFinalAddress for the service item still matches the shipment destination address.