### PR TITLE
B-18896 INT redefine orders audit history

### DIFF
--- a/migrations/app/migrations_manifest.txt
+++ b/migrations/app/migrations_manifest.txt
@@ -902,3 +902,4 @@
 20240207173709_updateTransportationOffices.up.sql
 20240212150834_20240212_disable_homesafe_stg_cert.up.sql
 20240214213247_updateTransportationOfficesGbloc.up.sql
+20240222144140_redefine_order_audit_table_grade_col.up.sql

--- a/migrations/app/schema/20240222144140_redefine_order_audit_table_grade_col.up.sql
+++ b/migrations/app/schema/20240222144140_redefine_order_audit_table_grade_col.up.sql
@@ -1,0 +1,13 @@
+SELECT add_audit_history_table(
+	target_table := 'orders',
+	audit_rows := BOOLEAN 't',
+	audit_query_text := BOOLEAN 't',
+	ignored_cols := ARRAY[
+		'created_at',
+		'updated_at',
+		'service_member_id',
+		'uploaded_orders_id',
+		'entitlement_id',
+		'uploaded_amended_orders_id'
+	] -- origin_duty_location_id and new_duty_location_id are fks but are utilized to display supplemental information
+);


### PR DESCRIPTION
## [Agility ticket](https://www13.v1host.com/USTRANSCOM38/story.mvc/Summary?oidToken=Story%3a907911)

## Summary

Previously, the grade column was in the list of ignored columns for the audit table entries for the `orders` table. This migration redefines the orders audit table without the grade in that list of ignored columns.

### How to test

1. As a services counselor, go to Move Details and edit the pay grade.
2. Go to the move history tab.
3. Verify that you see an event called "Updated orders" and in the details of that event, the updated pay grade.
________________________________________________________________________________________________

1. As a TOO, go to Move Details and edit the pay grade.
2. Go to the move history tab.
3. Verify that you see an event called "Updated orders" and in the details of that event, the updated pay grade.

________________________________________________________________________________________________
1. As a TIO, go to Move Details and edit the pay grade.
2. Go to the move history tab.
3. Verify that you see an event called "Updated orders" and in the details of that event, the updated pay grade.
________________________________________________________________________________________________

Before, no mention of grade being modified in the move history:
![image](https://github.com/transcom/mymove/assets/147537467/ceba70ed-f2ee-402f-b9e6-d5ad40578b0d)

After:
![image](https://github.com/transcom/mymove/assets/147537467/6de9d984-43e9-43a9-a416-ac011b0d0780)
