### PR TITLE
B 17984 update reminder email integration

### DIFF
--- a/pkg/notifications/move_payment_reminder.go
+++ b/pkg/notifications/move_payment_reminder.go
@@ -35,7 +35,7 @@ func NewPaymentReminder() (*PaymentReminder, error) {
 
 	return &PaymentReminder{
 		emailAfter:    "14 DAYS",
-		noEmailBefore: "2023-06-01",
+		noEmailBefore: "2019-06-01",
 		htmlTemplate:  paymentReminderHTMLTemplate,
 		textTemplate:  paymentReminderTextTemplate,
 	}, nil

--- a/pkg/notifications/move_payment_reminder_test.go
+++ b/pkg/notifications/move_payment_reminder_test.go
@@ -283,7 +283,7 @@ func (suite *NotificationSuite) TestPaymentReminderOnSuccess() {
 }
 
 func (suite *NotificationSuite) TestPaymentReminderHTMLTemplateRender() {
-	milMove := "https://my.move.mil"
+	milMove := "https://my.move.mil/"
 	pr, err := NewPaymentReminder()
 	suite.NoError(err)
 
@@ -297,7 +297,7 @@ func (suite *NotificationSuite) TestPaymentReminderHTMLTemplateRender() {
 		TOName:                  &name,
 		TOPhone:                 &phone,
 		Locator:                 "abc123",
-		MyMoveLink:              MyMoveLink,
+		MyMoveLink:              milMove,
 	}
 	expectedHTMLContent := `<p>We hope your move to DestDutyLocation went well.</p>
 
@@ -312,7 +312,7 @@ func (suite *NotificationSuite) TestPaymentReminderHTMLTemplateRender() {
 <p>To do that</p>
 
 <ul>
-  <li><a href="` + milMove + `">Log in to MilMove</a></li>
+  <li><a href="` + MyMoveLink + `">Log in to MilMove</a></li>
   <li>Click Request Payment</li>
   <li>Follow the instructions.</li>
 </ul>
@@ -350,6 +350,7 @@ func (suite *NotificationSuite) TestPaymentReminderHTMLTemplateRender() {
 func (suite *NotificationSuite) TestPaymentReminderHTMLTemplateRenderNoOriginDutyLocation() {
 	pr, err := NewPaymentReminder()
 	suite.NoError(err)
+	milMove := "https://my.move.mil/"
 
 	s := PaymentReminderEmailData{
 		DestinationDutyLocation: "DestDutyLocation",
@@ -359,7 +360,7 @@ func (suite *NotificationSuite) TestPaymentReminderHTMLTemplateRenderNoOriginDut
 		TOName:                  nil,
 		TOPhone:                 nil,
 		Locator:                 "abc123",
-		MyMoveLink:              MyMoveLink,
+		MyMoveLink:              milMove,
 	}
 	expectedHTMLContent := `<p>We hope your move to DestDutyLocation went well.</p>
 
@@ -423,7 +424,6 @@ func (suite *NotificationSuite) TestPaymentReminderTextTemplateRender() {
 		TOName:                  &name,
 		TOPhone:                 &phone,
 		Locator:                 "abc123",
-		MyMoveLink:              MyMoveLink,
 	}
 	expectedTextContent := `We hope your move to DestDutyLocation went well.
 
@@ -492,6 +492,8 @@ func (suite *NotificationSuite) TestFormatPaymentRequestedEmails() {
 	name3 := "to3"
 	name4 := "to4"
 
+	milMove := "https://my.move.mil/"
+
 	emailInfos := PaymentReminderEmailInfos{
 		{
 			Email:               &email1,
@@ -549,7 +551,7 @@ func (suite *NotificationSuite) TestFormatPaymentRequestedEmails() {
 			TOName:                  emailInfo.TOName,
 			TOPhone:                 emailInfo.TOPhone,
 			Locator:                 emailInfo.Locator,
-			MyMoveLink:              MyMoveLink,
+			MyMoveLink:              milMove,
 		}
 		htmlBody, err := pr.RenderHTML(suite.AppContextForTest(), data)
 		suite.NoError(err)


### PR DESCRIPTION
## B-17984

## Summary

As a Customer  you should receive an email if you haven't submitted any docs within the last 14 days of today.

## Verification Steps for Reviewers

These are to be checked by a reviewer.

- [ ] Has the branch been pulled in and checked out?
- [ ] Have the BL acceptance criteria been met for this change?
- [ ] Was the CircleCI build successful?
- [ ] Has the code been reviewed from a standards and best practices point of view?

### How to test

1. Create a move with an estimateDepartureDate that is <= 14 days from today, and has no null estimate values(incentive, weight), and set the personal email to one you can access
2. Approve this move as a service counselor
3. Run `aws-vault exec transcom-gov-dev` to get into the subshell
4. Run `go run ./cmd/milmove-tasks send-payment-reminder --email-backend=ses --aws-ses-domain=[devlocal.dp3.us](http://devlocal.dp3.us/) --aws-ses-region=us-gov-west-1`
5. You should get a payment reminder email in a couple minutes max

## Screenshots
<img width="1305" alt="Screenshot 2024-02-16 at 11 30 42 AM" src="https://github.com/transcom/mymove/assets/146969726/bf9fd5fa-0ae7-4b40-9b5e-53a0424a77a0">
