### PR TITLE
Int b 17960 integrate calc display

### DIFF
--- a/.github/workflows/main-to-integration-sync.yml
+++ b/.github/workflows/main-to-integration-sync.yml
@@ -1,0 +1,25 @@
+name: Integration Testing Syncing
+
+on:
+  pull_request:
+    branches: main
+    types: closed
+jobs:
+  merge-main-to-int-testing:
+    if: github.event.pull_request.merged == true
+    timeout-minutes: 2
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set Git config
+      run: |
+          git config --local user.email "actions@github.com"
+          git config --local user.name "Github Actions"
+    - name: Merge main to integrationTesting-Dummy
+      run: |
+          git fetch --unshallow
+          git checkout integrationTesting-Dummy
+          git pull
+          git merge --no-ff master -m "Auto-merge main to integrationTesting-Dummy"
+          git push

--- a/src/components/Customer/Review/Review.stories.jsx
+++ b/src/components/Customer/Review/Review.stories.jsx
@@ -29,6 +29,105 @@ const customerUuid = 'customerUuid';
 const mtoUuid = 'mtoUuid';
 const mtoLocator = 'XYZ890';
 
+const serviceMemberMoves = {
+  currentMove: [
+    {
+      id: mtoUuid,
+      moveCode: mtoLocator,
+      mtoShipments: [],
+      orders: {
+        authorizedWeight: 11000,
+        created_at: '2024-03-12T13:36:14.940Z',
+        entitlement: {
+          proGear: 2000,
+          proGearSpouse: 500,
+        },
+        grade: 'E_7',
+        has_dependents: false,
+        id: 'orderId',
+        issue_date: '2024-04-18',
+        new_duty_location: {
+          address: {
+            city: 'Flagstaff',
+            country: 'United States',
+            id: '02df4469-90e5-4dbe-b2e0-69c7f8367912',
+            postalCode: '86004',
+            state: 'AZ',
+            streetAddress1: 'n/a',
+          },
+          address_id: '02df4469-90e5-4dbe-b2e0-69c7f8367912',
+          affiliation: null,
+          created_at: '2024-02-27T20:40:42.164Z',
+          id: '6af688f3-7be2-422e-a07a-2a26a4069ec4',
+          name: 'Flagstaff, AZ 86004',
+          updated_at: '2024-02-27T20:40:42.164Z',
+        },
+        orders_type: 'PERMANENT_CHANGE_OF_STATION',
+        originDutyLocationGbloc: 'HAFC',
+        origin_duty_location: {
+          address: {
+            city: 'McAlester',
+            country: 'United States',
+            id: '7eccd9bc-c48b-4822-9324-7b0baa4256d1',
+            postalCode: '74501',
+            state: 'OK',
+            streetAddress1: 'n/a',
+          },
+          address_id: '7eccd9bc-c48b-4822-9324-7b0baa4256d1',
+          affiliation: 'ARMY',
+          created_at: '2024-02-27T20:40:47.436Z',
+          id: 'e017cd1a-a2b1-4e64-b887-e6e06e2d3f6c',
+          name: 'McAlester Army Ammunition Plant, OK 74501',
+          transportation_office: {
+            address: {
+              city: 'McAlester',
+              country: 'United States',
+              id: 'b52f5e75-620e-49c4-ac64-1330f495c956',
+              postalCode: '74501',
+              state: 'OK',
+              streetAddress1: '1 C Tree Rd',
+              streetAddress2: 'Bldg 31',
+            },
+            created_at: '2018-05-28T14:27:38.004Z',
+            gbloc: 'HAFC',
+            id: 'd1359c20-c762-4b04-9ed6-fd2b9060615b',
+            name: 'PPPO McAlester - USA',
+            phone_lines: [],
+            updated_at: '2018-05-28T14:27:38.004Z',
+          },
+          transportation_office_id: 'd1359c20-c762-4b04-9ed6-fd2b9060615b',
+          updated_at: '2024-02-27T20:40:47.436Z',
+        },
+        report_by_date: '2024-03-28',
+        service_member_id: 'ab65bff1-4da3-4a51-a36f-2bdb2c4edc4d',
+        spouse_has_pro_gear: false,
+        status: 'DRAFT',
+        updated_at: '2024-03-12T13:36:14.940Z',
+        uploaded_orders: {
+          id: '1d546f35-0a09-4007-9551-7934f148459d',
+          service_member_id: 'ab65bff1-4da3-4a51-a36f-2bdb2c4edc4d',
+          uploads: [
+            {
+              bytes: 1137126,
+              contentType: 'image/png',
+              createdAt: '2024-03-12T13:36:21.868Z',
+              filename: 'Screenshot 2024-02-15 at 12.22.53 PM.png',
+              id: '93374041-54a2-4ccd-9ff9-d8acb4cf440f',
+              status: 'PROCESSING',
+              updatedAt: '2024-03-12T13:36:21.868Z',
+              url: '/storage/user/71d01de6-2181-45af-bb2b-63328fffe194/uploads/93374041-54a2-4ccd-9ff9-d8acb4cf440f?contentType=image%2Fpng',
+            },
+          ],
+        },
+      },
+      status: MOVE_STATUSES.DRAFT,
+      submittedAt: '0001-01-01T00:00:00.000Z',
+      updatedAt: '0001-01-01T00:00:00.000Z',
+    },
+  ],
+  previousMoes: [],
+};
+
 const defaultProps = {
   currentMove: {
     id: mtoUuid,
@@ -92,6 +191,7 @@ const defaultProps = {
     last_name: 'Ash',
     telephone: '323-555-7890',
   },
+  serviceMemberMoves,
 };
 
 const HHGShipment = {
@@ -147,6 +247,58 @@ const IncompeletePPMShipment = {
   },
 };
 
+const serviceMemberMovesWithHhgShipment = {
+  ...serviceMemberMoves,
+  currentMove: [
+    {
+      ...serviceMemberMoves.currentMove[0],
+      mtoShipments: [HHGShipment],
+    },
+  ],
+};
+
+const serviceMemberMovesWithPpmShipment = {
+  ...serviceMemberMoves,
+  currentMove: [
+    {
+      ...serviceMemberMoves.currentMove[0],
+      mtoShipments: [PPMShipment],
+    },
+  ],
+};
+
+const serviceMemberMovesWithIncompletePpmShipment = {
+  ...serviceMemberMoves,
+  currentMove: [
+    {
+      ...serviceMemberMoves.currentMove[0],
+      mtoShipments: [IncompeletePPMShipment],
+    },
+  ],
+};
+
+const serviceMemberMovesSubmitted = {
+  ...serviceMemberMoves,
+  currentMove: [
+    {
+      ...serviceMemberMoves.currentMove[0],
+      mtoShipments: [HHGShipment, PPMShipment],
+      status: MOVE_STATUSES.SUBMITTED,
+    },
+  ],
+};
+
+const serviceMemberMovesApproved = {
+  ...serviceMemberMoves,
+  currentMove: [
+    {
+      ...serviceMemberMoves.currentMove[0],
+      mtoShipments: [HHGShipment, PPMShipment],
+      status: MOVE_STATUSES.APPROVED,
+    },
+  ],
+};
+
 export const WithNoShipments = () => {
   return <Summary {...defaultProps} />;
 };
@@ -155,6 +307,7 @@ export const WithHHGShipment = () => {
   const props = {
     ...defaultProps,
     mtoShipments: [HHGShipment],
+    serviceMemberMoves: serviceMemberMovesWithHhgShipment,
   };
 
   return <Summary {...props} />;
@@ -164,14 +317,16 @@ export const WithPPM = () => {
   const props = {
     ...defaultProps,
     mtoShipments: [PPMShipment],
+    serviceMemberMoves: serviceMemberMovesWithPpmShipment,
   };
   return <Summary {...props} />;
 };
 
-export const WithInCompletePPM = () => {
+export const WithIncompletePPM = () => {
   const props = {
     ...defaultProps,
     mtoShipments: [IncompeletePPMShipment],
+    serviceMemberMoves: serviceMemberMovesWithIncompletePpmShipment,
   };
   return <Summary {...props} />;
 };
@@ -184,6 +339,7 @@ export const AsSubmitted = () => {
       ...defaultProps.currentMove,
       status: MOVE_STATUSES.SUBMITTED,
     },
+    serviceMemberMoves: serviceMemberMovesSubmitted,
   };
 
   return <Summary {...props} />;
@@ -208,6 +364,7 @@ export const AsApproved = () => {
       ...defaultProps.currentMove,
       status: MOVE_STATUSES.APPROVED,
     },
+    serviceMemberMoves: serviceMemberMovesApproved,
   };
 
   return <Summary {...props} />;

--- a/src/components/Office/PPM/ReviewDocumentsSidePanel/ReviewDocumentsSidePanel.jsx
+++ b/src/components/Office/PPM/ReviewDocumentsSidePanel/ReviewDocumentsSidePanel.jsx
@@ -155,7 +155,7 @@ export default function ReviewDocumentsSidePanel({
                         <dl className={classnames(styles.ItemDetails)}>
                           <span>
                             <dt>Belongs To: </dt>
-                            <dd>{gear.selfProGear ? `Customer` : `Spouse`}</dd>
+                            <dd>{gear.belongsToSelf ? `Customer` : `Spouse`}</dd>
                           </span>
                           <span>
                             <dt>Missing Weight Ticket (Constructed)?</dt>

--- a/src/types/shipment.js
+++ b/src/types/shipment.js
@@ -223,7 +223,7 @@ export const StorageFacilityShape = shape({
 });
 
 export const ProGearTicketShape = shape({
-  selfProGear: bool,
+  belongsToSelf: bool,
   proGearWeight: number,
   description: string,
   missingWeightTicket: bool,


### PR DESCRIPTION
## [B-17960](https://www13.v1host.com/USTRANSCOM38/assetdetail.v1?number=B-17960)

## Summary

Hotfix for the PPM costing calculation breakout, fixes bug where all pro-gear tickets were shown as belonging to "spouse" at the final review screen during closeout.

### Files changed:
src/components/Office/PPM/ReviewDocumentsSidePanel/ReviewDocumentsSidePanel.jsx
src/types/shipment.js

The other 2 are changes from main making their way into integration.

### How to test

1. Run `db_dev_e2e_populate` if needed.
2. Login as a Service Counselor
3. Under "PPM Closeout" access the move with move code "CLOSE2" (or any move that has pro-gear weight tickets).
4. Review the documents, the second doc should be a pro gear ticket.
5. Confirm that if you choose "belong to Customer" that this value shows at the final review screen before clicking "Confirm".