### PR TITLE
INT B-18820 update office users table

### DIFF
--- a/migrations/app/migrations_manifest.txt
+++ b/migrations/app/migrations_manifest.txt
@@ -905,3 +905,4 @@
 20240223144515_add_pro_gear_weights_to_mto_shipments.up.sql
 20240223200739_updateDutyLocationsZip.up.sql
 20240226183440_add_county_column_to_address_table.up.sql
+20240227180121_add_status_edipi_other_unique_id_and_rej_reason_to_office_users_table.up.sql

--- a/migrations/app/schema/20240227180121_add_status_edipi_other_unique_id_and_rej_reason_to_office_users_table.up.sql
+++ b/migrations/app/schema/20240227180121_add_status_edipi_other_unique_id_and_rej_reason_to_office_users_table.up.sql
@@ -1,0 +1,19 @@
+CREATE TYPE office_user_status AS enum (
+    'APPROVED',
+	'REQUESTED',
+    'REJECTED'
+);
+
+-- Adds new columns to office_users table
+-- making status default of APPROVED to ensure past users using MM are already approved
+ALTER TABLE office_users
+ADD COLUMN status office_user_status DEFAULT 'APPROVED' NULL,
+ADD COLUMN edipi TEXT DEFAULT NULL,
+ADD COLUMN other_unique_id TEXT DEFAULT NULL,
+ADD COLUMN rejection_reason TEXT DEFAULT NULL;
+
+-- Comments on new columns
+COMMENT on COLUMN office_users.status IS 'Status of an office user account';
+COMMENT on COLUMN office_users.edipi IS 'DoD ID or EDIPI of office user';
+COMMENT on COLUMN office_users.other_unique_id IS 'Other unique id for PIV or ECA cert users';
+COMMENT on COLUMN office_users.rejection_reason IS 'Rejection reason when account request is rejected by an admin';

--- a/migrations/app/schema/20240227180121_add_status_edipi_other_unique_id_and_rej_reason_to_office_users_table.up.sql
+++ b/migrations/app/schema/20240227180121_add_status_edipi_other_unique_id_and_rej_reason_to_office_users_table.up.sql
@@ -8,8 +8,8 @@ CREATE TYPE office_user_status AS enum (
 -- making status default of APPROVED to ensure past users using MM are already approved
 ALTER TABLE office_users
 ADD COLUMN status office_user_status DEFAULT 'APPROVED' NULL,
-ADD COLUMN edipi TEXT DEFAULT NULL,
-ADD COLUMN other_unique_id TEXT DEFAULT NULL,
+ADD COLUMN edipi TEXT UNIQUE DEFAULT NULL,
+ADD COLUMN other_unique_id TEXT UNIQUE DEFAULT NULL,
 ADD COLUMN rejection_reason TEXT DEFAULT NULL;
 
 -- Comments on new columns


### PR DESCRIPTION
## [Agility ticket](https://www13.v1host.com/USTRANSCOM38/story.mvc/Summary?oidToken=Story%3a907114)

## Summary

We'll need some added columns to the `office_users` table to prep for office users requesting access as well as okta accounts being created for them on approval.

This PR does the following:
- adds four columns to the `office_users` table: `status`, `edipi`, `other_unique_id`, and `rejection_reason`

### How to test

1. Load up the branch
2. Run `make server_run` or `make db_dev_fresh`
3. Check out the `office_users` table
4. Should see four new columns, `status`, `edipi`, `other_unique_id`, and `rejection_reason` in the table
5. Verify that all office users currently in the table have an `APPROVED` status value

### Database

#### Any new migrations/schema changes:

- [x] Follows our guidelines for [Zero-Downtime Deploys](https://transcom.github.io/mymove-docs/docs/backend/setup/database-migrations#zero-downtime-migrations).
- [x] Have been communicated to #g-database.
- [x] Secure migrations have been tested following the instructions in our [docs](https://transcom.github.io/mymove-docs/docs/backend/setup/database-migrations#secure-migrations).
