### PR TITLE
make error message more descriptive for failure to find county

### DIFF
--- a/pkg/handlers/ghcapi/customer_test.go
+++ b/pkg/handlers/ghcapi/customer_test.go
@@ -138,14 +138,14 @@ func (suite *HandlerSuite) TestCreateCustomerWithOktaOptionHandler() {
 		StreetAddress1: handlers.FmtString("123 New Street"),
 		City:           handlers.FmtString("Newcity"),
 		State:          handlers.FmtString("MA"),
-		PostalCode:     handlers.FmtString("12345"),
+		PostalCode:     handlers.FmtString("02110"),
 	}
 
 	backupAddress := ghcmessages.Address{
 		StreetAddress1: handlers.FmtString("123 Backup Street"),
 		City:           handlers.FmtString("Backupcity"),
 		State:          handlers.FmtString("MA"),
-		PostalCode:     handlers.FmtString("67890"),
+		PostalCode:     handlers.FmtString("02115"),
 	}
 
 	affiliation := ghcmessages.AffiliationARMY

--- a/pkg/models/service_member.go
+++ b/pkg/models/service_member.go
@@ -148,6 +148,7 @@ func SaveServiceMember(appCtx appcontext.AppContext, serviceMember *ServiceMembe
 		if serviceMember.ResidentialAddress != nil {
 			county, err := FindCountyByZipCode(appCtx.DB(), serviceMember.ResidentialAddress.PostalCode)
 			if err != nil {
+				responseError = err
 				return err
 			}
 			serviceMember.ResidentialAddress.County = &county
@@ -162,6 +163,7 @@ func SaveServiceMember(appCtx appcontext.AppContext, serviceMember *ServiceMembe
 		if serviceMember.BackupMailingAddress != nil {
 			county, err := FindCountyByZipCode(appCtx.DB(), serviceMember.BackupMailingAddress.PostalCode)
 			if err != nil {
+				responseError = err
 				return err
 			}
 			serviceMember.BackupMailingAddress.County = &county


### PR DESCRIPTION
## [Integration PR #1](https://github.com/transcom/mymove/pull/12348)

## [Milmove_load_testing PR](https://github.com/transcom/milmove_load_testing/pull/544)

Returns a more descriptive error when running the load tests. The fix for the load testing issue was made in the milmove_load_testing repo, this is just a more informative error returned in the event the load_tests fail in the same spot in the future.