### PR TITLE
MAIN B-18652 MultiMove add download and Go to Move button for each move

### DIFF
--- a/src/pages/MyMove/Multi-Moves/MultiMovesMoveContainer/MultiMovesMoveContainer.jsx
+++ b/src/pages/MyMove/Multi-Moves/MultiMovesMoveContainer/MultiMovesMoveContainer.jsx
@@ -77,7 +77,15 @@ const MultiMovesMoveContainer = ({ moves }) => {
       <div className={styles.moveContainer}>
         <div className={styles.heading} key={index}>
           <h3>#{m.moveCode}</h3>
-          {m.status !== 'APPROVED' ? (
+          <div className={styles.moveContainerButtons} data-testid="headerBtns">
+            <ButtonDropdownMenu
+              data-testid="downloadBtn"
+              title="Download"
+              items={dropdownMenuItems}
+              divClassName={styles.dropdownBtn}
+              onItemClick={handleDropdownItemClick}
+              outline
+            />
             <Button
               data-testid="goToMoveBtn"
               className={styles.goToMoveBtn}
@@ -89,15 +97,7 @@ const MultiMovesMoveContainer = ({ moves }) => {
             >
               Go to Move
             </Button>
-          ) : (
-            <ButtonDropdownMenu
-              title="Download"
-              items={dropdownMenuItems}
-              divClassName={styles.dropdownBtn}
-              onItemClick={handleDropdownItemClick}
-              outline
-            />
-          )}
+          </div>
           <FontAwesomeIcon
             className={styles.icon}
             icon={classnames({

--- a/src/pages/MyMove/Multi-Moves/MultiMovesMoveContainer/MultiMovesMoveContainer.module.scss
+++ b/src/pages/MyMove/Multi-Moves/MultiMovesMoveContainer/MultiMovesMoveContainer.module.scss
@@ -19,7 +19,7 @@
     flex-direction: column;
     justify-content: space-between;
 
-  .heading {
+.heading {
     display: flex;
     align-items: center;
     justify-content: space-between;
@@ -29,12 +29,9 @@
     @include u-border('base-lighter');
     @include u-padding(2);
 
-    .goToMoveBtn {
-        margin-left: auto;
-    }
-
-    .dropdownBtn {
-        margin-left: auto;
+    .moveContainerButtons {
+      margin-left: auto;
+      display: flex;
     }
 
     h3 {
@@ -47,6 +44,28 @@
     .icon {
        margin-left: 1rem;
     }
+
+  // handling mobile device layout
+  // the buttons are too large to display so we will make them a column
+  @media (max-width: $tablet) {
+    flex-direction: column;
+
+    h3 {
+      margin-bottom: 0.5rem;
+    }
+
+    .moveContainerButtons {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 5px;
+      width: 100%;
+    }
+
+    .icon {
+      margin-top: 0.5rem;
+    }
+  }
 }
 
   .moveInfoList {

--- a/src/pages/MyMove/Multi-Moves/MultiMovesMoveContainer/MultiMovesMoveContainer.test.jsx
+++ b/src/pages/MyMove/Multi-Moves/MultiMovesMoveContainer/MultiMovesMoveContainer.test.jsx
@@ -56,4 +56,36 @@ describe('MultiMovesMoveContainer', () => {
     // The move details should be hidden again
     expect(screen.queryByText('Shipments')).not.toBeInTheDocument();
   });
+
+  it('renders Go to Move & Download buttons for current move', () => {
+    render(
+      <MockProviders>
+        <MultiMovesMoveContainer moves={mockCurrentMoves} />
+      </MockProviders>,
+    );
+
+    expect(screen.getByTestId('headerBtns')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Download' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Go to Move' })).toBeInTheDocument();
+  });
+
+  it('renders Go to Move & Download buttons for previous moves exceeding one', () => {
+    render(
+      <MockProviders>
+        <MultiMovesMoveContainer moves={mockPreviousMoves} />
+      </MockProviders>,
+    );
+
+    // Check for the container that holds the buttons - there should be 2
+    const headerBtnsElements = screen.getAllByTestId('headerBtns');
+    expect(headerBtnsElements).toHaveLength(2);
+
+    // Check for Download buttons - there should be 2
+    const downloadButtons = screen.getAllByRole('button', { name: 'Download' });
+    expect(downloadButtons).toHaveLength(2);
+
+    // Check for Go to Move buttons - there should be 2
+    const goToMoveButtons = screen.getAllByRole('button', { name: 'Go to Move' });
+    expect(goToMoveButtons).toHaveLength(2);
+  });
 });


### PR DESCRIPTION
[INTEGRATION BRANCH PR](https://github.com/transcom/mymove/pull/12036)

## [Agility ticket](https://www13.v1host.com/USTRANSCOM38/story.mvc/Summary?oidToken=Story%3a904807)

## Summary

We want to remove the conditional logic that determines if the button for a move on the multi-move dashboard shows the `Go to Move` or the `Download` buttons. Instead, we just want to show them both for each move. 

This PR does the following:
- removes logic on which button renders based on `move.status`
- updates css to consider mobile views, adding column flexbox to accommodate mobile screens
- updates tests associated with changes

### How to test

1. Access MM as a customer
2. Log in and you'll be navigated to the MM dashboard
3. You should see a "Download" button and "Go to Move" button for every move associated with that user

## Screenshots
![Screenshot 2024-02-22 at 8 21 57 AM](https://github.com/transcom/mymove/assets/136510600/e3ea482f-c470-40d9-b078-0e6ec0ac86e4)

