### PR TITLE
show actual move date for ppm

### DIFF
--- a/src/components/Office/ShipmentDetails/ShipmentDetailsMain.jsx
+++ b/src/components/Office/ShipmentDetails/ShipmentDetailsMain.jsx
@@ -216,6 +216,7 @@ const ShipmentDetailsMain = ({
       {shipmentType === SHIPMENT_OPTIONS.PPM && (
         <ImportantShipmentDates
           plannedMoveDate={plannedMoveDate ? formatDateWithUTC(plannedMoveDate) : null}
+          actualMoveDate={actualMoveDate ? formatDateWithUTC(actualMoveDate) : null}
           requestedDeliveryDate={requestedDeliveryDate ? formatDateWithUTC(requestedDeliveryDate) : null}
           scheduledDeliveryDate={scheduledDeliveryDate ? formatDateWithUTC(scheduledDeliveryDate) : null}
           actualDeliveryDate={actualMoveDate ? formatDateWithUTC(actualDeliveryDate) : null}

--- a/src/components/Office/ShipmentDetails/ShipmentDetailsMain.test.jsx
+++ b/src/components/Office/ShipmentDetails/ShipmentDetailsMain.test.jsx
@@ -5,6 +5,7 @@ import { futureSITShipment, noSITShipment, SITShipment } from '../ShipmentSITDis
 
 import ShipmentDetailsMain from './ShipmentDetailsMain';
 
+import { createPPMShipmentWithFinalIncentive } from 'utils/test/factories/ppmShipment';
 import { MockProviders } from 'testUtils';
 
 const shipmentDetailsMainParams = {
@@ -49,5 +50,26 @@ describe('Shipment Details Main', () => {
     );
 
     expect(screen.queryByText('SIT (STORAGE IN TRANSIT)')).not.toBeInTheDocument();
+  });
+  it('does display PPM shipment', () => {
+    const ppmShipment = createPPMShipmentWithFinalIncentive({
+      ppmShipment: {
+        expectedDepartureDate: '2024-01-01',
+        actualMoveDate: '2024-02-22',
+        estimatedWeight: 100,
+        shipment: {
+          estimatedIncentive: 2000,
+        },
+      },
+    });
+    render(
+      <MockProviders>
+        <ShipmentDetailsMain {...shipmentDetailsMainParams} shipment={ppmShipment} />
+      </MockProviders>,
+    );
+
+    expect(screen.queryByText('1/1/2024')).toBeInTheDocument();
+    expect(screen.queryByText('2/22/2024')).toBeInTheDocument();
+    expect(screen.queryByText('100 lbs')).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## B-18328

## Summary

This PR updates the TOO's PPM dashboard to show the "Actual Move Date" data.

### How to test

1. Create a PPM move
2. Submit move as counselor 
3. As customer "Upload Documents"
(setting the "departure date" will set the actual move date)
4. Login as a TOO
5. Click "Move Task Order" tab
6. Verify "Actual Move Date" shows the correct actual move date
If there is no actual move date a "-" should be shown

## Screenshots
<img width="975" alt="Screenshot 2024-02-02 at 11 02 22 AM" src="https://github.com/transcom/mymove/assets/146969726/15e7d620-31ff-4619-996b-4b762ed7078c">
