### PR TITLE
B 19035 update payment reminder email template integration

### DIFF
--- a/pkg/assets/notifications/templates/move_payment_reminder_template.html
+++ b/pkg/assets/notifications/templates/move_payment_reminder_template.html
@@ -18,7 +18,7 @@ To request payment, you should have copies of:</p>
 <ul>
 <li>       Weight tickets from certified scales, documenting empty and full weights for all vehicles and
 trailers you used for your move.</li>
-<li>       Receipts for reimbursable expenses (see our moving tips PDF for more info {{.OneSourceLink}})</li>
+<li>       Receipts for reimbursable expenses (see our moving tips PDF for more info <a href="{{.OneSourceLink}}">{{.OneSourceLink}})</a></li>
 </ul>
 
 <p>MilMove will ask you to upload copies of your documents as you complete your payment request.

--- a/pkg/assets/notifications/templates/move_payment_reminder_template.html
+++ b/pkg/assets/notifications/templates/move_payment_reminder_template.html
@@ -1,44 +1,37 @@
-<p>We hope your move to {{.DestinationDutyLocation}} went well.</p>
+<p>*** DO NOT REPLY directly to this email ***</p>
 
-<p>It’s been a couple of weeks, so we want to make sure you get paid for that move. {{.IncentiveTxt}}</p>
+<p>This is a reminder that your PPM with the assigned move code {{.Locator}} from INSERTADDRESSHERE
+to {{.DestinationDutyLocation}} is awaiting action in MilMove.</p>
 
-<p>To get your incentive, you need to request payment.</p>
+<p>To get your payment, you need to login to MilMove, document expenses, and request payment.</p>
 
-<p>Log in to MilMove and request payment</p>
+<p>To do that:</p>
 
-<p>We want to pay you for your PPM, but we can’t do that until you document expenses and request payment.</p>
+  * Log into MilMove
+  * Click on "Upload PPM Documents"
+  * Follow the instructions
 
-<p>To do that</p>
+To request payment, you should have copies of:</p>
 
 <ul>
-  <li><a href="{{.MyMoveLink}}">Log in to MilMove</a></li>
-  <li>Click Request Payment</li>
-  <li>Follow the instructions.</li>
+<li>*       Weight tickets from certified scales, documenting empty and full weights for all vehicles and
+trailers you used for your move.</li>
+<li>*       Receipts for reimbursable expenses (see our moving tips PDF for more info {{.OneSourceLink}})</li>
 </ul>
 
-<p>What documents do you need?</p>
+<p>MilMove will ask you to upload copies of your documents as you complete your payment request.
 
-<p>To request payment, you should have copies of:</p>
-<ul>
-  <li>Weight tickets from certified scales, documenting empty and full weights for all vehicles and trailers you used for your move</li>
-  <li>Receipts for reimbursable expenses (see our moving tips PDF for more info)</li>
-</ul>
+<p>If you are missing reciepts, you can still request payment but may not get reimbursement or a tax credit
+for those expenses.</p>
 
-<p>MilMove will ask you to upload copies of your documents as you complete your payment request.</p>
+<p>Payment request must be submitted within 45 days of your move date.</p>
 
-<p>What if you’re missing documents?</p>
+<p>If you have any questions, contact a government transportation office. You can see a listing of</p>
+transportation offices on Military OneSource here: <a href="https://installations.militaryonesource.mil/search?program-services=2/view-by=ALL"></a>
 
-<p>If you’re missing receipts, you can still request payment. You might not get reimbursement or a tax credit for those expenses.</p>
-{{ if .TOName }}
-<p>If you’re missing certified weight tickets, your PPPO will have to help. Call {{.TOName}}{{if .TOPhone}} at {{.TOPhone}}{{end}} to have them walk you through it. Reference your move locator code: {{.Locator}}.</p>
-{{- end -}}
+<p>Thank you,</p>
 
-{{ if not .TOName }}
-<p>If you are missing weight tickets, someone from the government will have to help. Consult Military OneSource's <a href="https://www.militaryonesource.mil/moving-housing/moving/planning-your-move/customer-service-contacts-for-military-pcs/">directory of PCS-related contacts</a> to find your best contact and reference your move code {{.Locator}}.</p>
-{{- end }}
+<p>USTRANSCOM MilMove Team</p>
 
-<p>Log in to MilMove to complete your request and get paid.</p>
-
-<p>Request payment within 45 days of your move date or you might not be able to get paid.</p>
-
-{{if .TOName}}<p>If you have any questions or concerns, you can talk to a human! Call your local PPPO at {{.TOName}}{{if .TOPhone}} at {{.TOPhone}}{{end}}. Reference your move locator code: {{.Locator}}.</p>{{end}}
+<p>The information contained in this email may contain Privacy Act information and is therefore protected
+under the Privacy Act of 1974. Failure to protect Privacy Act information could result in a $5,000 fine.</p>

--- a/pkg/assets/notifications/templates/move_payment_reminder_template.html
+++ b/pkg/assets/notifications/templates/move_payment_reminder_template.html
@@ -1,22 +1,24 @@
 <p>*** DO NOT REPLY directly to this email ***</p>
 
-<p>This is a reminder that your PPM with the assigned move code {{.Locator}} from INSERTADDRESSHERE
-to {{.DestinationDutyLocation}} is awaiting action in MilMove.</p>
+<p>This is a reminder that your PPM with the <strong>assigned move code {{.Locator}}</strong> from <strong>{{.OriginDutyLocation}}</strong>
+to <strong>{{.DestinationDutyLocation}}</strong> is awaiting action in MilMove.</p>
 
 <p>To get your payment, you need to login to MilMove, document expenses, and request payment.</p>
 
 <p>To do that:</p>
 
-  * Log into MilMove
-  * Click on "Upload PPM Documents"
-  * Follow the instructions
+<ul>
+  <li> Log into MilMove</li>
+  <li> Click on "Upload PPM Documents"</li>
+  <li> Follow the instructions</li>
+</ul>
 
 To request payment, you should have copies of:</p>
 
 <ul>
-<li>*       Weight tickets from certified scales, documenting empty and full weights for all vehicles and
+<li>       Weight tickets from certified scales, documenting empty and full weights for all vehicles and
 trailers you used for your move.</li>
-<li>*       Receipts for reimbursable expenses (see our moving tips PDF for more info {{.OneSourceLink}})</li>
+<li>       Receipts for reimbursable expenses (see our moving tips PDF for more info {{.OneSourceLink}})</li>
 </ul>
 
 <p>MilMove will ask you to upload copies of your documents as you complete your payment request.

--- a/pkg/assets/notifications/templates/move_payment_reminder_template.html
+++ b/pkg/assets/notifications/templates/move_payment_reminder_template.html
@@ -29,7 +29,7 @@ for those expenses.</p>
 <p>Payment request must be submitted within 45 days of your move date.</p>
 
 <p>If you have any questions, contact a government transportation office. You can see a listing of</p>
-transportation offices on Military OneSource here: <a href="{{.OneSourceLink}}"></a>
+transportation offices on Military OneSource here: &lt;<a href="{{.OneSourceLink}}">{{.OneSourceLink}}</a>&gt;
 
 <p>Thank you,</p>
 

--- a/pkg/assets/notifications/templates/move_payment_reminder_template.html
+++ b/pkg/assets/notifications/templates/move_payment_reminder_template.html
@@ -29,7 +29,7 @@ for those expenses.</p>
 <p>Payment request must be submitted within 45 days of your move date.</p>
 
 <p>If you have any questions, contact a government transportation office. You can see a listing of</p>
-transportation offices on Military OneSource here: <a href="https://installations.militaryonesource.mil/search?program-services=2/view-by=ALL"></a>
+transportation offices on Military OneSource here: <a href="{{.OneSourceLink}}"></a>
 
 <p>Thank you,</p>
 

--- a/pkg/assets/notifications/templates/move_payment_reminder_template.txt
+++ b/pkg/assets/notifications/templates/move_payment_reminder_template.txt
@@ -25,8 +25,7 @@ for those expenses.
 Payment request must be submitted within 45 days of your move date.
 
 If you have any questions, contact a government transportation office. You can see a listing of
-transportation offices on Military OneSource here: <https://installations.militaryonesource.mil/search?
-program-services=2/view-by=ALL>
+transportation offices on Military OneSource here: <{{.OneSourceLink}}>
 
 Thank you,
 

--- a/pkg/assets/notifications/templates/move_payment_reminder_template.txt
+++ b/pkg/assets/notifications/templates/move_payment_reminder_template.txt
@@ -1,35 +1,36 @@
-We hope your move to {{.DestinationDutyLocation}} went well.
+*** DO NOT REPLY directly to this email ***
 
-It’s been a couple of weeks, so we want to make sure you get paid for that move. {{.IncentiveTxt}}
+This is a reminder that your PPM with the assigned move code {{.Locator}} from INSERTADDRESSHERE
+to {{.DestinationDutyLocation}} is awaiting action in MilMove.
 
-To get your incentive, you need to request payment.
+To get your payment, you need to login to MilMove, document expenses, and request payment.
 
-Log in to MilMove and request payment
+To do that:
 
-We want to pay you for your PPM, but we can’t do that until you document expenses and request payment.
-
-To do that
-
-  * Log in to MilMove
-  * Click Request Payment
-  * Follow the instructions.
-
-What documents do you need?
+  * Log into MilMove
+  * Click on "Upload PPM Documents"
+  * Follow the instructions
 
 To request payment, you should have copies of:
-  * Weight tickets from certified scales, documenting empty and full weights for all vehicles and trailers you used for your move
-  * Receipts for reimbursable expenses (see our moving tips PDF for more info)
+
+*       Weight tickets from certified scales, documenting empty and full weights for all vehicles and
+trailers you used for your move.
+*       Receipts for reimbursable expenses (see our moving tips PDF for more info {{.OneSourceLink}})
 
 MilMove will ask you to upload copies of your documents as you complete your payment request.
 
-What if you’re missing documents?
+If you are missing reciepts, you can still request payment but may not get reimbursement or a tax credit
+for those expenses.
 
-If you’re missing receipts, you can still request payment. You might not get reimbursement or a tax credit for those expenses.
+Payment request must be submitted within 45 days of your move date.
 
-If you’re missing certified weight tickets, your PPPO will have to help. {{if .TOName}}Call {{.TOName}}{{if .TOPhone}} at {{.TOPhone}}{{end}} to have them walk you through it. Reference your move locator code: {{.Locator}}.{{end}}
+If you have any questions, contact a government transportation office. You can see a listing of
+transportation offices on Military OneSource here: <https://installations.militaryonesource.mil/search?
+program-services=2/view-by=ALL>
 
-Log in to MilMove to complete your request and get paid.
+Thank you,
 
-Request payment within 45 days of your move date or you might not be able to get paid.
+USTRANSCOM MilMove Team
 
-{{if .TOName}}If you have any questions or concerns, you can talk to a human! Call your local PPPO at {{.TOName}}{{if .TOPhone}} at {{ .TOPhone}}{{end}}. Reference your move locator code: {{.Locator}}.{{end}}
+The information contained in this email may contain Privacy Act information and is therefore protected
+under the Privacy Act of 1974. Failure to protect Privacy Act information could result in a $5,000 fine.

--- a/pkg/assets/notifications/templates/move_payment_reminder_template.txt
+++ b/pkg/assets/notifications/templates/move_payment_reminder_template.txt
@@ -1,6 +1,6 @@
 *** DO NOT REPLY directly to this email ***
 
-This is a reminder that your PPM with the assigned move code {{.Locator}} from INSERTADDRESSHERE
+This is a reminder that your PPM with the assigned move code {{.Locator}} from {{.OriginDutyLocation}}
 to {{.DestinationDutyLocation}} is awaiting action in MilMove.
 
 To get your payment, you need to login to MilMove, document expenses, and request payment.

--- a/pkg/notifications/move_payment_reminder.go
+++ b/pkg/notifications/move_payment_reminder.go
@@ -109,6 +109,7 @@ func (m PaymentReminder) formatEmails(appCtx appcontext.AppContext, PaymentRemin
 	var emails []emailContent
 	for _, PaymentReminderEmailInfo := range PaymentReminderEmailInfos {
 		htmlBody, textBody, err := m.renderTemplates(appCtx, PaymentReminderEmailData{
+			OriginDutyLocation:      PaymentReminderEmailInfo.OriginDutyLocationName,
 			DestinationDutyLocation: PaymentReminderEmailInfo.NewDutyLocationName,
 			Locator:                 PaymentReminderEmailInfo.Locator,
 			OneSourceLink:           OneSourceTransportationOfficeLink,
@@ -172,6 +173,7 @@ func (m PaymentReminder) OnSuccess(appCtx appcontext.AppContext, PaymentReminder
 
 // PaymentReminderEmailData is used to render an email template
 type PaymentReminderEmailData struct {
+	OriginDutyLocation      string
 	DestinationDutyLocation string
 	Locator                 string
 	OneSourceLink           string

--- a/pkg/notifications/move_payment_reminder.go
+++ b/pkg/notifications/move_payment_reminder.go
@@ -46,16 +46,14 @@ type PaymentReminderEmailInfos []PaymentReminderEmailInfo
 
 // PaymentReminderEmailInfo contains payment reminder data for rendering a template
 type PaymentReminderEmailInfo struct {
-	ServiceMemberID     uuid.UUID   `db:"id"`
-	Email               *string     `db:"personal_email"`
-	NewDutyLocationName string      `db:"new_duty_location_name"`
-	WeightEstimate      *unit.Pound `db:"weight_estimate"`
-	IncentiveEstimate   *unit.Cents `db:"incentive_estimate"`
-	IncentiveTxt        string
-	TOName              *string `db:"transportation_office_name"`
-	TOPhone             *string `db:"transportation_office_phone"`
-	MoveDate            string  `db:"move_date"`
-	Locator             string  `db:"locator"`
+	ServiceMemberID        uuid.UUID   `db:"id"`
+	Email                  *string     `db:"personal_email"`
+	NewDutyLocationName    string      `db:"new_duty_location_name"`
+	OriginDutyLocationName string      `db:"origin_duty_location_name"`
+	MoveDate               string      `db:"move_date"`
+	Locator                string      `db:"locator"`
+	WeightEstimate         *unit.Pound `db:"weight_estimate"`
+	IncentiveEstimate      *unit.Cents `db:"incentive_estimate"`
 }
 
 // GetEmailInfo fetches payment email information
@@ -66,23 +64,15 @@ func (m PaymentReminder) GetEmailInfo(appCtx appcontext.AppContext) (PaymentRemi
 	COALESCE(ps.estimated_incentive, 0) AS incentive_estimate,
 	ps.expected_departure_date  as move_date,
 	dln.name AS new_duty_location_name,
-	tos.name AS transportation_office_name,
-	opl.number AS transportation_office_phone,
+	dln2.name AS origin_duty_location_name,
 	m.locator
 FROM ppm_shipments ps
 	JOIN mto_shipments ms on ms.id = ps.shipment_id
 	JOIN moves m ON ms.move_id  = m.id
 	JOIN orders o ON m.orders_id = o.id
 	JOIN service_members sm ON o.service_member_id = sm.id
-	LEFT JOIN duty_locations dln ON o.new_duty_location_id = dln.id
-	LEFT JOIN transportation_offices tos ON tos.id = dln.transportation_office_id
-		LEFT JOIN office_phone_lines opl on opl.transportation_office_id = tos.id and opl.id =
-	(
-		SELECT opl2.id FROM office_phone_lines opl2
-		WHERE opl2.is_dsn_number IS false
-		AND tos.id = opl2.transportation_office_id
-		LIMIT 1
-	)
+	JOIN duty_locations dln ON o.new_duty_location_id = dln.id
+	JOIN duty_locations dln2 ON o.origin_duty_location_id = dln2.id
 	WHERE ps.status = 'WAITING_ON_CUSTOMER'::public."ppm_shipment_status"
 	AND ms.status = 'APPROVED'::public."mto_shipment_status"
 	AND ps.expected_departure_date <= now() - ($1)::interval
@@ -118,29 +108,10 @@ func (m PaymentReminder) emails(appCtx appcontext.AppContext) ([]emailContent, e
 func (m PaymentReminder) formatEmails(appCtx appcontext.AppContext, PaymentReminderEmailInfos PaymentReminderEmailInfos) ([]emailContent, error) {
 	var emails []emailContent
 	for _, PaymentReminderEmailInfo := range PaymentReminderEmailInfos {
-		incentiveTxt := ""
-		if PaymentReminderEmailInfo.WeightEstimate.Int() > 0 && PaymentReminderEmailInfo.IncentiveEstimate.Int() > 0 {
-			incentiveTxt = fmt.Sprintf("You expected to move about %d lbs, which gives you an estimated incentive of %s.", PaymentReminderEmailInfo.WeightEstimate.Int(), PaymentReminderEmailInfo.IncentiveEstimate.ToDollarString())
-		}
-		var toPhone *string
-		if PaymentReminderEmailInfo.TOPhone != nil {
-			toPhone = PaymentReminderEmailInfo.TOPhone
-		}
-
-		var toName *string
-		if PaymentReminderEmailInfo.TOPhone != nil {
-			toName = PaymentReminderEmailInfo.TOName
-		}
-
 		htmlBody, textBody, err := m.renderTemplates(appCtx, PaymentReminderEmailData{
 			DestinationDutyLocation: PaymentReminderEmailInfo.NewDutyLocationName,
-			WeightEstimate:          fmt.Sprintf("%d", PaymentReminderEmailInfo.WeightEstimate.Int()),
-			IncentiveEstimate:       PaymentReminderEmailInfo.IncentiveEstimate.ToDollarString(),
-			IncentiveTxt:            incentiveTxt,
-			TOName:                  toName,
-			TOPhone:                 toPhone,
 			Locator:                 PaymentReminderEmailInfo.Locator,
-			MyMoveLink:              MyMoveLink,
+			OneSourceLink:           OneSourceTransportationOfficeLink,
 		})
 		if err != nil {
 			appCtx.Logger().Error("error rendering template", zap.Error(err))
@@ -153,7 +124,7 @@ func (m PaymentReminder) formatEmails(appCtx appcontext.AppContext, PaymentRemin
 		}
 		smEmail := emailContent{
 			recipientEmail: *PaymentReminderEmailInfo.Email,
-			subject:        fmt.Sprintf("[MilMove] Reminder: request payment for your move to %s (move %s)", PaymentReminderEmailInfo.NewDutyLocationName, PaymentReminderEmailInfo.Locator),
+			subject:        "Complete your Personally Procured Move (PPM)",
 			htmlBody:       htmlBody,
 			textBody:       textBody,
 			onSuccess:      m.OnSuccess(appCtx, PaymentReminderEmailInfo),
@@ -202,13 +173,8 @@ func (m PaymentReminder) OnSuccess(appCtx appcontext.AppContext, PaymentReminder
 // PaymentReminderEmailData is used to render an email template
 type PaymentReminderEmailData struct {
 	DestinationDutyLocation string
-	WeightEstimate          string
-	IncentiveEstimate       string
-	IncentiveTxt            string
-	TOName                  *string
-	TOPhone                 *string
 	Locator                 string
-	MyMoveLink              string
+	OneSourceLink           string
 }
 
 // RenderHTML renders the html for the email

--- a/pkg/notifications/move_payment_reminder_test.go
+++ b/pkg/notifications/move_payment_reminder_test.go
@@ -321,7 +321,7 @@ for those expenses.</p>
 <p>Payment request must be submitted within 45 days of your move date.</p>
 
 <p>If you have any questions, contact a government transportation office. You can see a listing of</p>
-transportation offices on Military OneSource here: <a href="https://installations.militaryonesource.mil/search?program-services=2/view-by=ALL"></a>
+transportation offices on Military OneSource here: <a href="` + paymentReminderData.OneSourceLink + `"></a>
 
 <p>Thank you,</p>
 
@@ -374,8 +374,7 @@ for those expenses.
 Payment request must be submitted within 45 days of your move date.
 
 If you have any questions, contact a government transportation office. You can see a listing of
-transportation offices on Military OneSource here: <https://installations.militaryonesource.mil/search?
-program-services=2/view-by=ALL>
+transportation offices on Military OneSource here: <` + paymentReminderData.OneSourceLink + `>
 
 Thank you,
 

--- a/pkg/notifications/move_payment_reminder_test.go
+++ b/pkg/notifications/move_payment_reminder_test.go
@@ -321,7 +321,7 @@ for those expenses.</p>
 <p>Payment request must be submitted within 45 days of your move date.</p>
 
 <p>If you have any questions, contact a government transportation office. You can see a listing of</p>
-transportation offices on Military OneSource here: <a href="` + paymentReminderData.OneSourceLink + `"></a>
+transportation offices on Military OneSource here: &lt;<a href="` + paymentReminderData.OneSourceLink + `">` + paymentReminderData.OneSourceLink + `</a>&gt;
 
 <p>Thank you,</p>
 

--- a/pkg/notifications/move_payment_reminder_test.go
+++ b/pkg/notifications/move_payment_reminder_test.go
@@ -284,29 +284,33 @@ func (suite *NotificationSuite) TestPaymentReminderHTMLTemplateRender() {
 	suite.NoError(err)
 
 	paymentReminderData := PaymentReminderEmailData{
+		OriginDutyLocation:      "OriginDutyLocation",
 		DestinationDutyLocation: "DestDutyLocation",
 		Locator:                 "abc123",
 		OneSourceLink:           OneSourceTransportationOfficeLink,
 	}
 	expectedHTMLContent := `<p>*** DO NOT REPLY directly to this email ***</p>
 
-<p>This is a reminder that your PPM with the assigned move code ` + paymentReminderData.Locator + ` from INSERTADDRESSHERE
-to ` + paymentReminderData.DestinationDutyLocation + ` is awaiting action in MilMove.</p>
+<p>This is a reminder that your PPM with the <strong>assigned move code ` + paymentReminderData.Locator + `</strong> from <strong>` + paymentReminderData.OriginDutyLocation +
+		`</strong>
+to <strong>` + paymentReminderData.DestinationDutyLocation + `</strong> is awaiting action in MilMove.</p>
 
 <p>To get your payment, you need to login to MilMove, document expenses, and request payment.</p>
 
 <p>To do that:</p>
 
-  * Log into MilMove
-  * Click on "Upload PPM Documents"
-  * Follow the instructions
+<ul>
+  <li> Log into MilMove</li>
+  <li> Click on "Upload PPM Documents"</li>
+  <li> Follow the instructions</li>
+</ul>
 
 To request payment, you should have copies of:</p>
 
 <ul>
-<li>*       Weight tickets from certified scales, documenting empty and full weights for all vehicles and
+<li>       Weight tickets from certified scales, documenting empty and full weights for all vehicles and
 trailers you used for your move.</li>
-<li>*       Receipts for reimbursable expenses (see our moving tips PDF for more info ` + paymentReminderData.OneSourceLink + `)</li>
+<li>       Receipts for reimbursable expenses (see our moving tips PDF for more info ` + paymentReminderData.OneSourceLink + `)</li>
 </ul>
 
 <p>MilMove will ask you to upload copies of your documents as you complete your payment request.
@@ -337,13 +341,15 @@ func (suite *NotificationSuite) TestPaymentReminderTextTemplateRender() {
 	pr, err := NewPaymentReminder()
 	suite.NoError(err)
 	paymentReminderData := PaymentReminderEmailData{
+		OriginDutyLocation:      "OriginDutyLocation",
 		DestinationDutyLocation: "DestDutyLocation",
 		Locator:                 "abc123",
 		OneSourceLink:           OneSourceTransportationOfficeLink,
 	}
 	expectedTextContent := `*** DO NOT REPLY directly to this email ***
 
-This is a reminder that your PPM with the assigned move code ` + paymentReminderData.Locator + ` from INSERTADDRESSHERE
+This is a reminder that your PPM with the assigned move code ` + paymentReminderData.Locator + ` from ` + paymentReminderData.OriginDutyLocation +
+		`
 to ` + paymentReminderData.DestinationDutyLocation + ` is awaiting action in MilMove.
 
 To get your payment, you need to login to MilMove, document expenses, and request payment.

--- a/pkg/notifications/move_payment_reminder_test.go
+++ b/pkg/notifications/move_payment_reminder_test.go
@@ -310,7 +310,8 @@ To request payment, you should have copies of:</p>
 <ul>
 <li>       Weight tickets from certified scales, documenting empty and full weights for all vehicles and
 trailers you used for your move.</li>
-<li>       Receipts for reimbursable expenses (see our moving tips PDF for more info ` + paymentReminderData.OneSourceLink + `)</li>
+<li>       Receipts for reimbursable expenses (see our moving tips PDF for more info <a href="` + paymentReminderData.OneSourceLink + `">` +
+		paymentReminderData.OneSourceLink + `)</a></li>
 </ul>
 
 <p>MilMove will ask you to upload copies of your documents as you complete your payment request.


### PR DESCRIPTION
## B-19035

## Summary

As a Customer  you should receive an email if you haven't submitted any docs within the last 14 days of today.
This PR updates the original template and updates the trigger.

## Verification Steps for Reviewers

These are to be checked by a reviewer.

- [ ] Has the branch been pulled in and checked out?
- [ ] Have the BL acceptance criteria been met for this change?
- [ ] Was the CircleCI build successful?
- [ ] Has the code been reviewed from a standards and best practices point of view?

### How to test

1. Create a move with an estimateDepartureDate that is <= 14 days from today(i.e. today = January 14, 2024 estimateDeparture  could be January 1, 2024 ), and has no null estimate values(incentive, weight), and set the personal email to one you can access
2. Approve this move as a service counselor
3. Run `aws-vault exec transcom-gov-dev` to get into the subshell
4. Run `go run ./cmd/milmove-tasks send-payment-reminder --email-backend=ses --aws-ses-domain=devlocal.dp3.us  --aws-ses-region=us-gov-west-1`
5. You should get a payment reminder email in a couple minutes max

## Screenshots
**Actual Email**
<img width="1284" alt="paymentReminderEmail2" src="https://github.com/transcom/mymove/assets/146969726/11abd352-44b8-42fa-8f52-3648544c55fe">

**Email template from PO**
[Complete your PPM EMail.docx](https://github.com/transcom/mymove/files/14483166/Complete.your.PPM.EMail.docx)
