### PR TITLE
mount support api under office router with prime sim

### DIFF
--- a/pkg/handlers/routing/routing_init.go
+++ b/pkg/handlers/routing/routing_init.go
@@ -517,6 +517,33 @@ func mountPrimeSimulatorAPI(appCtx appcontext.AppContext, routingConfig *Config,
 				rAuth.Mount("/", api.Serve(tracingMiddleware))
 			})
 		})
+		// Support API serves to support Prime API testing outside of production environments, hence why it is
+		// mounted inside the Prime sim API without client cert middleware
+		if routingConfig.ServeSupport {
+			site.Route("/support/v1", func(r chi.Router) {
+				r.Method("GET", "/swagger.yaml",
+					handlers.NewFileHandler(routingConfig.FileSystem,
+						routingConfig.SupportSwaggerPath))
+				if routingConfig.ServeSwaggerUI {
+					appCtx.Logger().Info("Support API Swagger UI serving is enabled")
+					r.Method("GET", "/docs",
+						handlers.NewFileHandler(routingConfig.FileSystem,
+							path.Join(routingConfig.BuildRoot, "swagger-ui", "support.html")))
+				} else {
+					r.Method("GET", "/docs", http.NotFoundHandler())
+				}
+
+				// Mux for support API that enforces auth
+				r.Route("/", func(rAuth chi.Router) {
+					rAuth.Use(userAuthMiddleware)
+					rAuth.Use(addAuditUserToRequestContextMiddleware)
+					rAuth.Use(authentication.PrimeSimulatorAuthorizationMiddleware(appCtx.Logger()))
+					rAuth.Use(middleware.NoCache())
+					rAuth.Use(middleware.RequestLogger())
+					rAuth.Mount("/", supportapi.NewSupportAPIHandler(routingConfig.HandlerConfig))
+				})
+			})
+		}
 	}
 }
 


### PR DESCRIPTION
## [B-19139](https://www13.v1host.com/USTRANSCOM38/story.mvc/Summary?oidToken=Story%3A922317)

## Summary

Mounts the Support API under the Office router hosting the same security as Prime Sim API. This will allow us to test the Support API with the certificates that we use with Prime Sim and allow easy access for testers.