### PR TITLE
removing inactive annotation <no-unused-vars>

### DIFF
--- a/playwright/tests/my/milmove/ppms/customerPpmTestFixture.js
+++ b/playwright/tests/my/milmove/ppms/customerPpmTestFixture.js
@@ -1,5 +1,3 @@
-/* eslint-disable no-unused-vars */
-
 /**
  * Semi-automated converted from a cypress test, and thus may contain
  * non best-practices, in particular: heavy use of `page.locator`


### PR DESCRIPTION
Hotfix for the discrepancy between main story branch, and int story branch files for 19710 
B-17910-hal-sc-creates-or-modifies-a-shipment-2
B-17910-hal-sc-creates-or-modifies-a-shipment-3-int.

```git
@@ -1,5 +1,3 @@
-/* eslint-disable no-unused-vars */
-
```