### PR TITLE
B 18404 sit service item info population int (DO NOT MERGE BEFORE B-18885)

### DIFF
--- a/pkg/gen/ghcapi/embedded_spec.go
+++ b/pkg/gen/ghcapi/embedded_spec.go
@@ -6409,6 +6409,10 @@ func init() {
           "format": "date",
           "x-nullable": true
         },
+        "sitDeliveryMiles": {
+          "type": "integer",
+          "x-nullable": true
+        },
         "sitDepartureDate": {
           "type": "string",
           "format": "date-time",
@@ -6424,6 +6428,12 @@ func init() {
           "type": "string",
           "format": "date-time",
           "x-nullable": true
+        },
+        "sitOriginHHGActualAddress": {
+          "$ref": "#/definitions/Address"
+        },
+        "sitOriginHHGOriginalAddress": {
+          "$ref": "#/definitions/Address"
         },
         "sitRequestedDelivery": {
           "type": "string",
@@ -18284,6 +18294,10 @@ func init() {
           "format": "date",
           "x-nullable": true
         },
+        "sitDeliveryMiles": {
+          "type": "integer",
+          "x-nullable": true
+        },
         "sitDepartureDate": {
           "type": "string",
           "format": "date-time",
@@ -18299,6 +18313,12 @@ func init() {
           "type": "string",
           "format": "date-time",
           "x-nullable": true
+        },
+        "sitOriginHHGActualAddress": {
+          "$ref": "#/definitions/Address"
+        },
+        "sitOriginHHGOriginalAddress": {
+          "$ref": "#/definitions/Address"
         },
         "sitRequestedDelivery": {
           "type": "string",

--- a/pkg/gen/ghcmessages/m_t_o_service_item.go
+++ b/pkg/gen/ghcmessages/m_t_o_service_item.go
@@ -123,6 +123,9 @@ type MTOServiceItem struct {
 	// Format: date
 	SitCustomerContacted *strfmt.Date `json:"sitCustomerContacted,omitempty"`
 
+	// sit delivery miles
+	SitDeliveryMiles *int64 `json:"sitDeliveryMiles,omitempty"`
+
 	// sit departure date
 	// Format: date-time
 	SitDepartureDate *strfmt.DateTime `json:"sitDepartureDate,omitempty"`
@@ -136,6 +139,12 @@ type MTOServiceItem struct {
 	// sit entry date
 	// Format: date-time
 	SitEntryDate *strfmt.DateTime `json:"sitEntryDate,omitempty"`
+
+	// sit origin h h g actual address
+	SitOriginHHGActualAddress *Address `json:"sitOriginHHGActualAddress,omitempty"`
+
+	// sit origin h h g original address
+	SitOriginHHGOriginalAddress *Address `json:"sitOriginHHGOriginalAddress,omitempty"`
 
 	// sit requested delivery
 	// Format: date
@@ -240,6 +249,14 @@ func (m *MTOServiceItem) Validate(formats strfmt.Registry) error {
 	}
 
 	if err := m.validateSitEntryDate(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateSitOriginHHGActualAddress(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateSitOriginHHGOriginalAddress(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -572,6 +589,44 @@ func (m *MTOServiceItem) validateSitEntryDate(formats strfmt.Registry) error {
 	return nil
 }
 
+func (m *MTOServiceItem) validateSitOriginHHGActualAddress(formats strfmt.Registry) error {
+	if swag.IsZero(m.SitOriginHHGActualAddress) { // not required
+		return nil
+	}
+
+	if m.SitOriginHHGActualAddress != nil {
+		if err := m.SitOriginHHGActualAddress.Validate(formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("sitOriginHHGActualAddress")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("sitOriginHHGActualAddress")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (m *MTOServiceItem) validateSitOriginHHGOriginalAddress(formats strfmt.Registry) error {
+	if swag.IsZero(m.SitOriginHHGOriginalAddress) { // not required
+		return nil
+	}
+
+	if m.SitOriginHHGOriginalAddress != nil {
+		if err := m.SitOriginHHGOriginalAddress.Validate(formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("sitOriginHHGOriginalAddress")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("sitOriginHHGOriginalAddress")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
 func (m *MTOServiceItem) validateSitRequestedDelivery(formats strfmt.Registry) error {
 	if swag.IsZero(m.SitRequestedDelivery) { // not required
 		return nil
@@ -654,6 +709,14 @@ func (m *MTOServiceItem) ContextValidate(ctx context.Context, formats strfmt.Reg
 	}
 
 	if err := m.contextValidateSitDestinationOriginalAddress(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.contextValidateSitOriginHHGActualAddress(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.contextValidateSitOriginHHGOriginalAddress(ctx, formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -766,6 +829,48 @@ func (m *MTOServiceItem) contextValidateSitDestinationOriginalAddress(ctx contex
 				return ve.ValidateName("sitDestinationOriginalAddress")
 			} else if ce, ok := err.(*errors.CompositeError); ok {
 				return ce.ValidateName("sitDestinationOriginalAddress")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (m *MTOServiceItem) contextValidateSitOriginHHGActualAddress(ctx context.Context, formats strfmt.Registry) error {
+
+	if m.SitOriginHHGActualAddress != nil {
+
+		if swag.IsZero(m.SitOriginHHGActualAddress) { // not required
+			return nil
+		}
+
+		if err := m.SitOriginHHGActualAddress.ContextValidate(ctx, formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("sitOriginHHGActualAddress")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("sitOriginHHGActualAddress")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (m *MTOServiceItem) contextValidateSitOriginHHGOriginalAddress(ctx context.Context, formats strfmt.Registry) error {
+
+	if m.SitOriginHHGOriginalAddress != nil {
+
+		if swag.IsZero(m.SitOriginHHGOriginalAddress) { // not required
+			return nil
+		}
+
+		if err := m.SitOriginHHGOriginalAddress.ContextValidate(ctx, formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("sitOriginHHGOriginalAddress")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("sitOriginHHGOriginalAddress")
 			}
 			return err
 		}

--- a/pkg/handlers/ghcapi/internal/payloads/model_to_payload.go
+++ b/pkg/handlers/ghcapi/internal/payloads/model_to_payload.go
@@ -1404,6 +1404,8 @@ func MTOServiceItemModel(s *models.MTOServiceItem, storer storage.FileStorer) *g
 		Dimensions:                    MTOServiceItemDimensions(s.Dimensions),
 		CustomerContacts:              MTOServiceItemCustomerContacts(s.CustomerContacts),
 		SitAddressUpdates:             SITAddressUpdates(s.SITAddressUpdates),
+		SitOriginHHGOriginalAddress:   Address(s.SITOriginHHGOriginalAddress),
+		SitOriginHHGActualAddress:     Address(s.SITOriginHHGActualAddress),
 		SitDestinationOriginalAddress: Address(s.SITDestinationOriginalAddress),
 		SitDestinationFinalAddress:    Address(s.SITDestinationFinalAddress),
 		EstimatedWeight:               handlers.FmtPoundPtr(s.EstimatedWeight),
@@ -1414,6 +1416,7 @@ func MTOServiceItemModel(s *models.MTOServiceItem, storer storage.FileStorer) *g
 		ServiceRequestDocuments:       serviceRequestDocs,
 		ConvertToCustomerExpense:      *handlers.FmtBool(s.CustomerExpense),
 		CustomerExpenseReason:         handlers.FmtStringPtr(s.CustomerExpenseReason),
+		SitDeliveryMiles:              handlers.FmtIntPtrToInt64(s.SITDeliveryMiles),
 	}
 }
 

--- a/pkg/handlers/ghcapi/mto_service_items.go
+++ b/pkg/handlers/ghcapi/mto_service_items.go
@@ -279,6 +279,8 @@ func (h ListMTOServiceItemsHandler) Handle(params mtoserviceitemop.ListMTOServic
 				query.NewQueryAssociation("Dimensions"),
 				query.NewQueryAssociation("SITDestinationOriginalAddress"),
 				query.NewQueryAssociation("SITDestinationFinalAddress"),
+				query.NewQueryAssociation("SITOriginHHGOriginalAddress"),
+				query.NewQueryAssociation("SITOriginHHGActualAddress"),
 			})
 
 			var serviceItems models.MTOServiceItems

--- a/playwright/tests/office/txo/sitUpdates.spec.js
+++ b/playwright/tests/office/txo/sitUpdates.spec.js
@@ -243,8 +243,8 @@ test.describe('TOO user', () => {
       await expect(page.getByText('Total days of SIT approved')).toBeVisible();
       await expect(page.getByText('Total days used')).toBeVisible();
       await expect(page.getByText('Total days remaining')).toBeVisible();
-      await expect(page.getByText('SIT start date')).toBeVisible();
-      await expect(page.getByText('	SIT authorized end date')).toBeVisible();
+      await expect(page.getByText('SIT start date').nth(0)).toBeVisible();
+      await expect(page.getByText('SIT authorized end date')).toBeVisible();
       await expect(page.getByText('Calculated total SIT days')).toBeVisible();
     });
     test('is showing the SIT Departure Date section', async ({ page }) => {

--- a/src/components/Office/RequestedServiceItemsTable/RequestedServiceItemsTable.jsx
+++ b/src/components/Office/RequestedServiceItemsTable/RequestedServiceItemsTable.jsx
@@ -7,6 +7,8 @@ import { ServiceItemDetailsShape } from '../../../types/serviceItems';
 import styles from './RequestedServiceItemsTable.module.scss';
 
 import ServiceItemsTable from 'components/Office/ServiceItemsTable/ServiceItemsTable';
+import { ShipmentShape } from 'types';
+import { SitStatusShape } from 'types/sitStatusShape';
 
 const RequestedServiceItemsTable = ({
   serviceItems,
@@ -15,6 +17,8 @@ const RequestedServiceItemsTable = ({
   handleShowEditSitEntryDateModal,
   statusForTableType,
   serviceItemAddressUpdateAlert,
+  shipment,
+  sitStatus,
 }) => {
   const chooseTitleText = (status) => {
     switch (status) {
@@ -46,6 +50,8 @@ const RequestedServiceItemsTable = ({
         handleShowEditSitEntryDateModal={handleShowEditSitEntryDateModal}
         statusForTableType={statusForTableType}
         serviceItemAddressUpdateAlert={serviceItemAddressUpdateAlert}
+        shipment={shipment}
+        sitStatus={sitStatus}
       />
     </div>
   );
@@ -56,6 +62,13 @@ RequestedServiceItemsTable.propTypes = {
   handleShowRejectionDialog: PropTypes.func.isRequired,
   statusForTableType: PropTypes.string.isRequired,
   serviceItems: PropTypes.arrayOf(ServiceItemDetailsShape).isRequired,
+  shipment: ShipmentShape,
+  sitStatus: SitStatusShape,
+};
+
+RequestedServiceItemsTable.defaultProps = {
+  shipment: {},
+  sitStatus: undefined,
 };
 
 export default RequestedServiceItemsTable;

--- a/src/components/Office/RequestedServiceItemsTable/RequestedServiceItemsTable.test.jsx
+++ b/src/components/Office/RequestedServiceItemsTable/RequestedServiceItemsTable.test.jsx
@@ -70,22 +70,28 @@ const testDetails = (wrapper) => {
   expect(detailTypes.at(1).text()).toBe('Item size:');
   expect(detailDefinitions.at(1).text()).toBe('7"x2"x3.5"');
 
-  expect(detailTypes.at(3).text()).toBe('SIT entry date:');
+  expect(detailTypes.at(3).text()).toBe('Original pickup address:');
   expect(detailDefinitions.at(3).text().includes('-')).toBe(true);
-  expect(detailTypes.at(4).text()).toBe('First available delivery date 1:');
-  expect(detailDefinitions.at(4).text().includes('15 Sep 2020')).toBe(true);
-  expect(detailTypes.at(5).text()).toBe('Customer contact attempt 1:');
-  expect(detailDefinitions.at(5).text().includes('15 Sep 2020, 1200Z')).toBe(true);
+  expect(detailTypes.at(4).text()).toBe('Actual pickup address:');
+  expect(detailDefinitions.at(4).text().includes('-')).toBe(true);
+  expect(detailTypes.at(5).text()).toBe('Delivery into SIT miles:');
+  expect(detailDefinitions.at(5).text().includes('-')).toBe(true);
+  expect(detailTypes.at(6).text()).toBe('Original delivery address:');
+  expect(detailDefinitions.at(6).text().includes('-')).toBe(true);
+  expect(detailTypes.at(7).text()).toBe('SIT entry date:');
+  expect(detailDefinitions.at(7).text().includes('-')).toBe(true);
+  expect(detailTypes.at(8).text()).toBe('First available delivery date 1:');
+  expect(detailDefinitions.at(8).text().includes('15 Sep 2020')).toBe(true);
+  expect(detailTypes.at(9).text()).toBe('Customer contact attempt 1:');
+  expect(detailDefinitions.at(9).text().includes('15 Sep 2020, 1200Z')).toBe(true);
 
-  expect(detailTypes.at(6).text()).toBe('First available delivery date 2:');
-  expect(detailDefinitions.at(6).text().includes('21 Sep 2020')).toBe(true);
-  expect(detailTypes.at(7).text()).toBe('Customer contact attempt 2:');
-  expect(detailDefinitions.at(7).text().includes('21 Sep 2020, 2300Z')).toBe(true);
+  expect(detailTypes.at(10).text()).toBe('First available delivery date 2:');
+  expect(detailDefinitions.at(10).text().includes('21 Sep 2020')).toBe(true);
+  expect(detailTypes.at(11).text()).toBe('Customer contact attempt 2:');
+  expect(detailDefinitions.at(11).text().includes('21 Sep 2020, 2300Z')).toBe(true);
 
-  expect(detailTypes.at(9).text()).toBe('ZIP:');
-  expect(detailDefinitions.at(9).text().includes('12345')).toBe(true);
-  expect(detailTypes.at(8).text()).toBe('Reason:');
-  expect(detailDefinitions.at(8).text().includes('Took a detour')).toBe(true);
+  expect(detailTypes.at(12).text()).toBe('Reason:');
+  expect(detailDefinitions.at(12).text().includes('Took a detour')).toBe(true);
 };
 
 describe('RequestedServiceItemsTable', () => {
@@ -129,11 +135,11 @@ describe('RequestedServiceItemsTable', () => {
     expect(wrapper.find('.codeName').at(0).text()).toBe('Domestic crating ');
     expect(wrapper.find('.nameAndDate').at(0).text().includes('20 Nov 2020')).toBe(true);
 
-    expect(wrapper.find('.codeName').at(1).text()).toBe('Domestic destination 1st day SIT ');
-    expect(wrapper.find('.nameAndDate').at(1).text().includes('1 Sep 2020')).toBe(true);
+    expect(wrapper.find('.codeName').at(1).text()).toBe('Domestic origin 1st day SIT ');
+    expect(wrapper.find('.nameAndDate').at(1).text().includes('15 Oct 2020')).toBe(true);
 
-    expect(wrapper.find('.codeName').at(2).text()).toBe('Domestic origin 1st day SIT ');
-    expect(wrapper.find('.nameAndDate').at(2).text().includes('15 Oct 2020')).toBe(true);
+    expect(wrapper.find('.codeName').at(2).text()).toBe('Domestic destination 1st day SIT ');
+    expect(wrapper.find('.nameAndDate').at(2).text().includes('1 Sep 2020')).toBe(true);
   });
 
   it('shows the service item detail text', () => {

--- a/src/components/Office/ServiceItemDetails/ServiceItemDetails.jsx
+++ b/src/components/Office/ServiceItemDetails/ServiceItemDetails.jsx
@@ -1,13 +1,17 @@
 import React from 'react';
 import { isEmpty, sortBy } from 'lodash';
 import classnames from 'classnames';
+import moment from 'moment';
 
 import { ServiceItemDetailsShape } from '../../../types/serviceItems';
 import { trimFileName } from '../../../utils/serviceItems';
 
 import styles from './ServiceItemDetails.module.scss';
 
+import { ShipmentShape } from 'types/shipment';
+import { SitStatusShape } from 'types/sitStatusShape';
 import { formatDateWithUTC } from 'shared/dates';
+import { formatCityStateAndPostalCode } from 'utils/shipmentDisplay';
 import { formatWeight, convertFromThousandthInchToInch } from 'utils/formatters';
 
 function generateDetailText(details, id, className) {
@@ -20,7 +24,7 @@ function generateDetailText(details, id, className) {
   return detailList;
 }
 
-const generateDestinationSITDetailSection = (id, serviceRequestDocUploads, details, code) => {
+const generateDestinationSITDetailSection = (id, serviceRequestDocUploads, details, code, shipment, sitStatus) => {
   const { customerContacts } = details;
   // Below we are using the sortBy func in lodash to sort the customer contacts
   // by the firstAvailableDeliveryDate field. sortBy returns a new
@@ -34,76 +38,133 @@ const generateDestinationSITDetailSection = (id, serviceRequestDocUploads, detai
     'First available delivery date 1': '-',
     'Customer contact 1': '-',
   });
+  const numberOfDaysApprovedForDOASIT = shipment.sitDaysAllowance ? shipment.sitDaysAllowance - 1 : 0;
+  const sitEndDate =
+    sitStatus &&
+    sitStatus.currentSIT?.sitAllowanceEndDate &&
+    formatDateWithUTC(sitStatus.currentSIT.sitAllowanceEndDate, 'DD MMM YYYY');
 
   return (
     <div>
       <dl>
-        {code === 'DDDSIT'
+        {code === 'DDFSIT'
           ? generateDetailText({
-              'SIT departure date': details.sitDepartureDate
-                ? formatDateWithUTC(details.sitDepartureDate, 'DD MMM YYYY')
+              'Original delivery address': details.sitDestinationOriginalAddress
+                ? formatCityStateAndPostalCode(details.sitDestinationOriginalAddress)
                 : '-',
-            })
-          : null}
-        {code === 'DDFSIT' || code === 'DDASIT'
-          ? generateDetailText({
               'SIT entry date': details.sitEntryDate ? formatDateWithUTC(details.sitEntryDate, 'DD MMM YYYY') : '-',
             })
           : null}
-
-        {!isEmpty(sortedCustomerContacts)
-          ? sortedCustomerContacts.map((contact, index) => (
-              <>
-                {generateDetailText(
-                  {
-                    [`First available delivery date ${index + 1}`]:
-                      contact && contact.firstAvailableDeliveryDate
-                        ? formatDateWithUTC(contact.firstAvailableDeliveryDate, 'DD MMM YYYY')
-                        : '-',
-                    [`Customer contact attempt ${index + 1}`]:
-                      contact && contact.dateOfContact && contact.timeMilitary
-                        ? `${formatDateWithUTC(contact.dateOfContact, 'DD MMM YYYY')}, ${contact.timeMilitary}`
-                        : '-',
-                  },
-                  id,
-                )}
-              </>
-            ))
-          : defaultDetailText}
-        {generateDetailText({ Reason: details.reason ? details.reason : '-' })}
-        {details.rejectionReason &&
-          generateDetailText({ 'Rejection reason': details.rejectionReason }, id, 'margin-top-2')}
-        {!isEmpty(serviceRequestDocUploads) ? (
-          <div className={styles.uploads}>
-            <p className={styles.detailType}>Download service item documentation:</p>
-            {serviceRequestDocUploads.map((file) => (
+        {code === 'DDASIT'
+          ? generateDetailText(
+              {
+                'Original delivery address': details.sitDestinationOriginalAddress
+                  ? formatCityStateAndPostalCode(details.sitDestinationOriginalAddress)
+                  : '-',
+                "Add'l SIT Start Date": details.sitEntryDate
+                  ? moment.utc(details.sitEntryDate).add(1, 'days').format('DD MMM YYYY')
+                  : '-',
+                '# of days approved for': shipment.sitDaysAllowance ? `${numberOfDaysApprovedForDOASIT} days` : '-',
+                'SIT expiration date': sitEndDate || '-',
+                'Customer contacted homesafe': details.sitCustomerContacted
+                  ? formatDateWithUTC(details.sitCustomerContacted, 'DD MMM YYYY')
+                  : '-',
+                'Customer requested delivery date': details.sitRequestedDelivery
+                  ? formatDateWithUTC(details.sitRequestedDelivery, 'DD MMM YYYY')
+                  : '-',
+                'SIT departure date': details.sitDepartureDate
+                  ? formatDateWithUTC(details.sitDepartureDate, 'DD MMM YYYY')
+                  : '-',
+              },
+              id,
+            )
+          : null}
+        {code === 'DDSFSC'
+          ? generateDetailText(
+              {
+                'Original delivery address': details.sitDestinationOriginalAddress
+                  ? formatCityStateAndPostalCode(details.sitDestinationOriginalAddress)
+                  : '-',
+                'Final delivery address': details.sitDestinationFinalAddress
+                  ? formatCityStateAndPostalCode(details.sitDestinationFinalAddress)
+                  : '-',
+                'Delivery into SIT miles': details.sitDeliveryMiles ? details.sitDeliveryMiles : '-',
+              },
+              id,
+            )
+          : null}
+        {code === 'DDDSIT'
+          ? generateDetailText(
+              {
+                'Original delivery address': details.sitDestinationOriginalAddress
+                  ? formatCityStateAndPostalCode(details.sitDestinationOriginalAddress)
+                  : '-',
+                'Final delivery address': details.sitDestinationFinalAddress
+                  ? formatCityStateAndPostalCode(details.sitDestinationFinalAddress)
+                  : '-',
+                'Delivery into SIT miles': details.sitDeliveryMiles ? details.sitDeliveryMiles : '-',
+              },
+              id,
+            )
+          : null}
+        {code === 'DDFSIT' && (
+          <>
+            {!isEmpty(sortedCustomerContacts)
+              ? sortedCustomerContacts.map((contact, index) => (
+                  <>
+                    {generateDetailText(
+                      {
+                        [`First available delivery date ${index + 1}`]:
+                          contact && contact.firstAvailableDeliveryDate
+                            ? formatDateWithUTC(contact.firstAvailableDeliveryDate, 'DD MMM YYYY')
+                            : '-',
+                        [`Customer contact attempt ${index + 1}`]:
+                          contact && contact.dateOfContact && contact.timeMilitary
+                            ? `${formatDateWithUTC(contact.dateOfContact, 'DD MMM YYYY')}, ${contact.timeMilitary}`
+                            : '-',
+                      },
+                      id,
+                    )}
+                  </>
+                ))
+              : defaultDetailText}
+            {generateDetailText({ Reason: details.reason ? details.reason : '-' })}
+            {details.rejectionReason &&
+              generateDetailText({ 'Rejection reason': details.rejectionReason }, id, 'margin-top-2')}
+            {!isEmpty(serviceRequestDocUploads) ? (
               <div className={styles.uploads}>
-                <a href={file.url} download>
-                  {trimFileName(file.filename)}
-                </a>
+                <p className={styles.detailType}>Download service item documentation:</p>
+                {serviceRequestDocUploads.map((file) => (
+                  <div className={styles.uploads}>
+                    <a href={file.url} download>
+                      {trimFileName(file.filename)}
+                    </a>
+                  </div>
+                ))}
               </div>
-            ))}
-          </div>
-        ) : null}
+            ) : null}
+          </>
+        )}
       </dl>
     </div>
   );
 };
 
-const ServiceItemDetails = ({ id, code, details, serviceRequestDocs }) => {
+const ServiceItemDetails = ({ id, code, details, serviceRequestDocs, shipment, sitStatus }) => {
   const serviceRequestDocUploads = serviceRequestDocs?.map((doc) => doc.uploads[0]);
 
   let detailSection;
   switch (code) {
-    case 'DOFSIT':
-    case 'DOASIT': {
+    case 'DOFSIT': {
       detailSection = (
         <div>
           <dl>
             {generateDetailText(
               {
+                'Original pickup address': details.sitOriginHHGOriginalAddress
+                  ? formatCityStateAndPostalCode(details.sitOriginHHGOriginalAddress)
+                  : '-',
                 'SIT entry date': details.sitEntryDate ? formatDateWithUTC(details.sitEntryDate, 'DD MMM YYYY') : '-',
-                ZIP: details.SITPostalCode ? details.SITPostalCode : '-',
                 Reason: details.reason ? details.reason : '-',
               },
               id,
@@ -127,15 +188,105 @@ const ServiceItemDetails = ({ id, code, details, serviceRequestDocs }) => {
       );
       break;
     }
-    case 'DOPSIT':
+    case 'DOASIT': {
+      const numberOfDaysApprovedForDOASIT = shipment.sitDaysAllowance ? shipment.sitDaysAllowance - 1 : 0;
+      const sitEndDate =
+        sitStatus &&
+        sitStatus.currentSIT?.sitAllowanceEndDate &&
+        formatDateWithUTC(sitStatus.currentSIT.sitAllowanceEndDate, 'DD MMM YYYY');
+
+      detailSection = (
+        <div>
+          <dl>
+            {generateDetailText(
+              {
+                'Original pickup address': details.sitOriginHHGOriginalAddress
+                  ? formatCityStateAndPostalCode(details.sitOriginHHGOriginalAddress)
+                  : '-',
+                "Add'l SIT Start Date": details.sitEntryDate
+                  ? moment.utc(details.sitEntryDate).add(1, 'days').format('DD MMM YYYY')
+                  : '-',
+                '# of days approved for': shipment.sitDaysAllowance ? `${numberOfDaysApprovedForDOASIT} days` : '-',
+                'SIT expiration date': sitEndDate || '-',
+                'Customer contacted homesafe': details.sitCustomerContacted
+                  ? formatDateWithUTC(details.sitCustomerContacted, 'DD MMM YYYY')
+                  : '-',
+                'Customer requested delivery date': details.sitRequestedDelivery
+                  ? formatDateWithUTC(details.sitRequestedDelivery, 'DD MMM YYYY')
+                  : '-',
+                'SIT departure date': details.sitDepartureDate
+                  ? formatDateWithUTC(details.sitDepartureDate, 'DD MMM YYYY')
+                  : '-',
+              },
+              id,
+            )}
+            {details.rejectionReason &&
+              generateDetailText({ 'Rejection reason': details.rejectionReason }, id, 'margin-top-2')}
+            {!isEmpty(serviceRequestDocUploads) ? (
+              <div className={styles.uploads}>
+                <p className={styles.detailType}>Download service item documentation:</p>
+                {serviceRequestDocUploads.map((file) => (
+                  <div className={styles.uploads}>
+                    <a href={file.url} download>
+                      {trimFileName(file.filename)}
+                    </a>
+                  </div>
+                ))}
+              </div>
+            ) : null}
+          </dl>
+        </div>
+      );
+      break;
+    }
+    case 'DOPSIT': {
+      detailSection = (
+        <div>
+          <dl>
+            {generateDetailText(
+              {
+                'Original pickup address': details.sitOriginHHGOriginalAddress
+                  ? formatCityStateAndPostalCode(details.sitOriginHHGOriginalAddress)
+                  : '-',
+                'Actual pickup address': details.sitOriginHHGActualAddress
+                  ? formatCityStateAndPostalCode(details.sitOriginHHGActualAddress)
+                  : '-',
+                'Delivery into SIT miles': details.sitDeliveryMiles ? details.sitDeliveryMiles : '-',
+              },
+              id,
+            )}
+            {details.rejectionReason &&
+              generateDetailText({ 'Rejection reason': details.rejectionReason }, id, 'margin-top-2')}
+            {!isEmpty(serviceRequestDocUploads) ? (
+              <div className={styles.uploads}>
+                <p className={styles.detailType}>Download service item documentation:</p>
+                {serviceRequestDocUploads.map((file) => (
+                  <div className={styles.uploads}>
+                    <a href={file.url} download>
+                      {trimFileName(file.filename)}
+                    </a>
+                  </div>
+                ))}
+              </div>
+            ) : null}
+          </dl>
+        </div>
+      );
+      break;
+    }
     case 'DOSFSC': {
       detailSection = (
         <div>
           <dl>
             {generateDetailText(
               {
-                ZIP: details.SITPostalCode ? details.SITPostalCode : '-',
-                Reason: details.reason ? details.reason : '-',
+                'Original pickup address': details.sitOriginHHGOriginalAddress
+                  ? formatCityStateAndPostalCode(details.sitOriginHHGOriginalAddress)
+                  : '-',
+                'Actual pickup address': details.sitOriginHHGActualAddress
+                  ? formatCityStateAndPostalCode(details.sitOriginHHGActualAddress)
+                  : '-',
+                'Delivery into SIT miles': details.sitDeliveryMiles ? details.sitDeliveryMiles : '-',
               },
               id,
             )}
@@ -158,12 +309,38 @@ const ServiceItemDetails = ({ id, code, details, serviceRequestDocs }) => {
       );
       break;
     }
-
     case 'DDFSIT':
-    case 'DDASIT':
-    case 'DDDSIT':
+    case 'DDASIT': {
+      detailSection = generateDestinationSITDetailSection(
+        id,
+        serviceRequestDocUploads,
+        details,
+        code,
+        shipment,
+        sitStatus,
+      );
+      break;
+    }
+    case 'DDDSIT': {
+      detailSection = generateDestinationSITDetailSection(
+        id,
+        serviceRequestDocUploads,
+        details,
+        code,
+        shipment,
+        sitStatus,
+      );
+      break;
+    }
     case 'DDSFSC': {
-      detailSection = generateDestinationSITDetailSection(id, serviceRequestDocUploads, details, code);
+      detailSection = generateDestinationSITDetailSection(
+        id,
+        serviceRequestDocUploads,
+        details,
+        code,
+        shipment,
+        sitStatus,
+      );
       break;
     }
     case 'DCRT':
@@ -299,7 +476,15 @@ const ServiceItemDetails = ({ id, code, details, serviceRequestDocs }) => {
 
 ServiceItemDetails.propTypes = ServiceItemDetailsShape.isRequired;
 
+ServiceItemDetails.propTypes = {
+  details: ServiceItemDetailsShape,
+  shipment: ShipmentShape,
+  sitStatus: SitStatusShape,
+};
+
 ServiceItemDetails.defaultProps = {
   details: {},
+  shipment: {},
+  sitStatus: undefined,
 };
 export default ServiceItemDetails;

--- a/src/components/Office/ServiceItemDetails/ServiceItemDetails.test.jsx
+++ b/src/components/Office/ServiceItemDetails/ServiceItemDetails.test.jsx
@@ -3,11 +3,21 @@ import { render, screen } from '@testing-library/react';
 
 import ServiceItemDetails from './ServiceItemDetails';
 
+const sitStatus = {
+  currentSIT: {
+    sitAllowanceEndDate: '2024-03-17',
+  },
+};
+
+const shipment = {
+  sitDaysAllowance: 90,
+};
+
 const details = {
   description: 'some description',
   pickupPostalCode: '90210',
   SITPostalCode: '12345',
-  sitEntryDate: '2020-10-10',
+  sitEntryDate: '2024-03-11T00:00:00.000Z',
   reason: 'some reason',
   itemDimensions: { length: 1000, width: 2500, height: 3000 },
   crateDimensions: { length: 2000, width: 3500, height: 4000 },
@@ -16,6 +26,42 @@ const details = {
     { timeMilitary: '2300Z', firstAvailableDeliveryDate: '2020-09-21', dateOfContact: '2020-09-21' },
   ],
   estimatedWeight: 2500,
+  sitCustomerContacted: '2024-03-14T00:00:00.000Z',
+  sitRequestedDelivery: '2024-03-15T00:00:00.000Z',
+  sitDepartureDate: '2024-03-16T00:00:00.000Z',
+  sitDeliveryMiles: 50,
+  sitOriginHHGOriginalAddress: {
+    city: 'Origin Original Tampa',
+    eTag: 'MjAyNC0wMy0xMlQxOTo1OTowOC41NjkxMzla',
+    id: '7fd6cb90-54cd-44d8-8735-102e28734d84',
+    postalCode: '33621',
+    state: 'FL',
+    streetAddress1: 'MacDill',
+  },
+  sitOriginHHGActualAddress: {
+    city: 'Origin Actual MacDill',
+    eTag: 'HjAyNC0wMy0xMlQxOTo1OTowOC41NjkxMzla',
+    id: '8fd6cb90-54cd-44d8-8735-102e28734d84',
+    postalCode: '33621',
+    state: 'FL',
+    streetAddress1: 'MacDill',
+  },
+  sitDestinationOriginalAddress: {
+    city: 'Destination Original Tampa',
+    eTag: 'MjAyNC0wMy0xMlQxOTo1OTowOC41NjkxMzla',
+    id: '7fd6cb90-54cd-44d8-8735-102e28734d84',
+    postalCode: '33621',
+    state: 'FL',
+    streetAddress1: 'MacDill',
+  },
+  sitDestinationFinalAddress: {
+    city: 'Destination Final MacDill',
+    eTag: 'HjAyNC0wMy0xMlQxOTo1OTowOC41NjkxMzla',
+    id: '8fd6cb90-54cd-44d8-8735-102e28734d84',
+    postalCode: '33621',
+    state: 'FL',
+    streetAddress1: 'MacDill',
+  },
 };
 
 const serviceRequestDocs = [
@@ -34,30 +80,139 @@ const nilDetails = {
   estimatedWeight: null,
 };
 
-describe('ServiceItemDetails Domestic Origin SIT', () => {
-  it.each([['DOASIT'], ['DOPSIT']])('renders ZIP, reason, and service request documents', (code) => {
-    render(<ServiceItemDetails id="1" code={code} details={details} serviceRequestDocs={serviceRequestDocs} />);
+describe('ServiceItemDetails Domestic Destination SIT', () => {
+  it('renders DDASIT details', () => {
+    render(
+      <ServiceItemDetails
+        id="1"
+        code="DDASIT"
+        details={details}
+        shipment={shipment}
+        sitStatus={sitStatus}
+        serviceRequestDocs={serviceRequestDocs}
+      />,
+    );
+    expect(screen.getByText('Original delivery address:')).toBeInTheDocument();
+    expect(screen.getByText('Destination Original Tampa, FL 33621')).toBeInTheDocument();
 
-    expect(screen.getByText('ZIP:')).toBeInTheDocument();
-    expect(screen.getByText('12345')).toBeInTheDocument();
-    expect(screen.getByText('Reason:')).toBeInTheDocument();
-    expect(screen.getByText('some reason')).toBeInTheDocument();
-    expect(screen.getByText('Download service item documentation:')).toBeInTheDocument();
-    const downloadLink = screen.getByText('receipt.pdf');
-    expect(downloadLink).toBeInstanceOf(HTMLAnchorElement);
+    expect(screen.getByText("Add'l SIT Start Date:")).toBeInTheDocument();
+    expect(screen.getByText('12 Mar 2024')).toBeInTheDocument();
+
+    expect(screen.getByText('Customer contacted homesafe:')).toBeInTheDocument();
+    expect(screen.getByText('14 Mar 2024')).toBeInTheDocument();
+
+    expect(screen.getByText('# of days approved for:')).toBeInTheDocument();
+    expect(screen.getByText('89 days')).toBeInTheDocument();
+
+    expect(screen.getByText('SIT expiration date:')).toBeInTheDocument();
+    expect(screen.getByText('17 Mar 2024')).toBeInTheDocument();
+
+    expect(screen.getByText('Customer requested delivery date:')).toBeInTheDocument();
+    expect(screen.getByText('15 Mar 2024')).toBeInTheDocument();
+
+    expect(screen.getByText('SIT departure date:')).toBeInTheDocument();
+    expect(screen.getByText('16 Mar 2024')).toBeInTheDocument();
+  });
+
+  it('renders DDDSIT details', () => {
+    render(<ServiceItemDetails id="1" code="DDDSIT" details={details} serviceRequestDocs={serviceRequestDocs} />);
+    expect(screen.getByText('Original delivery address:')).toBeInTheDocument();
+    expect(screen.getByText('Destination Original Tampa, FL 33621')).toBeInTheDocument();
+
+    expect(screen.getByText('Final delivery address:')).toBeInTheDocument();
+    expect(screen.getByText('Destination Final MacDill, FL 33621')).toBeInTheDocument();
+
+    expect(screen.getByText('Delivery into SIT miles:')).toBeInTheDocument();
+    expect(screen.getByText('50')).toBeInTheDocument();
+  });
+  it('renders DDFSIT details', () => {
+    render(<ServiceItemDetails id="1" code="DDFSIT" details={details} serviceRequestDocs={serviceRequestDocs} />);
+    expect(screen.getByText('Original delivery address:')).toBeInTheDocument();
+    expect(screen.getByText('Destination Original Tampa, FL 33621')).toBeInTheDocument();
+  });
+  it('renders DDSFSC details', () => {
+    render(<ServiceItemDetails id="1" code="DDSFSC" details={details} serviceRequestDocs={serviceRequestDocs} />);
+    expect(screen.getByText('Original delivery address:')).toBeInTheDocument();
+    expect(screen.getByText('Destination Original Tampa, FL 33621')).toBeInTheDocument();
+
+    expect(screen.getByText('Final delivery address:')).toBeInTheDocument();
+    expect(screen.getByText('Destination Final MacDill, FL 33621')).toBeInTheDocument();
+
+    expect(screen.getByText('Delivery into SIT miles:')).toBeInTheDocument();
+    expect(screen.getByText('50')).toBeInTheDocument();
+  });
+});
+
+describe('ServiceItemDetails Domestic Origin SIT', () => {
+  it(`renders DOASIT details`, () => {
+    render(
+      <ServiceItemDetails
+        id="1"
+        code="DOASIT"
+        details={details}
+        shipment={shipment}
+        sitStatus={sitStatus}
+        serviceRequestDocs={serviceRequestDocs}
+      />,
+    );
+
+    expect(screen.getByText('Original pickup address:')).toBeInTheDocument();
+    expect(screen.getByText('Origin Original Tampa, FL 33621')).toBeInTheDocument();
+
+    expect(screen.getByText("Add'l SIT Start Date:")).toBeInTheDocument();
+    expect(screen.getByText('12 Mar 2024')).toBeInTheDocument();
+
+    expect(screen.getByText('# of days approved for:')).toBeInTheDocument();
+    expect(screen.getByText('89 days')).toBeInTheDocument();
+
+    expect(screen.getByText('SIT expiration date:')).toBeInTheDocument();
+    expect(screen.getByText('17 Mar 2024')).toBeInTheDocument();
+
+    expect(screen.getByText('Customer contacted homesafe:')).toBeInTheDocument();
+    expect(screen.getByText('14 Mar 2024')).toBeInTheDocument();
+
+    expect(screen.getByText('Customer requested delivery date:')).toBeInTheDocument();
+    expect(screen.getByText('15 Mar 2024')).toBeInTheDocument();
+
+    expect(screen.getByText('SIT departure date:')).toBeInTheDocument();
+    expect(screen.getByText('16 Mar 2024')).toBeInTheDocument();
+  });
+
+  it(`renders DOPSIT details`, () => {
+    render(<ServiceItemDetails id="1" code="DOPSIT" details={details} serviceRequestDocs={serviceRequestDocs} />);
+
+    expect(screen.getByText('Original pickup address:')).toBeInTheDocument();
+    expect(screen.getByText('Origin Original Tampa, FL 33621')).toBeInTheDocument();
+
+    expect(screen.getByText('Actual pickup address:')).toBeInTheDocument();
+    expect(screen.getByText('Origin Actual MacDill, FL 33621')).toBeInTheDocument();
+
+    expect(screen.getByText('Delivery into SIT miles:')).toBeInTheDocument();
+    expect(screen.getByText('50')).toBeInTheDocument();
+  });
+
+  it(`renders DOSFSC details`, () => {
+    render(<ServiceItemDetails id="1" code="DOSFSC" details={details} serviceRequestDocs={serviceRequestDocs} />);
+
+    expect(screen.getByText('Original pickup address:')).toBeInTheDocument();
+    expect(screen.getByText('Origin Original Tampa, FL 33621')).toBeInTheDocument();
+
+    expect(screen.getByText('Actual pickup address:')).toBeInTheDocument();
+    expect(screen.getByText('Origin Actual MacDill, FL 33621')).toBeInTheDocument();
+
+    expect(screen.getByText('Delivery into SIT miles:')).toBeInTheDocument();
+    expect(screen.getByText('50')).toBeInTheDocument();
   });
 });
 
 describe('ServiceItemDetails for DOFSIT', () => {
-  it('renders SIT entry date, ZIP, and reason', () => {
+  it('renders SIT entry date, ZIP, original pickup address, and reason', () => {
     render(<ServiceItemDetails id="1" code="DOFSIT" details={details} serviceRequestDocs={serviceRequestDocs} />);
 
+    expect(screen.getByText('Original pickup address:')).toBeInTheDocument();
+    expect(screen.getByText('Origin Original Tampa, FL 33621')).toBeInTheDocument();
     expect(screen.getByText('SIT entry date:')).toBeInTheDocument();
-    expect(screen.getByText('10 Oct 2020')).toBeInTheDocument();
-    expect(screen.getByText('ZIP:')).toBeInTheDocument();
-    expect(screen.getByText('12345')).toBeInTheDocument();
-    expect(screen.getByText('Reason:')).toBeInTheDocument();
-    expect(screen.getByText('some reason')).toBeInTheDocument();
+    expect(screen.getByText('11 Mar 2024')).toBeInTheDocument();
     expect(screen.getByText('Download service item documentation:')).toBeInTheDocument();
     const downloadLink = screen.getByText('receipt.pdf');
     expect(downloadLink).toBeInstanceOf(HTMLAnchorElement);
@@ -65,22 +220,19 @@ describe('ServiceItemDetails for DOFSIT', () => {
 });
 
 describe('ServiceItemDetails Domestic Destination SIT', () => {
-  it.each([['DDDSIT'], ['DDASIT'], ['DDFSIT']])(
-    'renders first and second customer contact and available delivery date',
-    (code) => {
-      render(<ServiceItemDetails id="1" code={code} details={details} serviceRequestDocs={serviceRequestDocs} />);
+  it('renders first and second customer contact and available delivery date', () => {
+    render(<ServiceItemDetails id="1" code="DDFSIT" details={details} serviceRequestDocs={serviceRequestDocs} />);
 
-      expect(screen.getByText('Customer contact attempt 1:')).toBeInTheDocument();
-      expect(screen.getByText('15 Sep 2020, 1200Z')).toBeInTheDocument();
-      expect(screen.getByText('15 Sep 2020')).toBeInTheDocument();
-      expect(screen.getByText('Customer contact attempt 2:')).toBeInTheDocument();
-      expect(screen.getByText('21 Sep 2020, 2300Z')).toBeInTheDocument();
-      expect(screen.getByText('21 Sep 2020')).toBeInTheDocument();
-      expect(screen.getByText('Download service item documentation:')).toBeInTheDocument();
-      const downloadLink = screen.getByText('receipt.pdf');
-      expect(downloadLink).toBeInstanceOf(HTMLAnchorElement);
-    },
-  );
+    expect(screen.getByText('Customer contact attempt 1:')).toBeInTheDocument();
+    expect(screen.getByText('15 Sep 2020, 1200Z')).toBeInTheDocument();
+    expect(screen.getByText('15 Sep 2020')).toBeInTheDocument();
+    expect(screen.getByText('Customer contact attempt 2:')).toBeInTheDocument();
+    expect(screen.getByText('21 Sep 2020, 2300Z')).toBeInTheDocument();
+    expect(screen.getByText('21 Sep 2020')).toBeInTheDocument();
+    expect(screen.getByText('Download service item documentation:')).toBeInTheDocument();
+    const downloadLink = screen.getByText('receipt.pdf');
+    expect(downloadLink).toBeInstanceOf(HTMLAnchorElement);
+  });
 });
 
 describe('ServiceItemDetails Crating', () => {

--- a/src/components/Office/ServiceItemsTable/ServiceItemsTable.jsx
+++ b/src/components/Office/ServiceItemsTable/ServiceItemsTable.jsx
@@ -18,6 +18,31 @@ import { permissionTypes } from 'constants/permissions';
 import { selectDateFieldByStatus, selectDatePrefixByStatus } from 'utils/dates';
 import { useGHCGetMoveHistory, useMovePaymentRequestsQueries } from 'hooks/queries';
 import ToolTip from 'shared/ToolTip/ToolTip';
+import { ShipmentShape } from 'types';
+
+// Sorts service items in an order preferred by the customer
+// Currently only SIT receives special sorting
+function sortServiceItems(items) {
+  // Filter and sort destination SIT. Code index is also the sort order
+  const destinationServiceItemCodes = ['DDFSIT', 'DDASIT', 'DDDSIT', 'DDSFSC'];
+  const destinationServiceItems = items.filter((item) => destinationServiceItemCodes.includes(item.code));
+  const sortedDestinationServiceItems = destinationServiceItems.sort(
+    (a, b) => destinationServiceItemCodes.indexOf(a.code) - destinationServiceItemCodes.indexOf(b.code),
+  );
+  // Filter origin SIT. Code index is also the sort order
+  const originServiceItemCodes = ['DOFSIT', 'DOASIT', 'DOPSIT', 'DOSFSC'];
+  const originServiceItems = items.filter((item) => originServiceItemCodes.includes(item.code));
+  const sortedOriginServiceItems = originServiceItems.sort(
+    (a, b) => originServiceItemCodes.indexOf(a.code) - originServiceItemCodes.indexOf(b.code),
+  );
+
+  // Filter all service items that are not specifically sorted
+  const remainingServiceItems = items.filter(
+    (item) => !destinationServiceItemCodes.includes(item.code) && !originServiceItemCodes.includes(item.code),
+  );
+
+  return [...remainingServiceItems, ...sortedOriginServiceItems, ...sortedDestinationServiceItems];
+}
 
 const ServiceItemsTable = ({
   serviceItems,
@@ -26,6 +51,7 @@ const ServiceItemsTable = ({
   handleShowRejectionDialog,
   handleShowEditSitAddressModal,
   handleShowEditSitEntryDateModal,
+  shipment,
 }) => {
   const getServiceItemDisplayDate = (item) => {
     const prefix = selectDatePrefixByStatus(statusForTableType);
@@ -129,7 +155,8 @@ const ServiceItemsTable = ({
     return resubmittedServiceItemValues;
   };
 
-  const tableRows = serviceItems.map((serviceItem) => {
+  const sortedServiceItems = sortServiceItems(serviceItems);
+  const tableRows = sortedServiceItems.map((serviceItem) => {
     const { id, code, details, mtoShipmentID, sitAddressUpdates, serviceRequestDocuments, ...item } = serviceItem;
     let hasPaymentRequestBeenMade;
     // if there are service items in the payment requests, we want to look to see if the service item is in there
@@ -181,6 +208,8 @@ const ServiceItemsTable = ({
               details={details}
               serviceRequestDocs={serviceRequestDocuments}
               serviceItem={serviceItem}
+              shipment={shipment}
+              sitStatus={shipment.sitStatus}
             />
           </td>
           <td>
@@ -296,6 +325,11 @@ ServiceItemsTable.propTypes = {
   handleShowRejectionDialog: PropTypes.func.isRequired,
   statusForTableType: PropTypes.string.isRequired,
   serviceItems: PropTypes.arrayOf(ServiceItemDetailsShape).isRequired,
+  shipment: ShipmentShape,
+};
+
+ServiceItemsTable.defaultProps = {
+  shipment: {},
 };
 
 export default ServiceItemsTable;

--- a/src/components/Office/ServiceItemsTable/ServiceItemsTable.test.jsx
+++ b/src/components/Office/ServiceItemsTable/ServiceItemsTable.test.jsx
@@ -95,6 +95,14 @@ describe('ServiceItemsTable', () => {
             },
             { timeMilitary: '0800Z', firstAvailableDeliveryDate: '2021-01-01', dateOfContact: '2021-01-01' },
           ],
+          sitDestinationOriginalAddress: {
+            city: 'Destination Original Tampa',
+            eTag: 'MjAyNC0wMy0xMlQxOTo1OTowOC41NjkxMzla',
+            id: '7fd6cb90-54cd-44d8-8735-102e28734d84',
+            postalCode: '33621',
+            state: 'FL',
+            streetAddress1: 'MacDill',
+          },
         },
       },
     ];
@@ -110,18 +118,21 @@ describe('ServiceItemsTable', () => {
     );
 
     expect(wrapper.find('table').exists()).toBe(true);
+    expect(wrapper.find('dt').at(0).text()).toBe('Original delivery address:');
+    expect(wrapper.find('dd').at(0).text()).toBe('Destination Original Tampa, FL 33621');
 
-    expect(wrapper.find('dt').at(0).text()).toBe('SIT entry date:');
-    expect(wrapper.find('dd').at(0).text()).toBe('31 Dec 2020');
-    expect(wrapper.find('dt').at(1).text()).toBe('First available delivery date 1:');
+    expect(wrapper.find('dt').at(1).text()).toBe('SIT entry date:');
     expect(wrapper.find('dd').at(1).text()).toBe('31 Dec 2020');
-    expect(wrapper.find('dt').at(2).text()).toBe('Customer contact attempt 1:');
-    expect(wrapper.find('dd').at(2).text()).toBe('31 Dec 2020, 0400Z');
 
-    expect(wrapper.find('dt').at(3).text()).toBe('First available delivery date 2:');
-    expect(wrapper.find('dd').at(3).text()).toBe('01 Jan 2021');
-    expect(wrapper.find('dt').at(4).text()).toBe('Customer contact attempt 2:');
-    expect(wrapper.find('dd').at(4).text()).toBe('01 Jan 2021, 0800Z');
+    expect(wrapper.find('dt').at(2).text()).toBe('First available delivery date 1:');
+    expect(wrapper.find('dd').at(2).text()).toBe('31 Dec 2020');
+    expect(wrapper.find('dt').at(3).text()).toBe('Customer contact attempt 1:');
+    expect(wrapper.find('dd').at(3).text()).toBe('31 Dec 2020, 0400Z');
+
+    expect(wrapper.find('dt').at(4).text()).toBe('First available delivery date 2:');
+    expect(wrapper.find('dd').at(4).text()).toBe('01 Jan 2021');
+    expect(wrapper.find('dt').at(5).text()).toBe('Customer contact attempt 2:');
+    expect(wrapper.find('dd').at(5).text()).toBe('01 Jan 2021, 0800Z');
   });
 
   it('should render the SITPostalCode ZIP, and reason for DOFSIT service item', () => {
@@ -136,6 +147,14 @@ describe('ServiceItemsTable', () => {
           SITPostalCode: '12345',
           reason: 'This is the reason',
           sitEntryDate: '2023-12-25T00:00:00.000Z',
+          sitOriginHHGOriginalAddress: {
+            city: 'Origin Original Tampa',
+            eTag: 'MjAyNC0wMy0xMlQxOTo1OTowOC41NjkxMzla',
+            id: '7fd6cb90-54cd-44d8-8735-102e28734d84',
+            postalCode: '33621',
+            state: 'FL',
+            streetAddress1: 'MacDill',
+          },
         },
       },
     ];
@@ -149,10 +168,11 @@ describe('ServiceItemsTable', () => {
         />
       </MockProviders>,
     );
-    expect(wrapper.find('dt').at(0).contains('SIT entry date')).toBe(true);
-    expect(wrapper.find('dd').at(0).contains('25 Dec 2023')).toBe(true);
-    expect(wrapper.find('dt').at(1).contains('ZIP')).toBe(true);
-    expect(wrapper.find('dd').at(1).contains('12345')).toBe(true);
+    expect(wrapper.find('dt').at(0).contains('Original pickup address')).toBe(true);
+    expect(wrapper.find('dd').at(0).contains('Origin Original Tampa, FL 33621')).toBe(true);
+
+    expect(wrapper.find('dt').at(1).contains('SIT entry date')).toBe(true);
+    expect(wrapper.find('dd').at(1).contains('25 Dec 2023')).toBe(true);
     expect(wrapper.find('dt').at(2).contains('Reason')).toBe(true);
     expect(wrapper.find('dd').at(2).contains('This is the reason')).toBe(true);
   });

--- a/src/pages/Office/MoveTaskOrder/MoveTaskOrder.jsx
+++ b/src/pages/Office/MoveTaskOrder/MoveTaskOrder.jsx
@@ -152,6 +152,13 @@ export const MoveTaskOrder = (props) => {
         rejectionReason: item.rejectionReason,
         sitDepartureDate: item.sitDepartureDate,
         sitEntryDate: item.sitEntryDate,
+        sitOriginHHGOriginalAddress: item.sitOriginHHGOriginalAddress,
+        sitOriginHHGActualAddress: item.sitOriginHHGActualAddress,
+        sitDestinationFinalAddress: item.sitDestinationFinalAddress,
+        sitDestinationOriginalAddress: item.sitDestinationOriginalAddress,
+        sitCustomerContacted: item.sitCustomerContacted,
+        sitRequestedDelivery: item.sitRequestedDelivery,
+        sitDeliveryMiles: item.sitDeliveryMiles,
       };
 
       if (serviceItemsForShipment[`${newItem.mtoShipmentID}`]) {
@@ -1089,6 +1096,8 @@ export const MoveTaskOrder = (props) => {
                     handleShowRejectionDialog={handleShowRejectionDialog}
                     handleShowEditSitEntryDateModal={handleShowEditSitEntryDateModal}
                     statusForTableType={SERVICE_ITEM_STATUSES.SUBMITTED}
+                    shipment={mtoShipment}
+                    sitStatus={mtoShipment.sitStatus}
                   />
                 )}
                 {approvedServiceItems?.length > 0 && (
@@ -1098,6 +1107,8 @@ export const MoveTaskOrder = (props) => {
                     handleShowRejectionDialog={handleShowRejectionDialog}
                     handleShowEditSitEntryDateModal={handleShowEditSitEntryDateModal}
                     statusForTableType={SERVICE_ITEM_STATUSES.APPROVED}
+                    shipment={mtoShipment}
+                    sitStatus={mtoShipment.sitStatus}
                   />
                 )}
                 {rejectedServiceItems?.length > 0 && (
@@ -1106,6 +1117,8 @@ export const MoveTaskOrder = (props) => {
                     handleUpdateMTOServiceItemStatus={handleUpdateMTOServiceItemStatus}
                     handleShowRejectionDialog={handleShowRejectionDialog}
                     statusForTableType={SERVICE_ITEM_STATUSES.REJECTED}
+                    shipment={mtoShipment}
+                    sitStatus={mtoShipment.sitStatus}
                   />
                 )}
               </ShipmentContainer>

--- a/swagger-def/definitions/MTOServiceItem.yaml
+++ b/swagger-def/definitions/MTOServiceItem.yaml
@@ -74,10 +74,17 @@ properties:
     x-nullable: true
   sitDestinationOriginalAddress:
     $ref: 'Address.yaml'
+  sitOriginHHGOriginalAddress:
+    $ref: 'Address.yaml'
+  sitOriginHHGActualAddress:
+    $ref: 'Address.yaml'
   sitDestinationFinalAddress:
     $ref: 'Address.yaml'
   sitAddressUpdates:
     $ref: 'SITAddressUpdates.yaml'
+  sitDeliveryMiles:
+    type: integer
+    x-nullable: true
   feeType:
     enum:
       - COUNSELING

--- a/swagger/ghc.yaml
+++ b/swagger/ghc.yaml
@@ -5372,6 +5372,8 @@ definitions:
         title: ZIP
         example: '90210'
         pattern: ^(\d{5})$
+      orderType:
+        type: string
       requestedPickupDate:
         type: string
         format: date
@@ -5384,8 +5386,6 @@ definitions:
         $ref: '#/definitions/GBLOC'
       destinationGBLOC:
         $ref: '#/definitions/GBLOC'
-      orderType:
-        type: string
   SearchMovesResult:
     type: object
     properties:
@@ -6225,10 +6225,17 @@ definitions:
         x-nullable: true
       sitDestinationOriginalAddress:
         $ref: '#/definitions/Address'
+      sitOriginHHGOriginalAddress:
+        $ref: '#/definitions/Address'
+      sitOriginHHGActualAddress:
+        $ref: '#/definitions/Address'
       sitDestinationFinalAddress:
         $ref: '#/definitions/Address'
       sitAddressUpdates:
         $ref: '#/definitions/SITAddressUpdates'
+      sitDeliveryMiles:
+        type: integer
+        x-nullable: true
       feeType:
         enum:
           - COUNSELING


### PR DESCRIPTION
## [Agility ticket](https://www13.v1host.com/USTRANSCOM38/assetdetail.v1?number=B-18404)

## Summary
Adjusts service item detail display as well as the service item model to payload handler. This allows the removal of redundant information and allows the UI to be to the customers desire (They attached screenshots in the ticket).

### Upstream
18885 is marked as an 'upstream' because SIT delivery miles were adjusted, and this PR adds SIT delivery miles to the service item payload.

### How to test

1. Login as Prime
2. Select a move
3. Create a new HHG shipment
4. Add a new origin SIT service item on that new shipment
5. Add a new destination SIT service item on that new shipment
6. Make note of your shipment information and your move code
7. Login as TOO
8. Navigate to your move
9. Approve your shipment
10. Review requested service items and their information
11. Optionally, adjust database values of these service items to see the changes reflect. Or, alternatively, navigate to existing seed data moves such as move locator code `ORGSIT`

## Screenshots

### Domestic Origin SIT
![image](https://github.com/transcom/mymove/assets/136814362/7a7a1c21-e5e9-4e16-8196-0998014e2980)

### Domestic Destination SIT
![image](https://github.com/transcom/mymove/assets/136814362/c1905e26-a5c3-4227-b133-309e40a39c25)
