### PR TITLE
INT B-18653 fix for I-12658

### DIFF
--- a/pkg/handlers/internalapi/moves.go
+++ b/pkg/handlers/internalapi/moves.go
@@ -95,6 +95,7 @@ func payloadForInternalMove(storer storage.FileStorer, list models.Moves) []*int
 			MoveCode:       move.Locator,
 			Orders:         orders,
 			CloseoutOffice: &closeOutOffice,
+			SubmittedAt:    *handlers.FmtDateTime(*move.SubmittedAt),
 		}
 
 		convertedCurrentMovesList = append(convertedCurrentMovesList, currentMove)


### PR DESCRIPTION
## [Agility ticket](https://www13.v1host.com/USTRANSCOM38/assetdetail.v1?number=B-18653)
## [Issue ticket](https://www13.v1host.com/USTRANSCOM38/assetdetail.v1?number=I-12658)

## Summary

When we added our `getAllMoves` endpoint, we did not pass the `submittedAt` value through the `payloadForInternalMove` function. This was causing the date that displayed under the "review request" section to be riggidy WRONG when the customer submitted their move.

### How to test

1. Access MM as a customer
2. Submit your move
3. Should see the right date showing up in the review section

## Screenshots

Out with the old
![Screenshot 2024-03-20 at 8 32 12 AM](https://github.com/transcom/mymove/assets/136510600/c4f2a6b4-94d5-4ad0-9504-325274e03807)

In with the new
![Screenshot 2024-03-20 at 9 15 24 AM](https://github.com/transcom/mymove/assets/136510600/d75af2f2-bdd4-4ae3-bb32-6fe27cfe8ec3)
