### PR TITLE
MAIN B-18314 (merge after B-18313)

### DIFF
--- a/pkg/gen/internalapi/embedded_spec.go
+++ b/pkg/gen/internalapi/embedded_spec.go
@@ -4203,6 +4203,10 @@ func init() {
         "orders": {
           "type": "object"
         },
+        "status": {
+          "type": "string",
+          "readOnly": true
+        },
         "updatedAt": {
           "type": "string",
           "format": "date-time",
@@ -12307,6 +12311,10 @@ func init() {
         },
         "orders": {
           "type": "object"
+        },
+        "status": {
+          "type": "string",
+          "readOnly": true
         },
         "updatedAt": {
           "type": "string",

--- a/pkg/gen/internalmessages/internal_move.go
+++ b/pkg/gen/internalmessages/internal_move.go
@@ -49,6 +49,10 @@ type InternalMove struct {
 	// orders
 	Orders interface{} `json:"orders,omitempty"`
 
+	// status
+	// Read Only: true
+	Status string `json:"status,omitempty"`
+
 	// updated at
 	// Read Only: true
 	// Format: date-time
@@ -170,6 +174,10 @@ func (m *InternalMove) ContextValidate(ctx context.Context, formats strfmt.Regis
 		res = append(res, err)
 	}
 
+	if err := m.contextValidateStatus(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
 	if err := m.contextValidateUpdatedAt(ctx, formats); err != nil {
 		res = append(res, err)
 	}
@@ -215,6 +223,15 @@ func (m *InternalMove) contextValidateMtoShipments(ctx context.Context, formats 
 		} else if ce, ok := err.(*errors.CompositeError); ok {
 			return ce.ValidateName("mtoShipments")
 		}
+		return err
+	}
+
+	return nil
+}
+
+func (m *InternalMove) contextValidateStatus(ctx context.Context, formats strfmt.Registry) error {
+
+	if err := validate.ReadOnly(ctx, "status", "body", string(m.Status)); err != nil {
 		return err
 	}
 

--- a/pkg/handlers/internalapi/moves.go
+++ b/pkg/handlers/internalapi/moves.go
@@ -159,6 +159,7 @@ func payloadForInternalMove(storer storage.FileStorer, list models.Moves) []*int
 			CreatedAt:    *handlers.FmtDateTime(move.CreatedAt),
 			ETag:         eTag,
 			ID:           *handlers.FmtUUID(move.ID),
+			Status:       string(move.Status),
 			MtoShipments: *payloadShipments,
 			MoveCode:     move.Locator,
 			Orders:       move.Orders,

--- a/pkg/models/move.go
+++ b/pkg/models/move.go
@@ -416,6 +416,7 @@ func FetchMovesByOrderID(db *pop.Connection, orderID uuid.UUID) (Moves, error) {
 		"Orders.UploadedOrders",
 		"Orders.ServiceMember",
 		"Orders.ServiceMember.User",
+		"Orders.OriginDutyLocation.Address",
 		"Orders.OriginDutyLocation.TransportationOffice",
 		"Orders.OriginDutyLocation.TransportationOffice.Address",
 		"Orders.NewDutyLocation.Address",

--- a/src/pages/MyMove/Multi-Moves/MultiMovesLandingPage.jsx
+++ b/src/pages/MyMove/Multi-Moves/MultiMovesLandingPage.jsx
@@ -21,9 +21,17 @@ import { loadInternalSchema } from 'shared/Swagger/ducks';
 import { loadUser } from 'store/auth/actions';
 import { initOnboarding } from 'store/onboarding/actions';
 import Helper from 'components/Customer/Home/Helper';
+import { customerRoutes } from 'constants/routes';
+import { withContext } from 'shared/AppContext';
+import withRouter from 'utils/routing';
+import requireCustomerState from 'containers/requireCustomerState/requireCustomerState';
+import { selectIsProfileComplete, selectServiceMemberFromLoggedInUser } from 'store/entities/selectors';
 
-const MultiMovesLandingPage = () => {
+const MultiMovesLandingPage = ({ serviceMemberMoves }) => {
   const [setErrorState] = useState({ hasError: false, error: undefined, info: undefined });
+  const navigate = useNavigate();
+  console.log('serviceMemberMoves', serviceMemberMoves);
+
   // ! This is just used for testing and viewing different variations of data that MilMove will use
   // user can add params of ?moveData=PCS, etc to view different views
   let moves;
@@ -146,4 +154,28 @@ const MultiMovesLandingPage = () => {
   );
 };
 
-export default MultiMovesLandingPage;
+MultiMovesLandingPage.defaultProps = {
+  serviceMember: null,
+};
+
+const mapStateToProps = (state) => {
+  const serviceMember = selectServiceMemberFromLoggedInUser(state);
+  const { serviceMemberMoves } = state.entities;
+
+  return {
+    isProfileComplete: selectIsProfileComplete(state),
+    serviceMember,
+    serviceMemberMoves,
+  };
+};
+
+// in order to avoid setting up proxy server only for storybook, pass in stub function so API requests don't fail
+const mergeProps = (stateProps, dispatchProps, ownProps) => ({
+  ...stateProps,
+  ...dispatchProps,
+  ...ownProps,
+});
+
+export default withContext(
+  withRouter(connect(mapStateToProps, mergeProps)(requireCustomerState(MultiMovesLandingPage))),
+);

--- a/src/pages/MyMove/Multi-Moves/MultiMovesLandingPage.jsx
+++ b/src/pages/MyMove/Multi-Moves/MultiMovesLandingPage.jsx
@@ -1,6 +1,8 @@
 import React, { useEffect, useState } from 'react';
 import { Button } from '@trussworks/react-uswds';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { useNavigate } from 'react-router';
+import { connect } from 'react-redux';
 
 import styles from './MultiMovesLandingPage.module.scss';
 import MultiMovesMoveHeader from './MultiMovesMoveHeader/MultiMovesMoveHeader';
@@ -94,7 +96,7 @@ const MultiMovesLandingPage = ({ serviceMember, serviceMemberMoves }) => {
             </Helper>
           )}
           <div className={styles.centeredContainer}>
-            <Button className={styles.createMoveBtn}>
+            <Button className={styles.createMoveBtn} onClick={handleCreateMoveBtnClick} data-testid="createMoveBtn">
               <span>Create a Move</span>
               <div>
                 <FontAwesomeIcon icon="plus" />
@@ -140,7 +142,7 @@ const MultiMovesLandingPage = ({ serviceMember, serviceMemberMoves }) => {
         </div>
       </div>
     </div>
-  );
+  ) : null;
 };
 
 MultiMovesLandingPage.defaultProps = {

--- a/src/pages/MyMove/Multi-Moves/MultiMovesLandingPage.test.jsx
+++ b/src/pages/MyMove/Multi-Moves/MultiMovesLandingPage.test.jsx
@@ -4,6 +4,8 @@ import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect'; // For additional matchers like toBeInTheDocument
 import MultiMovesLandingPage from './MultiMovesLandingPage';
 
+import { MockProviders } from 'testUtils';
+
 // Mock external dependencies
 jest.mock('utils/featureFlags', () => ({
   detectFlags: jest.fn(() => ({ multiMove: true })),
@@ -21,13 +23,166 @@ jest.mock('shared/Swagger/ducks', () => ({
   loadInternalSchema: jest.fn(),
 }));
 
+const defaultProps = {
+  serviceMember: {
+    id: v4(),
+    first_name: 'Jim',
+    last_name: 'Bean',
+  },
+  showLoggedInUser: jest.fn(),
+  isLoggedIn: true,
+  loggedInUserIsLoading: false,
+  loggedInUserSuccess: true,
+  isProfileComplete: true,
+  serviceMemberMoves: {
+    currentMove: [
+      {
+        createdAt: '2024-01-31T16:29:53.290Z',
+        eTag: 'MjAyNC0wMS0zMVQxNjoyOTo1My4yOTA0OTRa',
+        id: '9211d4e2-5b92-42bb-9758-7ac1f329a8d6',
+        moveCode: 'YJ9M34',
+        orders: {
+          id: '40475a80-5340-4722-88d1-3cc9764414d6',
+          created_at: '2024-01-31T16:29:53.285657Z',
+          updated_at: '2024-01-31T16:29:53.285657Z',
+          service_member_id: '6686d242-e7af-4a06-afd7-7be423bfca2d',
+          issue_date: '2024-01-31T00:00:00Z',
+          report_by_date: '2024-02-09T00:00:00Z',
+          orders_type: 'PERMANENT_CHANGE_OF_STATION',
+          orders_type_detail: null,
+          has_dependents: false,
+          spouse_has_pro_gear: false,
+          OriginDutyLocation: {
+            id: '2d6eab7d-1a21-4f29-933e-ee8fa7dbc314',
+            created_at: '2024-01-26T16:46:34.047004Z',
+            updated_at: '2024-01-26T16:46:34.047004Z',
+            name: 'Tinker AFB, OK 73145',
+            affiliation: 'AIR_FORCE',
+            address_id: '7e3ea97c-da9f-4fa1-8a11-87063c857635',
+            Address: {
+              id: '7e3ea97c-da9f-4fa1-8a11-87063c857635',
+              created_at: '2024-01-26T16:46:34.047004Z',
+              updated_at: '2024-01-26T16:46:34.047004Z',
+              street_address_1: 'n/a',
+              street_address_2: null,
+              street_address_3: null,
+              city: 'Tinker AFB',
+              state: 'OK',
+              postal_code: '73145',
+              country: 'United States',
+            },
+            transportation_office_id: '7876373d-57e4-4cde-b11f-c26a8feee9e8',
+            TransportationOffice: {
+              id: '7876373d-57e4-4cde-b11f-c26a8feee9e8',
+              shipping_office_id: 'c2c440ae-5394-4483-84fb-f872e32126bb',
+              ShippingOffice: null,
+              name: 'PPPO Tinker AFB - USAF',
+              Address: {
+                id: '410b18bc-b270-4b52-9211-532fffc6f59e',
+                created_at: '2018-05-28T14:27:40.597383Z',
+                updated_at: '2018-05-28T14:27:40.597383Z',
+                street_address_1: '7330 Century Blvd',
+                street_address_2: 'Bldg 469',
+                street_address_3: null,
+                city: 'Tinker AFB',
+                state: 'OK',
+                postal_code: '73145',
+                country: 'United States',
+              },
+              address_id: '410b18bc-b270-4b52-9211-532fffc6f59e',
+              latitude: 35.429035,
+              longitude: -97.39955,
+              PhoneLines: null,
+              Emails: null,
+              hours: 'Monday – Friday: 0715 – 1600; Limited Service from 1130-1230',
+              services: 'Walk-In Help; Briefings; Appointments; QA Inspections',
+              note: null,
+              gbloc: 'HAFC',
+              created_at: '2018-05-28T14:27:40.605679Z',
+              updated_at: '2018-05-28T14:27:40.60568Z',
+              provides_ppm_closeout: true,
+            },
+            provides_services_counseling: true,
+          },
+          origin_duty_location_id: '2d6eab7d-1a21-4f29-933e-ee8fa7dbc314',
+          new_duty_location_id: '5c182566-0e6e-46f2-9eef-f07963783575',
+          NewDutyLocation: {
+            id: '5c182566-0e6e-46f2-9eef-f07963783575',
+            created_at: '2024-01-26T16:46:34.047004Z',
+            updated_at: '2024-01-26T16:46:34.047004Z',
+            name: 'Fort Sill, OK 73503',
+            affiliation: 'ARMY',
+            address_id: 'ed62ba0b-a3cb-47ac-81ae-5b27ade4592b',
+            Address: {
+              id: 'ed62ba0b-a3cb-47ac-81ae-5b27ade4592b',
+              created_at: '2024-01-26T16:46:34.047004Z',
+              updated_at: '2024-01-26T16:46:34.047004Z',
+              street_address_1: 'n/a',
+              street_address_2: null,
+              street_address_3: null,
+              city: 'Fort Sill',
+              state: 'OK',
+              postal_code: '73503',
+              country: 'United States',
+            },
+            transportation_office_id: '7f5b64b8-979c-4cbd-890b-bffd6fdf56d9',
+            TransportationOffice: {
+              id: '7f5b64b8-979c-4cbd-890b-bffd6fdf56d9',
+              shipping_office_id: '5a3388e1-6d46-4639-ac8f-a8937dc26938',
+              ShippingOffice: null,
+              name: 'PPPO Fort Sill - USA',
+              Address: {
+                id: 'abbc0af9-2394-4e36-be84-811ad8f6060b',
+                created_at: '2018-05-28T14:27:35.538742Z',
+                updated_at: '2018-05-28T14:27:35.538743Z',
+                street_address_1: '4700 Mow Way Rd',
+                street_address_2: 'Room 110',
+                street_address_3: null,
+                city: 'Fort Sill',
+                state: 'OK',
+                postal_code: '73503',
+                country: 'United States',
+              },
+              address_id: 'abbc0af9-2394-4e36-be84-811ad8f6060b',
+              latitude: 34.647964,
+              longitude: -98.41231,
+              PhoneLines: null,
+              Emails: null,
+              hours: 'Monday - Friday 0830-1530; Sat/Sun/Federal Holidays closed',
+              services: 'Walk-In Help; Appointments; QA Inspections; Appointments 06 and above',
+              note: null,
+              gbloc: 'JEAT',
+              created_at: '2018-05-28T14:27:35.547257Z',
+              updated_at: '2018-05-28T14:27:35.547257Z',
+              provides_ppm_closeout: true,
+            },
+            provides_services_counseling: true,
+          },
+          uploaded_orders_id: 'f779f6a2-48e2-47fe-87be-d93e8aa711fe',
+          status: 'DRAFT',
+          grade: 'E_7',
+          Entitlement: null,
+          entitlement_id: 'a1bf0035-4f28-45b8-af1a-556848d29e44',
+          UploadedAmendedOrders: null,
+          uploaded_amended_orders_id: null,
+          amended_orders_acknowledged_at: null,
+          origin_duty_location_gbloc: 'HAFC',
+        },
+        status: 'DRAFT',
+        updatedAt: '0001-01-01T00:00:00.000Z',
+      },
+    ],
+    previousMoves: [],
+  },
+};
+
 describe('MultiMovesLandingPage', () => {
   it('renders the component with retirement moves', () => {
     render(<MultiMovesLandingPage />);
 
     // Check for specific elements
     expect(screen.getByTestId('customerHeader')).toBeInTheDocument();
-    expect(screen.getByText('First Last')).toBeInTheDocument();
+    expect(screen.getByTestId('welcomeHeader')).toBeInTheDocument();
     expect(screen.getByText('Welcome to MilMove!')).toBeInTheDocument();
     expect(screen.getByText('Create a Move')).toBeInTheDocument();
 
@@ -37,11 +192,17 @@ describe('MultiMovesLandingPage', () => {
   });
 
   it('renders move data correctly', () => {
-    render(<MultiMovesLandingPage />);
+    render(
+      <MockProviders>
+        <MultiMovesLandingPage {...defaultProps} />
+      </MockProviders>,
+    );
 
+    expect(screen.getByText('Jim Bean')).toBeInTheDocument();
+    expect(screen.getByText('#YJ9M34')).toBeInTheDocument();
     expect(screen.getByTestId('currentMoveHeader')).toBeInTheDocument();
     expect(screen.getByTestId('currentMoveContainer')).toBeInTheDocument();
     expect(screen.getByTestId('prevMovesHeader')).toBeInTheDocument();
-    expect(screen.getByTestId('prevMovesContainer')).toBeInTheDocument();
+    expect(screen.getByText('You have no previous moves.')).toBeInTheDocument();
   });
 });

--- a/src/pages/MyMove/Multi-Moves/MultiMovesLandingPage.test.jsx
+++ b/src/pages/MyMove/Multi-Moves/MultiMovesLandingPage.test.jsx
@@ -1,7 +1,9 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
+import { v4 } from 'uuid';
 
-import '@testing-library/jest-dom/extend-expect'; // For additional matchers like toBeInTheDocument
+import '@testing-library/jest-dom/extend-expect';
+
 import MultiMovesLandingPage from './MultiMovesLandingPage';
 
 import { MockProviders } from 'testUtils';
@@ -177,8 +179,12 @@ const defaultProps = {
 };
 
 describe('MultiMovesLandingPage', () => {
-  it('renders the component with retirement moves', () => {
-    render(<MultiMovesLandingPage />);
+  it('renders the component with moves', () => {
+    render(
+      <MockProviders>
+        <MultiMovesLandingPage {...defaultProps} />
+      </MockProviders>,
+    );
 
     // Check for specific elements
     expect(screen.getByTestId('customerHeader')).toBeInTheDocument();

--- a/src/pages/MyMove/Multi-Moves/MultiMovesMoveContainer/MultiMovesMoveContainer.jsx
+++ b/src/pages/MyMove/Multi-Moves/MultiMovesMoveContainer/MultiMovesMoveContainer.jsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import classnames from 'classnames';
 import { Button } from '@trussworks/react-uswds';
+import { useNavigate } from 'react-router';
 
 import MultiMovesMoveInfoList from '../MultiMovesMoveInfoList/MultiMovesMoveInfoList';
 import ButtonDropdownMenu from '../../../../components/ButtonDropdownMenu/ButtonDropdownMenu';
@@ -9,9 +10,11 @@ import ButtonDropdownMenu from '../../../../components/ButtonDropdownMenu/Button
 import styles from './MultiMovesMoveContainer.module.scss';
 
 import ShipmentContainer from 'components/Office/ShipmentContainer/ShipmentContainer';
+import { customerRoutes } from 'constants/routes';
 
 const MultiMovesMoveContainer = ({ moves }) => {
   const [expandedMoves, setExpandedMoves] = useState({});
+  const navigate = useNavigate();
 
   // this expands the moves when the arrow is clicked
   const handleExpandClick = (index) => {
@@ -63,13 +66,24 @@ const MultiMovesMoveContainer = ({ moves }) => {
     return 'Shipment';
   };
 
+  // sends user to the move page when clicking "Go to Move" btn
+  const handleGoToMoveClick = () => {
+    navigate(customerRoutes.MOVE_HOME_PAGE);
+  };
+
   const moveList = moves.map((m, index) => (
     <React.Fragment key={index}>
       <div className={styles.moveContainer}>
         <div className={styles.heading} key={index}>
           <h3>#{m.moveCode}</h3>
           {m.status !== 'APPROVED' ? (
-            <Button className={styles.goToMoveBtn} secondary outline>
+            <Button
+              data-testid="goToMoveBtn"
+              className={styles.goToMoveBtn}
+              secondary
+              outline
+              onClick={handleGoToMoveClick}
+            >
               Go to Move
             </Button>
           ) : (

--- a/src/pages/MyMove/Multi-Moves/MultiMovesMoveContainer/MultiMovesMoveContainer.jsx
+++ b/src/pages/MyMove/Multi-Moves/MultiMovesMoveContainer/MultiMovesMoveContainer.jsx
@@ -96,24 +96,28 @@ const MultiMovesMoveContainer = ({ moves }) => {
             <div className={styles.moveInfoListExpanded}>
               <MultiMovesMoveInfoList move={m} />
               <h3 className={styles.shipmentH3}>Shipments</h3>
-              {m.mtoShipments.map((s, sIndex) => (
-                <React.Fragment key={sIndex}>
-                  <div className={styles.shipment}>
-                    <ShipmentContainer
-                      key={s.id}
-                      shipmentType={s.shipmentType}
-                      className={classnames(styles.previewShipment)}
-                    >
-                      <div className={styles.innerWrapper}>
-                        <div className={styles.shipmentTypeHeading}>
-                          <h4>{generateShipmentTypeTitle(s.shipmentType)}</h4>
-                          <h5>#{m.moveCode}</h5>
+              {m.mtoShipments && m.mtoShipments.length > 0 ? (
+                m.mtoShipments.map((s, sIndex) => (
+                  <React.Fragment key={sIndex}>
+                    <div className={styles.shipment}>
+                      <ShipmentContainer
+                        key={s.id}
+                        shipmentType={s.shipmentType}
+                        className={classnames(styles.previewShipment)}
+                      >
+                        <div className={styles.innerWrapper}>
+                          <div className={styles.shipmentTypeHeading}>
+                            <h4>{generateShipmentTypeTitle(s.shipmentType)}</h4>
+                            <h5>#{m.moveCode}</h5>
+                          </div>
                         </div>
-                      </div>
-                    </ShipmentContainer>
-                  </div>
-                </React.Fragment>
-              ))}
+                      </ShipmentContainer>
+                    </div>
+                  </React.Fragment>
+                ))
+              ) : (
+                <div className={styles.shipment}>No shipments in move yet.</div>
+              )}
             </div>
           )}
         </div>

--- a/src/pages/MyMove/Multi-Moves/MultiMovesMoveContainer/MultiMovesMoveContainer.stories.jsx
+++ b/src/pages/MyMove/Multi-Moves/MultiMovesMoveContainer/MultiMovesMoveContainer.stories.jsx
@@ -4,18 +4,44 @@ import { mockMovesPCS, mockMovesRetirement, mockMovesSeparation } from '../Multi
 
 import MultiMovesMoveContainer from './MultiMovesMoveContainer';
 
+import { MockProviders } from 'testUtils';
+
 export default {
   title: 'Customer Components / MultiMovesContainer',
 };
 
-export const PCSCurrentMove = () => <MultiMovesMoveContainer moves={mockMovesPCS.currentMove} />;
+export const PCSCurrentMove = () => (
+  <MockProviders>
+    <MultiMovesMoveContainer moves={mockMovesPCS.currentMove} />
+  </MockProviders>
+);
 
-export const PCSPreviousMoves = () => <MultiMovesMoveContainer moves={mockMovesPCS.previousMoves} />;
+export const PCSPreviousMoves = () => (
+  <MockProviders>
+    <MultiMovesMoveContainer moves={mockMovesPCS.previousMoves} />
+  </MockProviders>
+);
 
-export const RetirementCurrentMove = () => <MultiMovesMoveContainer moves={mockMovesRetirement.currentMove} />;
+export const RetirementCurrentMove = () => (
+  <MockProviders>
+    <MultiMovesMoveContainer moves={mockMovesRetirement.currentMove} />
+  </MockProviders>
+);
 
-export const RetirementPreviousMoves = () => <MultiMovesMoveContainer moves={mockMovesRetirement.previousMoves} />;
+export const RetirementPreviousMoves = () => (
+  <MockProviders>
+    <MultiMovesMoveContainer moves={mockMovesRetirement.previousMoves} />
+  </MockProviders>
+);
 
-export const SeparationCurrentMove = () => <MultiMovesMoveContainer moves={mockMovesSeparation.currentMove} />;
+export const SeparationCurrentMove = () => (
+  <MockProviders>
+    <MultiMovesMoveContainer moves={mockMovesSeparation.currentMove} />
+  </MockProviders>
+);
 
-export const SeparationPreviousMoves = () => <MultiMovesMoveContainer moves={mockMovesSeparation.previousMoves} />;
+export const SeparationPreviousMoves = () => (
+  <MockProviders>
+    <MultiMovesMoveContainer moves={mockMovesSeparation.previousMoves} />
+  </MockProviders>
+);

--- a/src/pages/MyMove/Multi-Moves/MultiMovesMoveContainer/MultiMovesMoveContainer.test.jsx
+++ b/src/pages/MyMove/Multi-Moves/MultiMovesMoveContainer/MultiMovesMoveContainer.test.jsx
@@ -6,12 +6,18 @@ import { mockMovesPCS } from '../MultiMovesTestData';
 
 import MultiMovesMoveContainer from './MultiMovesMoveContainer';
 
+import { MockProviders } from 'testUtils';
+
 describe('MultiMovesMoveContainer', () => {
   const mockCurrentMoves = mockMovesPCS.currentMove;
   const mockPreviousMoves = mockMovesPCS.previousMoves;
 
   it('renders current move list correctly', () => {
-    render(<MultiMovesMoveContainer moves={mockCurrentMoves} />);
+    render(
+      <MockProviders>
+        <MultiMovesMoveContainer moves={mockCurrentMoves} />
+      </MockProviders>,
+    );
 
     expect(screen.getByTestId('move-info-container')).toBeInTheDocument();
     expect(screen.getByText('#MOVECO')).toBeInTheDocument();
@@ -19,7 +25,11 @@ describe('MultiMovesMoveContainer', () => {
   });
 
   it('renders previous move list correctly', () => {
-    render(<MultiMovesMoveContainer moves={mockPreviousMoves} />);
+    render(
+      <MockProviders>
+        <MultiMovesMoveContainer moves={mockPreviousMoves} />
+      </MockProviders>,
+    );
 
     expect(screen.queryByText('#SAMPLE')).toBeInTheDocument();
     expect(screen.queryByText('#EXAMPL')).toBeInTheDocument();
@@ -27,7 +37,11 @@ describe('MultiMovesMoveContainer', () => {
   });
 
   it('expands and collapses moves correctly', () => {
-    render(<MultiMovesMoveContainer moves={mockCurrentMoves} />);
+    render(
+      <MockProviders>
+        <MultiMovesMoveContainer moves={mockCurrentMoves} />
+      </MockProviders>,
+    );
 
     // Initially, the move details should not be visible
     expect(screen.queryByText('Shipment')).not.toBeInTheDocument();

--- a/src/pages/MyMove/Multi-Moves/MultiMovesMoveInfoList/MultiMovesInfoList.test.jsx
+++ b/src/pages/MyMove/Multi-Moves/MultiMovesMoveInfoList/MultiMovesInfoList.test.jsx
@@ -8,12 +8,12 @@ describe('MultiMovesMoveInfoList', () => {
   const mockMoveSeparation = {
     status: 'DRAFT',
     orders: {
-      date_issued: '2022-01-01',
-      ordersType: 'SEPARATION',
-      reportByDate: '2022-02-01',
-      originDutyLocation: {
+      issue_date: '2022-01-01',
+      orders_type: 'SEPARATION',
+      report_by_date: '2022-02-01',
+      OriginDutyLocation: {
         name: 'Fort Bragg North Station',
-        address: {
+        Address: {
           streetAddress1: '123 Main Ave',
           streetAddress2: 'Apartment 9000',
           streetAddress3: '',
@@ -23,9 +23,9 @@ describe('MultiMovesMoveInfoList', () => {
           country: 'USA',
         },
       },
-      destinationDutyLocation: {
+      NewDutyLocation: {
         name: 'Fort Bragg North Station',
-        address: {
+        Address: {
           streetAddress1: '123 Main Ave',
           streetAddress2: 'Apartment 9000',
           streetAddress3: '',
@@ -41,12 +41,12 @@ describe('MultiMovesMoveInfoList', () => {
   const mockMoveRetirement = {
     status: 'DRAFT',
     orders: {
-      date_issued: '2022-01-01',
-      ordersType: 'RETIREMENT',
-      reportByDate: '2022-02-01',
-      originDutyLocation: {
+      issue_date: '2022-01-01',
+      orders_type: 'RETIREMENT',
+      report_by_date: '2022-02-01',
+      OriginDutyLocation: {
         name: 'Fort Bragg North Station',
-        address: {
+        Address: {
           streetAddress1: '123 Main Ave',
           streetAddress2: 'Apartment 9000',
           streetAddress3: '',
@@ -56,9 +56,9 @@ describe('MultiMovesMoveInfoList', () => {
           country: 'USA',
         },
       },
-      destinationDutyLocation: {
+      NewDutyLocation: {
         name: 'Fort Bragg North Station',
-        address: {
+        Address: {
           streetAddress1: '123 Main Ave',
           streetAddress2: 'Apartment 9000',
           streetAddress3: '',
@@ -74,12 +74,12 @@ describe('MultiMovesMoveInfoList', () => {
   const mockMovePCS = {
     status: 'DRAFT',
     orders: {
-      date_issued: '2022-01-01',
-      ordersType: 'PERMANENT_CHANGE_OF_DUTY_STATION',
-      reportByDate: '2022-02-01',
-      originDutyLocation: {
+      issue_date: '2022-01-01',
+      orders_type: 'PERMANENT_CHANGE_OF_DUTY_STATION',
+      report_by_date: '2022-02-01',
+      OriginDutyLocation: {
         name: 'Fort Bragg North Station',
-        address: {
+        Address: {
           streetAddress1: '123 Main Ave',
           streetAddress2: 'Apartment 9000',
           streetAddress3: '',
@@ -89,9 +89,9 @@ describe('MultiMovesMoveInfoList', () => {
           country: 'USA',
         },
       },
-      destinationDutyLocation: {
+      NewDutyLocation: {
         name: 'Fort Bragg North Station',
-        address: {
+        Address: {
           streetAddress1: '123 Main Ave',
           streetAddress2: 'Apartment 9000',
           streetAddress3: '',
@@ -111,13 +111,13 @@ describe('MultiMovesMoveInfoList', () => {
     expect(getByText('DRAFT')).toBeInTheDocument();
 
     expect(getByText('Orders Issue Date')).toBeInTheDocument();
-    expect(getByText('2022-01-01')).toBeInTheDocument();
+    expect(getByText('01 Jan 2022')).toBeInTheDocument();
 
     expect(getByText('Orders Type')).toBeInTheDocument();
-    expect(getByText('SEPARATION')).toBeInTheDocument();
+    expect(getByText('Separation')).toBeInTheDocument();
 
     expect(getByText('Separation Date')).toBeInTheDocument();
-    expect(getByText('2022-02-01')).toBeInTheDocument();
+    expect(getByText('01 Feb 2022')).toBeInTheDocument();
 
     expect(getByText('Current Duty Location')).toBeInTheDocument();
     expect(getByText('HOR or PLEAD')).toBeInTheDocument();
@@ -130,13 +130,13 @@ describe('MultiMovesMoveInfoList', () => {
     expect(getByText('DRAFT')).toBeInTheDocument();
 
     expect(getByText('Orders Issue Date')).toBeInTheDocument();
-    expect(getByText('2022-01-01')).toBeInTheDocument();
+    expect(getByText('01 Jan 2022')).toBeInTheDocument();
 
     expect(getByText('Orders Type')).toBeInTheDocument();
-    expect(getByText('RETIREMENT')).toBeInTheDocument();
+    expect(getByText('Retirement')).toBeInTheDocument();
 
     expect(getByText('Retirement Date')).toBeInTheDocument();
-    expect(getByText('2022-02-01')).toBeInTheDocument();
+    expect(getByText('01 Feb 2022')).toBeInTheDocument();
 
     expect(getByText('Current Duty Location')).toBeInTheDocument();
     expect(getByText('HOR, HOS, or PLEAD')).toBeInTheDocument();
@@ -149,13 +149,13 @@ describe('MultiMovesMoveInfoList', () => {
     expect(getByText('DRAFT')).toBeInTheDocument();
 
     expect(getByText('Orders Issue Date')).toBeInTheDocument();
-    expect(getByText('2022-01-01')).toBeInTheDocument();
+    expect(getByText('01 Jan 2022')).toBeInTheDocument();
 
     expect(getByText('Orders Type')).toBeInTheDocument();
-    expect(getByText('PERMANENT_CHANGE_OF_DUTY_STATION')).toBeInTheDocument();
+    expect(getByText('Permanent Change of Station')).toBeInTheDocument();
 
     expect(getByText('Report by Date')).toBeInTheDocument();
-    expect(getByText('2022-02-01')).toBeInTheDocument();
+    expect(getByText('01 Feb 2022')).toBeInTheDocument();
 
     expect(getByText('Current Duty Location')).toBeInTheDocument();
 

--- a/src/pages/MyMove/Multi-Moves/MultiMovesMoveInfoList/MultiMovesInfoList.test.jsx
+++ b/src/pages/MyMove/Multi-Moves/MultiMovesMoveInfoList/MultiMovesInfoList.test.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { render } from '@testing-library/react';
-import '@testing-library/jest-dom/extend-expect'; // For expect assertions
+import '@testing-library/jest-dom/extend-expect';
 
 import MultiMovesMoveInfoList from './MultiMovesMoveInfoList';
 

--- a/src/pages/MyMove/Multi-Moves/MultiMovesMoveInfoList/MultiMovesMoveInfoList.jsx
+++ b/src/pages/MyMove/Multi-Moves/MultiMovesMoveInfoList/MultiMovesMoveInfoList.jsx
@@ -3,7 +3,7 @@ import React from 'react';
 import styles from './MultiMovesMoveInfoList.module.scss';
 
 import descriptionListStyles from 'styles/descriptionList.module.scss';
-import { formatAddress } from 'utils/shipmentDisplay';
+import { formatDateForDatePicker } from 'shared/dates';
 
 const MultiMovesMoveInfoList = ({ move }) => {
   const { orders } = move;
@@ -19,6 +19,17 @@ const MultiMovesMoveInfoList = ({ move }) => {
     return 'Report by Date';
   };
 
+  // function that determines label based on order type
+  const getOrdersTypeLabel = (ordersType) => {
+    if (ordersType === 'SEPARATION') {
+      return 'Separation';
+    }
+    if (ordersType === 'RETIREMENT') {
+      return 'Retirement';
+    }
+    return 'Permanent Change of Station';
+  };
+
   // destination duty location label will differ based on order type
   const getDestinationDutyLocationLabel = (ordersType) => {
     if (ordersType === 'SEPARATION') {
@@ -28,6 +39,36 @@ const MultiMovesMoveInfoList = ({ move }) => {
       return 'HOR, HOS, or PLEAD';
     }
     return 'Destination Duty Location';
+  };
+
+  const toCamelCase = (str) => {
+    return str.replace(/_([a-z])/g, (match, letter) => letter.toUpperCase());
+  };
+
+  const formatAddress = (address) => {
+    const camelCaseAddress = Object.keys(address).reduce((acc, key) => {
+      acc[toCamelCase(key)] = address[key];
+      return acc;
+    }, {});
+
+    const { streetAddress1, streetAddress2, streetAddress3, city, state, postalCode, id } = camelCaseAddress;
+
+    // Check for empty UUID
+    const isIdEmpty = id === '00000000-0000-0000-0000-000000000000';
+
+    // Check for null values and empty UUID
+    if (isIdEmpty) {
+      return '-';
+    }
+
+    return (
+      <>
+        {streetAddress1 && <>{streetAddress1},&nbsp;</>}
+        {streetAddress2 && <>{streetAddress2},&nbsp;</>}
+        {streetAddress3 && <>{streetAddress3},&nbsp;</>}
+        {city ? `${city}, ${state} ${postalCode}` : postalCode}
+      </>
+    );
   };
 
   return (
@@ -41,27 +82,27 @@ const MultiMovesMoveInfoList = ({ move }) => {
 
           <div className={descriptionListStyles.row}>
             <dt>Orders Issue Date</dt>
-            <dd>{orders.date_issued || '-'}</dd>
+            <dd>{formatDateForDatePicker(orders.issue_date) || '-'}</dd>
           </div>
 
           <div className={descriptionListStyles.row}>
             <dt>Orders Type</dt>
-            <dd>{orders.ordersType || '-'}</dd>
+            <dd>{getOrdersTypeLabel(orders.orders_type) || '-'}</dd>
           </div>
 
           <div className={descriptionListStyles.row}>
             <dt>{getReportByLabel(orders.ordersType)}</dt>
-            <dd>{orders.reportByDate || '-'}</dd>
+            <dd>{formatDateForDatePicker(orders.report_by_date) || '-'}</dd>
           </div>
 
           <div className={descriptionListStyles.row}>
             <dt>Current Duty Location</dt>
-            <dd>{formatAddress(orders.originDutyLocation.address) || '-'}</dd>
+            <dd>{formatAddress(orders.OriginDutyLocation.Address) || '-'}</dd>
           </div>
 
           <div className={descriptionListStyles.row}>
             <dt>{getDestinationDutyLocationLabel(orders.ordersType)}</dt>
-            <dd>{formatAddress(orders.destinationDutyLocation.address) || '-'}</dd>
+            <dd>{formatAddress(orders.NewDutyLocation.Address) || '-'}</dd>
           </div>
         </dl>
       </div>

--- a/src/pages/MyMove/Multi-Moves/MultiMovesMoveInfoList/MultiMovesMoveInfoList.jsx
+++ b/src/pages/MyMove/Multi-Moves/MultiMovesMoveInfoList/MultiMovesMoveInfoList.jsx
@@ -41,6 +41,7 @@ const MultiMovesMoveInfoList = ({ move }) => {
     return 'Destination Duty Location';
   };
 
+  // converts return from API to camelCase to avoid linter errors
   const toCamelCase = (str) => {
     return str.replace(/_([a-z])/g, (match, letter) => letter.toUpperCase());
   };
@@ -53,7 +54,7 @@ const MultiMovesMoveInfoList = ({ move }) => {
 
     const { streetAddress1, streetAddress2, streetAddress3, city, state, postalCode, id } = camelCaseAddress;
 
-    // Check for empty UUID
+    // Check for empty UUID (no address provided)
     const isIdEmpty = id === '00000000-0000-0000-0000-000000000000';
 
     // Check for null values and empty UUID
@@ -91,7 +92,7 @@ const MultiMovesMoveInfoList = ({ move }) => {
           </div>
 
           <div className={descriptionListStyles.row}>
-            <dt>{getReportByLabel(orders.ordersType)}</dt>
+            <dt>{getReportByLabel(orders.orders_type)}</dt>
             <dd>{formatDateForDatePicker(orders.report_by_date) || '-'}</dd>
           </div>
 
@@ -101,7 +102,7 @@ const MultiMovesMoveInfoList = ({ move }) => {
           </div>
 
           <div className={descriptionListStyles.row}>
-            <dt>{getDestinationDutyLocationLabel(orders.ordersType)}</dt>
+            <dt>{getDestinationDutyLocationLabel(orders.orders_type)}</dt>
             <dd>{formatAddress(orders.NewDutyLocation.Address) || '-'}</dd>
           </div>
         </dl>

--- a/src/pages/MyMove/Multi-Moves/MultiMovesTestData.js
+++ b/src/pages/MyMove/Multi-Moves/MultiMovesTestData.js
@@ -7,10 +7,10 @@ export const mockMovesPCS = {
       status: 'DRAFT',
       orders: {
         id: 'testOrder1',
-        destinationDutyLocation: {
+        NewDutyLocation: {
           id: 'testDDL1',
           name: 'Fort Bragg North Station',
-          address: {
+          Address: {
             streetAddress1: '123 Main Ave',
             streetAddress2: 'Apartment 9000',
             streetAddress3: '',
@@ -20,10 +20,10 @@ export const mockMovesPCS = {
             country: 'USA',
           },
         },
-        originDutyLocation: {
+        OriginDutyLocation: {
           id: 'testODL1',
           name: 'Fort Bragg North Station',
-          address: {
+          Address: {
             streetAddress1: '123 Main Ave',
             streetAddress2: 'Apartment 9000',
             streetAddress3: '',
@@ -93,10 +93,10 @@ export const mockMovesPCS = {
       status: 'APPROVED',
       orders: {
         id: 'testOrder2',
-        destinationDutyLocation: {
+        NewDutyLocation: {
           id: 'testDDL2',
           name: 'Fort Bragg South Station',
-          address: {
+          Address: {
             streetAddress1: '456 Oak St',
             streetAddress2: 'Apartment 8000',
             streetAddress3: '',
@@ -106,10 +106,10 @@ export const mockMovesPCS = {
             country: 'USA',
           },
         },
-        originDutyLocation: {
+        OriginDutyLocation: {
           id: 'testODL2',
           name: 'Fort Bragg South Station',
-          address: {
+          Address: {
             streetAddress1: '456 Oak St',
             streetAddress2: 'Apartment 8000',
             streetAddress3: '',
@@ -177,10 +177,10 @@ export const mockMovesPCS = {
       status: 'APPROVED',
       orders: {
         id: 'testOrder3',
-        destinationDutyLocation: {
+        NewDutyLocation: {
           id: 'testDDL3',
           name: 'Fort Bragg East Station',
-          address: {
+          Address: {
             streetAddress1: '789 Pine Ave',
             streetAddress2: 'Apartment 7000',
             streetAddress3: '',
@@ -190,10 +190,10 @@ export const mockMovesPCS = {
             country: 'USA',
           },
         },
-        originDutyLocation: {
+        OriginDutyLocation: {
           id: 'testODL3',
           name: 'Fort Bragg East Station',
-          address: {
+          Address: {
             streetAddress1: '789 Pine Ave',
             streetAddress2: 'Apartment 7000',
             streetAddress3: '',
@@ -266,10 +266,10 @@ export const mockMovesRetirement = {
       status: 'SUBMITTED',
       orders: {
         id: 'testOrder1',
-        destinationDutyLocation: {
+        NewDutyLocation: {
           id: 'testDDL1',
           name: 'Fort Bragg North Station',
-          address: {
+          Address: {
             streetAddress1: '123 Main Ave',
             streetAddress2: 'Apartment 9000',
             streetAddress3: '',
@@ -279,10 +279,10 @@ export const mockMovesRetirement = {
             country: 'USA',
           },
         },
-        originDutyLocation: {
+        OriginDutyLocation: {
           id: 'testODL1',
           name: 'Fort Bragg North Station',
-          address: {
+          Address: {
             streetAddress1: '123 Main Ave',
             streetAddress2: 'Apartment 9000',
             streetAddress3: '',
@@ -352,10 +352,10 @@ export const mockMovesRetirement = {
       status: 'APPROVED',
       orders: {
         id: 'testOrder2',
-        destinationDutyLocation: {
+        NewDutyLocation: {
           id: 'testDDL2',
           name: 'Fort Bragg South Station',
-          address: {
+          Address: {
             streetAddress1: '456 Oak St',
             streetAddress2: 'Apartment 8000',
             streetAddress3: '',
@@ -365,10 +365,10 @@ export const mockMovesRetirement = {
             country: 'USA',
           },
         },
-        originDutyLocation: {
+        OriginDutyLocation: {
           id: 'testODL2',
           name: 'Fort Bragg South Station',
-          address: {
+          Address: {
             streetAddress1: '456 Oak St',
             streetAddress2: 'Apartment 8000',
             streetAddress3: '',
@@ -436,10 +436,10 @@ export const mockMovesRetirement = {
       status: 'APPROVED',
       orders: {
         id: 'testOrder3',
-        destinationDutyLocation: {
+        NewDutyLocation: {
           id: 'testDDL3',
           name: 'Fort Bragg East Station',
-          address: {
+          Address: {
             streetAddress1: '789 Pine Ave',
             streetAddress2: 'Apartment 7000',
             streetAddress3: '',
@@ -449,10 +449,10 @@ export const mockMovesRetirement = {
             country: 'USA',
           },
         },
-        originDutyLocation: {
+        OriginDutyLocation: {
           id: 'testODL3',
           name: 'Fort Bragg East Station',
-          address: {
+          Address: {
             streetAddress1: '789 Pine Ave',
             streetAddress2: 'Apartment 7000',
             streetAddress3: '',
@@ -525,10 +525,10 @@ export const mockMovesSeparation = {
       status: 'DRAFT',
       orders: {
         id: 'testOrder1',
-        destinationDutyLocation: {
+        NewDutyLocation: {
           id: 'testDDL1',
           name: 'Fort Bragg North Station',
-          address: {
+          Address: {
             streetAddress1: '123 Main Ave',
             streetAddress2: 'Apartment 9000',
             streetAddress3: '',
@@ -538,10 +538,10 @@ export const mockMovesSeparation = {
             country: 'USA',
           },
         },
-        originDutyLocation: {
+        OriginDutyLocation: {
           id: 'testODL1',
           name: 'Fort Bragg North Station',
-          address: {
+          Address: {
             streetAddress1: '123 Main Ave',
             streetAddress2: 'Apartment 9000',
             streetAddress3: '',
@@ -611,10 +611,10 @@ export const mockMovesSeparation = {
       status: 'APPROVED',
       orders: {
         id: 'testOrder2',
-        destinationDutyLocation: {
+        NewDutyLocation: {
           id: 'testDDL2',
           name: 'Fort Bragg South Station',
-          address: {
+          Address: {
             streetAddress1: '456 Oak St',
             streetAddress2: 'Apartment 8000',
             streetAddress3: '',
@@ -624,10 +624,10 @@ export const mockMovesSeparation = {
             country: 'USA',
           },
         },
-        originDutyLocation: {
+        OriginDutyLocation: {
           id: 'testODL2',
           name: 'Fort Bragg South Station',
-          address: {
+          Address: {
             streetAddress1: '456 Oak St',
             streetAddress2: 'Apartment 8000',
             streetAddress3: '',
@@ -695,10 +695,10 @@ export const mockMovesSeparation = {
       status: 'APPROVED',
       orders: {
         id: 'testOrder3',
-        destinationDutyLocation: {
+        NewDutyLocation: {
           id: 'testDDL3',
           name: 'Fort Bragg East Station',
-          address: {
+          Address: {
             streetAddress1: '789 Pine Ave',
             streetAddress2: 'Apartment 7000',
             streetAddress3: '',
@@ -708,10 +708,10 @@ export const mockMovesSeparation = {
             country: 'USA',
           },
         },
-        originDutyLocation: {
+        OriginDutyLocation: {
           id: 'testODL3',
           name: 'Fort Bragg East Station',
-          address: {
+          Address: {
             streetAddress1: '789 Pine Ave',
             streetAddress2: 'Apartment 7000',
             streetAddress3: '',
@@ -784,10 +784,10 @@ export const mockMovesNoPreviousMoves = {
       status: 'DRAFT',
       orders: {
         id: 'testOrder1',
-        destinationDutyLocation: {
+        NewDutyLocation: {
           id: 'testDDL1',
           name: 'Fort Bragg North Station',
-          address: {
+          Address: {
             streetAddress1: '123 Main Ave',
             streetAddress2: 'Apartment 9000',
             streetAddress3: '',
@@ -797,10 +797,10 @@ export const mockMovesNoPreviousMoves = {
             country: 'USA',
           },
         },
-        originDutyLocation: {
+        OriginDutyLocation: {
           id: 'testODL1',
           name: 'Fort Bragg North Station',
-          address: {
+          Address: {
             streetAddress1: '123 Main Ave',
             streetAddress2: 'Apartment 9000',
             streetAddress3: '',
@@ -875,10 +875,10 @@ export const mockMovesNoCurrentMoveWithPreviousMoves = {
       status: 'APPROVED',
       orders: {
         id: 'testOrder2',
-        destinationDutyLocation: {
+        NewDutyLocation: {
           id: 'testDDL2',
           name: 'Fort Bragg South Station',
-          address: {
+          Address: {
             streetAddress1: '456 Oak St',
             streetAddress2: 'Apartment 8000',
             streetAddress3: '',
@@ -888,10 +888,10 @@ export const mockMovesNoCurrentMoveWithPreviousMoves = {
             country: 'USA',
           },
         },
-        originDutyLocation: {
+        OriginDutyLocation: {
           id: 'testODL2',
           name: 'Fort Bragg South Station',
-          address: {
+          Address: {
             streetAddress1: '456 Oak St',
             streetAddress2: 'Apartment 8000',
             streetAddress3: '',
@@ -959,10 +959,10 @@ export const mockMovesNoCurrentMoveWithPreviousMoves = {
       status: 'APPROVED',
       orders: {
         id: 'testOrder3',
-        destinationDutyLocation: {
+        NewDutyLocation: {
           id: 'testDDL3',
           name: 'Fort Bragg East Station',
-          address: {
+          Address: {
             streetAddress1: '789 Pine Ave',
             streetAddress2: 'Apartment 7000',
             streetAddress3: '',
@@ -972,10 +972,10 @@ export const mockMovesNoCurrentMoveWithPreviousMoves = {
             country: 'USA',
           },
         },
-        originDutyLocation: {
+        OriginDutyLocation: {
           id: 'testODL3',
           name: 'Fort Bragg East Station',
-          address: {
+          Address: {
             streetAddress1: '789 Pine Ave',
             streetAddress2: 'Apartment 7000',
             streetAddress3: '',

--- a/src/sagas/onboarding.js
+++ b/src/sagas/onboarding.js
@@ -11,7 +11,7 @@ import {
   getLoggedInUser,
   getMTOShipmentsForMove,
   createServiceMember as createServiceMemberApi,
-  getOrdersForServiceMember,
+  getAllMoves,
 } from 'services/internalApi';
 import { addEntities } from 'shared/Entities/actions';
 
@@ -20,7 +20,6 @@ export function* fetchCustomerData() {
   const user = yield call(getLoggedInUser);
   yield put(addEntities(user));
 
-  // TODO - fork/spawn additional API calls
   // Load MTO shipments if there is a move
   const { moves } = user;
   if (moves && Object.keys(moves).length > 0) {
@@ -30,17 +29,12 @@ export function* fetchCustomerData() {
     yield put(addEntities(mtoShipments));
   }
 
-  // if we have user data, we can load multiple move data
-  if (user) {
-    const currentMove = [];
-    const previousMoves = [];
-    const { serviceMembers } = user;
-    const [serviceMemberId] = Object.keys(serviceMembers);
-    const currentMoveData = yield call(getOrdersForServiceMember, serviceMemberId);
-    currentMove.push(currentMoveData);
-    const serviceMemberMoves = { currentMove: currentMoveData, previousMoves };
-    yield put(addEntities({ serviceMemberMoves }));
-  }
+  // loading serviceMemberMoves for the user
+  const { serviceMembers } = user;
+  const key = Object.keys(serviceMembers)[0];
+  const serviceMemberId = serviceMembers[key].id;
+  const allMoves = yield call(getAllMoves, serviceMemberId);
+  yield put(addEntities({ serviceMemberMoves: allMoves }));
 
   return user;
 }

--- a/src/sagas/onboarding.js
+++ b/src/sagas/onboarding.js
@@ -11,6 +11,7 @@ import {
   getLoggedInUser,
   getMTOShipmentsForMove,
   createServiceMember as createServiceMemberApi,
+  getOrdersForServiceMember,
 } from 'services/internalApi';
 import { addEntities } from 'shared/Entities/actions';
 
@@ -27,6 +28,18 @@ export function* fetchCustomerData() {
     // User has a move, load MTO shipments & store in entities
     const mtoShipments = yield call(getMTOShipmentsForMove, moveId);
     yield put(addEntities(mtoShipments));
+  }
+
+  // if we have user data, we can load multiple move data
+  if (user) {
+    const currentMove = [];
+    const previousMoves = [];
+    const { serviceMembers } = user;
+    const [serviceMemberId] = Object.keys(serviceMembers);
+    const currentMoveData = yield call(getOrdersForServiceMember, serviceMemberId);
+    currentMove.push(currentMoveData);
+    const serviceMemberMoves = { currentMove: currentMoveData, previousMoves };
+    yield put(addEntities({ serviceMemberMoves }));
   }
 
   return user;

--- a/src/sagas/onboarding.test.js
+++ b/src/sagas/onboarding.test.js
@@ -19,6 +19,7 @@ import {
   getLoggedInUser,
   createServiceMember as createServiceMemberApi,
   getMTOShipmentsForMove,
+  getAllMoves,
 } from 'services/internalApi';
 import { addEntities } from 'shared/Entities/actions';
 
@@ -53,6 +54,15 @@ describe('fetchCustomerData', () => {
           email: 'testuser@example.com',
         },
       },
+      serviceMembers: {
+        serviceMemberId: {
+          id: 'serviceMemberId',
+        },
+      },
+    };
+    const mockMultipleMoveResponseData = {
+      currentMove: [],
+      previousMoves: [],
     };
 
     it('makes an API call to request the logged in user', () => {
@@ -61,6 +71,20 @@ describe('fetchCustomerData', () => {
 
     it('stores the user data in entities', () => {
       expect(generator.next(mockResponseData).value).toEqual(put(addEntities(mockResponseData)));
+    });
+
+    it('makes an API call to request multiple moves', () => {
+      expect(generator.next().value).toEqual(call(getAllMoves, 'serviceMemberId'));
+    });
+
+    it('stores the multiple move data in entities', () => {
+      expect(generator.next(mockMultipleMoveResponseData).value).toEqual(
+        put(
+          addEntities({
+            serviceMemberMoves: mockMultipleMoveResponseData,
+          }),
+        ),
+      );
     });
 
     it('yields the user data to the caller', () => {
@@ -82,10 +106,19 @@ describe('fetchCustomerData', () => {
           email: 'testuser@example.com',
         },
       },
+      serviceMembers: {
+        serviceMemberId: {
+          id: 'serviceMemberId',
+        },
+      },
       moves: {
         testMoveId: {
           id: 'testMoveId',
         },
+      },
+      serviceMemberMoves: {
+        currentMove: [],
+        previousMoves: [],
       },
     };
 
@@ -95,6 +128,11 @@ describe('fetchCustomerData', () => {
           id: 'testMTOShipmentId',
         },
       },
+    };
+
+    const mockMultipleMoveResponseData = {
+      currentMove: [],
+      previousMoves: [],
     };
 
     it('makes an API call to request the logged in user', () => {
@@ -111,6 +149,20 @@ describe('fetchCustomerData', () => {
 
     it('stores the MTO shipment data in entities', () => {
       expect(generator.next(mockMTOResponseData).value).toEqual(put(addEntities(mockMTOResponseData)));
+    });
+
+    it('makes an API call to request multiple moves', () => {
+      expect(generator.next().value).toEqual(call(getAllMoves, 'serviceMemberId'));
+    });
+
+    it('stores the multiple move data in entities', () => {
+      expect(generator.next(mockMultipleMoveResponseData).value).toEqual(
+        put(
+          addEntities({
+            serviceMemberMoves: mockMultipleMoveResponseData,
+          }),
+        ),
+      );
     });
 
     it('yields the user data to the caller', () => {

--- a/src/services/internalApi.js
+++ b/src/services/internalApi.js
@@ -239,6 +239,18 @@ export async function deleteUpload(uploadId) {
 }
 
 /** MOVES */
+export async function getAllMoves(serviceMemberId) {
+  return makeInternalRequest(
+    'moves.getAllMoves',
+    {
+      serviceMemberId,
+    },
+    {
+      normalize: false,
+    },
+  );
+}
+
 export async function getMove(moveId) {
   return makeInternalRequest(
     'moves.showMove',

--- a/src/shared/Entities/modules/moves.js
+++ b/src/shared/Entities/modules/moves.js
@@ -18,6 +18,7 @@ const cancelMoveLabel = 'Moves.CancelMove';
 export const loadMoveLabel = 'Moves.loadMove';
 export const getMoveDatesSummaryLabel = 'Moves.getMoveDatesSummary';
 export const getMoveByLocatorOperation = 'move.getMove';
+export const getAllMovesLabel = 'move.getAllMoves';
 
 export default function reducer(state = {}, action) {
   switch (action.type) {
@@ -30,6 +31,11 @@ export default function reducer(state = {}, action) {
     default:
       return state;
   }
+}
+
+export function getAllMoves(serviceMemberId, label = getAllMovesLabel) {
+  const swaggerTag = 'moves.getAllMoves';
+  return swaggerRequest(getClient, swaggerTag, { serviceMemberId }, { label });
 }
 
 export function getMoveByLocator(locator, label = getMoveByLocatorOperation) {

--- a/src/shared/Entities/modules/oktaUser.js
+++ b/src/shared/Entities/modules/oktaUser.js
@@ -10,7 +10,5 @@ export function getOktaUser() {
 
 // load Okta user
 export function selectOktaUser(state) {
-  // console.log('loading from entities', state);
-
   return get(state, `entities.oktaUser`);
 }

--- a/src/shared/Entities/reducer.js
+++ b/src/shared/Entities/reducer.js
@@ -45,6 +45,7 @@ const initialState = {
   personallyProcuredMoves: {},
   mtoShipments: {},
   reimbursements: {},
+  serviceMemberMoves: {},
   signedCertifications: {},
   oktaUser: {},
 };
@@ -77,5 +78,6 @@ export function entitiesReducer(state = initialState, action) {
       oktaUser: action.oktaUser || {},
     };
   }
+
   return state;
 }

--- a/src/shared/Entities/schema.js
+++ b/src/shared/Entities/schema.js
@@ -42,6 +42,14 @@ export const move = new schema.Entity('moves', {
 });
 export const moves = new schema.Array(move);
 
+export const currentMove = new schema.Array(move);
+export const previousMoves = new schema.Array(move);
+
+export const multiMoves = new schema.Entity('multiMoves', {
+  currentMove: currentMove,
+  previousMoves: previousMoves,
+});
+
 // Orders
 
 export const order = new schema.Entity('orders');

--- a/src/store/entities/selectors.js
+++ b/src/store/entities/selectors.js
@@ -145,6 +145,11 @@ export const selectCurrentMove = (state) => {
   return activeMove || moves[0] || null;
 };
 
+export const selectAllMoves = (state) => {
+  if (state.entities.serviceMemberMoves) return state.entities.serviceMemberMoves;
+  return { currentMove: [], previousMoves: [] };
+};
+
 export const selectMoveIsApproved = createSelector(selectCurrentMove, (move) => move?.status === 'APPROVED');
 
 export const selectMoveIsInDraft = createSelector(selectCurrentMove, (move) => move?.status === MOVE_STATUSES.DRAFT);

--- a/swagger-def/internal.yaml
+++ b/swagger-def/internal.yaml
@@ -2411,6 +2411,9 @@ definitions:
         type: string
       orders:
         type: object
+      status:
+        type: string
+        readOnly: true
       updatedAt:
         format: date-time
         type: string

--- a/swagger/internal.yaml
+++ b/swagger/internal.yaml
@@ -2444,6 +2444,9 @@ definitions:
         type: string
       orders:
         type: object
+      status:
+        type: string
+        readOnly: true
       updatedAt:
         format: date-time
         type: string


### PR DESCRIPTION
[INTEGRATION PR](https://github.com/transcom/mymove/pull/11897)

***NOTE*** 
Merge after https://github.com/transcom/mymove/pull/12041

## [Agility ticket](https://www13.v1host.com/USTRANSCOM38/story.mvc/Summary?oidToken=Story%3a873920)

## Summary

As we transition to multiple moves and integrating the new multiple move landing page, we need to stop using test data and use the user's actual data returned from the recently implemented [`getAllMoves` API endpoint ](https://github.com/transcom/mymove/pull/11866). 

This PR does the following:
- adds a small enhancement to return the move status & origin address from the backend
- removed dummy test data being used
- implemented redux into `MultiMovesLandingPage` and added appropriate wrappers
- using `serviceMember` data to populate first name & last name
- updated helper text box that is based on if the user has previous moves or not
- updated null value handling when generating components (async issues were causing some errors)
- updated values used in components to match what is being sent from API endpoint
- updated `onboarding.js` to add `serviceMemberMoves` to state on load
- updated all relevant tests

### How to test

1. Access MM as a customer
2. Log in and you should see the multi-move dashboard
3. The data displayed to you should be accurate and relevant to the user that you are signed in as
4. Expand the move container to show shipments (if any) - if not, you should see "no shipments in move yet"

![Screenshot 2024-02-02 at 9 04 46 AM](https://github.com/transcom/mymove/assets/136510600/93478050-4ef0-4b8e-8638-9da130d9faf1)