### PR TITLE
INT-B-19074

### DIFF
--- a/package.json
+++ b/package.json
@@ -130,7 +130,7 @@
     "@babel/core": "~7.22.8",
     "@babel/helper-builder-react-jsx": "^7.22.5",
     "@babel/helper-builder-react-jsx-experimental": "^7.12.11",
-    "@faker-js/faker": "^8.0.2",
+    "@faker-js/faker": "^8.4.1",
     "@jackfranklin/test-data-bot": "^2.1.0",
     "@playwright/test": "^1.36.0",
     "@stoplight/spectral-cli": "^6.10.0",

--- a/pkg/assets/notifications/templates/ppm_packet_email_template.html
+++ b/pkg/assets/notifications/templates/ppm_packet_email_template.html
@@ -3,13 +3,14 @@
 <h4>Next steps:</h4>
 {{if eq .ServiceBranch "Marine Corps, Navy, and Coast Guard"}}
 <p>For Marine Corps, Navy, and Coast Guard personnel:</p>
-<p>You can now log into MilMove <a href="{{.MyMoveLink}}/">{{.MyMoveLink}}/</a> and view your payment packet; however, you do not need to forward your packet to finance as your closeout location is associated with your finance office and they will handle this step for you.</p>
+<p>You can now log into MilMove <a href="{{.MyMoveLink}}">{{.MyMoveLink}}</a> and view your payment packet; however, you do not need to forward your payment packet to finance as your closeout location is associated with your finance office and they will handle this step for you.</p>
 <p>Note: Not all claimed expenses may have been accepted during PPM closeout if they did not meet the definition of a valid expense.</p>
 {{else}}
 <p>For {{.ServiceBranch}} personnel (FURTHER ACTION REQUIRED):</p>
-<p>You can now log into MilMove <a href="{{.MyMoveLink}}/">{{.MyMoveLink}}/</a> and download your payment packet to submit to {{.SubmitLocation}}. <strong>You must complete this step to receive final settlement of your PPM.</strong></p>
+<p>You can now log into MilMove <a href="{{.MyMoveLink}}">{{.MyMoveLink}}</a> and download your payment packet to submit to {{.SubmitLocation}}. <strong>You must complete this step to receive final settlement of your PPM.</strong></p>
 <p>{{if eq .ServiceBranch "Air Force and Space Force"}}Note: The Transportation Office does not determine claimable expenses. Claimable expenses will be determined by finance{{else if eq .ServiceBranch "Army"}}Note: Not all claimed expenses may have been accepted during PPM closeout if they did not meet the definition of a valid expense{{end}}.</p>
 {{end}}
+<p>Please be advised, your local finance office may require a DD Form 1351-2 to process payment. You can obtain a copy of this form by utilizing the search feature at <a href="{{.WashingtonHQServicesLink}}">{{.WashingtonHQServicesLink}}</a>.</p>
 <p>If you have any questions, contact a government transportation office. You can see a listing of transportation offices on Military One Source here: <a href="{{.OneSourceTransportationOfficeLink}}">{{.OneSourceTransportationOfficeLink}}</a></p>
 
 <p>Thank you,</p>

--- a/pkg/assets/notifications/templates/ppm_packet_email_template.txt
+++ b/pkg/assets/notifications/templates/ppm_packet_email_template.txt
@@ -6,15 +6,17 @@ Next steps:
 {{if eq .ServiceBranch "Marine Corps, Navy, and Coast Guard"}}
 For Marine Corps, Navy, and Coast Guard personnel:
 
-You can now log into MilMove <{{.MyMoveLink}}/> and view your payment packet; however, you do not need to forward your packet to finance as your closeout location is associated with your finance office and they will handle this step for you.
+You can now log into MilMove <{{.MyMoveLink}}> and view your payment packet; however, you do not need to forward your payment packet to finance as your closeout location is associated with your finance office and they will handle this step for you.
 
 Note: Not all claimed expenses may have been accepted during PPM closeout if they did not meet the definition of a valid expense.
 {{else}}
 For {{.ServiceBranch}} personnel (FURTHER ACTION REQUIRED):
 
-You can now log into MilMove <{{.MyMoveLink}}/> and download your payment packet to submit to {{.SubmitLocation}}. You must complete this step to receive final settlement of your PPM.
+You can now log into MilMove <{{.MyMoveLink}}> and download your payment packet to submit to {{.SubmitLocation}}. You must complete this step to receive final settlement of your PPM.
 
 {{if eq .ServiceBranch "Air Force and Space Force"}}Note: The Transportation Office does not determine claimable expenses. Claimable expenses will be determined by finance{{else if eq .ServiceBranch "Army"}}Note: Not all claimed expenses may have been accepted during PPM closeout if they did not meet the definition of a valid expense.{{end}}{{end}}
+
+Please be advised, your local finance office may require a DD Form 1351-2 to process payment. You can obtain a copy of this form by utilizing the search feature at {{.WashingtonHQServicesLink}}.
 
 If you have any questions, contact a government transportation office. You can see a listing of transportation offices on Military One Source here: {{.OneSourceTransportationOfficeLink}}
 

--- a/pkg/notifications/constants.go
+++ b/pkg/notifications/constants.go
@@ -2,3 +2,4 @@ package notifications
 
 const OneSourceTransportationOfficeLink = "https://installations.militaryonesource.mil/search?program-service=2/view-by=ALL"
 const MyMoveLink = "https://my.move.mil/"
+const WashingtonHQServicesLink = "www.esd.whs.mil"

--- a/pkg/notifications/constants.go
+++ b/pkg/notifications/constants.go
@@ -2,4 +2,4 @@ package notifications
 
 const OneSourceTransportationOfficeLink = "https://installations.militaryonesource.mil/search?program-service=2/view-by=ALL"
 const MyMoveLink = "https://my.move.mil/"
-const WashingtonHQServicesLink = "www.esd.whs.mil"
+const WashingtonHQServicesLink = "https://www.esd.whs.mil"

--- a/pkg/notifications/ppm_packet_email.go
+++ b/pkg/notifications/ppm_packet_email.go
@@ -41,6 +41,7 @@ type PpmPacketEmailData struct {
 	ServiceBranch                     string
 	Locator                           string
 	OneSourceTransportationOfficeLink string
+	WashingtonHQServicesLink          string
 	MyMoveLink                        string
 }
 
@@ -168,6 +169,7 @@ func (p PpmPacketEmail) GetEmailData(appCtx appcontext.AppContext) (PpmPacketEma
 				ServiceBranch:                     affiliationDisplayValue[*serviceMember.Affiliation],
 				Locator:                           move.Locator,
 				OneSourceTransportationOfficeLink: OneSourceTransportationOfficeLink,
+				WashingtonHQServicesLink:          WashingtonHQServicesLink,
 				MyMoveLink:                        MyMoveLink,
 			},
 			LoggerData{
@@ -185,6 +187,7 @@ func (p PpmPacketEmail) GetEmailData(appCtx appcontext.AppContext) (PpmPacketEma
 			ServiceBranch:                     affiliationDisplayValue[*serviceMember.Affiliation],
 			Locator:                           move.Locator,
 			OneSourceTransportationOfficeLink: OneSourceTransportationOfficeLink,
+			WashingtonHQServicesLink:          WashingtonHQServicesLink,
 			MyMoveLink:                        MyMoveLink,
 		},
 		LoggerData{

--- a/pkg/notifications/ppm_packet_email_test.go
+++ b/pkg/notifications/ppm_packet_email_test.go
@@ -122,6 +122,7 @@ func (suite *NotificationSuite) TestPpmPacketEmailHTMLTemplateRenderForAirAndSpa
 		ServiceBranch:                     affiliationDisplayValue[*serviceMember.Affiliation],
 		Locator:                           move.Locator,
 		OneSourceTransportationOfficeLink: OneSourceTransportationOfficeLink,
+		WashingtonHQServicesLink:          WashingtonHQServicesLink,
 		MyMoveLink:                        MyMoveLink,
 	})
 
@@ -130,10 +131,11 @@ func (suite *NotificationSuite) TestPpmPacketEmailHTMLTemplateRenderForAirAndSpa
 <h4>Next steps:</h4>
 
 <p>For ` + affiliationDisplayValue[*serviceMember.Affiliation] + ` personnel (FURTHER ACTION REQUIRED):</p>
-<p>You can now log into MilMove <a href="` + MyMoveLink + `/">` + MyMoveLink + `/</a> and download your payment packet to submit to ` + allOtherSubmitLocation + `. <strong>You must complete this step to receive final settlement of your PPM.</strong></p>
+<p>You can now log into MilMove <a href="` + MyMoveLink + `">` + MyMoveLink + `</a> and download your payment packet to submit to ` + allOtherSubmitLocation + `. <strong>You must complete this step to receive final settlement of your PPM.</strong></p>
 <p>Note: The Transportation Office does not determine claimable expenses. Claimable expenses will be determined by finance.</p>
 
-<p>If you have any questions, contact a government transportation office. You can see a listing of transportation offices on Military One Source here: <a href="https://installations.militaryonesource.mil/search?program-service=2/view-by=ALL">https://installations.militaryonesource.mil/search?program-service=2/view-by=ALL</a></p>
+<p>Please be advised, your local finance office may require a DD Form 1351-2 to process payment. You can obtain a copy of this form by utilizing the search feature at <a href="` + WashingtonHQServicesLink + `">` + WashingtonHQServicesLink + `</a>.</p>
+<p>If you have any questions, contact a government transportation office. You can see a listing of transportation offices on Military One Source here: <a href="` + OneSourceTransportationOfficeLink + `">` + OneSourceTransportationOfficeLink + `</a></p>
 
 <p>Thank you,</p>
 
@@ -212,6 +214,7 @@ func (suite *NotificationSuite) TestPpmPacketEmailHTMLTemplateRenderForArmy() {
 		ServiceBranch:                     affiliationDisplayValue[*serviceMember.Affiliation],
 		Locator:                           move.Locator,
 		OneSourceTransportationOfficeLink: OneSourceTransportationOfficeLink,
+		WashingtonHQServicesLink:          WashingtonHQServicesLink,
 		MyMoveLink:                        MyMoveLink,
 	})
 
@@ -220,10 +223,11 @@ func (suite *NotificationSuite) TestPpmPacketEmailHTMLTemplateRenderForArmy() {
 <h4>Next steps:</h4>
 
 <p>For ` + affiliationDisplayValue[*serviceMember.Affiliation] + ` personnel (FURTHER ACTION REQUIRED):</p>
-<p>You can now log into MilMove <a href="` + MyMoveLink + `/">` + MyMoveLink + `/</a> and download your payment packet to submit to ` + armySubmitLocation + `. <strong>You must complete this step to receive final settlement of your PPM.</strong></p>
+<p>You can now log into MilMove <a href="` + MyMoveLink + `">` + MyMoveLink + `</a> and download your payment packet to submit to ` + armySubmitLocation + `. <strong>You must complete this step to receive final settlement of your PPM.</strong></p>
 <p>Note: Not all claimed expenses may have been accepted during PPM closeout if they did not meet the definition of a valid expense.</p>
 
-<p>If you have any questions, contact a government transportation office. You can see a listing of transportation offices on Military One Source here: <a href="https://installations.militaryonesource.mil/search?program-service=2/view-by=ALL">https://installations.militaryonesource.mil/search?program-service=2/view-by=ALL</a></p>
+<p>Please be advised, your local finance office may require a DD Form 1351-2 to process payment. You can obtain a copy of this form by utilizing the search feature at <a href="` + WashingtonHQServicesLink + `">` + WashingtonHQServicesLink + `</a>.</p>
+<p>If you have any questions, contact a government transportation office. You can see a listing of transportation offices on Military One Source here: <a href="` + OneSourceTransportationOfficeLink + `">` + OneSourceTransportationOfficeLink + `</a></p>
 
 <p>Thank you,</p>
 
@@ -302,6 +306,7 @@ func (suite *NotificationSuite) TestPpmPacketEmailHTMLTemplateRenderForNavalBran
 		ServiceBranch:                     affiliationDisplayValue[*serviceMember.Affiliation],
 		Locator:                           move.Locator,
 		OneSourceTransportationOfficeLink: OneSourceTransportationOfficeLink,
+		WashingtonHQServicesLink:          WashingtonHQServicesLink,
 		MyMoveLink:                        MyMoveLink,
 	})
 
@@ -310,10 +315,11 @@ func (suite *NotificationSuite) TestPpmPacketEmailHTMLTemplateRenderForNavalBran
 <h4>Next steps:</h4>
 
 <p>For ` + affiliationDisplayValue[*serviceMember.Affiliation] + ` personnel:</p>
-<p>You can now log into MilMove <a href="` + MyMoveLink + `/">` + MyMoveLink + `/</a> and view your payment packet; however, you do not need to forward your packet to finance as your closeout location is associated with your finance office and they will handle this step for you.</p>
+<p>You can now log into MilMove <a href="` + MyMoveLink + `">` + MyMoveLink + `</a> and view your payment packet; however, you do not need to forward your payment packet to finance as your closeout location is associated with your finance office and they will handle this step for you.</p>
 <p>Note: Not all claimed expenses may have been accepted during PPM closeout if they did not meet the definition of a valid expense.</p>
 
-<p>If you have any questions, contact a government transportation office. You can see a listing of transportation offices on Military One Source here: <a href="https://installations.militaryonesource.mil/search?program-service=2/view-by=ALL">https://installations.militaryonesource.mil/search?program-service=2/view-by=ALL</a></p>
+<p>Please be advised, your local finance office may require a DD Form 1351-2 to process payment. You can obtain a copy of this form by utilizing the search feature at <a href="` + WashingtonHQServicesLink + `">` + WashingtonHQServicesLink + `</a>.</p>
+<p>If you have any questions, contact a government transportation office. You can see a listing of transportation offices on Military One Source here: <a href="` + OneSourceTransportationOfficeLink + `">` + OneSourceTransportationOfficeLink + `</a></p>
 
 <p>Thank you,</p>
 
@@ -390,9 +396,11 @@ Next steps:
 
 For ` + affiliationDisplayValue[*serviceMember.Affiliation] + ` personnel (FURTHER ACTION REQUIRED):
 
-You can now log into MilMove <` + MyMoveLink + `/> and download your payment packet to submit to ` + armySubmitLocation + `. You must complete this step to receive final settlement of your PPM.
+You can now log into MilMove <` + MyMoveLink + `> and download your payment packet to submit to ` + armySubmitLocation + `. You must complete this step to receive final settlement of your PPM.
 
 Note: Not all claimed expenses may have been accepted during PPM closeout if they did not meet the definition of a valid expense.
+
+Please be advised, your local finance office may require a DD Form 1351-2 to process payment. You can obtain a copy of this form by utilizing the search feature at ` + WashingtonHQServicesLink + `.
 
 If you have any questions, contact a government transportation office. You can see a listing of transportation offices on Military One Source here: ` + OneSourceTransportationOfficeLink + `
 
@@ -459,6 +467,7 @@ func (suite *NotificationSuite) TestPpmPacketEmailZipcodeFallback() {
 		ServiceBranch:                     affiliationDisplayValue[*serviceMember.Affiliation],
 		Locator:                           move.Locator,
 		OneSourceTransportationOfficeLink: OneSourceTransportationOfficeLink,
+		WashingtonHQServicesLink:          WashingtonHQServicesLink,
 		MyMoveLink:                        MyMoveLink,
 	})
 	// <strong>Des Moines, IA</strong> to <strong>Fort Eisenhower, GA</strong>
@@ -467,10 +476,11 @@ func (suite *NotificationSuite) TestPpmPacketEmailZipcodeFallback() {
 <h4>Next steps:</h4>
 
 <p>For ` + affiliationDisplayValue[*serviceMember.Affiliation] + ` personnel (FURTHER ACTION REQUIRED):</p>
-<p>You can now log into MilMove <a href="` + MyMoveLink + `/">` + MyMoveLink + `/</a> and download your payment packet to submit to ` + allOtherSubmitLocation + `. <strong>You must complete this step to receive final settlement of your PPM.</strong></p>
+<p>You can now log into MilMove <a href="` + MyMoveLink + `">` + MyMoveLink + `</a> and download your payment packet to submit to ` + allOtherSubmitLocation + `. <strong>You must complete this step to receive final settlement of your PPM.</strong></p>
 <p>Note: The Transportation Office does not determine claimable expenses. Claimable expenses will be determined by finance.</p>
 
-<p>If you have any questions, contact a government transportation office. You can see a listing of transportation offices on Military One Source here: <a href="https://installations.militaryonesource.mil/search?program-service=2/view-by=ALL">https://installations.militaryonesource.mil/search?program-service=2/view-by=ALL</a></p>
+<p>Please be advised, your local finance office may require a DD Form 1351-2 to process payment. You can obtain a copy of this form by utilizing the search feature at <a href="` + WashingtonHQServicesLink + `">` + WashingtonHQServicesLink + `</a>.</p>
+<p>If you have any questions, contact a government transportation office. You can see a listing of transportation offices on Military One Source here: <a href="` + OneSourceTransportationOfficeLink + `">` + OneSourceTransportationOfficeLink + `</a></p>
 
 <p>Thank you,</p>
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2008,10 +2008,10 @@
     minimatch "^3.1.2"
     strip-json-comments "^3.1.1"
 
-"@faker-js/faker@^8.0.2":
-  version "8.0.2"
-  resolved "https://registry.npmjs.org/@faker-js/faker/-/faker-8.0.2.tgz"
-  integrity sha512-Uo3pGspElQW91PCvKSIAXoEgAUlRnH29sX2/p89kg7sP1m2PzCufHINd0FhTXQf6DYGiUlVncdSPa2F9wxed2A==
+"@faker-js/faker@^8.4.1":
+  version "8.4.1"
+  resolved "https://registry.yarnpkg.com/@faker-js/faker/-/faker-8.4.1.tgz#5d5e8aee8fce48f5e189bf730ebd1f758f491451"
+  integrity sha512-XQ3cU+Q8Uqmrbf2e0cIC/QN43sTBSC8KF12u29Mb47tWrt2hAgBXSgpZMj4Ao8Uk0iJcU99QsOCaIL8934obCg==
 
 "@fal-works/esbuild-plugin-global-externals@^2.1.2":
   version "2.1.2"


### PR DESCRIPTION
## [B-19074](https://www13.v1host.com/USTRANSCOM38/assetdetail.v1?number=B-19074)

## Summary

Govt. came back after completion of B-19034 with a request to add "payment" to a sentence for the naval branches, and to add a paragraph before the final sign-off that informs the customer that they may need to fill out a DD Form 1351-2. This PR adds these to the .txt and .html templates, adds a relevant link to the constants.go file, and updates the tests to match the new content.

### How to test

Follow the steps given in #12090 and ensure that the sent email content matches the new template.

If you chose a naval branch, the first line should now read (Change in **bold**): "You can now log into MilMove and view your payment packet; however, you do not need to forward your **payment packet** to finance as your closeout location is associated with your finance office and they will handle this step for you."

And **all** branches should now have a new line before the final one, that reads: "Please be advised, your local finance office may require a DD Form 1351-2 to process payment. You can obtain a copy of this form by utilizing the search feature at www.esd.whs.mil".