### PR TITLE
Main b 19074

### DIFF
--- a/pkg/assets/notifications/templates/ppm_packet_email_template.html
+++ b/pkg/assets/notifications/templates/ppm_packet_email_template.html
@@ -3,13 +3,14 @@
 <h4>Next steps:</h4>
 {{if eq .ServiceBranch "Marine Corps, Navy, and Coast Guard"}}
 <p>For Marine Corps, Navy, and Coast Guard personnel:</p>
-<p>You can now log into MilMove <a href="{{.MyMoveLink}}/">{{.MyMoveLink}}/</a> and view your payment packet; however, you do not need to forward your packet to finance as your closeout location is associated with your finance office and they will handle this step for you.</p>
+<p>You can now log into MilMove <a href="{{.MyMoveLink}}">{{.MyMoveLink}}</a> and view your payment packet; however, you do not need to forward your payment packet to finance as your closeout location is associated with your finance office and they will handle this step for you.</p>
 <p>Note: Not all claimed expenses may have been accepted during PPM closeout if they did not meet the definition of a valid expense.</p>
 {{else}}
 <p>For {{.ServiceBranch}} personnel (FURTHER ACTION REQUIRED):</p>
-<p>You can now log into MilMove <a href="{{.MyMoveLink}}/">{{.MyMoveLink}}/</a> and download your payment packet to submit to {{.SubmitLocation}}. <strong>You must complete this step to receive final settlement of your PPM.</strong></p>
+<p>You can now log into MilMove <a href="{{.MyMoveLink}}">{{.MyMoveLink}}</a> and download your payment packet to submit to {{.SubmitLocation}}. <strong>You must complete this step to receive final settlement of your PPM.</strong></p>
 <p>{{if eq .ServiceBranch "Air Force and Space Force"}}Note: The Transportation Office does not determine claimable expenses. Claimable expenses will be determined by finance{{else if eq .ServiceBranch "Army"}}Note: Not all claimed expenses may have been accepted during PPM closeout if they did not meet the definition of a valid expense{{end}}.</p>
 {{end}}
+<p>Please be advised, your local finance office may require a DD Form 1351-2 to process payment. You can obtain a copy of this form by utilizing the search feature at <a href="{{.WashingtonHQServicesLink}}">{{.WashingtonHQServicesLink}}</a>.</p>
 <p>If you have any questions, contact a government transportation office. You can see a listing of transportation offices on Military One Source here: <a href="{{.OneSourceTransportationOfficeLink}}">{{.OneSourceTransportationOfficeLink}}</a></p>
 
 <p>Thank you,</p>

--- a/pkg/assets/notifications/templates/ppm_packet_email_template.txt
+++ b/pkg/assets/notifications/templates/ppm_packet_email_template.txt
@@ -6,15 +6,17 @@ Next steps:
 {{if eq .ServiceBranch "Marine Corps, Navy, and Coast Guard"}}
 For Marine Corps, Navy, and Coast Guard personnel:
 
-You can now log into MilMove <{{.MyMoveLink}}/> and view your payment packet; however, you do not need to forward your packet to finance as your closeout location is associated with your finance office and they will handle this step for you.
+You can now log into MilMove <{{.MyMoveLink}}> and view your payment packet; however, you do not need to forward your payment packet to finance as your closeout location is associated with your finance office and they will handle this step for you.
 
 Note: Not all claimed expenses may have been accepted during PPM closeout if they did not meet the definition of a valid expense.
 {{else}}
 For {{.ServiceBranch}} personnel (FURTHER ACTION REQUIRED):
 
-You can now log into MilMove <{{.MyMoveLink}}/> and download your payment packet to submit to {{.SubmitLocation}}. You must complete this step to receive final settlement of your PPM.
+You can now log into MilMove <{{.MyMoveLink}}> and download your payment packet to submit to {{.SubmitLocation}}. You must complete this step to receive final settlement of your PPM.
 
 {{if eq .ServiceBranch "Air Force and Space Force"}}Note: The Transportation Office does not determine claimable expenses. Claimable expenses will be determined by finance{{else if eq .ServiceBranch "Army"}}Note: Not all claimed expenses may have been accepted during PPM closeout if they did not meet the definition of a valid expense.{{end}}{{end}}
+
+Please be advised, your local finance office may require a DD Form 1351-2 to process payment. You can obtain a copy of this form by utilizing the search feature at {{.WashingtonHQServicesLink}}.
 
 If you have any questions, contact a government transportation office. You can see a listing of transportation offices on Military One Source here: {{.OneSourceTransportationOfficeLink}}
 

--- a/pkg/notifications/constants.go
+++ b/pkg/notifications/constants.go
@@ -2,3 +2,4 @@ package notifications
 
 const OneSourceTransportationOfficeLink = "https://installations.militaryonesource.mil/search?program-service=2/view-by=ALL"
 const MyMoveLink = "https://my.move.mil/"
+const WashingtonHQServicesLink = "www.esd.whs.mil"

--- a/pkg/notifications/constants.go
+++ b/pkg/notifications/constants.go
@@ -2,4 +2,4 @@ package notifications
 
 const OneSourceTransportationOfficeLink = "https://installations.militaryonesource.mil/search?program-service=2/view-by=ALL"
 const MyMoveLink = "https://my.move.mil/"
-const WashingtonHQServicesLink = "www.esd.whs.mil"
+const WashingtonHQServicesLink = "https://www.esd.whs.mil"

--- a/pkg/notifications/ppm_packet_email.go
+++ b/pkg/notifications/ppm_packet_email.go
@@ -41,6 +41,7 @@ type PpmPacketEmailData struct {
 	ServiceBranch                     string
 	Locator                           string
 	OneSourceTransportationOfficeLink string
+	WashingtonHQServicesLink          string
 	MyMoveLink                        string
 }
 
@@ -166,6 +167,7 @@ func (p PpmPacketEmail) GetEmailData(appCtx appcontext.AppContext) (PpmPacketEma
 				ServiceBranch:                     affiliationDisplayValue[*serviceMember.Affiliation],
 				Locator:                           move.Locator,
 				OneSourceTransportationOfficeLink: OneSourceTransportationOfficeLink,
+				WashingtonHQServicesLink:          WashingtonHQServicesLink,
 				MyMoveLink:                        MyMoveLink,
 			},
 			LoggerData{
@@ -183,6 +185,7 @@ func (p PpmPacketEmail) GetEmailData(appCtx appcontext.AppContext) (PpmPacketEma
 			ServiceBranch:                     affiliationDisplayValue[*serviceMember.Affiliation],
 			Locator:                           move.Locator,
 			OneSourceTransportationOfficeLink: OneSourceTransportationOfficeLink,
+			WashingtonHQServicesLink:          WashingtonHQServicesLink,
 			MyMoveLink:                        MyMoveLink,
 		},
 		LoggerData{

--- a/pkg/notifications/ppm_packet_email_test.go
+++ b/pkg/notifications/ppm_packet_email_test.go
@@ -120,6 +120,7 @@ func (suite *NotificationSuite) TestPpmPacketEmailHTMLTemplateRenderForAirAndSpa
 		ServiceBranch:                     affiliationDisplayValue[*serviceMember.Affiliation],
 		Locator:                           move.Locator,
 		OneSourceTransportationOfficeLink: OneSourceTransportationOfficeLink,
+		WashingtonHQServicesLink:          WashingtonHQServicesLink,
 		MyMoveLink:                        MyMoveLink,
 	})
 
@@ -128,10 +129,11 @@ func (suite *NotificationSuite) TestPpmPacketEmailHTMLTemplateRenderForAirAndSpa
 <h4>Next steps:</h4>
 
 <p>For ` + affiliationDisplayValue[*serviceMember.Affiliation] + ` personnel (FURTHER ACTION REQUIRED):</p>
-<p>You can now log into MilMove <a href="` + MyMoveLink + `/">` + MyMoveLink + `/</a> and download your payment packet to submit to ` + allOtherSubmitLocation + `. <strong>You must complete this step to receive final settlement of your PPM.</strong></p>
+<p>You can now log into MilMove <a href="` + MyMoveLink + `">` + MyMoveLink + `</a> and download your payment packet to submit to ` + allOtherSubmitLocation + `. <strong>You must complete this step to receive final settlement of your PPM.</strong></p>
 <p>Note: The Transportation Office does not determine claimable expenses. Claimable expenses will be determined by finance.</p>
 
-<p>If you have any questions, contact a government transportation office. You can see a listing of transportation offices on Military One Source here: <a href="https://installations.militaryonesource.mil/search?program-service=2/view-by=ALL">https://installations.militaryonesource.mil/search?program-service=2/view-by=ALL</a></p>
+<p>Please be advised, your local finance office may require a DD Form 1351-2 to process payment. You can obtain a copy of this form by utilizing the search feature at <a href="` + WashingtonHQServicesLink + `">` + WashingtonHQServicesLink + `</a>.</p>
+<p>If you have any questions, contact a government transportation office. You can see a listing of transportation offices on Military One Source here: <a href="` + OneSourceTransportationOfficeLink + `">` + OneSourceTransportationOfficeLink + `</a></p>
 
 <p>Thank you,</p>
 
@@ -208,6 +210,7 @@ func (suite *NotificationSuite) TestPpmPacketEmailHTMLTemplateRenderForArmy() {
 		ServiceBranch:                     affiliationDisplayValue[*serviceMember.Affiliation],
 		Locator:                           move.Locator,
 		OneSourceTransportationOfficeLink: OneSourceTransportationOfficeLink,
+		WashingtonHQServicesLink:          WashingtonHQServicesLink,
 		MyMoveLink:                        MyMoveLink,
 	})
 
@@ -216,10 +219,11 @@ func (suite *NotificationSuite) TestPpmPacketEmailHTMLTemplateRenderForArmy() {
 <h4>Next steps:</h4>
 
 <p>For ` + affiliationDisplayValue[*serviceMember.Affiliation] + ` personnel (FURTHER ACTION REQUIRED):</p>
-<p>You can now log into MilMove <a href="` + MyMoveLink + `/">` + MyMoveLink + `/</a> and download your payment packet to submit to ` + armySubmitLocation + `. <strong>You must complete this step to receive final settlement of your PPM.</strong></p>
+<p>You can now log into MilMove <a href="` + MyMoveLink + `">` + MyMoveLink + `</a> and download your payment packet to submit to ` + armySubmitLocation + `. <strong>You must complete this step to receive final settlement of your PPM.</strong></p>
 <p>Note: Not all claimed expenses may have been accepted during PPM closeout if they did not meet the definition of a valid expense.</p>
 
-<p>If you have any questions, contact a government transportation office. You can see a listing of transportation offices on Military One Source here: <a href="https://installations.militaryonesource.mil/search?program-service=2/view-by=ALL">https://installations.militaryonesource.mil/search?program-service=2/view-by=ALL</a></p>
+<p>Please be advised, your local finance office may require a DD Form 1351-2 to process payment. You can obtain a copy of this form by utilizing the search feature at <a href="` + WashingtonHQServicesLink + `">` + WashingtonHQServicesLink + `</a>.</p>
+<p>If you have any questions, contact a government transportation office. You can see a listing of transportation offices on Military One Source here: <a href="` + OneSourceTransportationOfficeLink + `">` + OneSourceTransportationOfficeLink + `</a></p>
 
 <p>Thank you,</p>
 
@@ -296,6 +300,7 @@ func (suite *NotificationSuite) TestPpmPacketEmailHTMLTemplateRenderForNavalBran
 		ServiceBranch:                     affiliationDisplayValue[*serviceMember.Affiliation],
 		Locator:                           move.Locator,
 		OneSourceTransportationOfficeLink: OneSourceTransportationOfficeLink,
+		WashingtonHQServicesLink:          WashingtonHQServicesLink,
 		MyMoveLink:                        MyMoveLink,
 	})
 
@@ -304,10 +309,11 @@ func (suite *NotificationSuite) TestPpmPacketEmailHTMLTemplateRenderForNavalBran
 <h4>Next steps:</h4>
 
 <p>For ` + affiliationDisplayValue[*serviceMember.Affiliation] + ` personnel:</p>
-<p>You can now log into MilMove <a href="` + MyMoveLink + `/">` + MyMoveLink + `/</a> and view your payment packet; however, you do not need to forward your packet to finance as your closeout location is associated with your finance office and they will handle this step for you.</p>
+<p>You can now log into MilMove <a href="` + MyMoveLink + `">` + MyMoveLink + `</a> and view your payment packet; however, you do not need to forward your payment packet to finance as your closeout location is associated with your finance office and they will handle this step for you.</p>
 <p>Note: Not all claimed expenses may have been accepted during PPM closeout if they did not meet the definition of a valid expense.</p>
 
-<p>If you have any questions, contact a government transportation office. You can see a listing of transportation offices on Military One Source here: <a href="https://installations.militaryonesource.mil/search?program-service=2/view-by=ALL">https://installations.militaryonesource.mil/search?program-service=2/view-by=ALL</a></p>
+<p>Please be advised, your local finance office may require a DD Form 1351-2 to process payment. You can obtain a copy of this form by utilizing the search feature at <a href="` + WashingtonHQServicesLink + `">` + WashingtonHQServicesLink + `</a>.</p>
+<p>If you have any questions, contact a government transportation office. You can see a listing of transportation offices on Military One Source here: <a href="` + OneSourceTransportationOfficeLink + `">` + OneSourceTransportationOfficeLink + `</a></p>
 
 <p>Thank you,</p>
 
@@ -384,9 +390,11 @@ Next steps:
 
 For ` + affiliationDisplayValue[*serviceMember.Affiliation] + ` personnel (FURTHER ACTION REQUIRED):
 
-You can now log into MilMove <` + MyMoveLink + `/> and download your payment packet to submit to ` + armySubmitLocation + `. You must complete this step to receive final settlement of your PPM.
+You can now log into MilMove <` + MyMoveLink + `> and download your payment packet to submit to ` + armySubmitLocation + `. You must complete this step to receive final settlement of your PPM.
 
 Note: Not all claimed expenses may have been accepted during PPM closeout if they did not meet the definition of a valid expense.
+
+Please be advised, your local finance office may require a DD Form 1351-2 to process payment. You can obtain a copy of this form by utilizing the search feature at ` + WashingtonHQServicesLink + `.
 
 If you have any questions, contact a government transportation office. You can see a listing of transportation offices on Military One Source here: ` + OneSourceTransportationOfficeLink + `
 
@@ -449,6 +457,7 @@ func (suite *NotificationSuite) TestPpmPacketEmailZipcodeFallback() {
 		ServiceBranch:                     affiliationDisplayValue[*serviceMember.Affiliation],
 		Locator:                           move.Locator,
 		OneSourceTransportationOfficeLink: OneSourceTransportationOfficeLink,
+		WashingtonHQServicesLink:          WashingtonHQServicesLink,
 		MyMoveLink:                        MyMoveLink,
 	})
 
@@ -457,10 +466,11 @@ func (suite *NotificationSuite) TestPpmPacketEmailZipcodeFallback() {
 <h4>Next steps:</h4>
 
 <p>For ` + affiliationDisplayValue[*serviceMember.Affiliation] + ` personnel (FURTHER ACTION REQUIRED):</p>
-<p>You can now log into MilMove <a href="` + MyMoveLink + `/">` + MyMoveLink + `/</a> and download your payment packet to submit to ` + allOtherSubmitLocation + `. <strong>You must complete this step to receive final settlement of your PPM.</strong></p>
+<p>You can now log into MilMove <a href="` + MyMoveLink + `">` + MyMoveLink + `</a> and download your payment packet to submit to ` + allOtherSubmitLocation + `. <strong>You must complete this step to receive final settlement of your PPM.</strong></p>
 <p>Note: The Transportation Office does not determine claimable expenses. Claimable expenses will be determined by finance.</p>
 
-<p>If you have any questions, contact a government transportation office. You can see a listing of transportation offices on Military One Source here: <a href="https://installations.militaryonesource.mil/search?program-service=2/view-by=ALL">https://installations.militaryonesource.mil/search?program-service=2/view-by=ALL</a></p>
+<p>Please be advised, your local finance office may require a DD Form 1351-2 to process payment. You can obtain a copy of this form by utilizing the search feature at <a href="` + WashingtonHQServicesLink + `">` + WashingtonHQServicesLink + `</a>.</p>
+<p>If you have any questions, contact a government transportation office. You can see a listing of transportation offices on Military One Source here: <a href="` + OneSourceTransportationOfficeLink + `">` + OneSourceTransportationOfficeLink + `</a></p>
 
 <p>Thank you,</p>
 


### PR DESCRIPTION
## [B-19074](https://www13.v1host.com/USTRANSCOM38/assetdetail.v1?number=B-19074)

## Integration PR
#12141 

## Summary

Govt. came back after completion of B-19034 with a request to add "payment" to a sentence for the naval branches, and to add a paragraph before the final sign-off that informs the customer that they may need to fill out a DD Form 1351-2. This PR adds these to the .txt and .html templates, adds a relevant link to the constants.go file, and updates the tests to match the new content.

### How to test

Follow the steps given in #12090 and ensure that the sent email content matches the new template.

If you chose a naval branch, the first line should now read (Change in **bold**): "You can now log into MilMove and view your payment packet; however, you do not need to forward your **payment packet** to finance as your closeout location is associated with your finance office and they will handle this step for you."

And **all** branches should now have a new line before the final one, that reads: "Please be advised, your local finance office may require a DD Form 1351-2 to process payment. You can obtain a copy of this form by utilizing the search feature at www.esd.whs.mil".