### PR TITLE
I-12742 (issue) B-18855 (story) Unable to submit payment request without adding weight billed - Internal Service Error

### DIFF
--- a/pkg/payment_request/service_param_value_lookups/weight_billed_lookup.go
+++ b/pkg/payment_request/service_param_value_lookups/weight_billed_lookup.go
@@ -60,18 +60,21 @@ func (r WeightBilledLookup) lookup(appCtx appcontext.AppContext, keyData *Servic
 		where sipk.key = 'WeightBilled' and psi.payment_request_id = $1`
 
 		err := appCtx.DB().RawQuery(query, keyData.PaymentRequestID).First(&weightBilled)
+
 		if err != nil && err != sql.ErrNoRows {
 			return "", err
-		} else if len(weightBilled) > 0 {
+		}
+
+		if len(weightBilled) > 0 {
 			return weightBilled, nil
 		} else if keyData.MTOServiceItem.MTOShipment.PPMShipment != nil {
 			if len((string)(*keyData.MTOServiceItem.MTOShipment.BillableWeightCap)) > 0 {
-				weightBilled = (string)(*keyData.MTOServiceItem.MTOShipment.BillableWeightCap)
+				return (string)(*keyData.MTOServiceItem.MTOShipment.BillableWeightCap), nil
 			}
 		}
-		estimatedWeight = keyData.MTOServiceItem.MTOShipment.PrimeEstimatedWeight
+		estimatedWeight = r.MTOShipment.PrimeEstimatedWeight
 
-		originalWeight = keyData.MTOServiceItem.MTOShipment.PrimeActualWeight
+		originalWeight = r.MTOShipment.PrimeActualWeight
 
 		if originalWeight == nil {
 			// TODO: Do we need a different error -- is this a "normal" scenario?


### PR DESCRIPTION
This is for a kickback on original ticket [B-18855](https://www13.v1host.com/USTRANSCOM38/assetdetail.v1?number=B-18855)

## Test steps I took to recreate
1. Use the "HHGMoveInSITEndsToday" option from the Test harness list.
2. Copy the move locator from the JSON object displayed (see Fig1 below)
3. Navigate back to the sign in page for milmove office users
4. Sign in as a Multi-role user under the KKFA GBLOC.
5. Start by clicking the Sign in button for a Prime user.
6. Search for the move by the move locator you copied earlier. Then click on that move in the list.
7. Click the "Create payment request" button.
8. From the list of service items you are able to select from you should see an item called "Domestic origin SIT fuel surcharge". Put a check in the checkbox for that item ("Add to payment request"). Do not enter a Billed Weight at this time.
9. Click the "Submit payment request" button at the bottom of the form.
10. There should be no errors at the top of the page. It should say that the payment request was submitted.

## Fig1
![Screenshot 2024-03-25 at 2 13 29 PM](https://github.com/transcom/mymove/assets/147739091/e18e2206-9755-4d71-9a4a-8e99127cd97b)