### PR TITLE
INT-B-19148 do not send emails on BLUEBARK moves

### DIFF
--- a/pkg/handlers/ghcapi/move_task_order.go
+++ b/pkg/handlers/ghcapi/move_task_order.go
@@ -111,7 +111,9 @@ func (h UpdateMoveTaskOrderStatusHandlerFunc) Handle(params movetaskorderops.Upd
 				if checkErr != nil {
 					return movetaskorderops.NewUpdateMoveTaskOrderStatusInternalServerError(), err
 				}
-				if availableAfter {
+
+				/* Do not send TOO approving and submitting service items email if BLUEBARK */
+				if availableAfter && mto.Orders.OrdersType != "BLUEBARK" {
 					emailErr := h.NotificationSender().SendNotification(appCtx,
 						notifications.NewMoveIssuedToPrime(moveTaskOrderID),
 					)
@@ -217,9 +219,12 @@ func (h UpdateMTOStatusServiceCounselingCompletedHandlerFunc) Handle(params move
 				appCtx.Logger().Error("ghcapi.UpdateMTOStatusServiceCounselingCompletedHandlerFunc could not generate the event")
 			}
 
-			err = h.NotificationSender().SendNotification(appCtx, notifications.NewMoveCounseled(moveTaskOrderID))
-			if err != nil {
-				appCtx.Logger().Error("problem sending email to user", zap.Error(err))
+			/* Do not send SC Move Details Submitted email if orders type is BLUEBARK */
+			if mto.Orders.OrdersType != "BLUEBARK" {
+				err = h.NotificationSender().SendNotification(appCtx, notifications.NewMoveCounseled(moveTaskOrderID))
+				if err != nil {
+					appCtx.Logger().Error("problem sending email to user", zap.Error(err))
+				}
 			}
 
 			return movetaskorderops.NewUpdateMTOStatusServiceCounselingCompletedOK().WithPayload(moveTaskOrderPayload), nil

--- a/pkg/handlers/ghcapi/mto_shipment.go
+++ b/pkg/handlers/ghcapi/mto_shipment.go
@@ -841,12 +841,15 @@ func (h RequestShipmentReweighHandler) Handle(params shipmentops.RequestShipment
 			moveID := shipment.MoveTaskOrderID
 			h.triggerRequestShipmentReweighEvent(appCtx, shipmentID, moveID, params)
 
-			err = h.NotificationSender().SendNotification(appCtx,
-				notifications.NewReweighRequested(moveID, *shipment),
-			)
-			if err != nil {
-				appCtx.Logger().Error("problem sending email to user", zap.Error(err))
-				return handlers.ResponseForError(appCtx.Logger(), err), err
+			/* Don't send emails for BLUEBARK moves */
+			if shipment.MoveTaskOrder.Orders.OrdersType != "BLUEBARK" {
+				err = h.NotificationSender().SendNotification(appCtx,
+					notifications.NewReweighRequested(moveID, *shipment),
+				)
+				if err != nil {
+					appCtx.Logger().Error("problem sending email to user", zap.Error(err))
+					return handlers.ResponseForError(appCtx.Logger(), err), err
+				}
 			}
 
 			shipmentSITStatus, err := h.CalculateShipmentSITStatus(appCtx, reweigh.Shipment)

--- a/pkg/handlers/ghcapi/ppm_document.go
+++ b/pkg/handlers/ghcapi/ppm_document.go
@@ -133,11 +133,14 @@ func (h FinishDocumentReviewHandler) Handle(params ppmdocumentops.FinishDocument
 
 			returnPayload := payloads.PPMShipment(h.FileStorer(), ppmShipment)
 
-			err = h.NotificationSender().SendNotification(appCtx,
-				notifications.NewPpmPacketEmail(ppmShipment.ID),
-			)
-			if err != nil {
-				appCtx.Logger().Error("problem sending email to user", zap.Error(err))
+			/* Don't send emails to BLUEBARK moves */
+			if ppmShipment.Shipment.MoveTaskOrder.Orders.OrdersType != "BLUEBARK" {
+				err = h.NotificationSender().SendNotification(appCtx,
+					notifications.NewPpmPacketEmail(ppmShipment.ID),
+				)
+				if err != nil {
+					appCtx.Logger().Error("problem sending email to user", zap.Error(err))
+				}
 			}
 
 			return ppmdocumentops.NewFinishDocumentReviewOK().WithPayload(returnPayload), nil

--- a/pkg/handlers/internalapi/moves.go
+++ b/pkg/handlers/internalapi/moves.go
@@ -235,12 +235,15 @@ func (h SubmitMoveHandler) Handle(params moveop.SubmitMoveForApprovalParams) mid
 				return handlers.ResponseForError(logger, err), err
 			}
 
-			err = h.NotificationSender().SendNotification(appCtx,
-				notifications.NewMoveSubmitted(moveID),
-			)
-			if err != nil {
-				logger.Error("problem sending email to user", zap.Error(err))
-				return handlers.ResponseForError(logger, err), err
+			/* Don't send Move Creation email if orders type is BLUEBARK */
+			if move.Orders.OrdersType != "BLUEBARK" {
+				err = h.NotificationSender().SendNotification(appCtx,
+					notifications.NewMoveSubmitted(moveID),
+				)
+				if err != nil {
+					logger.Error("problem sending email to user", zap.Error(err))
+					return handlers.ResponseForError(logger, err), err
+				}
 			}
 
 			movePayload, err := payloadForMoveModel(h.FileStorer(), move.Orders, *move)

--- a/pkg/handlers/internalapi/office.go
+++ b/pkg/handlers/internalapi/office.go
@@ -112,9 +112,12 @@ func (h CancelMoveHandler) Handle(params officeop.CancelMoveParams) middleware.R
 				return handlers.ResponseForVErrors(logger, verrs, err), err
 			}
 
-			err = h.NotificationSender().SendNotification(appCtx,
-				notifications.NewMoveCanceled(moveID),
-			)
+			/* Don't send emails to BLUEBARK moves */
+			if move.Orders.OrdersType != "BLUEBARK" {
+				err = h.NotificationSender().SendNotification(appCtx,
+					notifications.NewMoveCanceled(moveID),
+				)
+			}
 
 			if err != nil {
 				logger.Error("problem sending email to user", zap.Error(err))

--- a/pkg/handlers/primeapi/move_task_order.go
+++ b/pkg/handlers/primeapi/move_task_order.go
@@ -196,13 +196,17 @@ func (h UpdateMTOPostCounselingInformationHandler) Handle(params movetaskorderop
 			}
 
 			mtoPayload := payloads.MoveTaskOrder(mto)
-			err = h.NotificationSender().SendNotification(appCtx,
-				notifications.NewPrimeCounselingComplete(*mtoPayload),
-			)
-			if err != nil {
-				appCtx.Logger().Error(err.Error())
-				return movetaskorderops.NewUpdateMTOPostCounselingInformationInternalServerError().WithPayload(
-					payloads.InternalServerError(nil, h.GetTraceIDFromRequest(params.HTTPRequest))), err
+
+			/* Don't send prime related emails on BLUEBARK moves */
+			if mto.Orders.OrdersType != "BLUEBARK" {
+				err = h.NotificationSender().SendNotification(appCtx,
+					notifications.NewPrimeCounselingComplete(*mtoPayload),
+				)
+				if err != nil {
+					appCtx.Logger().Error(err.Error())
+					return movetaskorderops.NewUpdateMTOPostCounselingInformationInternalServerError().WithPayload(
+						payloads.InternalServerError(nil, h.GetTraceIDFromRequest(params.HTTPRequest))), err
+				}
 			}
 
 			return movetaskorderops.NewUpdateMTOPostCounselingInformationOK().WithPayload(mtoPayload), nil

--- a/pkg/services/mto_shipment/mto_shipment_updater.go
+++ b/pkg/services/mto_shipment/mto_shipment_updater.go
@@ -642,11 +642,14 @@ func (f *mtoShipmentUpdater) updateShipmentRecord(appCtx appcontext.AppContext, 
 
 	if len(autoReweighShipments) > 0 {
 		for _, shipment := range autoReweighShipments {
-			err := f.sender.SendNotification(appCtx,
-				notifications.NewReweighRequested(shipment.MoveTaskOrderID, shipment),
-			)
-			if err != nil {
-				return err
+			/* Don't send emails to BLUEBARK moves */
+			if shipment.MoveTaskOrder.Orders.OrdersType != "BLUEBARK" {
+				err := f.sender.SendNotification(appCtx,
+					notifications.NewReweighRequested(shipment.MoveTaskOrderID, shipment),
+				)
+				if err != nil {
+					return err
+				}
 			}
 		}
 	}


### PR DESCRIPTION
## [Agility ticket](tbd)

## Summary

Is there anything you would like reviewers to give additional scrutiny?

[this article](tbd) explains more about the approach used.

## Verification Steps for the Author

These are to be checked by the author.

- [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
- [ ] Have the Agility acceptance criteria been met for this change?

## Verification Steps for Reviewers

These are to be checked by a reviewer.

- [ ] Has the branch been pulled in and checked out?
- [ ] Have the BL acceptance criteria been met for this change?
- [ ] Was the CircleCI build successful?
- [ ] Has the code been reviewed from a standards and best practices point of view?

### Setup to Run the Code

- [Instructions for starting storybook](https://transcom.github.io/mymove-docs/docs/frontend/setup/storybook)
- [Instructions for starting the MilMove application](https://transcom.github.io/mymove-docs/docs/getting-started/application-setup/)
- [Instructions for running tests](https://transcom.github.io/mymove-docs/docs/getting-started/development/testing)

### How to test

1. Access the
2. Login as a
3.

### Frontend

- [ ] There are no aXe warnings for UI.
- [ ] This works in [Supported Browsers and their phone views](https://transcom.github.io/mymove-docs/docs/adrs/Browser-Support/#minimum-browser-requirements) (Chrome, Firefox, Edge).
- [ ] There are no new console errors in the browser devtools.
- [ ] There are no new console errors in the test output.
- [ ] If this PR adds a new component to Storybook, it ensures the component is fully responsive, OR if it is intentionally not, a wrapping div using the `officeApp` class or custom `min-width` styling is used to hide any states the would not be visible to the user.
- [ ] This change meets the standards for [Section 508 compliance](https://www.ssa.gov/accessibility/andi/help/install.html).

### Backend

- [ ] Code follows the guidelines for [Logging](https://transcom.github.io/mymove-docs/docs/getting-started/development/logging).
- [ ] The requirements listed in [Querying the Database Safely](https://transcom.github.io/mymove-docs/docs/backend/guides/golang-guide#querying-the-database-safely) have been satisfied.

### Database

#### Any new migrations/schema changes:

- [ ] Follows our guidelines for [Zero-Downtime Deploys](https://transcom.github.io/mymove-docs/docs/backend/setup/database-migrations#zero-downtime-migrations).
- [ ] Have been communicated to #g-database.
- [ ] Secure migrations have been tested following the instructions in our [docs](https://transcom.github.io/mymove-docs/docs/backend/setup/database-migrations#secure-migrations).

## Screenshots
