### PR TITLE
Integration B-19034

### DIFF
--- a/pkg/handlers/ghcapi/ppm_document.go
+++ b/pkg/handlers/ghcapi/ppm_document.go
@@ -15,6 +15,7 @@ import (
 	"github.com/transcom/mymove/pkg/gen/ghcmessages"
 	"github.com/transcom/mymove/pkg/handlers"
 	"github.com/transcom/mymove/pkg/handlers/ghcapi/internal/payloads"
+	"github.com/transcom/mymove/pkg/notifications"
 	"github.com/transcom/mymove/pkg/services"
 )
 
@@ -131,6 +132,13 @@ func (h FinishDocumentReviewHandler) Handle(params ppmdocumentops.FinishDocument
 			}
 
 			returnPayload := payloads.PPMShipment(h.FileStorer(), ppmShipment)
+
+			err = h.NotificationSender().SendNotification(appCtx,
+				notifications.NewPpmPacketEmail(ppmShipment.ID),
+			)
+			if err != nil {
+				appCtx.Logger().Error("problem sending email to user", zap.Error(err))
+			}
 
 			return ppmdocumentops.NewFinishDocumentReviewOK().WithPayload(returnPayload), nil
 		})

--- a/pkg/handlers/internalapi/ppm_shipment.go
+++ b/pkg/handlers/internalapi/ppm_shipment.go
@@ -14,7 +14,6 @@ import (
 	ppmops "github.com/transcom/mymove/pkg/gen/internalapi/internaloperations/ppm"
 	"github.com/transcom/mymove/pkg/handlers"
 	"github.com/transcom/mymove/pkg/handlers/internalapi/internal/payloads"
-	"github.com/transcom/mymove/pkg/notifications"
 	"github.com/transcom/mymove/pkg/services"
 )
 
@@ -123,13 +122,6 @@ func (h SubmitPPMShipmentDocumentationHandler) Handle(params ppmops.SubmitPPMShi
 			}
 
 			returnPayload := payloads.PPMShipment(h.FileStorer(), ppmShipment)
-
-			err = h.NotificationSender().SendNotification(appCtx,
-				notifications.NewPpmPacketEmail(ppmShipment.ID),
-			)
-			if err != nil {
-				appCtx.Logger().Error("problem sending email to user", zap.Error(err))
-			}
 
 			return ppmops.NewSubmitPPMShipmentDocumentationOK().WithPayload(returnPayload), nil
 		})


### PR DESCRIPTION
## [B-19034](https://www13.v1host.com/USTRANSCOM38/story.mvc/Summary?oidToken=Story%3a912699)

Re-created in order to show *only* the relevant file changes.

## Relevant PRs:
#11793
#11737
#11938 

## Summary

This branch updates the notification added in the above PRs to instead trigger when a Services Counselor has reviewed the document set for a PPM shipment, in accordance to new requirements sent from the government.

### How to test

1. Run the server with the following command to activate sending emails through local dev: 
`EMAIL_BACKEND=ses AWS_REGION=us-gov-west-1  aws-vault exec transcom-gov-dev -- make server_run`
2. Access the "testharness scenarios" page from milmovelocal:3000 

*If using the new "multi move" GUI, complete the steps laid out in step 3 and skip step 4. If using the old GUI, you can take the shortcut mentioned in step 4 (and skip step 3).

In order to opt-out of the multi-move GUI (and thus use the shortcuts in step 4), edit the .envrc file, search for "multi" and you should see a multi move flag set to true. Replace with false then rebuild the client. You should now be on the old version of MilMove.

Multi-move GUI:
3a. If using the new "multi move" customer GUI: You'll need to create a user from scratch, using your email address, the other info is inconsequential. You'll also have to make the PPM from scratch.

3b. Create the PPM shipment and sign. Then login as an SC and find your move in the first tab. Use "Edit Order" to fill out the TAC and other necessary info, then save and click "Submit Move Details".

Non multi-move:
4a. Select the **MoveWithPPMShipmentReadyForFinalCloseout** option to create a move at the final stage with all needed receipts/docs already uploaded.
![scenario](https://github.com/transcom/mymove/assets/146959895/f2424600-bbfc-4558-89dd-c01d5b210b15)

4b. Login as that new user (it will always be the top result on the user list if you haven't done anything else after creating).
![firstuser](https://github.com/transcom/mymove/assets/146959895/6d7b03b3-7450-4e5b-91d3-060fe419b83f)

4c. Before uploading, click "edit" next to step 1 "Profile". In the first section, edit your email to be your CACI email (if you're in the local dev env, you can have as many users pointing to the same email as you want).Screenshot 2024-01-11 at 5.43.42 PM
![Screenshot 2024-01-11 at 5 43 47 PM](https://github.com/transcom/mymove/assets/146959895/0725567b-dc13-45a4-802b-c3b8320e0615)
![Screenshot 2024-01-11 at 5 43 55 PM](https://github.com/transcom/mymove/assets/146959895/d65c3be4-b82e-4925-a025-d4354147f492)
![Screenshot 2024-01-11 at 5 44 06 PM](https://github.com/transcom/mymove/assets/146959895/65e841b8-9fef-4766-8eaa-799e195626ab)

5. Now click "Upload PPM Documentation", and add documents as necessary. These will already be filled out if using the shortcut.

6. Sign your name and then login as SC.

7.  Find your move under the *PPM Closeout* tab, click "Review Documents", and complete the process by clicking "Confirm". You should get an email shortly: 
![Screenshot 2024-01-11 at 5 45 43 PM](https://github.com/transcom/mymove/assets/146959895/1b7e1c19-2bed-48e4-9c57-7474ce0431e0)


This scenario create an ARMY service member. If you want to test the other templates for air/space force, and the naval branches of service, you'll have to go through the entire process manually. (Submit PPM Move -> Login as SC and approve -> Login as TOO and approve if needed -> Login as user and complete step 5)

### Backend

- [x] Code follows the guidelines for [Logging](https://transcom.github.io/mymove-docs/docs/getting-started/development/logging).
- [x] The requirements listed in [Querying the Database Safely](https://transcom.github.io/mymove-docs/docs/backend/guides/golang-guide#querying-the-database-safely) have been satisfied.