### PR TITLE
INT-B-19143

### DIFF
--- a/pkg/services/mto_shipment/mto_shipment_updater.go
+++ b/pkg/services/mto_shipment/mto_shipment_updater.go
@@ -564,12 +564,15 @@ func (f *mtoShipmentUpdater) updateShipmentRecord(appCtx appcontext.AppContext, 
 			return apperror.NewInvalidInputError(newShipment.ID, nil, nil, errMessage)
 		}
 
+		weightsCalculator := NewShipmentBillableWeightCalculator()
+		calculatedBillableWeight := weightsCalculator.CalculateShipmentBillableWeight(dbShipment).CalculatedBillableWeight
+
 		// If the max allowable weight for a shipment has been adjusted set a flag to recalculate payment requests for
 		// this shipment
 		runShipmentRecalculate := false
 		if newShipment.BillableWeightCap != nil {
 			// new billable cap has a value and it is not the same as the previous value
-			if dbShipment.BillableWeightCap == nil || *newShipment.BillableWeightCap != *dbShipment.BillableWeightCap {
+			if *newShipment.BillableWeightCap != *calculatedBillableWeight {
 				runShipmentRecalculate = true
 			}
 		} else if dbShipment.BillableWeightCap != nil {


### PR DESCRIPTION
## [Agility ticket](https://www13.v1host.com/USTRANSCOM38/story.mvc/Summary?oidToken=Story%3A922552&RoomContext=TeamRoom%3A848240&concept=TeamRoom)

## Summary

First review of shipment weights won't deprecate payment requests if the weight hasn't changed.

### How to test

1. Create a new move and go through the normal steps until it hits the TIO queue
2. Login as a TIO
3. Click Review Weights -> Review Shipment Weights -> Edit
4. Add a comment but do not modify the weight
5. Save
6. Should not have deprecated the payment request
