### PR TITLE
INT B-17960 - Add receipt total

### DIFF
--- a/src/components/Office/PPM/ReviewDocumentsSidePanel/ReviewDocumentsSidePanel.jsx
+++ b/src/components/Office/PPM/ReviewDocumentsSidePanel/ReviewDocumentsSidePanel.jsx
@@ -226,14 +226,19 @@ export default function ReviewDocumentsSidePanel({
                   })
                 : null}
               {expenseTickets.length > 0 ? (
-                <div className={classnames(styles.ItemDetails)}>
-                  <dl>
-                    <span>
-                      <dt>Authorized Receipt Total:</dt>
-                      <dd>${formatCents(total)}</dd>
-                    </span>
-                  </dl>
-                </div>
+                <>
+                  <hr />
+                  <li className={styles.rowContainer}>
+                    <div className={classnames(styles.ItemDetails)}>
+                      <dl>
+                        <span className={classnames(styles.ReceiptTotal)}>
+                          <dt>Authorized Receipt Total:</dt>
+                          <dd>${formatCents(total)}</dd>
+                        </span>
+                      </dl>
+                    </div>
+                  </li>
+                </>
               ) : null}
             </ul>
           </DocumentViewerSidebar.Content>

--- a/src/components/Office/PPM/ReviewDocumentsSidePanel/ReviewDocumentsSidePanel.module.scss
+++ b/src/components/Office/PPM/ReviewDocumentsSidePanel/ReviewDocumentsSidePanel.module.scss
@@ -21,6 +21,10 @@
   dt {
     font-weight: bold;
   }
+
+  .ReceiptTotal {
+    margin-top: 1.5rem;
+  }
 }
 
 .ReviewDocumentsSidePanel {

--- a/src/components/Office/PPM/ReviewDocumentsSidePanel/ReviewDocumentsSidePanel.test.jsx
+++ b/src/components/Office/PPM/ReviewDocumentsSidePanel/ReviewDocumentsSidePanel.test.jsx
@@ -89,7 +89,7 @@ describe('ReviewDocumentsSidePanel', () => {
     );
 
     const listItems = await screen.getAllByRole('listitem');
-    expect(listItems).toHaveLength(8);
+    expect(listItems).toHaveLength(9);
 
     // weight ticket 1
     expect(listItems[0]).toHaveTextContent(/Trip 1/);


### PR DESCRIPTION
## [B-17960](https://www13.v1host.com/USTRANSCOM38/assetdetail.v1?number=B-17960)

## Summary

Another quick fix that adds the missing "Authorized Receipt Total" field at the end of the receipt/weight ticket summary screen. The total does not include any excluded or rejected receipts, and per government request, does not include SIT/Storage receipts.

To test, make a PPM closeout shipment with one of each type expense receipt. When at the end of the screen, you should notice that the storage receipt is not added onto the total.

You can also go back and test that exclusions/rejections are not included in the total amount by rejecting/excluding certain receipts.
