### PR TITLE
INT B-18891 Update customer contact info as any office user (I-12710)

### DIFF
--- a/pkg/gen/ghcapi/embedded_spec.go
+++ b/pkg/gen/ghcapi/embedded_spec.go
@@ -5960,7 +5960,7 @@ func init() {
         "secondaryTelephone": {
           "type": "string",
           "format": "telephone",
-          "pattern": "^[2-9]\\d{2}-\\d{3}-\\d{4}$",
+          "pattern": "^[2-9]\\d{2}-\\d{3}-\\d{4}$|^$",
           "x-nullable": true
         },
         "suffix": {
@@ -10412,7 +10412,7 @@ func init() {
         "secondaryTelephone": {
           "type": "string",
           "format": "telephone",
-          "pattern": "^[2-9]\\d{2}-\\d{3}-\\d{4}$",
+          "pattern": "^[2-9]\\d{2}-\\d{3}-\\d{4}$|^$",
           "x-nullable": true
         },
         "suffix": {
@@ -18546,7 +18546,7 @@ func init() {
         "secondaryTelephone": {
           "type": "string",
           "format": "telephone",
-          "pattern": "^[2-9]\\d{2}-\\d{3}-\\d{4}$",
+          "pattern": "^[2-9]\\d{2}-\\d{3}-\\d{4}$|^$",
           "x-nullable": true
         },
         "suffix": {
@@ -23056,7 +23056,7 @@ func init() {
         "secondaryTelephone": {
           "type": "string",
           "format": "telephone",
-          "pattern": "^[2-9]\\d{2}-\\d{3}-\\d{4}$",
+          "pattern": "^[2-9]\\d{2}-\\d{3}-\\d{4}$|^$",
           "x-nullable": true
         },
         "suffix": {

--- a/pkg/gen/ghcmessages/customer.go
+++ b/pkg/gen/ghcmessages/customer.go
@@ -69,7 +69,7 @@ type Customer struct {
 	PhoneIsPreferred bool `json:"phoneIsPreferred,omitempty"`
 
 	// secondary telephone
-	// Pattern: ^[2-9]\d{2}-\d{3}-\d{4}$
+	// Pattern: ^[2-9]\d{2}-\d{3}-\d{4}$|^$
 	SecondaryTelephone *string `json:"secondaryTelephone,omitempty"`
 
 	// suffix
@@ -222,7 +222,7 @@ func (m *Customer) validateSecondaryTelephone(formats strfmt.Registry) error {
 		return nil
 	}
 
-	if err := validate.Pattern("secondaryTelephone", "body", *m.SecondaryTelephone, `^[2-9]\d{2}-\d{3}-\d{4}$`); err != nil {
+	if err := validate.Pattern("secondaryTelephone", "body", *m.SecondaryTelephone, `^[2-9]\d{2}-\d{3}-\d{4}$|^$`); err != nil {
 		return err
 	}
 

--- a/pkg/gen/ghcmessages/update_customer_payload.go
+++ b/pkg/gen/ghcmessages/update_customer_payload.go
@@ -59,7 +59,7 @@ type UpdateCustomerPayload struct {
 	PhoneIsPreferred bool `json:"phoneIsPreferred,omitempty"`
 
 	// secondary telephone
-	// Pattern: ^[2-9]\d{2}-\d{3}-\d{4}$
+	// Pattern: ^[2-9]\d{2}-\d{3}-\d{4}$|^$
 	SecondaryTelephone *string `json:"secondaryTelephone,omitempty"`
 
 	// suffix
@@ -165,7 +165,7 @@ func (m *UpdateCustomerPayload) validateSecondaryTelephone(formats strfmt.Regist
 		return nil
 	}
 
-	if err := validate.Pattern("secondaryTelephone", "body", *m.SecondaryTelephone, `^[2-9]\d{2}-\d{3}-\d{4}$`); err != nil {
+	if err := validate.Pattern("secondaryTelephone", "body", *m.SecondaryTelephone, `^[2-9]\d{2}-\d{3}-\d{4}$|^$`); err != nil {
 		return err
 	}
 

--- a/pkg/handlers/authentication/permissions.go
+++ b/pkg/handlers/authentication/permissions.go
@@ -35,6 +35,7 @@ var TOO = RolePermissions{
 		"update.SITExtension",
 		"update.MTOServiceItem",
 		"update.excessWeightRisk",
+		"update.customer",
 		"view.closeoutOffice",
 		"update.MTOPage",
 	},
@@ -53,6 +54,7 @@ var TIO = RolePermissions{
 		"update.paymentRequest",
 		"update.paymentServiceItemStatus",
 		"update.MTOPage",
+		"update.customer",
 	},
 }
 

--- a/src/components/Office/CustomerContactInfoForm/CustomerContactInfoForm.jsx
+++ b/src/components/Office/CustomerContactInfoForm/CustomerContactInfoForm.jsx
@@ -98,8 +98,13 @@ CustomerContactInfoForm.propTypes = {
     email: PropTypes.string,
     customerAddress: ResidentialAddressShape,
   }).isRequired,
-  onSubmit: PropTypes.func.isRequired,
-  onBack: PropTypes.func.isRequired,
+  onSubmit: PropTypes.func,
+  onBack: PropTypes.func,
+};
+
+CustomerContactInfoForm.defaultProps = {
+  onSubmit: () => {},
+  onBack: () => {},
 };
 
 export default CustomerContactInfoForm;

--- a/src/components/Office/CustomerContactInfoForm/CustomerContactInfoForm.test.jsx
+++ b/src/components/Office/CustomerContactInfoForm/CustomerContactInfoForm.test.jsx
@@ -47,6 +47,9 @@ describe('CustomerContactInfoForm Component', () => {
 
       expect(screen.getAllByLabelText('Phone')[0]).toBeInstanceOf(HTMLInputElement);
       expect(screen.getAllByLabelText('Phone')[0]).toBeRequired();
+
+      expect(screen.getAllByLabelText(/Alternate Phone/)[0]).toBeInstanceOf(HTMLInputElement);
+
       expect(screen.getAllByLabelText('Email')[0]).toBeInstanceOf(HTMLInputElement);
       expect(screen.getAllByLabelText('Email')[0]).toBeRequired();
 

--- a/src/components/Office/DefinitionLists/CustomerInfoList.jsx
+++ b/src/components/Office/DefinitionLists/CustomerInfoList.jsx
@@ -5,7 +5,8 @@ import styles from './OfficeDefinitionLists.module.scss';
 
 import { BackupContactShape } from 'types/backupContact';
 import descriptionListStyles from 'styles/descriptionList.module.scss';
-import { ResidentialAddressShape } from 'types/address';
+import { AddressShape } from 'types/address';
+import { formatCustomerContactFullAddress } from 'utils/formatters';
 
 const CustomerInfoList = ({ customerInfo }) => {
   return (
@@ -21,7 +22,11 @@ const CustomerInfoList = ({ customerInfo }) => {
         </div>
         <div className={descriptionListStyles.row}>
           <dt>Phone</dt>
-          <dd data-testid="phone">{customerInfo.phone}</dd>
+          <dd data-testid="phone">{`+1 ${customerInfo.phone}`}</dd>
+        </div>
+        <div className={descriptionListStyles.row}>
+          <dt>Alt. Phone</dt>
+          <dd data-testid="phone">{customerInfo.altPhone ? `+1 ${customerInfo.altPhone}` : '—'}</dd>
         </div>
         <div className={descriptionListStyles.row}>
           <dt>Email</dt>
@@ -30,14 +35,16 @@ const CustomerInfoList = ({ customerInfo }) => {
         <div className={descriptionListStyles.row}>
           <dt>Current address</dt>
           <dd data-testid="currentAddress">
-            {`${customerInfo.currentAddress?.streetAddress1}, ${customerInfo.currentAddress?.city}, ${customerInfo.currentAddress?.state} ${customerInfo.currentAddress?.postalCode}`}
+            {customerInfo.currentAddress?.streetAddress1
+              ? formatCustomerContactFullAddress(customerInfo.currentAddress)
+              : '—'}
           </dd>
         </div>
         <div className={descriptionListStyles.row}>
           <dt>Backup address</dt>
           <dd data-testid="backupAddress">
             {customerInfo.backupAddress?.streetAddress1
-              ? `${customerInfo.backupAddress.streetAddress1}, ${customerInfo.backupAddress.city}, ${customerInfo.backupAddress.state} ${customerInfo.backupAddress.postalCode}`
+              ? formatCustomerContactFullAddress(customerInfo.backupAddress)
               : '—'}
           </dd>
         </div>
@@ -70,8 +77,8 @@ CustomerInfoList.propTypes = {
     dodId: PropTypes.string,
     phone: PropTypes.string,
     email: PropTypes.string,
-    currentAddress: ResidentialAddressShape,
-    backupAddress: ResidentialAddressShape,
+    currentAddress: AddressShape,
+    backupAddress: AddressShape,
     backupContact: BackupContactShape,
   }).isRequired,
 };

--- a/src/components/Office/DefinitionLists/CustomerInfoList.test.jsx
+++ b/src/components/Office/DefinitionLists/CustomerInfoList.test.jsx
@@ -6,7 +6,8 @@ import CustomerInfoList from './CustomerInfoList';
 const info = {
   name: 'Smith, Kerry',
   dodId: '9999999999',
-  phone: '+1 999-999-9999',
+  phone: '999-999-9999',
+  altPhone: '888-888-8888',
   email: 'ksmith@email.com',
   currentAddress: {
     streetAddress1: '812 S 129th St',
@@ -15,7 +16,8 @@ const info = {
     postalCode: '78234',
   },
   backupAddress: {
-    streetAddress1: '813 S 129th St',
+    streetAddress1: '812½ S 129th St',
+    streetAddress2: 'Apt B',
     city: 'San Antonio',
     state: 'TX',
     postalCode: '78234',
@@ -33,7 +35,11 @@ describe('CustomerInfoList', () => {
     Object.keys(info)
       .filter((k) => k !== 'currentAddress' && k !== 'backupAddress' && k !== 'backupContact')
       .forEach((key) => {
-        expect(screen.getByText(info[key])).toBeInTheDocument();
+        if (key === 'phone' || key === 'altPhone') {
+          screen.getByText(`+1 ${info[key]}`);
+        } else {
+          expect(screen.getByText(info[key])).toBeInTheDocument();
+        }
       });
   });
 
@@ -44,7 +50,7 @@ describe('CustomerInfoList', () => {
 
   it('renders formatted backup address', () => {
     render(<CustomerInfoList customerInfo={info} />);
-    expect(screen.getByText('813 S 129th St, San Antonio, TX 78234')).toBeInTheDocument();
+    expect(screen.getByText('812½ S 129th St, Apt B, San Antonio, TX 78234')).toBeInTheDocument();
   });
 
   it('renders formatted backup contact name', () => {

--- a/src/components/form/CustomerAltContactInfoFields/CustomerAltContactInfoFields.test.jsx
+++ b/src/components/form/CustomerAltContactInfoFields/CustomerAltContactInfoFields.test.jsx
@@ -24,7 +24,7 @@ describe('CustomerAltContactInfoFields component', () => {
 
     expect(screen.getAllByText('Phone')).toBeInstanceOf(Array);
     expect(screen.getAllByText('Email')).toBeInstanceOf(Array);
-    expect(screen.getByText('Alternate Phone')).toBeInstanceOf(HTMLLabelElement);
+    expect(screen.getByLabelText(/Alternate Phone/)).toBeInstanceOf(HTMLInputElement);
     expect(screen.getByText('Preferred contact method')).toBeInstanceOf(HTMLLabelElement);
   });
 
@@ -51,7 +51,7 @@ describe('CustomerAltContactInfoFields component', () => {
       expect(screen.getByLabelText(/Suffix/)).toHaveValue(initialValues.suffix);
       expect(screen.getByDisplayValue(initialValues.customerTelephone)).toBeInstanceOf(HTMLInputElement);
       expect(screen.getByDisplayValue(initialValues.customerEmail)).toBeInstanceOf(HTMLInputElement);
-      expect(screen.getByLabelText('Alternate Phone')).toHaveValue(initialValues.secondaryPhone);
+      expect(screen.getByLabelText(/Alternate Phone/)).toHaveValue(initialValues.secondaryPhone);
     });
   });
 });

--- a/src/components/form/CustomerAltContactInfoFields/index.jsx
+++ b/src/components/form/CustomerAltContactInfoFields/index.jsx
@@ -48,7 +48,7 @@ export const CustomerAltContactInfoFields = ({ legend, className, render }) => {
                 type="tel"
                 minimum="12"
                 mask="000{-}000{-}0000"
-                required
+                labelHint="Optional"
               />
             </div>
           </div>

--- a/src/constants/permissions.js
+++ b/src/constants/permissions.js
@@ -19,4 +19,5 @@ export const permissionTypes = {
   createReportViolation: 'create.reportViolation',
   viewCloseoutOffice: 'view.closeoutOffice',
   updateMTOPage: 'update.MTOPage',
+  updateCustomer: 'update.customer',
 };

--- a/src/constants/routes.js
+++ b/src/constants/routes.js
@@ -109,6 +109,8 @@ export const tooRoutes = {
   BASE_ORDERS_EDIT_PATH: `${BASE_MOVES_PATH}/orders`,
   ORDERS_EDIT_PATH: 'orders',
   BASE_SHIPMENT_ADVANCE_PATH_TOO: `${BASE_MOVES_PATH}/shipments/:shipmentId/advance`,
+  BASE_CUSTOMER_INFO_EDIT_PATH: `${BASE_MOVES_PATH}/customer`,
+  CUSTOMER_INFO_EDIT_PATH: 'customer',
 };
 
 export const qaeCSRRoutes = {

--- a/src/pages/Office/CustomerInfo/CustomerInfo.jsx
+++ b/src/pages/Office/CustomerInfo/CustomerInfo.jsx
@@ -33,13 +33,13 @@ const CustomerInfo = ({ customer, isLoading, isError, ordersId, onUpdate }) => {
       });
       queryClient.invalidateQueries([CUSTOMER, variables.customerId]);
       queryClient.invalidateQueries([ORDERS, ordersId]);
-      onUpdate('success');
       handleClose();
+      onUpdate('success');
     },
     onError: () => {
       // TODO: Handle error some how - see https://dp3.atlassian.net/browse/MB-5597
-      onUpdate('error');
       handleClose();
+      onUpdate('error');
     },
   });
 
@@ -80,20 +80,20 @@ const CustomerInfo = ({ customer, isLoading, isError, ordersId, onUpdate }) => {
       backupAddress,
       phoneIsPreferred,
       emailIsPreferred,
-      secondaryTelephone: secondaryPhone || null,
+      secondaryTelephone: secondaryPhone,
     };
     mutateCustomerInfo({ customerId: customer.id, ifMatchETag: customer.eTag, body });
   };
   const initialValues = {
     firstName: customer.first_name,
     lastName: customer.last_name,
-    middleName: customer.middle_name,
-    suffix: customer.suffix,
+    middleName: customer.middle_name || '',
+    suffix: customer.suffix || '',
     customerTelephone: customer.phone,
     customerEmail: customer.email,
     name: customer.backup_contact.name,
     telephone: customer.backup_contact.phone,
-    secondaryPhone: customer.secondaryTelephone,
+    secondaryPhone: customer.secondaryTelephone || '',
     email: customer.backup_contact.email,
     customerAddress: customer.current_address,
     backupAddress: customer.backupAddress,
@@ -116,6 +116,11 @@ CustomerInfo.propTypes = {
   isLoading: PropTypes.bool.isRequired,
   isError: PropTypes.bool.isRequired,
   ordersId: PropTypes.string.isRequired,
-  onUpdate: PropTypes.func.isRequired,
+  onUpdate: PropTypes.func,
 };
+
+CustomerInfo.defaultProps = {
+  onUpdate: () => {},
+};
+
 export default CustomerInfo;

--- a/src/pages/Office/CustomerInfo/CustomerInfo.test.jsx
+++ b/src/pages/Office/CustomerInfo/CustomerInfo.test.jsx
@@ -43,6 +43,7 @@ const mockCustomer = {
   middle_name: 'Quincey',
   suffix: 'Jr.',
   phone: '223-444-3434',
+  secondaryTelephone: '234-567-8901',
 };
 
 const loadingReturnValue = {
@@ -114,6 +115,7 @@ describe('CustomerInfo', () => {
       expect(screen.getByDisplayValue(mockCustomer.backup_contact.phone).value).toEqual(
         mockCustomer.backup_contact.phone,
       );
+      expect(screen.getByLabelText(/Alternate Phone/i).value).toEqual(mockCustomer.secondaryTelephone);
       // to get around the two inputs labeled "Email" on the screen
       expect(screen.getByDisplayValue(mockCustomer.email).value).toEqual(mockCustomer.email);
       expect(screen.getByDisplayValue(mockCustomer.backup_contact.email).value).toEqual(

--- a/src/pages/Office/MoveDetails/MoveDetails.jsx
+++ b/src/pages/Office/MoveDetails/MoveDetails.jsx
@@ -10,6 +10,7 @@ import 'styles/office.scss';
 
 import hasRiskOfExcess from 'utils/hasRiskOfExcess';
 import { MOVES, MTO_SERVICE_ITEMS, MTO_SHIPMENTS } from 'constants/queryKeys';
+import { tooRoutes } from 'constants/routes';
 import SERVICE_ITEM_STATUSES from 'constants/serviceItems';
 import { ADDRESS_UPDATE_STATUS, shipmentStatuses } from 'constants/shipments';
 import AllowancesList from 'components/Office/DefinitionLists/AllowancesList';
@@ -266,7 +267,8 @@ const MoveDetails = ({
   const customerInfo = {
     name: formattedCustomerName(customer.last_name, customer.first_name, customer.suffix, customer.middle_name),
     dodId: customer.dodID,
-    phone: `+1 ${customer.phone}`,
+    phone: customer.phone,
+    altPhone: customer.secondaryTelephone,
     email: customer.email,
     currentAddress: customer.current_address,
     backupAddress: customerData.backupAddress,
@@ -435,7 +437,20 @@ const MoveDetails = ({
             </DetailsPanel>
           </div>
           <div className={styles.section} id="customer-info">
-            <DetailsPanel title="Customer info">
+            <DetailsPanel
+              title="Customer info"
+              editButton={
+                <Restricted to={permissionTypes.updateCustomer}>
+                  <Link
+                    className="usa-button usa-button--secondary"
+                    data-testid="edit-customer-info"
+                    to={`../${tooRoutes.CUSTOMER_INFO_EDIT_PATH}`}
+                  >
+                    Edit customer info
+                  </Link>
+                </Restricted>
+              }
+            >
               <CustomerInfoList customerInfo={customerInfo} />
             </DetailsPanel>
           </div>

--- a/src/pages/Office/MoveDetails/MoveDetails.test.jsx
+++ b/src/pages/Office/MoveDetails/MoveDetails.test.jsx
@@ -1116,6 +1116,26 @@ describe('MoveDetails page', () => {
       expect(await screen.getByRole('link', { name: 'View allowances' })).toBeInTheDocument();
       expect(screen.queryByRole('link', { name: 'Edit allowances' })).not.toBeInTheDocument();
     });
+
+    it('renders edit customer info button when user has permission', async () => {
+      render(
+        <MockProviders permissions={[permissionTypes.updateCustomer]}>
+          <MoveDetails {...testProps} />
+        </MockProviders>,
+      );
+
+      expect(await screen.getByRole('link', { name: 'Edit customer info' })).toBeInTheDocument();
+    });
+
+    it('does not show edit customer info button when user does not have permission', async () => {
+      render(
+        <MockProviders>
+          <MoveDetails {...testProps} />
+        </MockProviders>,
+      );
+
+      expect(screen.queryByRole('link', { name: 'Edit customer info' })).not.toBeInTheDocument();
+    });
   });
 
   describe('when MTO shipments are not yet defined', () => {

--- a/src/pages/Office/ServicesCounselingMoveDetails/ServicesCounselingMoveDetails.jsx
+++ b/src/pages/Office/ServicesCounselingMoveDetails/ServicesCounselingMoveDetails.jsx
@@ -279,7 +279,8 @@ const ServicesCounselingMoveDetails = ({ infoSavedAlert, setUnapprovedShipmentCo
   const customerInfo = {
     name: formattedCustomerName(customer.last_name, customer.first_name, customer.suffix, customer.middle_name),
     dodId: customer.dodID,
-    phone: `+1 ${customer.phone}`,
+    phone: customer.phone,
+    altPhone: customer.secondaryTelephone,
     email: customer.email,
     currentAddress: customer.current_address,
     backupAddress: customerData.backupAddress,
@@ -613,7 +614,7 @@ const ServicesCounselingMoveDetails = ({ infoSavedAlert, setUnapprovedShipmentCo
             <DetailsPanel
               title="Customer info"
               editButton={
-                (counselorCanEdit || counselorCanEditNonPPM) && (
+                <Restricted to={permissionTypes.updateCustomer}>
                   <Link
                     className="usa-button usa-button--secondary"
                     data-testid="edit-customer-info"
@@ -621,7 +622,7 @@ const ServicesCounselingMoveDetails = ({ infoSavedAlert, setUnapprovedShipmentCo
                   >
                     Edit customer info
                   </Link>
-                )
+                </Restricted>
               }
               ppmShipmentInfoNeedsApproval={ppmShipmentsInfoNeedsApproval}
             >

--- a/src/pages/Office/ServicesCounselingMoveDetails/ServicesCounselingMoveDetails.test.jsx
+++ b/src/pages/Office/ServicesCounselingMoveDetails/ServicesCounselingMoveDetails.test.jsx
@@ -401,7 +401,7 @@ const ppmShipmentQuery = {
   ],
 };
 
-const renderComponent = (props, permissions = [permissionTypes.updateShipment]) => {
+const renderComponent = (props, permissions = [permissionTypes.updateShipment, permissionTypes.updateCustomer]) => {
   return render(
     <MockProviders permissions={permissions} {...mockRoutingOptions}>
       <ServicesCounselingMoveDetails setUnapprovedShipmentCount={jest.fn()} {...props} />
@@ -880,7 +880,7 @@ describe('MoveDetails page', () => {
         expect(screen.queryByRole('button', { name: 'Edit shipment' })).not.toBeInTheDocument();
         expect(screen.queryByRole('link', { name: 'View and edit orders' })).not.toBeInTheDocument();
         expect(screen.queryByRole('link', { name: 'Edit allowances' })).not.toBeInTheDocument();
-        expect(screen.queryByRole('link', { name: 'Edit customer info' })).not.toBeInTheDocument();
+        expect(screen.queryByRole('link', { name: 'Edit customer info' })).toBeInTheDocument();
       });
     });
 
@@ -905,6 +905,16 @@ describe('MoveDetails page', () => {
         );
 
         expect(screen.queryByText('Flag move for financial review')).not.toBeInTheDocument();
+      });
+
+      it('does not show the edit customer info button if user does not have permission', () => {
+        render(
+          <MockProviders {...mockRoutingOptions}>
+            <ServicesCounselingMoveDetails setUnapprovedShipmentCount={jest.fn()} />
+          </MockProviders>,
+        );
+
+        expect(screen.queryByText('Edit customer info')).not.toBeInTheDocument();
       });
     });
   });

--- a/src/pages/Office/TXOMoveInfo/TXOMoveInfo.jsx
+++ b/src/pages/Office/TXOMoveInfo/TXOMoveInfo.jsx
@@ -5,7 +5,7 @@ import { useSelector } from 'react-redux';
 import 'styles/office.scss';
 
 import { permissionTypes } from 'constants/permissions';
-import { qaeCSRRoutes, tioRoutes } from 'constants/routes';
+import { qaeCSRRoutes, tioRoutes, tooRoutes } from 'constants/routes';
 import TXOTabNav from 'components/Office/TXOTabNav/TXOTabNav';
 import Restricted from 'components/Restricted/Restricted';
 import LoadingPlaceholder from 'shared/LoadingPlaceholder';
@@ -26,6 +26,7 @@ const EvaluationViolations = lazy(() => import('pages/Office/EvaluationViolation
 const MoveHistory = lazy(() => import('pages/Office/MoveHistory/MoveHistory'));
 const MovePaymentRequests = lazy(() => import('pages/Office/MovePaymentRequests/MovePaymentRequests'));
 const Forbidden = lazy(() => import('pages/Office/Forbidden/Forbidden'));
+const CustomerInfo = lazy(() => import('pages/Office/CustomerInfo/CustomerInfo'));
 
 const TXOMoveInfo = () => {
   const [unapprovedShipmentCount, setUnapprovedShipmentCount] = React.useState(0);
@@ -67,6 +68,13 @@ const TXOMoveInfo = () => {
     matchPath(
       {
         path: tioRoutes.BILLABLE_WEIGHT_PATH,
+        end: true,
+      },
+      pathname,
+    ) ||
+    matchPath(
+      {
+        path: tooRoutes.BASE_CUSTOMER_INFO_EDIT_PATH,
         end: true,
       },
       pathname,
@@ -198,7 +206,15 @@ const TXOMoveInfo = () => {
               }
             />
           )}
-
+          {order.grade && (
+            <Route
+              path={tooRoutes.CUSTOMER_INFO_EDIT_PATH}
+              end
+              element={
+                <CustomerInfo ordersId={order.id} customer={customerData} isLoading={isLoading} isError={isError} />
+              }
+            />
+          )}
           <Route path="history" end element={<MoveHistory moveCode={moveCode} />} />
           {/* TODO - clarify role/tab access */}
           <Route path="/" element={<Navigate to={`/moves/${moveCode}/details`} replace />} />

--- a/src/pages/Office/TXOMoveInfo/TXOMoveInfo.test.jsx
+++ b/src/pages/Office/TXOMoveInfo/TXOMoveInfo.test.jsx
@@ -23,6 +23,7 @@ mockPage('pages/Office/EvaluationReport/EvaluationReport');
 mockPage('pages/Office/EvaluationViolations/EvaluationViolations');
 mockPage('pages/Office/MoveHistory/MoveHistory');
 mockPage('pages/Office/MovePaymentRequests/MovePaymentRequests');
+mockPage('pages/Office/CustomerInfo/CustomerInfo');
 mockPage('pages/Office/Forbidden/Forbidden');
 
 const testMoveCode = '1A5PM3';
@@ -211,6 +212,7 @@ describe('TXO Move Info Container', () => {
       ['Customer Support Remarks', 'customer-support-remarks'],
       ['Evaluation Reports', 'evaluation-reports'],
       ['Move History', 'history'],
+      ['Customer Info', 'customer'],
       ['Forbidden', 'evaluation-reports/123'], // Permission restricted
       ['Forbidden', 'evaluation-reports/report123/violations'], // Permission restricted
     ])('should render the %s component when at the route: /moves/:moveCode/%s', async (componentName, nestedPath) => {

--- a/src/utils/formatters.js
+++ b/src/utils/formatters.js
@@ -181,6 +181,41 @@ export const formatEvaluationReportShipmentAddress = (address) => {
   return `${streetAddress1}, ${city}, ${state} ${postalCode}`;
 };
 
+export const formatCustomerContactFullAddress = (address) => {
+  let formattedAddress = '';
+  if (address.streetAddress1) {
+    formattedAddress += `${address.streetAddress1}`;
+  }
+
+  if (address.streetAddress2) {
+    formattedAddress += `, ${address.streetAddress2}`;
+  }
+
+  if (address.streetAddress3) {
+    formattedAddress += `, ${address.streetAddress3}`;
+  }
+
+  if (address.city) {
+    formattedAddress += `, ${address.city}`;
+  }
+
+  if (address.state) {
+    formattedAddress += `, ${address.state}`;
+  }
+
+  if (address.postalCode) {
+    formattedAddress += ` ${address.postalCode}`;
+  }
+
+  if (formattedAddress[0] === ',') {
+    formattedAddress = formattedAddress.substring(1);
+  }
+
+  formattedAddress = formattedAddress.trim();
+
+  return formattedAddress;
+};
+
 export const formatMoveHistoryFullAddress = (address) => {
   let formattedAddress = '';
   if (address.street_address_1) {

--- a/src/utils/formatters.test.js
+++ b/src/utils/formatters.test.js
@@ -292,4 +292,35 @@ describe('formatters', () => {
       expect(formatQAReportID(uuid)).toEqual('#QA-7E37E');
     });
   });
+
+  describe('formatCustomerContactFullAddress', () => {
+    it('should conditionally include address lines 2 and 3', () => {
+      const addressWithoutLine2And3 = {
+        city: 'Beverly Hills',
+        country: 'US',
+        postalCode: '90210',
+        state: 'CA',
+        streetAddress1: '54321 Any Street',
+        streetAddress2: '',
+        streetAddress3: '',
+      };
+
+      const addressWithLine2And3 = {
+        city: 'Beverly Hills',
+        country: 'US',
+        postalCode: '90210',
+        state: 'CA',
+        streetAddress1: '12345 Any Street',
+        streetAddress2: 'Apt 12B',
+        streetAddress3: 'c/o Leo Spaceman',
+      };
+
+      expect(formatters.formatCustomerContactFullAddress(addressWithoutLine2And3)).toEqual(
+        '54321 Any Street, Beverly Hills, CA 90210',
+      );
+      expect(formatters.formatCustomerContactFullAddress(addressWithLine2And3)).toEqual(
+        '12345 Any Street, Apt 12B, c/o Leo Spaceman, Beverly Hills, CA 90210',
+      );
+    });
+  });
 });

--- a/swagger-def/ghc.yaml
+++ b/swagger-def/ghc.yaml
@@ -3672,7 +3672,7 @@ definitions:
       secondaryTelephone:
         type: string
         format: telephone
-        pattern: '^[2-9]\d{2}-\d{3}-\d{4}$'
+        pattern: '^[2-9]\d{2}-\d{3}-\d{4}$|^$'
         x-nullable: true
       backupAddress:
         $ref: "definitions/Address.yaml"
@@ -3774,7 +3774,7 @@ definitions:
       secondaryTelephone:
         type: string
         format: telephone
-        pattern: '^[2-9]\d{2}-\d{3}-\d{4}$'
+        pattern: '^[2-9]\d{2}-\d{3}-\d{4}$|^$'
         x-nullable: true
       backupAddress:
         allOf:

--- a/swagger/ghc.yaml
+++ b/swagger/ghc.yaml
@@ -3808,7 +3808,7 @@ definitions:
       secondaryTelephone:
         type: string
         format: telephone
-        pattern: ^[2-9]\d{2}-\d{3}-\d{4}$
+        pattern: ^[2-9]\d{2}-\d{3}-\d{4}$|^$
         x-nullable: true
       backupAddress:
         $ref: '#/definitions/Address'
@@ -3910,7 +3910,7 @@ definitions:
       secondaryTelephone:
         type: string
         format: telephone
-        pattern: ^[2-9]\d{2}-\d{3}-\d{4}$
+        pattern: ^[2-9]\d{2}-\d{3}-\d{4}$|^$
         x-nullable: true
       backupAddress:
         allOf:


### PR DESCRIPTION
## [B-18891](https://www13.v1host.com/USTRANSCOM38/story.mvc/Summary?oidToken=Story%3A907848)
### [I-12710](https://www13.v1host.com/USTRANSCOM38/Issue.mvc/Summary?oidToken=Issue%3A929598)

## Summary

This change allows SC, TIO, and TOO users to modify customer contact info for any move they have access to. Services Counselors were already able to only before they submitted the move. This wasn't the understanding of the task when broken down but was confirmed to be the desire of the PO.

This also added the customer's alternate phone number and all address lines to the Customer Contact Info card on the Move Details page for all office users.

This also addresses I-12710 where a user was unable to submit a blank Alternate Phone number when there had previously been a value. [A null check](https://github.com/transcom/mymove/commit/aeb770f64dd806dc6a9f7aa766cd300b79d8fbb6) was introduced to prevent an error when submitting a blank alternate phone number but the value was persisting when an empty value was submitted. That null check was overwritten in the merge to allow an empty value to be submitted.

## Verification Steps for the Author

These are to be checked by the author.

- [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
- [ ] Have the Agility acceptance criteria been met for this change?

## Verification Steps for Reviewers

These are to be checked by a reviewer.

- [ ] Has the branch been pulled in and checked out?
- [ ] Have the BL acceptance criteria been met for this change?
- [ ] Was the CircleCI build successful?
- [ ] Has the code been reviewed from a standards and best practices point of view?

### Setup to Run the Code

- [Instructions for starting storybook](https://transcom.github.io/mymove-docs/docs/frontend/setup/storybook)
- [Instructions for starting the MilMove application](https://transcom.github.io/mymove-docs/docs/getting-started/application-setup/)
- [Instructions for running tests](https://transcom.github.io/mymove-docs/docs/getting-started/development/testing)

### How to test

1. Access the office app.
2. Login as a Services Counselor
3. Filter your Queue to show moves other than those in need of counseling, select one.
4. Scroll to the bottom of the Move Details page and verify the "Edit customer info" button is available in the Customer Info card.
5. Edit the customer's contact info, ensuring that changes to the alternate phone number and address lines 2 and 3 both persist and are displayed on the custom contact info card on the Move Details page.
6. Log out then log in as a TOO.
7. Select any move available to you and verify you can edit the customer contact info.
8. Log out then log in as a TIO.
9. Select any move available to you, navigate to the move details page, and verify you can edit the customer contact info. 

### Frontend

- [ ] There are no aXe warnings for UI.
- [ ] This works in [Supported Browsers and their phone views](https://transcom.github.io/mymove-docs/docs/adrs/Browser-Support/#minimum-browser-requirements) (Chrome, Firefox, Edge).
- [ ] There are no new console errors in the browser devtools.
- [ ] There are no new console errors in the test output.
- [ ] If this PR adds a new component to Storybook, it ensures the component is fully responsive, OR if it is intentionally not, a wrapping div using the `officeApp` class or custom `min-width` styling is used to hide any states the would not be visible to the user.
- [ ] This change meets the standards for [Section 508 compliance](https://www.ssa.gov/accessibility/andi/help/install.html).

### Backend

- [ ] Code follows the guidelines for [Logging](https://transcom.github.io/mymove-docs/docs/getting-started/development/logging).
- [ ] The requirements listed in [Querying the Database Safely](https://transcom.github.io/mymove-docs/docs/backend/guides/golang-guide#querying-the-database-safely) have been satisfied.

### Database

#### Any new migrations/schema changes:

- [ ] Follows our guidelines for [Zero-Downtime Deploys](https://transcom.github.io/mymove-docs/docs/backend/setup/database-migrations#zero-downtime-migrations).
- [ ] Have been communicated to #g-database.
- [ ] Secure migrations have been tested following the instructions in our [docs](https://transcom.github.io/mymove-docs/docs/backend/setup/database-migrations#secure-migrations).

## Screenshots
<img width="1081" alt="Screenshot 2024-04-01 at 2 38 02 PM" src="https://github.com/transcom/mymove/assets/158500142/e4dce7cb-60d9-46cf-bea1-1cd309f518d0">

<img width="1081" alt="Screenshot 2024-04-01 at 2 37 13 PM" src="https://github.com/transcom/mymove/assets/158500142/6c525f8c-0dcd-4f58-980c-c7e3adbd99fc">
