### PR TITLE
Kickback B18855 I12705 Partial Deliveries are not recalculating

### DIFF
--- a/pkg/payment_request/service_param_value_lookups/weight_billed_lookup.go
+++ b/pkg/payment_request/service_param_value_lookups/weight_billed_lookup.go
@@ -64,28 +64,31 @@ func (r WeightBilledLookup) lookup(appCtx appcontext.AppContext, keyData *Servic
 			return "", err
 		} else if len(weightBilled) > 0 {
 			return weightBilled, nil
-		} else {
-			estimatedWeight = keyData.MTOServiceItem.EstimatedWeight
-
-			originalWeight = keyData.MTOServiceItem.ActualWeight
-
-			if originalWeight == nil {
-				// TODO: Do we need a different error -- is this a "normal" scenario?
-				return "", fmt.Errorf("could not find actual weight for MTOServiceItemID [%s]", keyData.MTOServiceItem.ID)
+		} else if keyData.MTOServiceItem.MTOShipment.PPMShipment != nil {
+			if len((string)(*keyData.MTOServiceItem.MTOShipment.BillableWeightCap)) > 0 {
+				weightBilled = (string)(*keyData.MTOServiceItem.MTOShipment.BillableWeightCap)
 			}
+		}
+		estimatedWeight = keyData.MTOServiceItem.MTOShipment.PrimeEstimatedWeight
 
-			if estimatedWeight != nil {
-				estimatedWeightCap := math.Round(float64(*estimatedWeight) * 1.10)
-				if float64(*originalWeight) > estimatedWeightCap {
-					value = applyMinimum(keyData.MTOServiceItem.ReService.Code, r.MTOShipment.ShipmentType, int(estimatedWeightCap))
-				} else {
-					value = applyMinimum(keyData.MTOServiceItem.ReService.Code, r.MTOShipment.ShipmentType, int(*originalWeight))
-				}
+		originalWeight = keyData.MTOServiceItem.MTOShipment.PrimeActualWeight
+
+		if originalWeight == nil {
+			// TODO: Do we need a different error -- is this a "normal" scenario?
+			return "", fmt.Errorf("could not find actual weight for MTOServiceItemID [%s]", keyData.MTOServiceItem.ID)
+		}
+
+		if estimatedWeight != nil {
+			estimatedWeightCap := math.Round(float64(*estimatedWeight) * 1.10)
+			if float64(*originalWeight) > estimatedWeightCap {
+				value = applyMinimum(keyData.MTOServiceItem.ReService.Code, r.MTOShipment.ShipmentType, int(estimatedWeightCap))
 			} else {
 				value = applyMinimum(keyData.MTOServiceItem.ReService.Code, r.MTOShipment.ShipmentType, int(*originalWeight))
 			}
-			return value, nil
+		} else {
+			value = applyMinimum(keyData.MTOServiceItem.ReService.Code, r.MTOShipment.ShipmentType, int(*originalWeight))
 		}
+		return value, nil
 
 	default:
 		// Shipments that are a diversion must utilize the lowest weight that can be found


### PR DESCRIPTION
## [Original PR into INT](https://github.com/transcom/mymove/pull/12325)
## [Original PR into MAIN](https://github.com/transcom/mymove/pull/12333)
## [New kickback ticket |-12705](https://www13.v1host.com/USTRANSCOM38/Issue.mvc/Summary?oidToken=Issue%3A929331)
## [Agility Ticket for the associated story B-18855](https://www13.v1host.com/USTRANSCOM38/assetdetail.v1?number=B-18855)

# Reason for kickback
In the case where a partial PPM was used in conjunction with the HHG shipment, the FSC multiplier was not recalculated as intended.

## Steps used to test
1. Use the "ApprovedMoveWithPPMWeightTicketOfficeWithHHG" option from the Test harness list.
2. Copy the move locator from the JSON object displayed (see Fig1 below)
3. Search for the move in the DB (replace '46HDCW' with your move's locator):
```
select * from moves m where m."locator" = '46HDCW'
```
4. Copy the date/time value from the created_at field to the date/time value for the available_to_prime_at field (this will allow the prime user to see this movie. It isn't necessary to do this step if you created the partial ppm with the hhg move manually).
5. Navigate back to the sign in page for milmove office users
6. Sign in as a Multi-role user under the KKFA GBLOC.
7. Start by clicking the Sign in button for a Prime user.
8. Search for the move by the move locator you copied earlier. Then click on that move in the list.
9. Click the "Add Service Item" button and choose either Origin SIT or Destination SIT and enter any required information. Make sure that you enter a number that is not 5001-10000 (for testing purposes).
10. Switch to the TOO user role and search for the move.
11. Click on the entry for the move.
12. Make sure to approve each of the requested service items.
13. After approving the service items, switch back to the Prime user role and search for the move.
14. Click on the entry for the move.
15. Click the "Create payment request" button.
16. From the list of service items you are able to select from you should see an item called either Domestic or Origin "... SIT fuel surcharge". Put a check in the checkbox for that item ("Add to payment request").
17. In the input field labeled "Weight Billed (if different from shipment weight)", enter a weight between 5001-10000.
Note: Since you entered a number that is not between 5001-10000, entering a number between 5001-10000 should produce a FSC Multiplier of "0.0006255". For further details, see the chart called Fig2 below.
18. Click the "Submit payment request" button at the bottom of the form.
19. Click the "Change user role" link at the top of the page.
20. Make the appropriate selection to log in as a TOO user.
21. Search for the same move locator and click on the associated move.
22. Click the "Payment requests" tab.
Note: there is a known issue when certain conditions are met that the TOO must review weights associated. Steps 15-16 are to workaround this known issue.
23. Click the "Review Weights" button.
24. Click the "Payment requests" tab again.
25. Click the "Review Service Items" button.
26. Observe that the service item called "Domestic origin SIT fuel surcharge" has a "Show calculations" link. Click that link to show the "Weight-based distance multiplier". Observe that the correct multiplier is shown in accordance with the following chart in Fig2. The multiplier should take Billed Weight entered when the payment request is created as priority over the actual or estimated weights entered throughout the shipment creation process.

## Fig1
![Screenshot 2024-03-25 at 2 13 29 PM](https://github.com/transcom/mymove/assets/147739091/e18e2206-9755-4d71-9a4a-8e99127cd97b)

## Fig2
weight billed will be referred to as "WB" in the following figure.
WB <= 5000: multiplier is "0.000417"
WB between 5001-10000: multiplier is "0.0006255"
WB between 10001-24000: multiplier is "0.000834"
WB 24001+: multiplier is "0.00139"