### PR TITLE
B-18855 Delivery out of SIT FSC Calculation Issue

### DIFF
--- a/pkg/payment_request/service_param_value_lookups/weight_billed_lookup.go
+++ b/pkg/payment_request/service_param_value_lookups/weight_billed_lookup.go
@@ -1,6 +1,7 @@
 package serviceparamvaluelookups
 
 import (
+	"database/sql"
 	"fmt"
 	"math"
 	"strconv"
@@ -46,6 +47,46 @@ func (r WeightBilledLookup) lookup(appCtx appcontext.AppContext, keyData *Servic
 			value = applyMinimum(keyData.MTOServiceItem.ReService.Code, r.MTOShipment.ShipmentType, int(*originalWeight))
 		}
 		return value, nil
+	case models.ReServiceCodeDDSFSC,
+		models.ReServiceCodeDOSFSC:
+
+		var weightBilled string
+
+		// Check if a value is in WeightBilled
+		query := `select psip.value from payment_service_item_params psip
+		join payment_service_items psi on psip.payment_service_item_id = psi.id
+		join payment_requests pr on psi.payment_request_id = pr.id
+		join service_item_param_keys sipk on sipk.id = psip.service_item_param_key_id
+		where sipk.key = 'WeightBilled' and psi.payment_request_id = $1`
+
+		err := appCtx.DB().RawQuery(query, keyData.PaymentRequestID).First(&weightBilled)
+		if err != nil && err != sql.ErrNoRows {
+			return "", err
+		} else if len(weightBilled) > 0 {
+			return weightBilled, nil
+		} else {
+			estimatedWeight = keyData.MTOServiceItem.EstimatedWeight
+
+			originalWeight = keyData.MTOServiceItem.ActualWeight
+
+			if originalWeight == nil {
+				// TODO: Do we need a different error -- is this a "normal" scenario?
+				return "", fmt.Errorf("could not find actual weight for MTOServiceItemID [%s]", keyData.MTOServiceItem.ID)
+			}
+
+			if estimatedWeight != nil {
+				estimatedWeightCap := math.Round(float64(*estimatedWeight) * 1.10)
+				if float64(*originalWeight) > estimatedWeightCap {
+					value = applyMinimum(keyData.MTOServiceItem.ReService.Code, r.MTOShipment.ShipmentType, int(estimatedWeightCap))
+				} else {
+					value = applyMinimum(keyData.MTOServiceItem.ReService.Code, r.MTOShipment.ShipmentType, int(*originalWeight))
+				}
+			} else {
+				value = applyMinimum(keyData.MTOServiceItem.ReService.Code, r.MTOShipment.ShipmentType, int(*originalWeight))
+			}
+			return value, nil
+		}
+
 	default:
 		// Shipments that are a diversion must utilize the lowest weight that can be found
 		// in their "diverted shipment chain". Diverted shipments are tied together by "divertedFromShipmentId"s after the implementation
@@ -92,6 +133,7 @@ func (r WeightBilledLookup) lookup(appCtx appcontext.AppContext, keyData *Servic
 			// Once we have looped over all shipments in the diversion chain, return the minimim billable weight for this item
 			return strconv.Itoa(lowestWeight), nil
 		}
+
 		// If not a diversion, proceed with calculations normally
 		return calculateMinimumBillableWeight(appCtx, r.MTOShipment, keyData)
 	}

--- a/playwright/tests/office/txo/tooFlows.spec.js
+++ b/playwright/tests/office/txo/tooFlows.spec.js
@@ -441,6 +441,56 @@ test.describe('TOO user', () => {
     });
   });
 
+  let moveLoc;
+  test.describe('with payment requests', () => {
+    test.beforeEach(async ({ officePage, page }) => {
+      const move = await officePage.testHarness.buildHHGMoveInSITEndsToday();
+      moveLoc = move.locator;
+      await officePage.signInAsNewMultiRoleUser();
+
+      await page.getByRole('link', { name: 'Change user role' }).click();
+      await page.getByRole('button', { name: 'Select prime_simulator' }).click();
+      await page.locator('#moveCode').click();
+      await page.locator('#moveCode').fill(moveLoc);
+      await page.locator('#moveCode').press('Enter');
+      await page.getByTestId('moveCode-0').click();
+      await page.getByRole('link', { name: 'Create Payment Request' }).click();
+      await page.waitForSelector('h3:has-text("Domestic origin SIT fuel surcharge")');
+      const serviceItemID = await page.$eval(
+        `//h3[text()='Domestic origin SIT fuel surcharge']/following-sibling::div[contains(@class, 'descriptionList_row__TsTvp')]//dt[text()='ID:']/following-sibling::dd[1]`,
+        (ddElement) => ddElement.textContent.trim(),
+      );
+      await page.locator(`label[for="${serviceItemID}"]`).nth(0).check();
+      await page.locator(`input[name="params\\.${serviceItemID}\\.WeightBilled"]`).fill('10000');
+      await page.locator(`input[name="params\\.${serviceItemID}\\.WeightBilled"]`).blur();
+      await page.getByTestId('form').getByTestId('button').click();
+      await page.getByRole('link', { name: 'Change user role' }).click();
+      await page.getByRole('button', { name: 'Select transportation_ordering_officer' }).click();
+    });
+    test('weight-based multiplier prioritizes billed weight', async ({ page }) => {
+      await page.getByRole('row', { name: 'Select...' }).getByTestId('locator').getByTestId('TextBoxFilter').click();
+      await page
+        .getByRole('row', { name: 'Select...' })
+        .getByTestId('locator')
+        .getByTestId('TextBoxFilter')
+        .fill(moveLoc);
+      await page
+        .getByRole('row', { name: 'Select...' })
+        .getByTestId('locator')
+        .getByTestId('TextBoxFilter')
+        .press('Enter');
+      await page.getByTestId('locator-0').click();
+      await page.getByRole('link', { name: 'Payment requests' }).click();
+      await page.getByRole('button', { name: 'Review weights' }).click();
+      await page.getByRole('button', { name: 'Review shipment weights' }).click();
+      await page.getByRole('button', { name: 'Back' }).click();
+      await page.getByRole('link', { name: 'Payment requests' }).click();
+      await page.getByTestId('reviewBtn').click();
+      await page.getByTestId('toggleCalculations').click();
+      await expect(page.getByText('Weight-based distance multiplier: 0.0006255')).toBeVisible();
+    });
+  });
+
   test('approves a delivery address change request for an HHG shipment', async ({ officePage, page }) => {
     const shipmentAddressUpdate = await officePage.testHarness.bulidHHGMoveWithAddressChangeRequest();
     await officePage.signInAsNewTOOUser();


### PR DESCRIPTION
## [Previous PR into INT](https://github.com/transcom/mymove/pull/12325)

[B-18855](https://www13.v1host.com/USTRANSCOM38/assetdetail.v1?number=B-18855)

## Steps used to test
1. Use the "HHGMoveInSITEndsToday" option from the Test harness list.
2. Copy the move locator from the JSON object displayed (see Fig1 below)
3. Navigate back to the sign in page for milmove office users
4. Sign in as a Multi-role user under the KKFA GBLOC.
5. Start by clicking the Sign in button for a Prime user.
6. Search for the move by the move locator you copied earlier. Then click on that move in the list.
7. Click the "Create payment request" button.
8. From the list of service items you are able to select from you should see an item called "Domestic origin SIT fuel surcharge". Put a check in the checkbox for that item ("Add to payment request").
9. In the input field labeled "Weight Billed (if different from shipment weight)", enter a weight such as 10000 or greater.
Note: Since by default the shipment will have less than 5000 set for each of the estimated and actual weights on this shipment, entering 10000 should produce a FSC Multiplier of "0.0006255". For further details, see the chart called Fig2 below.
10. Click the "Submit payment request" button at the bottom of the form.
11. Click the "Change user role" link at the top of the page.
12. Make the appropriate selection to log in as a TOO user.
13. Search for the same move locator and click on the associated move.
14. Click the "Payment requests" tab.
Note: there is a known issue when certain conditions are met that the TOO must review weights associated. Steps 15-16 are to workaround this known issue.
15. Click the "Review Weights" button.
16. Click the "Payment requests" tab again.
17. Click the "Review Service Items" button.
18. Observe that the service item called "Domestic origin SIT fuel surcharge" has a "Show calculations" link. Click that link to show the "Weight-based distance multiplier". Observe that the correct multiplier is shown in accordance with the following chart in Fig2. The multiplier should take Billed Weight entered when the payment request is created as priority over the actual or estimated weights entered throughout the shipment creation process.

You may also test the DB entered the correct data by using the following DB query. Make sure to replace the locator (QCDHDH) with your move's locator.
```
select psip.value from payment_service_item_params psip
join payment_service_items psi on psip.payment_service_item_id = psi.id
join payment_requests pr on psi.payment_request_id = pr.id
join service_item_param_keys sipk on psip.service_item_param_key_id = sipk.id
join moves m on pr.move_id = m.id
where m."locator" = 'QCDHDH' and sipk.key = 'WeightBilled'
```

## Fig1
![Screenshot 2024-03-25 at 2 13 29 PM](https://github.com/transcom/mymove/assets/147739091/e18e2206-9755-4d71-9a4a-8e99127cd97b)

## Fig2
weight billed will be referred to as "WB" in the following figure.
WB <= 5000: multiplier is "0.000417"
WB between 5001-10000: multiplier is "0.0006255"
WB between 10001-24000: multiplier is "0.000834"
WB 24001+: multiplier is "0.00139"