### PR TITLE
INT B-18756 move history log delete weight pro gear expense

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1261,7 +1261,7 @@ jobs:
             #
             # The trailing hyphen in restore_cache seems important
             # according to the page linked above
-            - v11-spectral-lint-
+            - v12-spectral-lint-
       - run:
           name: Save Baseline Spectral Lint
           command: |
@@ -1320,7 +1320,7 @@ jobs:
             # Use the BuildNum to update the cache key so that the
             # coverage cache is always updated
             - save_cache:
-                key: v11-spectral-lint-{{ .BuildNum }}
+                key: v12-spectral-lint-{{ .BuildNum }}
                 paths:
                   - ~/transcom/mymove/spectral
       - store_artifacts:

--- a/src/constants/MoveHistory/EventTemplates/CreateUpload/CreatePPMUpload.jsx
+++ b/src/constants/MoveHistory/EventTemplates/CreateUpload/CreatePPMUpload.jsx
@@ -26,8 +26,13 @@ export default {
   action: a.INSERT,
   eventName: o.createPPMUpload,
   tableName: t.user_uploads,
-  getEventNameDisplay: () => {
-    return <div>Uploaded document</div>;
+  getEventNameDisplay: ({ context }) => {
+    const eventLabel =
+      context[0]?.upload_type === 'fullWeightTicket' || context[0]?.upload_type === 'emptyWeightTicket'
+        ? 'Uploaded trip document'
+        : 'Uploaded document';
+
+    return <div>{eventLabel}</div>;
   },
   getDetails: (historyRecord) => {
     return <LabeledDetails historyRecord={formatChangedValues(historyRecord)} />;

--- a/src/constants/MoveHistory/EventTemplates/DeleteMovingExpense/DeleteMovingExpenseUserUploads.jsx
+++ b/src/constants/MoveHistory/EventTemplates/DeleteMovingExpense/DeleteMovingExpenseUserUploads.jsx
@@ -26,7 +26,7 @@ export default {
   eventName: o.deleteMovingExpense,
   tableName: t.user_uploads,
   getEventNameDisplay: () => {
-    return <div>Deleted upload</div>;
+    return <div>Deleted document</div>;
   },
   getDetails: (historyRecord) => {
     return <LabeledDetails historyRecord={formatChangedValues(historyRecord)} />;

--- a/src/constants/MoveHistory/EventTemplates/DeleteMovingExpense/DeleteMovingExpenseUserUploads.jsx
+++ b/src/constants/MoveHistory/EventTemplates/DeleteMovingExpense/DeleteMovingExpenseUserUploads.jsx
@@ -14,7 +14,11 @@ const formatChangedValues = (historyRecord) => {
     ...formatDataForPPM(historyRecord),
   };
 
-  return { ...historyRecord, changedValues: newChangedValues };
+  const newOldValues = { ...historyRecord.oldValues };
+  if (historyRecord.context[0]?.moving_expense_type)
+    newOldValues.moving_expense_type = historyRecord.context[0].moving_expense_type;
+
+  return { ...historyRecord, changedValues: newChangedValues, oldValues: newOldValues };
 };
 
 export default {

--- a/src/constants/MoveHistory/EventTemplates/DeleteMovingExpense/DeleteMovingExpenseUserUploads.test.jsx
+++ b/src/constants/MoveHistory/EventTemplates/DeleteMovingExpense/DeleteMovingExpenseUserUploads.test.jsx
@@ -31,7 +31,7 @@ describe('When given a deleted expense receipt upload', () => {
     const template = getTemplate(historyRecord);
 
     render(template.getEventNameDisplay(historyRecord));
-    expect(screen.getByText('Deleted upload')).toBeInTheDocument();
+    expect(screen.getByText('Deleted document')).toBeInTheDocument();
   });
 
   describe('properly renders shipment labels for ', () => {

--- a/src/constants/MoveHistory/EventTemplates/DeleteProGearWeightTicket/DeleteProGearWeightTicketUserUploads.jsx
+++ b/src/constants/MoveHistory/EventTemplates/DeleteProGearWeightTicket/DeleteProGearWeightTicketUserUploads.jsx
@@ -14,7 +14,11 @@ const formatChangedValues = (historyRecord) => {
     ...formatDataForPPM(historyRecord),
   };
 
-  return { ...historyRecord, changedValues: newChangedValues };
+  const newOldValues = { ...historyRecord.oldValues };
+  if (historyRecord.context[0]?.upload_type === 'proGearWeightTicket') newOldValues.belongs_to_self = true;
+  else if (historyRecord.context[0]?.upload_type === 'spouseProGearWeightTicket') newOldValues.belongs_to_self = false;
+
+  return { ...historyRecord, changedValues: newChangedValues, oldValues: newOldValues };
 };
 
 export default {

--- a/src/constants/MoveHistory/EventTemplates/DeleteProGearWeightTicket/DeleteProGearWeightTicketUserUploads.jsx
+++ b/src/constants/MoveHistory/EventTemplates/DeleteProGearWeightTicket/DeleteProGearWeightTicketUserUploads.jsx
@@ -26,7 +26,7 @@ export default {
   eventName: o.deleteProGearWeightTicket,
   tableName: t.user_uploads,
   getEventNameDisplay: () => {
-    return <div>Deleted upload</div>;
+    return <div>Deleted document</div>;
   },
   getDetails: (historyRecord) => {
     return <LabeledDetails historyRecord={formatChangedValues(historyRecord)} />;

--- a/src/constants/MoveHistory/EventTemplates/DeleteProGearWeightTicket/DeleteProGearWeightTicketUserUploads.test.jsx
+++ b/src/constants/MoveHistory/EventTemplates/DeleteProGearWeightTicket/DeleteProGearWeightTicketUserUploads.test.jsx
@@ -28,7 +28,7 @@ describe('When given a deleted pro-gear weight ticket upload', () => {
     const template = getTemplate(historyRecord);
 
     render(template.getEventNameDisplay(historyRecord));
-    expect(screen.getByText('Deleted upload')).toBeInTheDocument();
+    expect(screen.getByText('Deleted document')).toBeInTheDocument();
   });
 
   it('displays details of shipment type, shipment ID', () => {

--- a/src/constants/MoveHistory/EventTemplates/DeleteProGearWeightTicket/DeleteProGearWeightTicketUserUploads.test.jsx
+++ b/src/constants/MoveHistory/EventTemplates/DeleteProGearWeightTicket/DeleteProGearWeightTicketUserUploads.test.jsx
@@ -35,7 +35,7 @@ describe('When given a deleted pro-gear weight ticket upload', () => {
     const template = getTemplate(historyRecord);
 
     render(template.getDetails(historyRecord));
-    expect(screen.getByText('PPM shipment #125D1')).toBeInTheDocument();
+    expect(screen.getByText('PPM shipment #125D1, Spouse pro-gear')).toBeInTheDocument();
   });
 
   it('displays details the deleted document', () => {

--- a/src/constants/MoveHistory/EventTemplates/DeleteWeightTicket/DeleteWeightTicketUserUploads.jsx
+++ b/src/constants/MoveHistory/EventTemplates/DeleteWeightTicket/DeleteWeightTicketUserUploads.jsx
@@ -21,8 +21,13 @@ export default {
   action: a.UPDATE,
   eventName: o.deleteWeightTicket,
   tableName: t.user_uploads,
-  getEventNameDisplay: () => {
-    return <div>Deleted upload</div>;
+  getEventNameDisplay: ({ context }) => {
+    const eventLabel =
+      context[0]?.upload_type === 'fullWeightTicket' || context[0]?.upload_type === 'emptyWeightTicket'
+        ? 'Deleted trip document'
+        : 'Deleted document';
+
+    return <div>{eventLabel}</div>;
   },
   getDetails: (historyRecord) => {
     return <LabeledDetails historyRecord={formatChangedValues(historyRecord)} />;

--- a/src/constants/MoveHistory/EventTemplates/DeleteWeightTicket/DeleteWeightTicketUserUploads.test.jsx
+++ b/src/constants/MoveHistory/EventTemplates/DeleteWeightTicket/DeleteWeightTicketUserUploads.test.jsx
@@ -27,7 +27,15 @@ describe('When given a deleted trip weight ticket upload', () => {
     const template = getTemplate(historyRecord);
 
     render(template.getEventNameDisplay(historyRecord));
-    expect(screen.getByText('Deleted upload')).toBeInTheDocument();
+    expect(screen.getByText('Deleted document')).toBeInTheDocument();
+  });
+
+  it('displays trip event properly', () => {
+    historyRecord.context[0].upload_type = 'fullWeightTicket';
+    const template = getTemplate(historyRecord);
+
+    render(template.getEventNameDisplay(historyRecord));
+    expect(screen.getByText('Deleted trip document')).toBeInTheDocument();
   });
 
   it('displays details of shipment type, shipment ID', () => {


### PR DESCRIPTION
## [B-18756](https://www13.v1host.com/USTRANSCOM38/assetdetail.v1?number=B-18756)

Similar to [B-18755](https://www13.v1host.com/USTRANSCOM38/assetdetail.v1?number=B-18755) but for deletes.

## Summary

This is for fixing data displayed in Move History log when deletes for PPM trip weight, pro-gear, and expense tickets occur when customer is submitting their documentation. Some entries were already updated by the other story I've worked on(B-18755 Upload/update), but this also includes some of the missing updates.

### How to test

1. Create a PPM move and get to the step where customer is able to upload PPM documents(trip weight, pro-gear, and expenses).
2. Create weights, pro-gears, and expense tickets.
3. Delete any entry in those and check as a office user if all the necessary details are displayed in the Move History Log.

## Screenshots
![image](https://github.com/transcom/mymove/assets/146856854/6b78a2c6-0e18-41b3-bbf1-4c19623eb9fc)
