### PR TITLE
Added nil check for AdvanceAmountReceived MAIN-B-17960

### DIFF
--- a/pkg/services/ppm_closeout/ppm_closeout.go
+++ b/pkg/services/ppm_closeout/ppm_closeout.go
@@ -72,7 +72,7 @@ func (p *ppmCloseoutFetcher) GetPPMCloseout(appCtx appcontext.AppContext, ppmShi
 		return &models.PPMCloseout{}, err
 	}
 	if ppmShipment.FinalIncentive != nil {
-		if *ppmShipment.HasRequestedAdvance {
+		if *ppmShipment.HasRequestedAdvance && ppmShipment.AdvanceAmountReceived != nil {
 			remainingIncentive = *ppmShipment.FinalIncentive - *ppmShipment.AdvanceAmountReceived
 		} else {
 			remainingIncentive = *ppmShipment.FinalIncentive


### PR DESCRIPTION
Quick one-line fix for crashes happening during PPM closeout identified in staging.

Adds a nil check before use of AdvanceAmountReceived in `ppm_closeout.go`.