### PR TITLE
B 18313 int updates

### DIFF
--- a/src/pages/MyMove/Profile/Profile.jsx
+++ b/src/pages/MyMove/Profile/Profile.jsx
@@ -3,7 +3,6 @@ import { connect } from 'react-redux';
 import { arrayOf, bool } from 'prop-types';
 import { Alert, Button } from '@trussworks/react-uswds';
 import { Link, useLocation, useNavigate } from 'react-router-dom';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
 import styles from './Profile.module.scss';
 
@@ -37,6 +36,7 @@ const Profile = ({ serviceMember, currentOrders, currentBackupContacts, moveIsIn
     email: currentBackupContacts[0]?.email || '',
   };
   const [needsToVerifyProfile, setNeedsToVerifyProfile] = useState(false);
+  const [profileValidated, setProfileValidated] = useState(false);
 
   const navigate = useNavigate();
   const { state } = useLocation();
@@ -51,6 +51,10 @@ const Profile = ({ serviceMember, currentOrders, currentBackupContacts, moveIsIn
 
   const handleCreateMoveClick = () => {
     navigate(customerRoutes.MOVE_HOME_PAGE);
+  };
+
+  const handleValidateProfileClick = () => {
+    setProfileValidated(true);
   };
 
   // displays the profile data for MilMove & Okta
@@ -69,14 +73,6 @@ const Profile = ({ serviceMember, currentOrders, currentBackupContacts, moveIsIn
           )}
           <div className={styles.profileHeader}>
             <h1>Profile</h1>
-            {needsToVerifyProfile && (
-              <Button className={styles.createMoveBtn} onClick={handleCreateMoveClick} data-testid="createMoveBtn">
-                <span>Create a Move</span>
-                <div>
-                  <FontAwesomeIcon icon="plus" />
-                </div>
-              </Button>
-            )}
           </div>
           {showMessages && (
             <Alert headingLevel="h4" type="info">
@@ -85,7 +81,11 @@ const Profile = ({ serviceMember, currentOrders, currentBackupContacts, moveIsIn
           )}
           {needsToVerifyProfile && (
             <Alert type="info" className={styles.verifyProfileAlert} data-testid="profileConfirmAlert">
-              <strong>Please verify & confirm your profile before starting the process of creating your move.</strong>
+              <strong>
+                Please confirm your profile information is accurate prior to starting a new move. When all information
+                is up to date, click the &quot;Validate Profile&quot; button at the bottom of the page and you may begin
+                your move.
+              </strong>
             </Alert>
           )}
           <SectionWrapper className={formStyles.formSection}>
@@ -125,6 +125,26 @@ const Profile = ({ serviceMember, currentOrders, currentBackupContacts, moveIsIn
               oktaEdipi={oktaUser?.cac_edipi || 'Not Provided'}
               editURL={customerRoutes.EDIT_OKTA_PROFILE_PATH}
             />
+          </SectionWrapper>
+          <SectionWrapper data-testid="validateProfileContainer" className={styles.validateProfileBtnContainer}>
+            <Button
+              onClick={handleValidateProfileClick}
+              className={styles.validateProfileBtn}
+              data-testid="validateProfileBtn"
+              disabled={profileValidated}
+            >
+              {profileValidated ? 'Profile Validated' : 'Validate Profile'}
+            </Button>
+            {needsToVerifyProfile && (
+              <Button
+                className={styles.createMoveBtn}
+                onClick={handleCreateMoveClick}
+                data-testid="createMoveBtn"
+                disabled={!profileValidated}
+              >
+                <span>Create a Move</span>
+              </Button>
+            )}
           </SectionWrapper>
         </div>
       </div>

--- a/src/pages/MyMove/Profile/Profile.jsx
+++ b/src/pages/MyMove/Profile/Profile.jsx
@@ -126,16 +126,16 @@ const Profile = ({ serviceMember, currentOrders, currentBackupContacts, moveIsIn
               editURL={customerRoutes.EDIT_OKTA_PROFILE_PATH}
             />
           </SectionWrapper>
-          <SectionWrapper data-testid="validateProfileContainer" className={styles.validateProfileBtnContainer}>
-            <Button
-              onClick={handleValidateProfileClick}
-              className={styles.validateProfileBtn}
-              data-testid="validateProfileBtn"
-              disabled={profileValidated}
-            >
-              {profileValidated ? 'Profile Validated' : 'Validate Profile'}
-            </Button>
-            {needsToVerifyProfile && (
+          {needsToVerifyProfile && (
+            <SectionWrapper data-testid="validateProfileContainer" className={styles.validateProfileBtnContainer}>
+              <Button
+                onClick={handleValidateProfileClick}
+                className={styles.validateProfileBtn}
+                data-testid="validateProfileBtn"
+                disabled={profileValidated}
+              >
+                {profileValidated ? 'Profile Validated' : 'Validate Profile'}
+              </Button>
               <Button
                 className={styles.createMoveBtn}
                 onClick={handleCreateMoveClick}
@@ -144,8 +144,8 @@ const Profile = ({ serviceMember, currentOrders, currentBackupContacts, moveIsIn
               >
                 <span>Create a Move</span>
               </Button>
-            )}
-          </SectionWrapper>
+            </SectionWrapper>
+          )}
         </div>
       </div>
     </div>

--- a/src/pages/MyMove/Profile/Profile.module.scss
+++ b/src/pages/MyMove/Profile/Profile.module.scss
@@ -12,7 +12,6 @@
       display: flex;
       justify-content: space-between;
       align-items: center;
-      @include u-margin-top(-1);
       span {
         @include u-margin-right(.5em)
       }
@@ -32,4 +31,9 @@
 
 .verifyProfileAlert {
     margin-bottom: -1rem;
+}
+
+.validateProfileBtnContainer {
+  display: flex;
+  justify-content: center;
 }

--- a/src/pages/MyMove/Profile/Profile.test.jsx
+++ b/src/pages/MyMove/Profile/Profile.test.jsx
@@ -1,6 +1,6 @@
 /* eslint-disable react/jsx-props-no-spreading */
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import { useLocation } from 'react-router-dom';
 
 import ConnectedProfile from './Profile';
@@ -398,10 +398,24 @@ describe('Profile component', () => {
     const returnToDashboardLink = screen.getByText('Return to Dashboard');
     expect(returnToDashboardLink).toBeInTheDocument();
 
+    const validateProfileContainer = screen.getByTestId('validateProfileContainer');
+    expect(validateProfileContainer).toBeInTheDocument();
+
     const createMoveBtn = screen.getByTestId('createMoveBtn');
     expect(createMoveBtn).toBeInTheDocument();
+    expect(createMoveBtn).toBeDisabled();
+
+    const validateProfileBtn = screen.getByTestId('validateProfileBtn');
+    expect(validateProfileBtn).toBeInTheDocument();
+    expect(validateProfileBtn).toBeEnabled();
 
     const profileConfirmAlert = screen.getByTestId('profileConfirmAlert');
     expect(profileConfirmAlert).toBeInTheDocument();
+
+    // user validates their profile, which enables create move btn
+    fireEvent.click(validateProfileBtn);
+    expect(createMoveBtn).toBeEnabled();
+    expect(validateProfileBtn).toBeDisabled();
+    expect(screen.getByText('Profile Validated')).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## [Agility ticket](https://www13.v1host.com/USTRANSCOM38/story.mvc/Summary?oidToken=Story%3a873918)

## Summary

After merging [previous PR for B-18313](https://github.com/transcom/mymove/pull/11859) the gov wanted to add in a way to force the service member to validate their profile.

The solution is to add a `Validate Profile` button that, when clicked, enables the `Create a Move` button.

This PR does the following:
- adds in `profileValidated` state that controls the enablement/disablement of the validate & create a move buttons
- moved buttons to the bottom of the page in a section wrapper that will require the service member to scroll all the way down past their profile info
- updated tests to reflect changes

### How to test

1. Access MM as customer that has previous moves
2. Click the `Create a Move` button on the multi-move dashboard
3. You'll be directed to the profile screen to review your profile
4. Scroll to the bottom and you'll see you cannot proceed until you click `Validate Profile`

## Screenshots
![Screenshot 2024-02-02 at 11 16 59 AM](https://github.com/transcom/mymove/assets/136510600/c1b3f9b9-76bb-4fa0-a20a-b3be6dbdbdbb)

![Screenshot 2024-02-02 at 11 18 10 AM](https://github.com/transcom/mymove/assets/136510600/ccfb75e3-0ade-45c9-8f6f-ead64851c88b)
