### PR TITLE
INT B-18642 GBLOC fix for USMC

### DIFF
--- a/src/components/CustomerHeader/index.jsx
+++ b/src/components/CustomerHeader/index.jsx
@@ -36,7 +36,8 @@ const CustomerHeader = ({ customer, order, moveCode, move, userRole }) => {
     !move?.shipmentGBLOC
       ? order.originDutyLocationGBLOC
       : move.shipmentGBLOC;
-  const originGBLOCDisplay = order.agency === SERVICE_MEMBER_AGENCIES.MARINES ? `${originGBLOC} / USMC` : originGBLOC;
+  const originGBLOCDisplay =
+    order.agency === SERVICE_MEMBER_AGENCIES.MARINES ? `${order.originDutyLocationGBLOC} / USMC` : originGBLOC;
 
   return (
     <div className={styles.custHeader}>

--- a/src/hooks/queries.test.jsx
+++ b/src/hooks/queries.test.jsx
@@ -356,6 +356,11 @@ describe('useTXOMoveInfoQueries', () => {
       isLoading: false,
       isError: false,
       isSuccess: true,
+      move: {
+        id: '1234',
+        ordersId: '4321',
+        moveCode: 'ABCDEF',
+      },
     });
   });
 });


### PR DESCRIPTION
## [B-18642](https://www13.v1host.com/USTRANSCOM38/assetdetail.v1?number=B-18642)

## Summary

Quick fix for PR that was already merged in https://github.com/transcom/mymove/pull/12335
The GBLOC showing for USMC should be `"SC's GBLOC / USMC"`, but I had `"TOO/TIO's GBLOC / USMC"`.


### How to test

#### USMC:
1. Create a move as a Marine Corps BOS or use `HHGMoveAsUSMCNeedsSC` testharness.
2. Make sure to have your Origin Duty Location Zip be in different GBLOC from your Shipment Pickup address Zip. (Use Scott AFB & 32223) if you want
3. Access either as SC, TOO, TIO, or QAE with `USMC` GBLOC (complete counseling for the move if you want to access as TOO/TIO).
4. Go to the move of your choice and look at the move information header and you should see Origin GBLOC matching the origin GLOBC for SC with  `/ USMC` added (See image below).

NOTE: SC vs TOO/TIO/QAE may show different origin GBLOC and this is intentional according to this [confluence page](https://dp3.atlassian.net/wiki/spaces/MT/pages/1631092737/Office+Routing+Explained).

## Screenshots

![image](https://github.com/transcom/mymove/assets/146856854/98d74eeb-00e8-4590-ab91-2aeb344b2dc7)

