### PR TITLE
MAIN B-18313 Multi-Moves Profile Validation & Create a Move Btn Functionality

### DIFF
--- a/src/components/Customer/Profile/ContactInfoDisplay/ContactInfoDisplay.jsx
+++ b/src/components/Customer/Profile/ContactInfoDisplay/ContactInfoDisplay.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Link } from 'react-router-dom';
+import { Link, useLocation } from 'react-router-dom';
 
 import styles from './ContactInfoDisplay.module.scss';
 
@@ -28,11 +28,15 @@ const ContactInfoDisplay = ({
     preferredContactMethod = 'Email';
   }
 
+  const { state } = useLocation();
+
   return (
     <div className={styles.contactInfoContainer}>
       <div className={styles.contactInfoHeader}>
         <h2>Contact info</h2>
-        <Link to={editURL}>Edit</Link>
+        <Link to={editURL} state={state}>
+          Edit
+        </Link>
       </div>
 
       <div className={styles.contactInfoSection}>

--- a/src/components/Customer/Profile/OktaInfoDisplay/OktaInfoDisplay.jsx
+++ b/src/components/Customer/Profile/OktaInfoDisplay/OktaInfoDisplay.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { string, PropTypes } from 'prop-types';
-import { Link } from 'react-router-dom';
+import { Link, useLocation } from 'react-router-dom';
 
 import oktaLogo from '../../../../shared/images/okta_logo.png';
 
@@ -9,11 +9,13 @@ import oktaInfoDisplayStyles from './OktaInfoDisplay.module.scss';
 import descriptionListStyles from 'styles/descriptionList.module.scss';
 
 const OktaInfoDisplay = ({ editURL, oktaUsername, oktaEmail, oktaFirstName, oktaLastName, oktaEdipi }) => {
+  const { state } = useLocation();
+
   return (
     <div className={oktaInfoDisplayStyles.serviceInfoContainer}>
       <div className={oktaInfoDisplayStyles.header}>
         <img className={oktaInfoDisplayStyles.oktaLogo} src={oktaLogo} alt="Okta logo" />
-        <Link className={oktaInfoDisplayStyles.oktaEditLink} to={editURL}>
+        <Link className={oktaInfoDisplayStyles.oktaEditLink} to={editURL} state={state}>
           Edit
         </Link>
       </div>

--- a/src/components/Customer/Review/ServiceInfoDisplay/ServiceInfoDisplay.jsx
+++ b/src/components/Customer/Review/ServiceInfoDisplay/ServiceInfoDisplay.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { string, bool } from 'prop-types';
-import { Link } from 'react-router-dom';
+import { Link, useLocation } from 'react-router-dom';
 
 import serviceInfoDisplayStyles from './ServiceInfoDisplay.module.scss';
 
@@ -19,11 +19,17 @@ const ServiceInfoDisplay = ({
   editURL,
   payGrade,
 }) => {
+  const { state } = useLocation();
+
   return (
     <div className={serviceInfoDisplayStyles.serviceInfoContainer}>
       <div className={serviceInfoDisplayStyles.header}>
         <h2>Service info</h2>
-        {isEditable && <Link to={editURL}>Edit</Link>}
+        {isEditable && (
+          <Link to={editURL} state={state}>
+            Edit
+          </Link>
+        )}
       </div>
       {!isEditable && showMessage && (
         <div className={serviceInfoDisplayStyles.whoToContactContainer}>

--- a/src/pages/MyMove/Multi-Moves/MultiMovesLandingPage.jsx
+++ b/src/pages/MyMove/Multi-Moves/MultiMovesLandingPage.jsx
@@ -1,6 +1,8 @@
 import React, { useEffect, useState } from 'react';
 import { Button } from '@trussworks/react-uswds';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { useNavigate } from 'react-router';
+import { connect } from 'react-redux';
 
 import styles from './MultiMovesLandingPage.module.scss';
 import MultiMovesMoveHeader from './MultiMovesMoveHeader/MultiMovesMoveHeader';
@@ -14,6 +16,7 @@ import {
   mockMovesNoCurrentOrPreviousMoves,
 } from './MultiMovesTestData';
 
+import { detectFlags } from 'utils/featureFlags';
 import { generatePageTitle } from 'hooks/custom';
 import { milmoveLogger } from 'utils/milmoveLog';
 import retryPageLoading from 'utils/retryPageLoading';
@@ -21,9 +24,20 @@ import { loadInternalSchema } from 'shared/Swagger/ducks';
 import { loadUser } from 'store/auth/actions';
 import { initOnboarding } from 'store/onboarding/actions';
 import Helper from 'components/Customer/Home/Helper';
+import { customerRoutes } from 'constants/routes';
+import { withContext } from 'shared/AppContext';
+import withRouter from 'utils/routing';
+import requireCustomerState from 'containers/requireCustomerState/requireCustomerState';
+import {
+  selectCurrentMove,
+  selectIsProfileComplete,
+  selectServiceMemberFromLoggedInUser,
+} from 'store/entities/selectors';
 
 const MultiMovesLandingPage = () => {
   const [setErrorState] = useState({ hasError: false, error: undefined, info: undefined });
+  const navigate = useNavigate();
+
   // ! This is just used for testing and viewing different variations of data that MilMove will use
   // user can add params of ?moveData=PCS, etc to view different views
   let moves;
@@ -53,7 +67,6 @@ const MultiMovesLandingPage = () => {
       break;
   }
   // ! end of test data
-
   useEffect(() => {
     const fetchData = async () => {
       try {
@@ -81,7 +94,22 @@ const MultiMovesLandingPage = () => {
     fetchData();
   }, [setErrorState]);
 
-  return (
+  const flags = detectFlags(process.env.NODE_ENV, window.location.host, window.location.search);
+
+  // handles logic when user clicks "Create a Move" button
+  // if they have previous moves, they'll need to validate their profile
+  // if they do not have previous moves, then they don't need to validate
+  const handleCreateMoveBtnClick = () => {
+    if (moves.previousMoves.length > 0) {
+      const profileEditPath = customerRoutes.PROFILE_PATH;
+      navigate(profileEditPath, { state: { needsToVerifyProfile: true } });
+    } else {
+      navigate(customerRoutes.MOVE_HOME_PAGE);
+    }
+  };
+
+  // ! WILL ONLY SHOW IF MULTIMOVE FLAG IS TRUE
+  return flags.multiMove ? (
     <div>
       <div className={styles.homeContainer}>
         <header data-testid="customerHeader" className={styles.customerHeader}>
@@ -91,13 +119,13 @@ const MultiMovesLandingPage = () => {
         </header>
         <div className={`usa-prose grid-container ${styles['grid-container']}`}>
           <Helper title="Welcome to MilMove!" className={styles['helper-paragraph-only']}>
-            <p>
+            <p data-testid="welcomeHeader">
               We can put information at the top here - potentially important contact info or basic instructions on how
               to start a move?
             </p>
           </Helper>
           <div className={styles.centeredContainer}>
-            <Button className={styles.createMoveBtn}>
+            <Button className={styles.createMoveBtn} onClick={handleCreateMoveBtnClick} data-testid="createMoveBtn">
               <span>Create a Move</span>
               <div>
                 <FontAwesomeIcon icon="plus" />
@@ -143,7 +171,31 @@ const MultiMovesLandingPage = () => {
         </div>
       </div>
     </div>
-  );
+  ) : null;
 };
 
-export default MultiMovesLandingPage;
+MultiMovesLandingPage.defaultProps = {
+  serviceMember: null,
+};
+
+const mapStateToProps = (state) => {
+  const serviceMember = selectServiceMemberFromLoggedInUser(state);
+  const move = selectCurrentMove(state) || {};
+
+  return {
+    isProfileComplete: selectIsProfileComplete(state),
+    serviceMember,
+    move,
+  };
+};
+
+// in order to avoid setting up proxy server only for storybook, pass in stub function so API requests don't fail
+const mergeProps = (stateProps, dispatchProps, ownProps) => ({
+  ...stateProps,
+  ...dispatchProps,
+  ...ownProps,
+});
+
+export default withContext(
+  withRouter(connect(mapStateToProps, mergeProps)(requireCustomerState(MultiMovesLandingPage))),
+);

--- a/src/pages/MyMove/Multi-Moves/MultiMovesLandingPage.test.jsx
+++ b/src/pages/MyMove/Multi-Moves/MultiMovesLandingPage.test.jsx
@@ -1,8 +1,13 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
+import { v4 } from 'uuid';
 
-import '@testing-library/jest-dom/extend-expect'; // For additional matchers like toBeInTheDocument
+import '@testing-library/jest-dom/extend-expect';
+
 import MultiMovesLandingPage from './MultiMovesLandingPage';
+
+import { MockProviders } from 'testUtils';
+import { MOVE_STATUSES } from 'shared/constants';
 
 // Mock external dependencies
 jest.mock('utils/featureFlags', () => ({
@@ -21,12 +26,50 @@ jest.mock('shared/Swagger/ducks', () => ({
   loadInternalSchema: jest.fn(),
 }));
 
+const defaultProps = {
+  serviceMember: {
+    id: v4(),
+    current_location: {
+      transportation_office: {
+        name: 'Test Transportation Office Name',
+        phone_lines: ['555-555-5555'],
+      },
+    },
+    weight_allotment: {
+      total_weight_self: 8000,
+      total_weight_self_plus_dependents: 11000,
+    },
+  },
+  showLoggedInUser: jest.fn(),
+  createServiceMember: jest.fn(),
+  getSignedCertification: jest.fn(),
+  mtoShipments: [],
+  mtoShipment: {},
+  isLoggedIn: true,
+  loggedInUserIsLoading: false,
+  loggedInUserSuccess: true,
+  isProfileComplete: true,
+  loadMTOShipments: jest.fn(),
+  updateShipmentList: jest.fn(),
+  move: {
+    id: v4(),
+    status: MOVE_STATUSES.DRAFT,
+  },
+  uploadedOrderDocuments: [],
+  uploadedAmendedOrderDocuments: [],
+};
+
 describe('MultiMovesLandingPage', () => {
-  it('renders the component with retirement moves', () => {
-    render(<MultiMovesLandingPage />);
+  it('renders the component with moves', () => {
+    render(
+      <MockProviders>
+        <MultiMovesLandingPage {...defaultProps} />
+      </MockProviders>,
+    );
 
     // Check for specific elements
     expect(screen.getByTestId('customerHeader')).toBeInTheDocument();
+    expect(screen.getByTestId('welcomeHeader')).toBeInTheDocument();
     expect(screen.getByText('First Last')).toBeInTheDocument();
     expect(screen.getByText('Welcome to MilMove!')).toBeInTheDocument();
     expect(screen.getByText('Create a Move')).toBeInTheDocument();
@@ -37,7 +80,11 @@ describe('MultiMovesLandingPage', () => {
   });
 
   it('renders move data correctly', () => {
-    render(<MultiMovesLandingPage />);
+    render(
+      <MockProviders>
+        <MultiMovesLandingPage />
+      </MockProviders>,
+    );
 
     expect(screen.getByTestId('currentMoveHeader')).toBeInTheDocument();
     expect(screen.getByTestId('currentMoveContainer')).toBeInTheDocument();

--- a/src/pages/MyMove/Multi-Moves/MultiMovesMoveContainer/MultiMovesMoveContainer.jsx
+++ b/src/pages/MyMove/Multi-Moves/MultiMovesMoveContainer/MultiMovesMoveContainer.jsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import classnames from 'classnames';
 import { Button } from '@trussworks/react-uswds';
+import { useNavigate } from 'react-router';
 
 import MultiMovesMoveInfoList from '../MultiMovesMoveInfoList/MultiMovesMoveInfoList';
 import ButtonDropdownMenu from '../../../../components/ButtonDropdownMenu/ButtonDropdownMenu';
@@ -9,9 +10,11 @@ import ButtonDropdownMenu from '../../../../components/ButtonDropdownMenu/Button
 import styles from './MultiMovesMoveContainer.module.scss';
 
 import ShipmentContainer from 'components/Office/ShipmentContainer/ShipmentContainer';
+import { customerRoutes } from 'constants/routes';
 
 const MultiMovesMoveContainer = ({ moves }) => {
   const [expandedMoves, setExpandedMoves] = useState({});
+  const navigate = useNavigate();
 
   // this expands the moves when the arrow is clicked
   const handleExpandClick = (index) => {
@@ -63,13 +66,24 @@ const MultiMovesMoveContainer = ({ moves }) => {
     return 'Shipment';
   };
 
+  // sends user to the move page when clicking "Go to Move" btn
+  const handleGoToMoveClick = () => {
+    navigate(customerRoutes.MOVE_HOME_PAGE);
+  };
+
   const moveList = moves.map((m, index) => (
     <React.Fragment key={index}>
       <div className={styles.moveContainer}>
         <div className={styles.heading} key={index}>
           <h3>#{m.moveCode}</h3>
           {m.status !== 'APPROVED' ? (
-            <Button className={styles.goToMoveBtn} secondary outline>
+            <Button
+              data-testid="goToMoveBtn"
+              className={styles.goToMoveBtn}
+              secondary
+              outline
+              onClick={handleGoToMoveClick}
+            >
               Go to Move
             </Button>
           ) : (

--- a/src/pages/MyMove/Multi-Moves/MultiMovesMoveContainer/MultiMovesMoveContainer.stories.jsx
+++ b/src/pages/MyMove/Multi-Moves/MultiMovesMoveContainer/MultiMovesMoveContainer.stories.jsx
@@ -4,18 +4,44 @@ import { mockMovesPCS, mockMovesRetirement, mockMovesSeparation } from '../Multi
 
 import MultiMovesMoveContainer from './MultiMovesMoveContainer';
 
+import { MockProviders } from 'testUtils';
+
 export default {
   title: 'Customer Components / MultiMovesContainer',
 };
 
-export const PCSCurrentMove = () => <MultiMovesMoveContainer moves={mockMovesPCS.currentMove} />;
+export const PCSCurrentMove = () => (
+  <MockProviders>
+    <MultiMovesMoveContainer moves={mockMovesPCS.currentMove} />
+  </MockProviders>
+);
 
-export const PCSPreviousMoves = () => <MultiMovesMoveContainer moves={mockMovesPCS.previousMoves} />;
+export const PCSPreviousMoves = () => (
+  <MockProviders>
+    <MultiMovesMoveContainer moves={mockMovesPCS.previousMoves} />
+  </MockProviders>
+);
 
-export const RetirementCurrentMove = () => <MultiMovesMoveContainer moves={mockMovesRetirement.currentMove} />;
+export const RetirementCurrentMove = () => (
+  <MockProviders>
+    <MultiMovesMoveContainer moves={mockMovesRetirement.currentMove} />
+  </MockProviders>
+);
 
-export const RetirementPreviousMoves = () => <MultiMovesMoveContainer moves={mockMovesRetirement.previousMoves} />;
+export const RetirementPreviousMoves = () => (
+  <MockProviders>
+    <MultiMovesMoveContainer moves={mockMovesRetirement.previousMoves} />
+  </MockProviders>
+);
 
-export const SeparationCurrentMove = () => <MultiMovesMoveContainer moves={mockMovesSeparation.currentMove} />;
+export const SeparationCurrentMove = () => (
+  <MockProviders>
+    <MultiMovesMoveContainer moves={mockMovesSeparation.currentMove} />
+  </MockProviders>
+);
 
-export const SeparationPreviousMoves = () => <MultiMovesMoveContainer moves={mockMovesSeparation.previousMoves} />;
+export const SeparationPreviousMoves = () => (
+  <MockProviders>
+    <MultiMovesMoveContainer moves={mockMovesSeparation.previousMoves} />
+  </MockProviders>
+);

--- a/src/pages/MyMove/Multi-Moves/MultiMovesMoveContainer/MultiMovesMoveContainer.test.jsx
+++ b/src/pages/MyMove/Multi-Moves/MultiMovesMoveContainer/MultiMovesMoveContainer.test.jsx
@@ -6,12 +6,18 @@ import { mockMovesPCS } from '../MultiMovesTestData';
 
 import MultiMovesMoveContainer from './MultiMovesMoveContainer';
 
+import { MockProviders } from 'testUtils';
+
 describe('MultiMovesMoveContainer', () => {
   const mockCurrentMoves = mockMovesPCS.currentMove;
   const mockPreviousMoves = mockMovesPCS.previousMoves;
 
   it('renders current move list correctly', () => {
-    render(<MultiMovesMoveContainer moves={mockCurrentMoves} />);
+    render(
+      <MockProviders>
+        <MultiMovesMoveContainer moves={mockCurrentMoves} />
+      </MockProviders>,
+    );
 
     expect(screen.getByTestId('move-info-container')).toBeInTheDocument();
     expect(screen.getByText('#MOVECO')).toBeInTheDocument();
@@ -19,7 +25,11 @@ describe('MultiMovesMoveContainer', () => {
   });
 
   it('renders previous move list correctly', () => {
-    render(<MultiMovesMoveContainer moves={mockPreviousMoves} />);
+    render(
+      <MockProviders>
+        <MultiMovesMoveContainer moves={mockPreviousMoves} />
+      </MockProviders>,
+    );
 
     expect(screen.queryByText('#SAMPLE')).toBeInTheDocument();
     expect(screen.queryByText('#EXAMPL')).toBeInTheDocument();
@@ -27,7 +37,11 @@ describe('MultiMovesMoveContainer', () => {
   });
 
   it('expands and collapses moves correctly', () => {
-    render(<MultiMovesMoveContainer moves={mockCurrentMoves} />);
+    render(
+      <MockProviders>
+        <MultiMovesMoveContainer moves={mockCurrentMoves} />
+      </MockProviders>,
+    );
 
     // Initially, the move details should not be visible
     expect(screen.queryByText('Shipment')).not.toBeInTheDocument();

--- a/src/pages/MyMove/Multi-Moves/MultiMovesMoveInfoList/MultiMovesInfoList.test.jsx
+++ b/src/pages/MyMove/Multi-Moves/MultiMovesMoveInfoList/MultiMovesInfoList.test.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { render } from '@testing-library/react';
-import '@testing-library/jest-dom/extend-expect'; // For expect assertions
+import '@testing-library/jest-dom/extend-expect';
 
 import MultiMovesMoveInfoList from './MultiMovesMoveInfoList';
 

--- a/src/pages/MyMove/Profile/EditContactInfo.jsx
+++ b/src/pages/MyMove/Profile/EditContactInfo.jsx
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import React, { useState } from 'react';
 import { connect } from 'react-redux';
-import { useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 import { Alert, Grid, GridContainer } from '@trussworks/react-uswds';
 
 import EditContactInfoForm, {
@@ -28,6 +28,7 @@ export const EditContactInfo = ({
   updateServiceMember,
 }) => {
   const navigate = useNavigate();
+  const { state } = useLocation();
   const [serverError, setServerError] = useState(null);
 
   const initialValues = {
@@ -58,7 +59,7 @@ export const EditContactInfo = ({
   };
 
   const handleCancel = () => {
-    navigate(customerRoutes.PROFILE_PATH);
+    navigate(customerRoutes.PROFILE_PATH, { state });
   };
 
   const handleSubmit = async (values) => {
@@ -117,11 +118,9 @@ export const EditContactInfo = ({
       .then(updateServiceMember)
       .then(() => {
         setFlashMessage('EDIT_CONTACT_INFO_SUCCESS', 'success', "You've updated your information.");
-        navigate(customerRoutes.PROFILE_PATH);
+        navigate(customerRoutes.PROFILE_PATH, { state });
       })
       .catch((e) => {
-        //     // TODO - error handling - below is rudimentary error handling to approximate existing UX
-        //     // Error shape: https://github.com/swagger-api/swagger-js/blob/master/docs/usage/http-client.md#errors
         const { response } = e;
         const errorMessage = getResponseError(response, 'Failed to update service member due to server error');
 

--- a/src/pages/MyMove/Profile/EditContactInfo.test.jsx
+++ b/src/pages/MyMove/Profile/EditContactInfo.test.jsx
@@ -6,6 +6,7 @@ import { EditContactInfo } from './EditContactInfo';
 
 import { patchBackupContact, patchServiceMember } from 'services/internalApi';
 import { customerRoutes } from 'constants/routes';
+import { MockProviders } from 'testUtils';
 
 const mockNavigate = jest.fn();
 jest.mock('react-router-dom', () => ({
@@ -62,7 +63,11 @@ describe('EditContactInfo page', () => {
   };
 
   it('renders the EditContactInfo form', async () => {
-    render(<EditContactInfo {...testProps} />);
+    render(
+      <MockProviders>
+        <EditContactInfo {...testProps} />
+      </MockProviders>,
+    );
 
     const h1 = await screen.findByRole('heading', { name: 'Edit contact info', level: 1 });
     expect(h1).toBeInTheDocument();
@@ -81,13 +86,17 @@ describe('EditContactInfo page', () => {
   });
 
   it('goes back to the profile page when the cancel button is clicked', async () => {
-    render(<EditContactInfo {...testProps} />);
+    render(
+      <MockProviders>
+        <EditContactInfo {...testProps} />
+      </MockProviders>,
+    );
 
     const cancelButton = await screen.findByRole('button', { name: 'Cancel' });
 
     await userEvent.click(cancelButton);
 
-    expect(mockNavigate).toHaveBeenCalledWith(customerRoutes.PROFILE_PATH);
+    expect(mockNavigate).toHaveBeenCalledWith(customerRoutes.PROFILE_PATH, { state: null });
   });
 
   it('saves backup contact info when it is updated and the save button is clicked', async () => {
@@ -105,7 +114,11 @@ describe('EditContactInfo page', () => {
     patchBackupContact.mockImplementation(() => Promise.resolve(patchResponse));
     patchServiceMember.mockImplementation(() => Promise.resolve());
 
-    render(<EditContactInfo {...testProps} />);
+    render(
+      <MockProviders>
+        <EditContactInfo {...testProps} />
+      </MockProviders>,
+    );
 
     const backupNameInput = await screen.findByLabelText('Name');
 
@@ -138,7 +151,11 @@ describe('EditContactInfo page', () => {
       }),
     );
 
-    render(<EditContactInfo {...testProps} />);
+    render(
+      <MockProviders>
+        <EditContactInfo {...testProps} />
+      </MockProviders>,
+    );
 
     const backupNameInput = await screen.findByLabelText('Name');
 
@@ -165,7 +182,11 @@ describe('EditContactInfo page', () => {
   it('does not save backup contact info if it is not updated and the save button is clicked', async () => {
     patchServiceMember.mockImplementation(() => Promise.resolve());
 
-    render(<EditContactInfo {...testProps} />);
+    render(
+      <MockProviders>
+        <EditContactInfo {...testProps} />
+      </MockProviders>,
+    );
 
     const saveButton = screen.getByRole('button', { name: 'Save' });
 
@@ -191,7 +212,11 @@ describe('EditContactInfo page', () => {
 
     patchServiceMember.mockImplementation(() => Promise.resolve(patchResponse));
 
-    render(<EditContactInfo {...testProps} />);
+    render(
+      <MockProviders>
+        <EditContactInfo {...testProps} />
+      </MockProviders>,
+    );
 
     const secondaryPhoneInput = await screen.findByLabelText(/Alt. phone/);
 
@@ -213,7 +238,11 @@ describe('EditContactInfo page', () => {
   it('sets a flash message when the save button is clicked', async () => {
     patchServiceMember.mockImplementation(() => Promise.resolve());
 
-    render(<EditContactInfo {...testProps} />);
+    render(
+      <MockProviders>
+        <EditContactInfo {...testProps} />
+      </MockProviders>,
+    );
 
     const saveButton = screen.getByRole('button', { name: 'Save' });
 
@@ -231,14 +260,36 @@ describe('EditContactInfo page', () => {
   it('routes to the profile page when the save button is clicked', async () => {
     patchServiceMember.mockImplementation(() => Promise.resolve());
 
-    render(<EditContactInfo {...testProps} />);
+    render(
+      <MockProviders>
+        <EditContactInfo {...testProps} />
+      </MockProviders>,
+    );
 
     const saveButton = screen.getByRole('button', { name: 'Save' });
 
     await userEvent.click(saveButton);
 
     await waitFor(() => {
-      expect(mockNavigate).toHaveBeenCalledWith(customerRoutes.PROFILE_PATH);
+      expect(mockNavigate).toHaveBeenCalledWith(customerRoutes.PROFILE_PATH, { state: null });
+    });
+  });
+
+  it('routes to the profile page when the cancel button is clicked', async () => {
+    patchServiceMember.mockImplementation(() => Promise.resolve());
+
+    render(
+      <MockProviders>
+        <EditContactInfo {...testProps} />
+      </MockProviders>,
+    );
+
+    const cancelButton = screen.getByRole('button', { name: 'Cancel' });
+
+    await userEvent.click(cancelButton);
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith(customerRoutes.PROFILE_PATH, { state: null });
     });
   });
 
@@ -256,7 +307,11 @@ describe('EditContactInfo page', () => {
       }),
     );
 
-    render(<EditContactInfo {...testProps} />);
+    render(
+      <MockProviders>
+        <EditContactInfo {...testProps} />
+      </MockProviders>,
+    );
 
     const saveButton = screen.getByRole('button', { name: 'Save' });
 

--- a/src/pages/MyMove/Profile/EditOktaInfo.jsx
+++ b/src/pages/MyMove/Profile/EditOktaInfo.jsx
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import React, { useState } from 'react';
 import { connect } from 'react-redux';
-import { useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 import { Alert, Grid, GridContainer } from '@trussworks/react-uswds';
 
 import { OktaUserInfoShape } from 'types/user';
@@ -15,6 +15,7 @@ import { setFlashMessage as setFlashMessageAction } from 'store/flash/actions';
 
 export const EditOktaInfo = ({ serviceMember, setFlashMessage, oktaUser, updateOktaUserState }) => {
   const navigate = useNavigate();
+  const { state } = useLocation();
   const [serverError, setServerError] = useState(null);
   const [noChangeError, setNoChangeError] = useState(null);
 
@@ -28,7 +29,7 @@ export const EditOktaInfo = ({ serviceMember, setFlashMessage, oktaUser, updateO
   };
 
   const handleCancel = () => {
-    navigate(customerRoutes.PROFILE_PATH);
+    navigate(customerRoutes.PROFILE_PATH, { state });
   };
 
   // sends POST request to Okta API with form values
@@ -60,7 +61,7 @@ export const EditOktaInfo = ({ serviceMember, setFlashMessage, oktaUser, updateO
         .then((response) => {
           updateOktaUserState(response);
           setFlashMessage('EDIT_OKTA_PROFILE_SUCCESS', 'success', "You've updated your Okta profile.");
-          navigate(customerRoutes.PROFILE_PATH);
+          navigate(customerRoutes.PROFILE_PATH, { state });
         })
         .catch((e) => {
           const { response } = e;

--- a/src/pages/MyMove/Profile/EditOktaInfo.test.jsx
+++ b/src/pages/MyMove/Profile/EditOktaInfo.test.jsx
@@ -101,7 +101,7 @@ describe('EditOktaInfo page', () => {
 
     await userEvent.click(cancelButton);
 
-    expect(mockNavigate).toHaveBeenCalledWith(customerRoutes.PROFILE_PATH);
+    expect(mockNavigate).toHaveBeenCalledWith(customerRoutes.PROFILE_PATH, { state: null });
   });
 
   afterEach(jest.resetAllMocks);

--- a/src/pages/MyMove/Profile/EditOrdersPayGradeAndOriginLocation.test.jsx
+++ b/src/pages/MyMove/Profile/EditOrdersPayGradeAndOriginLocation.test.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router';
 
 import { EditServiceInfo } from './EditServiceInfo';
 
@@ -86,7 +87,11 @@ describe('EditServiceInfo page updates orders table information', () => {
     };
     createOrders.mockImplementation(() => Promise.resolve(testOrdersValues));
 
-    render(<EditServiceInfo {...testProps} serviceMember={testServiceMemberValues} currentOrders={testOrdersValues} />);
+    render(
+      <MemoryRouter>
+        <EditServiceInfo {...testProps} serviceMember={testServiceMemberValues} currentOrders={testOrdersValues} />
+      </MemoryRouter>,
+    );
 
     getOrdersForServiceMember.mockImplementation(() => Promise.resolve(testOrdersValues));
     patchOrders.mockImplementation(() => Promise.resolve(testOrdersValues));
@@ -169,7 +174,11 @@ describe('EditServiceInfo page updates orders table information', () => {
     };
     createOrders.mockImplementation(() => Promise.resolve(testOrdersValues));
 
-    render(<EditServiceInfo {...testProps} serviceMember={testServiceMemberValues} currentOrders={testOrdersValues} />);
+    render(
+      <MemoryRouter>
+        <EditServiceInfo {...testProps} serviceMember={testServiceMemberValues} currentOrders={testOrdersValues} />
+      </MemoryRouter>,
+    );
 
     getOrdersForServiceMember.mockImplementation(() => Promise.resolve(testOrdersValues));
     patchOrders.mockImplementation(() => Promise.resolve(testOrdersValues));

--- a/src/pages/MyMove/Profile/EditServiceInfo.jsx
+++ b/src/pages/MyMove/Profile/EditServiceInfo.jsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { GridContainer, Alert } from '@trussworks/react-uswds';
 import { connect } from 'react-redux';
-import { useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 
 import ServiceInfoForm from 'components/Customer/ServiceInfoForm/ServiceInfoForm';
 import { patchServiceMember, patchOrders, getResponseError } from 'services/internalApi';
@@ -32,6 +32,7 @@ export const EditServiceInfo = ({
 }) => {
   const navigate = useNavigate();
   const [serverError, setServerError] = useState(null);
+  const { state } = useLocation();
 
   useEffect(() => {
     if (!moveIsInDraft) {
@@ -84,7 +85,7 @@ export const EditServiceInfo = ({
           setFlashMessage('EDIT_SERVICE_INFO_SUCCESS', 'success', '', 'Your changes have been saved.');
         }
 
-        navigate(customerRoutes.PROFILE_PATH);
+        navigate(customerRoutes.PROFILE_PATH, { state });
       })
       .catch((e) => {
         // Error shape: https://github.com/swagger-api/swagger-js/blob/master/docs/usage/http-client.md#errors
@@ -122,7 +123,7 @@ export const EditServiceInfo = ({
           setFlashMessage('EDIT_SERVICE_INFO_SUCCESS', 'success', '', 'Your changes have been saved.');
         }
 
-        navigate(customerRoutes.PROFILE_PATH);
+        navigate(customerRoutes.PROFILE_PATH, { state });
       })
       .catch((e) => {
         // Error shape: https://github.com/swagger-api/swagger-js/blob/master/docs/usage/http-client.md#errors
@@ -133,7 +134,7 @@ export const EditServiceInfo = ({
   };
 
   const handleCancel = () => {
-    navigate(customerRoutes.PROFILE_PATH);
+    navigate(customerRoutes.PROFILE_PATH, { state });
   };
 
   return (

--- a/src/pages/MyMove/Profile/EditServiceInfo.test.jsx
+++ b/src/pages/MyMove/Profile/EditServiceInfo.test.jsx
@@ -5,6 +5,7 @@ import userEvent from '@testing-library/user-event';
 import { EditServiceInfo } from './EditServiceInfo';
 
 import { patchServiceMember } from 'services/internalApi';
+import { MockProviders } from 'testUtils';
 
 const mockNavigate = jest.fn();
 jest.mock('react-router-dom', () => ({
@@ -33,21 +34,28 @@ describe('EditServiceInfo page', () => {
   };
 
   it('renders the EditServiceInfo form', async () => {
-    render(<EditServiceInfo {...testProps} />);
+    render(
+      <MockProviders>
+        <EditServiceInfo {...testProps} />
+      </MockProviders>,
+    );
 
     expect(await screen.findByRole('heading', { name: 'Edit service info', level: 1 })).toBeInTheDocument();
   });
 
   it('the cancel button goes back to the profile page', async () => {
-    render(<EditServiceInfo {...testProps} />);
-
+    render(
+      <MockProviders>
+        <EditServiceInfo {...testProps} />
+      </MockProviders>,
+    );
     const cancelButton = await screen.findByText('Cancel');
     await waitFor(() => {
       expect(cancelButton).toBeInTheDocument();
     });
 
     await userEvent.click(cancelButton);
-    expect(mockNavigate).toHaveBeenCalledWith('/service-member/profile');
+    expect(mockNavigate).toHaveBeenCalledWith('/service-member/profile', { state: null });
   });
 
   it('save button submits the form and goes to the profile page', async () => {
@@ -79,15 +87,17 @@ describe('EditServiceInfo page', () => {
 
     // Need to provide initial values because we aren't testing the form here, and just want to submit immediately
     render(
-      <EditServiceInfo
-        {...testProps}
-        serviceMember={testServiceMemberValues}
-        currentOrders={{
-          has_dependents: false,
-          grade: testServiceMemberValues.rank,
-          origin_duty_location: testServiceMemberValues.current_location,
-        }}
-      />,
+      <MockProviders>
+        <EditServiceInfo
+          {...testProps}
+          serviceMember={testServiceMemberValues}
+          currentOrders={{
+            has_dependents: false,
+            grade: testServiceMemberValues.rank,
+            origin_duty_location: testServiceMemberValues.current_location,
+          }}
+        />
+      </MockProviders>,
     );
 
     const submitButton = await screen.findByText('Save');
@@ -106,7 +116,7 @@ describe('EditServiceInfo page', () => {
       'Your changes have been saved.',
     );
 
-    expect(mockNavigate).toHaveBeenCalledWith('/service-member/profile');
+    expect(mockNavigate).toHaveBeenCalledWith('/service-member/profile', { state: null });
   });
 
   it('displays a flash message about entitlement when the pay grade changes', async () => {
@@ -174,15 +184,17 @@ describe('EditServiceInfo page', () => {
 
     // Need to provide initial values because we aren't testing the form here, and just want to submit immediately
     render(
-      <EditServiceInfo
-        {...testProps}
-        serviceMember={testServiceMemberValues}
-        currentOrders={{
-          grade: testServiceMemberValues.rank,
-          has_dependents: true,
-          origin_duty_location: testServiceMemberValues.current_location,
-        }}
-      />,
+      <MockProviders>
+        <EditServiceInfo
+          {...testProps}
+          serviceMember={testServiceMemberValues}
+          currentOrders={{
+            grade: testServiceMemberValues.rank,
+            has_dependents: true,
+            origin_duty_location: testServiceMemberValues.current_location,
+          }}
+        />
+      </MockProviders>,
     );
 
     const payGradeInput = await screen.findByLabelText('Pay grade');
@@ -204,7 +216,7 @@ describe('EditServiceInfo page', () => {
       'Your changes have been saved. Note that the entitlement has also changed.',
     );
 
-    expect(mockNavigate).toHaveBeenCalledWith('/service-member/profile');
+    expect(mockNavigate).toHaveBeenCalledWith('/service-member/profile', { state: null });
   });
 
   it('shows an error if the API returns an error', async () => {
@@ -253,14 +265,16 @@ describe('EditServiceInfo page', () => {
 
     // Need to provide complete & valid initial values because we aren't testing the form here, and just want to submit immediately
     render(
-      <EditServiceInfo
-        {...testProps}
-        serviceMember={testServiceMemberValues}
-        currentOrders={{
-          grade: testServiceMemberValues.rank,
-          origin_duty_location: testServiceMemberValues.current_location,
-        }}
-      />,
+      <MockProviders>
+        <EditServiceInfo
+          {...testProps}
+          serviceMember={testServiceMemberValues}
+          currentOrders={{
+            grade: testServiceMemberValues.rank,
+            origin_duty_location: testServiceMemberValues.current_location,
+          }}
+        />
+      </MockProviders>,
     );
 
     const submitButton = await screen.findByText('Save');
@@ -279,7 +293,11 @@ describe('EditServiceInfo page', () => {
 
   describe('if the current move has been submitted', () => {
     it('redirects to the home page', async () => {
-      render(<EditServiceInfo {...testProps} moveIsInDraft={false} />);
+      render(
+        <MockProviders>
+          <EditServiceInfo {...testProps} moveIsInDraft={false} />
+        </MockProviders>,
+      );
 
       await waitFor(() => {
         expect(mockNavigate).toHaveBeenCalledWith('/');

--- a/src/pages/MyMove/Profile/Profile.jsx
+++ b/src/pages/MyMove/Profile/Profile.jsx
@@ -3,7 +3,6 @@ import { connect } from 'react-redux';
 import { arrayOf, bool } from 'prop-types';
 import { Alert, Button } from '@trussworks/react-uswds';
 import { Link, useLocation, useNavigate } from 'react-router-dom';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
 import styles from './Profile.module.scss';
 
@@ -37,6 +36,7 @@ const Profile = ({ serviceMember, currentOrders, currentBackupContacts, moveIsIn
     email: currentBackupContacts[0]?.email || '',
   };
   const [needsToVerifyProfile, setNeedsToVerifyProfile] = useState(false);
+  const [profileValidated, setProfileValidated] = useState(false);
 
   const navigate = useNavigate();
   const { state } = useLocation();
@@ -51,6 +51,10 @@ const Profile = ({ serviceMember, currentOrders, currentBackupContacts, moveIsIn
 
   const handleCreateMoveClick = () => {
     navigate(customerRoutes.MOVE_HOME_PAGE);
+  };
+
+  const handleValidateProfileClick = () => {
+    setProfileValidated(true);
   };
 
   // displays the profile data for MilMove & Okta
@@ -69,14 +73,6 @@ const Profile = ({ serviceMember, currentOrders, currentBackupContacts, moveIsIn
           )}
           <div className={styles.profileHeader}>
             <h1>Profile</h1>
-            {needsToVerifyProfile && (
-              <Button className={styles.createMoveBtn} onClick={handleCreateMoveClick} data-testid="createMoveBtn">
-                <span>Create a Move</span>
-                <div>
-                  <FontAwesomeIcon icon="plus" />
-                </div>
-              </Button>
-            )}
           </div>
           {showMessages && (
             <Alert headingLevel="h4" type="info">
@@ -85,7 +81,11 @@ const Profile = ({ serviceMember, currentOrders, currentBackupContacts, moveIsIn
           )}
           {needsToVerifyProfile && (
             <Alert type="info" className={styles.verifyProfileAlert} data-testid="profileConfirmAlert">
-              <strong>Please verify & confirm your profile before starting the process of creating your move.</strong>
+              <strong>
+                Please confirm your profile information is accurate prior to starting a new move. When all information
+                is up to date, click the &quot;Validate Profile&quot; button at the bottom of the page and you may begin
+                your move.
+              </strong>
             </Alert>
           )}
           <SectionWrapper className={formStyles.formSection}>
@@ -126,6 +126,26 @@ const Profile = ({ serviceMember, currentOrders, currentBackupContacts, moveIsIn
               editURL={customerRoutes.EDIT_OKTA_PROFILE_PATH}
             />
           </SectionWrapper>
+          {needsToVerifyProfile && (
+            <SectionWrapper data-testid="validateProfileContainer" className={styles.validateProfileBtnContainer}>
+              <Button
+                onClick={handleValidateProfileClick}
+                className={styles.validateProfileBtn}
+                data-testid="validateProfileBtn"
+                disabled={profileValidated}
+              >
+                {profileValidated ? 'Profile Validated' : 'Validate Profile'}
+              </Button>
+              <Button
+                className={styles.createMoveBtn}
+                onClick={handleCreateMoveClick}
+                data-testid="createMoveBtn"
+                disabled={!profileValidated}
+              >
+                <span>Create a Move</span>
+              </Button>
+            </SectionWrapper>
+          )}
         </div>
       </div>
     </div>

--- a/src/pages/MyMove/Profile/Profile.jsx
+++ b/src/pages/MyMove/Profile/Profile.jsx
@@ -1,8 +1,11 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { connect } from 'react-redux';
 import { arrayOf, bool } from 'prop-types';
-import { Alert } from '@trussworks/react-uswds';
-import { Link } from 'react-router-dom';
+import { Alert, Button } from '@trussworks/react-uswds';
+import { Link, useLocation, useNavigate } from 'react-router-dom';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+
+import styles from './Profile.module.scss';
 
 import ConnectedFlashMessage from 'containers/FlashMessage/FlashMessage';
 import ContactInfoDisplay from 'components/Customer/Profile/ContactInfoDisplay/ContactInfoDisplay';
@@ -33,6 +36,22 @@ const Profile = ({ serviceMember, currentOrders, currentBackupContacts, moveIsIn
     telephone: currentBackupContacts[0]?.telephone || '',
     email: currentBackupContacts[0]?.email || '',
   };
+  const [needsToVerifyProfile, setNeedsToVerifyProfile] = useState(false);
+
+  const navigate = useNavigate();
+  const { state } = useLocation();
+
+  useEffect(() => {
+    if (state && state.needsToVerifyProfile) {
+      setNeedsToVerifyProfile(state.needsToVerifyProfile);
+    } else {
+      setNeedsToVerifyProfile(false);
+    }
+  }, [state]);
+
+  const handleCreateMoveClick = () => {
+    navigate(customerRoutes.MOVE_HOME_PAGE);
+  };
 
   // displays the profile data for MilMove & Okta
   // Profile w/contact info for servicemember & backup contact
@@ -43,11 +62,30 @@ const Profile = ({ serviceMember, currentOrders, currentBackupContacts, moveIsIn
       <ConnectedFlashMessage />
       <div className="grid-row">
         <div className="grid-col-12">
-          <Link to={generalRoutes.HOME_PATH}>Return to Move</Link>
-          <h1>Profile</h1>
+          {needsToVerifyProfile ? (
+            <Link to={generalRoutes.HOME_PATH}>Return to Dashboard</Link>
+          ) : (
+            <Link to={generalRoutes.HOME_PATH}>Return to Move</Link>
+          )}
+          <div className={styles.profileHeader}>
+            <h1>Profile</h1>
+            {needsToVerifyProfile && (
+              <Button className={styles.createMoveBtn} onClick={handleCreateMoveClick} data-testid="createMoveBtn">
+                <span>Create a Move</span>
+                <div>
+                  <FontAwesomeIcon icon="plus" />
+                </div>
+              </Button>
+            )}
+          </div>
           {showMessages && (
             <Alert headingLevel="h4" type="info">
               You can change these details later by talking to a move counselor or customer care representative.
+            </Alert>
+          )}
+          {needsToVerifyProfile && (
+            <Alert type="info" className={styles.verifyProfileAlert} data-testid="profileConfirmAlert">
+              <strong>Please verify & confirm your profile before starting the process of creating your move.</strong>
             </Alert>
           )}
           <SectionWrapper className={formStyles.formSection}>

--- a/src/pages/MyMove/Profile/Profile.module.scss
+++ b/src/pages/MyMove/Profile/Profile.module.scss
@@ -1,0 +1,35 @@
+@import 'shared/styles/colors';
+@import 'shared/styles/_basics';
+@import 'shared/styles/_variables';
+
+.profileHeader {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: -1rem;
+
+    .createMoveBtn {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      @include u-margin-top(-1);
+      span {
+        @include u-margin-right(.5em)
+      }
+
+      @media (max-width: $tablet) {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        width: auto;
+        gap: 3px;
+        span {
+          @include u-margin-right(0);
+        }
+      }
+    }
+}
+
+.verifyProfileAlert {
+    margin-bottom: -1rem;
+}

--- a/src/pages/MyMove/Profile/Profile.module.scss
+++ b/src/pages/MyMove/Profile/Profile.module.scss
@@ -12,7 +12,6 @@
       display: flex;
       justify-content: space-between;
       align-items: center;
-      @include u-margin-top(-1);
       span {
         @include u-margin-right(.5em)
       }
@@ -32,4 +31,9 @@
 
 .verifyProfileAlert {
     margin-bottom: -1rem;
+}
+
+.validateProfileBtnContainer {
+  display: flex;
+  justify-content: center;
 }

--- a/src/pages/MyMove/Profile/Profile.test.jsx
+++ b/src/pages/MyMove/Profile/Profile.test.jsx
@@ -1,6 +1,6 @@
 /* eslint-disable react/jsx-props-no-spreading */
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import { useLocation } from 'react-router-dom';
 
 import ConnectedProfile from './Profile';
@@ -398,10 +398,24 @@ describe('Profile component', () => {
     const returnToDashboardLink = screen.getByText('Return to Dashboard');
     expect(returnToDashboardLink).toBeInTheDocument();
 
+    const validateProfileContainer = screen.getByTestId('validateProfileContainer');
+    expect(validateProfileContainer).toBeInTheDocument();
+
     const createMoveBtn = screen.getByTestId('createMoveBtn');
     expect(createMoveBtn).toBeInTheDocument();
+    expect(createMoveBtn).toBeDisabled();
+
+    const validateProfileBtn = screen.getByTestId('validateProfileBtn');
+    expect(validateProfileBtn).toBeInTheDocument();
+    expect(validateProfileBtn).toBeEnabled();
 
     const profileConfirmAlert = screen.getByTestId('profileConfirmAlert');
     expect(profileConfirmAlert).toBeInTheDocument();
+
+    // user validates their profile, which enables create move btn
+    fireEvent.click(validateProfileBtn);
+    expect(createMoveBtn).toBeEnabled();
+    expect(validateProfileBtn).toBeDisabled();
+    expect(screen.getByText('Profile Validated')).toBeInTheDocument();
   });
 });

--- a/src/pages/MyMove/Profile/Profile.test.jsx
+++ b/src/pages/MyMove/Profile/Profile.test.jsx
@@ -1,10 +1,16 @@
 /* eslint-disable react/jsx-props-no-spreading */
 import React from 'react';
 import { render, screen } from '@testing-library/react';
+import { useLocation } from 'react-router-dom';
 
 import ConnectedProfile from './Profile';
 
 import { MockProviders } from 'testUtils';
+
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useLocation: jest.fn(),
+}));
 
 describe('Profile component', () => {
   const testProps = {};
@@ -82,6 +88,8 @@ describe('Profile component', () => {
         },
       },
     };
+    useLocation.mockReturnValue({});
+
     render(
       <MockProviders initialState={mockState}>
         <ConnectedProfile {...testProps} />
@@ -107,6 +115,16 @@ describe('Profile component', () => {
     const homeLink = screen.getByText('Return to Move');
 
     expect(homeLink).toBeInTheDocument();
+
+    // these should be false since needsToVerifyProfile is not true
+    const returnToDashboardLink = screen.queryByText('Return to Dashboard');
+    expect(returnToDashboardLink).not.toBeInTheDocument();
+
+    const createMoveBtn = screen.queryByText('createMoveBtn');
+    expect(createMoveBtn).not.toBeInTheDocument();
+
+    const profileConfirmAlert = screen.queryByText('profileConfirmAlert');
+    expect(profileConfirmAlert).not.toBeInTheDocument();
   });
 
   it('renders the Profile Page when there are no orders', async () => {
@@ -161,6 +179,8 @@ describe('Profile component', () => {
         },
       },
     };
+    useLocation.mockReturnValue({});
+
     render(
       <MockProviders initialState={mockState}>
         <ConnectedProfile {...testProps} />
@@ -266,6 +286,8 @@ describe('Profile component', () => {
         },
       },
     };
+    useLocation.mockReturnValue({});
+
     render(
       <MockProviders initialState={mockState}>
         <ConnectedProfile {...testProps} />
@@ -289,5 +311,97 @@ describe('Profile component', () => {
     const homeLink = screen.getByText('Return to Move');
 
     expect(homeLink).toBeInTheDocument();
+  });
+
+  it('renders the Profile Page with needsToVerifyProfile set to true', async () => {
+    const mockState = {
+      entities: {
+        user: {
+          testUserId: {
+            id: 'testUserId',
+            email: 'testuser@example.com',
+            service_member: 'testServiceMemberId',
+          },
+        },
+        orders: {
+          test: {
+            new_duty_location: {
+              name: 'Test Duty Location',
+            },
+            status: 'DRAFT',
+            moves: ['testMove'],
+          },
+        },
+        moves: {
+          testMove: {
+            created_at: '2020-12-17T15:54:48.873Z',
+            id: 'testMove',
+            locator: 'test',
+            orders_id: 'test',
+            selected_move_type: '',
+            service_member_id: 'testServiceMemberId',
+            status: 'DRAFT',
+          },
+        },
+        serviceMembers: {
+          testServiceMemberId: {
+            id: 'testServiceMemberId',
+            rank: 'test rank',
+            edipi: '1234567890',
+            affiliation: 'ARMY',
+            first_name: 'Tester',
+            last_name: 'Testperson',
+            telephone: '1234567890',
+            personal_email: 'test@example.com',
+            email_is_preferred: true,
+            residential_address: {
+              city: 'San Diego',
+              state: 'CA',
+              postalCode: '92131',
+              streetAddress1: 'Some Street',
+              country: 'USA',
+            },
+            backup_mailing_address: {
+              city: 'San Diego',
+              state: 'CA',
+              postalCode: '92131',
+              streetAddress1: 'Some Backup Street',
+              country: 'USA',
+            },
+            current_location: {
+              origin_duty_location: {
+                name: 'Current Station',
+              },
+              grade: 'E-5',
+            },
+            backup_contacts: [
+              {
+                name: 'Backup Contact',
+                telephone: '555-555-5555',
+                email: 'backup@test.com',
+              },
+            ],
+            orders: ['test'],
+          },
+        },
+      },
+    };
+
+    useLocation.mockReturnValue({ state: { needsToVerifyProfile: true } });
+
+    render(
+      <MockProviders initialState={mockState}>
+        <ConnectedProfile {...testProps} />
+      </MockProviders>,
+    );
+
+    const returnToDashboardLink = screen.getByText('Return to Dashboard');
+    expect(returnToDashboardLink).toBeInTheDocument();
+
+    const createMoveBtn = screen.getByTestId('createMoveBtn');
+    expect(createMoveBtn).toBeInTheDocument();
+
+    const profileConfirmAlert = screen.getByTestId('profileConfirmAlert');
+    expect(profileConfirmAlert).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
[INTEGRATION PR](https://github.com/transcom/mymove/pull/11859)
[INTEGRATION PR - updates](https://github.com/transcom/mymove/pull/11911)

## [Agility ticket](https://www13.v1host.com/USTRANSCOM38/story.mvc/Summary?oidToken=Story%3A873918&RoomContext=TeamRoom%3A808731&concept=TeamRoom)

## Summary

As we transition to allowing for multiple moves, we need to allow for the customer to validate their profile prior to starting a new move. If the service member does not have a previous move, then there's no need for them to validate their profile - technically it should already be current.

I went ahead and leveraged the `useLocation` hook to pass around a state value (`needsToVerifyProfile`) when a user is validating their profile. At first I was using `searchParams` but it felt a little clunky and was a lot harder to test, so I transitioned to using local `state` and passing that `state` to the relevant components.

This PR does the following:
- updates profile links to pass around the `state` object holding the current value of `needsToVerifyProfile`
- based on that state, specifically in the `Profile` component, conditional rendering will occur of links and an alert banner
- updated tests

### How to test Scenario 1 (previous moves)

1. Access MM as a customer
2. Once logged in you should be directed to the multi move home page
3. You'll see the multi move dashboard (currently using dummy/static data)
4. With default data, click on the `Create a Move` button
5. This will navigate the user to the profile page with an alert, a `Create a Move` button, and `Return to Dashboard` (instead of `Return to Move`)
6. Validate any data/cancel any data and the alert/button/dashboard link should remain
7. Once you're finished, click the `Create a Move` button and you'll be navigated to the current home page

### How to test Scenario 2 (no previous moves)

1. Access MM as a customer
2. Once logged in, put in `http://milmovelocal:3000/?moveData=noMoves` into the url
3. You'll see the multi move dashboard with no current or previous moves
4. Click on the `Create a Move` button
5. This will navigate the user to the current home page since there is no previous data to validate

## Screenshots

![Screenshot 2024-01-25 at 2 19 15 PM](https://github.com/transcom/mymove/assets/136510600/ddca29ff-6a6c-4af6-a008-2814c35e8756)