### PR TITLE
B-17908-INT after rebase

### DIFF
--- a/src/constants/MoveHistory/Database/FieldMappings.js
+++ b/src/constants/MoveHistory/Database/FieldMappings.js
@@ -118,4 +118,6 @@ export default {
   sit_location: 'SIT location',
   sit_estimated_cost: 'SIT estimated cost',
   estimated_incentive: 'PPM estimated incentive',
+  ppm_type: 'PPM type',
+  distance: 'Distance in miles',
 };

--- a/src/constants/MoveHistory/EventTemplates/CreateMTOShipment/CreateMTOShipmentUpdateMoves.jsx
+++ b/src/constants/MoveHistory/EventTemplates/CreateMTOShipment/CreateMTOShipmentUpdateMoves.jsx
@@ -1,0 +1,25 @@
+import React from 'react';
+
+import a from 'constants/MoveHistory/Database/Actions';
+import o from 'constants/MoveHistory/UIDisplay/Operations';
+import t from 'constants/MoveHistory/Database/Tables';
+import LabeledDetails from 'pages/Office/MoveHistory/LabeledDetails';
+import { getMtoShipmentLabel } from 'utils/formatMtoShipment';
+
+const formatChangedValues = (historyRecord) => {
+  const { changedValues } = historyRecord;
+  const newChangedValues = {
+    ...changedValues,
+    ...getMtoShipmentLabel(historyRecord),
+  };
+
+  return { ...historyRecord, changedValues: newChangedValues };
+};
+
+export default {
+  action: a.UPDATE,
+  eventName: o.createMTOShipment,
+  tableName: t.moves,
+  getEventNameDisplay: () => 'Updated move',
+  getDetails: (historyRecord) => <LabeledDetails historyRecord={formatChangedValues(historyRecord)} />,
+};

--- a/src/constants/MoveHistory/EventTemplates/CreateMTOShipment/CreateMTOShipmentUpdateMoves.test.jsx
+++ b/src/constants/MoveHistory/EventTemplates/CreateMTOShipment/CreateMTOShipmentUpdateMoves.test.jsx
@@ -1,0 +1,33 @@
+import { render, screen } from '@testing-library/react';
+
+import getTemplate from 'constants/MoveHistory/TemplateManager';
+import o from 'constants/MoveHistory/UIDisplay/Operations';
+import a from 'constants/MoveHistory/Database/Actions';
+import t from 'constants/MoveHistory/Database/Tables';
+
+describe('When given a move with an updated ppm type', () => {
+  const historyRecord = {
+    action: a.UPDATE,
+    changedValues: {
+      ppm_type: 'FULL',
+    },
+    context: null,
+    eventName: o.createMTOShipment,
+    tableName: t.moves,
+  };
+
+  it('displays event properly', () => {
+    const template = getTemplate(historyRecord);
+
+    render(template.getEventNameDisplay(historyRecord));
+    expect(screen.getByText('Updated move')).toBeInTheDocument();
+  });
+
+  it('displays details ppmType', () => {
+    const template = getTemplate(historyRecord);
+
+    render(template.getDetails(historyRecord));
+    expect(screen.getByText('PPM type')).toBeInTheDocument();
+    expect(screen.getByText(': FULL')).toBeInTheDocument();
+  });
+});

--- a/src/constants/MoveHistory/EventTemplates/index.js
+++ b/src/constants/MoveHistory/EventTemplates/index.js
@@ -67,3 +67,4 @@ export { default as updateMovingExpense } from './UpdateMovingExpense/UpdateMovi
 export { default as updateWeightTicketProGear } from './UpdateWeightTicket/updateWeightTicketProGear';
 export { default as createMTOShipmentPPMDetails } from './CreateMTOShipment/createMTOShipmentPPMDetails';
 export { default as deleteShipmentPPM } from './DeleteShipment/DeleteShipmentPPM';
+export { default as createMTOShipmentUpdateMoves } from './CreateMTOShipment/CreateMTOShipmentUpdateMoves';


### PR DESCRIPTION
## [17908](https://www13.v1host.com/USTRANSCOM38/story.mvc/Summary?oidToken=Story%3a867942)

## Summary

Add missing events and fields for move history records related to a customer creating/editing a PPM prior to submitting for initial approval

### How to test

1. Login as a customer and create a new move
2. Add a PPM shipment
3. Once the shipment is created, edit the shipment and edit all the details
4. Login as a QAE and locate the shipment
5. View the move history and confirm the following events are tracked:
- When a customer adds a PPM shipment to their move
- When a customer updates their PPM shipment details
- When a customer has Added, Updated or Deleted Pro-gear
- When a customer’s Incentive is Estimated or Re-estimated after customer updates
- When a customer has Requested or Changed their Advance Details