### PR TITLE
INT B-18642 add origin gbloc to move screen front end

### DIFF
--- a/pkg/gen/ghcapi/embedded_spec.go
+++ b/pkg/gen/ghcapi/embedded_spec.go
@@ -7316,6 +7316,10 @@ func init() {
           "format": "date-time",
           "x-nullable": true
         },
+        "shipmentGBLOC": {
+          "x-nullable": true,
+          "$ref": "#/definitions/GBLOC"
+        },
         "status": {
           "$ref": "#/definitions/MoveStatus"
         },
@@ -19752,6 +19756,10 @@ func init() {
           "type": "string",
           "format": "date-time",
           "x-nullable": true
+        },
+        "shipmentGBLOC": {
+          "x-nullable": true,
+          "$ref": "#/definitions/GBLOC"
         },
         "status": {
           "$ref": "#/definitions/MoveStatus"

--- a/pkg/gen/ghcmessages/move.go
+++ b/pkg/gen/ghcmessages/move.go
@@ -95,6 +95,9 @@ type Move struct {
 	// Format: date-time
 	ServiceCounselingCompletedAt *strfmt.DateTime `json:"serviceCounselingCompletedAt,omitempty"`
 
+	// shipment g b l o c
+	ShipmentGBLOC GBLOC `json:"shipmentGBLOC,omitempty"`
+
 	// status
 	Status MoveStatus `json:"status,omitempty"`
 
@@ -168,6 +171,10 @@ func (m *Move) Validate(formats strfmt.Registry) error {
 	}
 
 	if err := m.validateServiceCounselingCompletedAt(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateShipmentGBLOC(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -378,6 +385,23 @@ func (m *Move) validateServiceCounselingCompletedAt(formats strfmt.Registry) err
 	return nil
 }
 
+func (m *Move) validateShipmentGBLOC(formats strfmt.Registry) error {
+	if swag.IsZero(m.ShipmentGBLOC) { // not required
+		return nil
+	}
+
+	if err := m.ShipmentGBLOC.Validate(formats); err != nil {
+		if ve, ok := err.(*errors.Validation); ok {
+			return ve.ValidateName("shipmentGBLOC")
+		} else if ce, ok := err.(*errors.CompositeError); ok {
+			return ce.ValidateName("shipmentGBLOC")
+		}
+		return err
+	}
+
+	return nil
+}
+
 func (m *Move) validateStatus(formats strfmt.Registry) error {
 	if swag.IsZero(m.Status) { // not required
 		return nil
@@ -440,6 +464,10 @@ func (m *Move) ContextValidate(ctx context.Context, formats strfmt.Registry) err
 	}
 
 	if err := m.contextValidateOrders(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.contextValidateShipmentGBLOC(ctx, formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -529,6 +557,24 @@ func (m *Move) contextValidateOrders(ctx context.Context, formats strfmt.Registr
 			}
 			return err
 		}
+	}
+
+	return nil
+}
+
+func (m *Move) contextValidateShipmentGBLOC(ctx context.Context, formats strfmt.Registry) error {
+
+	if swag.IsZero(m.ShipmentGBLOC) { // not required
+		return nil
+	}
+
+	if err := m.ShipmentGBLOC.ContextValidate(ctx, formats); err != nil {
+		if ve, ok := err.(*errors.Validation); ok {
+			return ve.ValidateName("shipmentGBLOC")
+		} else if ce, ok := err.(*errors.CompositeError); ok {
+			return ce.ValidateName("shipmentGBLOC")
+		}
+		return err
 	}
 
 	return nil

--- a/pkg/handlers/ghcapi/internal/payloads/model_to_payload.go
+++ b/pkg/handlers/ghcapi/internal/payloads/model_to_payload.go
@@ -43,6 +43,13 @@ func Move(move *models.Move) *ghcmessages.Move {
 	if move == nil {
 		return nil
 	}
+	// Adds shipmentGBLOC to be used for TOO/TIO's origin GBLOC
+	var gbloc ghcmessages.GBLOC
+	if len(move.ShipmentGBLOC) > 0 && move.ShipmentGBLOC[0].GBLOC != nil {
+		gbloc = ghcmessages.GBLOC(*move.ShipmentGBLOC[0].GBLOC)
+	} else if move.Orders.OriginDutyLocationGBLOC != nil {
+		gbloc = ghcmessages.GBLOC(*move.Orders.OriginDutyLocationGBLOC)
+	}
 
 	payload := &ghcmessages.Move{
 		ID:                           strfmt.UUID(move.ID.String()),
@@ -68,6 +75,7 @@ func Move(move *models.Move) *ghcmessages.Move {
 		FinancialReviewRemarks:       move.FinancialReviewRemarks,
 		CloseoutOfficeID:             handlers.FmtUUIDPtr(move.CloseoutOfficeID),
 		CloseoutOffice:               TransportationOffice(move.CloseoutOffice),
+		ShipmentGBLOC:                gbloc,
 	}
 
 	return payload

--- a/pkg/services/move/move_fetcher.go
+++ b/pkg/services/move/move_fetcher.go
@@ -23,7 +23,8 @@ func NewMoveFetcher() services.MoveFetcher {
 func (f moveFetcher) FetchMove(appCtx appcontext.AppContext, locator string, searchParams *services.MoveFetcherParams) (*models.Move, error) {
 	move := &models.Move{}
 	query := appCtx.DB().
-		EagerPreload("CloseoutOffice.Address", "Contractor").
+		EagerPreload("CloseoutOffice.Address", "Contractor", "ShipmentGBLOC").
+		LeftJoin("move_to_gbloc", "move_to_gbloc.move_id = moves.id").
 		Where("locator = $1", locator)
 
 	if searchParams == nil || !searchParams.IncludeHidden {

--- a/pkg/testdatagen/scenario/shared.go
+++ b/pkg/testdatagen/scenario/shared.go
@@ -10617,6 +10617,77 @@ func createHHGNeedsServicesCounselingUSMC2(appCtx appcontext.AppContext, userUpl
 
 }
 
+func CreateHHGNeedsServicesCounselingUSMC3(appCtx appcontext.AppContext, userUploader *uploader.UserUploader, locator string) models.Move {
+	db := appCtx.DB()
+
+	marineCorps := models.AffiliationMARINES
+	submittedAt := time.Now()
+
+	move := factory.BuildMove(db, []factory.Customization{
+		{
+			Model: models.DutyLocation{
+				ProvidesServicesCounseling: true,
+			},
+			Type: &factory.DutyLocations.OriginDutyLocation,
+		},
+		{
+			Model: models.Move{
+				Locator:     locator,
+				Status:      models.MoveStatusNeedsServiceCounseling,
+				SubmittedAt: &submittedAt,
+			},
+		},
+		{
+			Model: models.ServiceMember{
+				Affiliation: &marineCorps,
+				LastName:    models.StringPointer("Marine"),
+				FirstName:   models.StringPointer("Ted"),
+			},
+		},
+		{
+			Model: models.UserUpload{},
+			ExtendedParams: &factory.UserUploadExtendedParams{
+				UserUploader: userUploader,
+				AppContext:   appCtx,
+			},
+		},
+	}, nil)
+	requestedPickupDate := submittedAt.Add(60 * 24 * time.Hour)
+	requestedDeliveryDate := requestedPickupDate.Add(7 * 24 * time.Hour)
+	factory.BuildMTOShipment(db, []factory.Customization{
+		{
+			Model:    move,
+			LinkOnly: true,
+		},
+		{
+			Model: models.MTOShipment{
+				ShipmentType:          models.MTOShipmentTypeHHG,
+				Status:                models.MTOShipmentStatusSubmitted,
+				RequestedPickupDate:   &requestedPickupDate,
+				RequestedDeliveryDate: &requestedDeliveryDate,
+			},
+		},
+	}, nil)
+
+	requestedPickupDate = submittedAt.Add(30 * 24 * time.Hour)
+	requestedDeliveryDate = requestedPickupDate.Add(7 * 24 * time.Hour)
+	factory.BuildMTOShipment(db, []factory.Customization{
+		{
+			Model:    move,
+			LinkOnly: true,
+		},
+		{
+			Model: models.MTOShipment{
+				ShipmentType:          models.MTOShipmentTypeHHG,
+				Status:                models.MTOShipmentStatusSubmitted,
+				RequestedPickupDate:   &requestedPickupDate,
+				RequestedDeliveryDate: &requestedDeliveryDate,
+			},
+		},
+	}, nil)
+	return move
+}
+
 func createHHGServicesCounselingCompleted(appCtx appcontext.AppContext) {
 	db := appCtx.DB()
 	servicesCounselingCompletedAt := time.Now()

--- a/pkg/testdatagen/testharness/dispatch.go
+++ b/pkg/testdatagen/testharness/dispatch.go
@@ -41,6 +41,9 @@ var actionDispatcher = map[string]actionFunc{
 	"HHGMoveNeedsSC": func(appCtx appcontext.AppContext) testHarnessResponse {
 		return MakeHHGMoveNeedsSC(appCtx)
 	},
+	"HHGMoveAsUSMCNeedsSC": func(appCtx appcontext.AppContext) testHarnessResponse {
+		return MakeHHGMoveNeedsServicesCounselingUSMC(appCtx)
+	},
 	"HHGMoveWithAmendedOrders": func(appCtx appcontext.AppContext) testHarnessResponse {
 		return MakeHHGMoveWithAmendedOrders(appCtx)
 	},

--- a/pkg/testdatagen/testharness/make_move.go
+++ b/pkg/testdatagen/testharness/make_move.go
@@ -2539,6 +2539,21 @@ func MakeHHGMoveNeedsSC(appCtx appcontext.AppContext) models.Move {
 	return *newmove
 }
 
+// MakeHHGMoveNeedsServicesCounselingUSMC creates an fully ready move as USMC needing SC approval
+func MakeHHGMoveNeedsServicesCounselingUSMC(appCtx appcontext.AppContext) models.Move {
+	userUploader := newUserUploader(appCtx)
+	locator := models.GenerateLocator()
+	move := scenario.CreateHHGNeedsServicesCounselingUSMC3(appCtx, userUploader, locator)
+
+	// re-fetch the move so that we ensure we have exactly what is in
+	// the db
+	newmove, err := models.FetchMove(appCtx.DB(), &auth.Session{}, move.ID)
+	if err != nil {
+		log.Panic(fmt.Errorf("Failed to fetch move: %w", err))
+	}
+	return *newmove
+}
+
 // MakeHHGMoveWithAmendedOrders creates a move needing SC approval with amended orders
 func MakeHHGMoveWithAmendedOrders(appCtx appcontext.AppContext) models.Move {
 	pcos := internalmessages.OrdersTypePERMANENTCHANGEOFSTATION

--- a/playwright/tests/office/servicescounseling/servicesCounselingFlows.spec.js
+++ b/playwright/tests/office/servicescounseling/servicesCounselingFlows.spec.js
@@ -96,6 +96,24 @@ test.describe('Services counselor user', () => {
 
       await expect(page.locator('.usa-alert__text')).toContainText('Your changes were saved.');
     });
+    test('is able to view Origin GBLOC', async ({ page }) => {
+      // Check for Origin GBLOC label
+      await expect(page.getByTestId('originGBLOC')).toHaveText('Origin GBLOC');
+      await expect(page.getByTestId('infoBlock')).toContainText('KKFA');
+    });
+  });
+
+  test.describe('with HHG Move with Marine Corps as BOS', () => {
+    test.beforeEach(async ({ scPage }) => {
+      const move = await scPage.testHarness.buildHHGMoveAsUSMCNeedsSC();
+      await scPage.navigateToMove(move.locator);
+    });
+
+    test('is able to view USMC as Origin GBLOC', async ({ page }) => {
+      // Check for Origin GBLOC label
+      await expect(page.getByTestId('originGBLOC')).toHaveText('Origin GBLOC');
+      await expect(page.getByTestId('infoBlock')).toContainText('KKFA / USMC');
+    });
   });
 
   test.describe('with HHG Move with amended orders', () => {

--- a/playwright/tests/office/txo/tioFlows.spec.js
+++ b/playwright/tests/office/txo/tioFlows.spec.js
@@ -459,6 +459,12 @@ test.describe('TIO user', () => {
 
       // await expect(page.locator('[data-testid="tag"]')).toContainText('Reviewed');
     });
+
+    test('is able to view Origin GBLOC', async ({ page }) => {
+      // Check for Origin GBLOC label
+      await expect(page.getByTestId('originGBLOC')).toHaveText('Origin GBLOC');
+      await expect(page.getByTestId('infoBlock')).toContainText('KKFA');
+    });
   });
 
   test.describe('with NTSR moves without service items', () => {

--- a/playwright/tests/office/txo/tooFlows.spec.js
+++ b/playwright/tests/office/txo/tooFlows.spec.js
@@ -405,6 +405,12 @@ test.describe('TOO user', () => {
       // Make sure we go to move details page
       expect(page.url()).toContain(`/moves/${tooFlowPage.moveLocator}/details`);
     });
+
+    test('is able to view Origin GBLOC', async ({ page }) => {
+      // Check for Origin GBLOC label
+      await expect(page.getByTestId('originGBLOC')).toHaveText('Origin GBLOC');
+      await expect(page.getByTestId('infoBlock')).toContainText('KKFA');
+    });
   });
 
   test.describe('with retiree moves', () => {

--- a/playwright/tests/utils/testharness.js
+++ b/playwright/tests/utils/testharness.js
@@ -333,6 +333,14 @@ export class TestHarness {
   }
 
   /**
+   * Use testharness to build hhg move as USMC needing SC approval
+   * @returns {Promise<Move>}
+   */
+  async buildHHGMoveAsUSMCNeedsSC() {
+    return this.buildDefault('HHGMoveAsUSMCNeedsSC');
+  }
+
+  /**
    * Use testharness to build hhg move with amended orders
    * @returns {Promise<Move>}
    */

--- a/src/components/CustomerHeader/CustomerHeader.test.jsx
+++ b/src/components/CustomerHeader/CustomerHeader.test.jsx
@@ -12,12 +12,16 @@ const props = {
     originDutyLocation: {
       name: 'JBSA Lackland',
     },
+    originDutyLocationGBLOC: 'AGFM',
     destinationDutyLocation: {
       name: 'JB Lewis-McChord',
     },
     report_by_date: '2018-08-01',
   },
   moveCode: 'FKLCTR',
+  move: {
+    shipmentGBLOC: 'AGFM',
+  },
 };
 
 const propsRetiree = {
@@ -35,10 +39,34 @@ const propsRetiree = {
     report_by_date: '2018-08-01',
   },
   moveCode: 'FKLCTR',
+  move: {
+    shipmentGBLOC: 'AGFM',
+  },
+};
+
+const propsUSMC = {
+  customer: { last_name: 'Kerry', first_name: 'Smith', dodID: '999999999' },
+  order: {
+    agency: 'MARINES',
+    grade: 'E_6',
+    originDutyLocation: {
+      name: 'JBSA Lackland',
+    },
+    originDutyLocationGBLOC: 'AGFM',
+    destinationDutyLocation: {
+      name: 'JB Lewis-McChord',
+    },
+    report_by_date: '2018-08-01',
+  },
+  moveCode: 'FKLCTR',
+  move: {
+    shipmentGBLOC: 'AGFM',
+  },
 };
 
 const mountCustomerHeader = () => mount(<CustomerHeader {...props} />);
 const mountCustomerHeaderRetiree = () => mount(<CustomerHeader {...propsRetiree} />);
+const mountCustomerHeaderUSMC = () => mount(<CustomerHeader {...propsUSMC} />);
 
 describe('CustomerHeader component', () => {
   const wrapper = mountCustomerHeader();
@@ -53,11 +81,17 @@ describe('CustomerHeader component', () => {
     expect(wrapper.find('[data-testid="infoBlock"]').text()).toContain('JBSA Lackland');
     expect(wrapper.find('[data-testid="infoBlock"]').text()).toContain('JB Lewis-McChord');
     expect(wrapper.find('[data-testid="infoBlock"]').text()).toContain('01 Aug 2018');
+    expect(wrapper.find('[data-testid="infoBlock"]').text()).toContain('AGFM');
   });
 
   const wrapperRetiree = mountCustomerHeaderRetiree();
   it('renders expected values for a retiree', () => {
     expect(wrapperRetiree.find('[data-testid="destinationLabel"]').text()).toContain('HOR, HOS or PLEAD');
     expect(wrapperRetiree.find('[data-testid="reportDateLabel"]').text()).toContain('Date of retirement');
+  });
+
+  const wrapperUSMC = mountCustomerHeaderUSMC();
+  it('renders expected values for a USMC', () => {
+    expect(wrapperUSMC.find('[data-testid="infoBlock"]').text()).toContain('AGFM / USMC');
   });
 });

--- a/src/components/CustomerHeader/index.jsx
+++ b/src/components/CustomerHeader/index.jsx
@@ -33,7 +33,7 @@ const CustomerHeader = ({ customer, order, moveCode, move, userRole }) => {
   const originGBLOC =
     move?.status === MOVE_STATUSES.NEEDS_SERVICE_COUNSELING ||
     userRole === roleTypes.SERVICES_COUNSELOR ||
-    !move.shipmentGBLOC
+    move?.shipmentGBLOC == null
       ? order.originDutyLocationGBLOC
       : move.shipmentGBLOC;
   const originGBLOCDisplay = order.agency === SERVICE_MEMBER_AGENCIES.MARINES ? `${originGBLOC} / USMC` : originGBLOC;

--- a/src/components/CustomerHeader/index.jsx
+++ b/src/components/CustomerHeader/index.jsx
@@ -31,7 +31,7 @@ const CustomerHeader = ({ customer, order, moveCode, move, userRole }) => {
   const reportDateLabel = formatLabelReportByDate(orderType);
   // This logic to show different originGLBOC is based on queue table's backend logic
   const originGBLOC =
-    move.status === MOVE_STATUSES.NEEDS_SERVICE_COUNSELING ||
+    move?.status === MOVE_STATUSES.NEEDS_SERVICE_COUNSELING ||
     userRole === roleTypes.SERVICES_COUNSELOR ||
     !move.shipmentGBLOC
       ? order.originDutyLocationGBLOC

--- a/src/components/CustomerHeader/index.jsx
+++ b/src/components/CustomerHeader/index.jsx
@@ -33,7 +33,7 @@ const CustomerHeader = ({ customer, order, moveCode, move, userRole }) => {
   const originGBLOC =
     move?.status === MOVE_STATUSES.NEEDS_SERVICE_COUNSELING ||
     userRole === roleTypes.SERVICES_COUNSELOR ||
-    move?.shipmentGBLOC == null
+    !move?.shipmentGBLOC
       ? order.originDutyLocationGBLOC
       : move.shipmentGBLOC;
   const originGBLOCDisplay = order.agency === SERVICE_MEMBER_AGENCIES.MARINES ? `${originGBLOC} / USMC` : originGBLOC;

--- a/src/components/CustomerHeader/index.jsx
+++ b/src/components/CustomerHeader/index.jsx
@@ -11,8 +11,11 @@ import {
   ORDERS_PAY_GRADE_OPTIONS,
   SPECIAL_ORDERS_TYPES,
 } from 'constants/orders.js';
+import SERVICE_MEMBER_AGENCIES from 'content/serviceMemberAgencies';
+import MOVE_STATUSES from 'constants/moves';
+import { roleTypes } from 'constants/userRoles';
 
-const CustomerHeader = ({ customer, order, moveCode }) => {
+const CustomerHeader = ({ customer, order, moveCode, move, userRole }) => {
   // eslint-disable-next-line camelcase
   const { order_type: orderType } = order;
 
@@ -26,6 +29,14 @@ const CustomerHeader = ({ customer, order, moveCode }) => {
    * Date of separation (SEPARATION)
    */
   const reportDateLabel = formatLabelReportByDate(orderType);
+  // This logic to show different originGLBOC is based on queue table's backend logic
+  const originGBLOC =
+    move.status === MOVE_STATUSES.NEEDS_SERVICE_COUNSELING ||
+    userRole === roleTypes.SERVICES_COUNSELOR ||
+    !move.shipmentGBLOC
+      ? order.originDutyLocationGBLOC
+      : move.shipmentGBLOC;
+  const originGBLOCDisplay = order.agency === SERVICE_MEMBER_AGENCIES.MARINES ? `${originGBLOC} / USMC` : originGBLOC;
 
   return (
     <div className={styles.custHeader}>
@@ -69,6 +80,10 @@ const CustomerHeader = ({ customer, order, moveCode }) => {
         <div>
           <p data-testid="reportDateLabel">{reportDateLabel}</p>
           <h4>{formatCustomerDate(order.report_by_date)}</h4>
+        </div>
+        <div>
+          <p data-testid="originGBLOC">Origin GBLOC</p>
+          <h4>{originGBLOCDisplay}</h4>
         </div>
       </div>
     </div>

--- a/src/hooks/queries.js
+++ b/src/hooks/queries.js
@@ -145,6 +145,7 @@ export const useTXOMoveInfoQueries = (moveCode) => {
   const { isLoading, isError, isSuccess } = getQueriesStatus([moveQuery, orderQuery, customerQuery]);
 
   return {
+    move,
     order,
     customerData,
     isLoading,

--- a/src/hooks/queries.test.jsx
+++ b/src/hooks/queries.test.jsx
@@ -356,6 +356,11 @@ describe('useTXOMoveInfoQueries', () => {
       isLoading: false,
       isError: false,
       isSuccess: true,
+      move: {
+        id: '1234',
+        ordersId: '4321',
+        moveCode: 'ABCDEF',
+      },
     });
   });
 });

--- a/src/pages/Office/EditShipmentDetails/EditShipmentDetails.jsx
+++ b/src/pages/Office/EditShipmentDetails/EditShipmentDetails.jsx
@@ -52,7 +52,7 @@ const EditShipmentDetails = () => {
 
   return (
     <>
-      <CustomerHeader order={order} customer={customer} moveCode={moveCode} />
+      <CustomerHeader move={move} order={order} customer={customer} moveCode={moveCode} />
       <div className={styles.tabContent}>
         <div className={styles.container}>
           <GridContainer className={styles.gridContainer}>

--- a/src/pages/Office/ServicesCounselingMoveInfo/ServicesCounselingMoveInfo.jsx
+++ b/src/pages/Office/ServicesCounselingMoveInfo/ServicesCounselingMoveInfo.jsx
@@ -11,6 +11,7 @@ import { servicesCounselingRoutes } from 'constants/routes';
 import { useTXOMoveInfoQueries } from 'hooks/queries';
 import LoadingPlaceholder from 'shared/LoadingPlaceholder';
 import SomethingWentWrong from 'shared/SomethingWentWrong';
+import { roleTypes } from 'constants/userRoles';
 
 const ServicesCounselingMoveDocumentWrapper = lazy(() =>
   import('pages/Office/ServicesCounselingMoveDocumentWrapper/ServicesCounselingMoveDocumentWrapper'),
@@ -69,7 +70,7 @@ const ServicesCounselingMoveInfo = () => {
   }, [infoSavedAlert, location]);
 
   const { moveCode } = useParams();
-  const { order, customerData, isLoading, isError } = useTXOMoveInfoQueries(moveCode);
+  const { move, order, customerData, isLoading, isError } = useTXOMoveInfoQueries(moveCode);
 
   const { pathname } = useLocation();
   const hideNav =
@@ -121,7 +122,13 @@ const ServicesCounselingMoveInfo = () => {
 
   return (
     <>
-      <CustomerHeader order={order} customer={customerData} moveCode={moveCode} />
+      <CustomerHeader
+        move={move}
+        order={order}
+        customer={customerData}
+        moveCode={moveCode}
+        userRole={roleTypes.SERVICES_COUNSELOR}
+      />
       {hasRecentError && (
         <SystemError>
           Something isn&apos;t working, but we&apos;re not sure what. Wait a minute and try again.

--- a/src/pages/Office/TXOMoveInfo/TXOMoveInfo.jsx
+++ b/src/pages/Office/TXOMoveInfo/TXOMoveInfo.jsx
@@ -40,7 +40,7 @@ const TXOMoveInfo = () => {
   const { hasRecentError, traceId } = useSelector((state) => state.interceptor);
   const { moveCode, reportId } = useParams();
   const { pathname } = useLocation();
-  const { order, customerData, isLoading, isError } = useTXOMoveInfoQueries(moveCode);
+  const { move, order, customerData, isLoading, isError } = useTXOMoveInfoQueries(moveCode);
 
   const hideNav =
     matchPath(
@@ -77,7 +77,7 @@ const TXOMoveInfo = () => {
 
   return (
     <>
-      <CustomerHeader order={order} customer={customerData} moveCode={moveCode} />
+      <CustomerHeader move={move} order={order} customer={customerData} moveCode={moveCode} />
       {hasRecentError && (
         <SystemError>
           Something isn&apos;t working, but we&apos;re not sure what. Wait a minute and try again.

--- a/swagger-def/ghc.yaml
+++ b/swagger-def/ghc.yaml
@@ -4011,6 +4011,9 @@ definitions:
         format: date-time
       eTag:
         type: string
+      shipmentGBLOC:
+        $ref: '#/definitions/GBLOC'
+        x-nullable: true
   MoveHistory:
     properties:
       id:

--- a/swagger/ghc.yaml
+++ b/swagger/ghc.yaml
@@ -4154,6 +4154,9 @@ definitions:
         format: date-time
       eTag:
         type: string
+      shipmentGBLOC:
+        $ref: '#/definitions/GBLOC'
+        x-nullable: true
   MoveHistory:
     properties:
       id:


### PR DESCRIPTION
## [B-18642](https://www13.v1host.com/USTRANSCOM38/assetdetail.v1?number=B-18642)

## Summary

This is the frontend work to implement origin GBLOC in the move headers for office users.

USMC moves are unique and therefore the moves as Marine Corps as BOS will display `/ USMC` in addition to origin GBLOC. e.g. `KKFA / USMC`

### How to test

#### Non-USMC:
1. Create any move or use any existing moves you have.
2. Access either as SC, TOO, TIO, or QAE (complete counseling for the move if you want to access as TOO/TIO).
3. Go to the move of your choice and look at the move information header and you should see Origin GBLOC matching the origin GLOBC of the move (See image below).

#### USMC:
1. Create a move as a Marine Corps BOS or use `HHGMoveAsUSMCNeedsSC` testharness.
3. Access either as SC, TOO, TIO, or QAE with `USMC` GBLOC (complete counseling for the move if you want to access as TOO/TIO).
4. Go to the move of your choice and look at the move information header and you should see Origin GBLOC matching the origin GLOBC of the move with  `/ USMC` added (See image below).

NOTE: SC vs TOO/TIO/QAE may show different origin GBLOC and this is intentional according to this [confluence page](https://dp3.atlassian.net/wiki/spaces/MT/pages/1631092737/Office+Routing+Explained).

## Screenshots
![image](https://github.com/transcom/mymove/assets/146856854/b005fda3-2476-4f00-b3a6-5fe977b3082b)

![image](https://github.com/transcom/mymove/assets/146856854/98d74eeb-00e8-4590-ab91-2aeb344b2dc7)

