### PR TITLE
B 18909 no approve button for rejected DSH or DLH service item

### DIFF
--- a/src/components/Office/ServiceItemsTable/ServiceItemsTable.jsx
+++ b/src/components/Office/ServiceItemsTable/ServiceItemsTable.jsx
@@ -139,6 +139,16 @@ const ServiceItemsTable = ({
     }
     const resubmittedToolTip = renderToolTipWithOldDataIfResubmission(id);
 
+    // we don't want to display the "Accept" button for a DLH or DSH service item that was rejected by a shorthaul to linehaul change or vice versa
+    let rejectedDSHorDLHServiceItem = false;
+    if (
+      (serviceItem.code === 'DLH' || serviceItem.code === 'DSH') &&
+      serviceItem.details.rejectionReason ===
+        'Automatically rejected due to change in destination address affecting the ZIP code qualification for short haul / line haul.'
+    ) {
+      rejectedDSHorDLHServiceItem = true;
+    }
+
     return (
       <React.Fragment key={`sit-alert-${id}`}>
         <tr key={id}>
@@ -242,7 +252,7 @@ const ServiceItemsTable = ({
                 </div>
               </Restricted>
             )}
-            {statusForTableType === SERVICE_ITEM_STATUS.REJECTED && (
+            {statusForTableType === SERVICE_ITEM_STATUS.REJECTED && !rejectedDSHorDLHServiceItem && (
               <Restricted to={permissionTypes.updateMTOServiceItem}>
                 <div className={styles.statusAction}>
                   <Button

--- a/src/components/Office/ServiceItemsTable/ServiceItemsTable.test.jsx
+++ b/src/components/Office/ServiceItemsTable/ServiceItemsTable.test.jsx
@@ -252,6 +252,138 @@ describe('ServiceItemsTable', () => {
     expect(wrapper.find('button[data-testid="rejectTextButton"]').length).toBeFalsy();
   });
 
+  it('does not show accept button when DSH is rejected as a result of destination address change', () => {
+    const serviceItems = [
+      {
+        id: 'dsh123',
+        mtoShipmentID: 'xyz789',
+        submittedAt: '2020-11-20',
+        serviceItem: 'Domestic shorthaul',
+        code: 'DSH',
+        details: {
+          rejectionReason:
+            'Automatically rejected due to change in destination address affecting the ZIP code qualification for short haul / line haul.',
+        },
+      },
+    ];
+
+    const wrapper = mount(
+      <MockProviders permissions={[permissionTypes.updateMTOServiceItem]}>
+        <ServiceItemsTable
+          {...defaultProps}
+          serviceItems={serviceItems}
+          statusForTableType={SERVICE_ITEM_STATUS.REJECTED}
+        />
+      </MockProviders>,
+    );
+
+    const approveTextButton = wrapper.find('button[data-testid="approveTextButton"]');
+
+    expect(approveTextButton.length).toBeFalsy();
+
+    expect(approveTextButton.at(0).find('svg[data-icon="check"]').length).toBe(0);
+    expect(approveTextButton.at(0).contains('Approve')).toBe(false);
+  });
+
+  it('does not show accept button when DLH is rejected as a result of destination address change', () => {
+    const serviceItems = [
+      {
+        id: 'dlh123',
+        mtoShipmentID: 'xyz789',
+        submittedAt: '2020-11-20',
+        serviceItem: 'Domestic linehaul',
+        code: 'DLH',
+        details: {
+          rejectionReason:
+            'Automatically rejected due to change in destination address affecting the ZIP code qualification for short haul / line haul.',
+        },
+      },
+    ];
+
+    const wrapper = mount(
+      <MockProviders permissions={[permissionTypes.updateMTOServiceItem]}>
+        <ServiceItemsTable
+          {...defaultProps}
+          serviceItems={serviceItems}
+          statusForTableType={SERVICE_ITEM_STATUS.REJECTED}
+        />
+      </MockProviders>,
+    );
+
+    const approveTextButton = wrapper.find('button[data-testid="approveTextButton"]');
+
+    expect(approveTextButton.length).toBeFalsy();
+
+    expect(approveTextButton.at(0).find('svg[data-icon="check"]').length).toBe(0);
+    expect(approveTextButton.at(0).contains('Approve')).toBe(false);
+  });
+
+  it('shows accept button when DSH is rejected but NOT as a result of destination address change', () => {
+    const serviceItems = [
+      {
+        id: 'dsh123',
+        mtoShipmentID: 'xyz789',
+        submittedAt: '2020-11-20',
+        serviceItem: 'Domestic shorthaul',
+        code: 'DSH',
+        details: {
+          rejectionReason:
+            'Any reason other than "Automatically rejected due to change in destination address affecting the ZIP code qualification for short haul / line haul."',
+        },
+      },
+    ];
+
+    const wrapper = mount(
+      <MockProviders permissions={[permissionTypes.updateMTOServiceItem]}>
+        <ServiceItemsTable
+          {...defaultProps}
+          serviceItems={serviceItems}
+          statusForTableType={SERVICE_ITEM_STATUS.REJECTED}
+        />
+      </MockProviders>,
+    );
+
+    const approveTextButton = wrapper.find('button[data-testid="approveTextButton"]');
+
+    expect(approveTextButton.length).toBeTruthy();
+
+    expect(approveTextButton.at(0).find('svg[data-icon="check"]').length).toBe(1);
+    expect(approveTextButton.at(0).contains('Approve')).toBe(true);
+  });
+
+  it('shows accept button when DLH is rejected but NOT as a result of destination address change', () => {
+    const serviceItems = [
+      {
+        id: 'dlh123',
+        mtoShipmentID: 'xyz789',
+        submittedAt: '2020-11-20',
+        serviceItem: 'Domestic linehaul',
+        code: 'DLH',
+        details: {
+          rejectionReason:
+            'Any reason other than "Automatically rejected due to change in destination address affecting the ZIP code qualification for short haul / line haul."',
+        },
+      },
+    ];
+
+    const wrapper = mount(
+      <MockProviders permissions={[permissionTypes.updateMTOServiceItem]}>
+        <ServiceItemsTable
+          {...defaultProps}
+          serviceItems={serviceItems}
+          statusForTableType={SERVICE_ITEM_STATUS.REJECTED}
+        />
+      </MockProviders>,
+    );
+
+    const approveTextButton = wrapper.find('button[data-testid="approveTextButton"]');
+
+    expect(approveTextButton.length).toBeTruthy();
+
+    expect(approveTextButton.at(0).find('svg[data-icon="check"]').length).toBe(1);
+    expect(approveTextButton.at(0).contains('Approve')).toBe(true);
+  });
+
   it('does not show edit/review request button when service item code is not DDDSIT', () => {
     const serviceItems = [
       {


### PR DESCRIPTION
## [Agility ticket](https://www13.v1host.com/USTRANSCOM38/assetdetail.v1?number=B-18909)

When an address change results in a move from short haul to line haul or vice versa, we reject the old DSH or DLH service and create a new one. For the rejected service item, we want to show it on the MTO page in the rejected section, but without the "Approve" button.

Other rejected service items will have the Approve button, but if it's a DSH or DLH that was auto rejected as a result of a shipment address change, we take away the approve button.

DLH example with other rejected service items: 
![image](https://github.com/transcom/mymove/assets/147537467/8d8abf22-0189-4c98-8fa3-12643f460216)

DSH example:
![image](https://github.com/transcom/mymove/assets/147537467/b9d66b65-3141-4c33-9b58-a5a9181bb423)
