### PR TITLE
MAIN B-19187 remove download button from multi move landing page

### DIFF
--- a/src/pages/MyMove/Multi-Moves/MultiMovesMoveContainer/MultiMovesMoveContainer.jsx
+++ b/src/pages/MyMove/Multi-Moves/MultiMovesMoveContainer/MultiMovesMoveContainer.jsx
@@ -17,6 +17,8 @@ import { setMoveId } from 'store/general/actions';
 
 const MultiMovesMoveContainer = ({ moves }) => {
   const [expandedMoves, setExpandedMoves] = useState({});
+  // TODO once work in E-05362 is completed, we can turn this true or just remove it entirely and take out the conditional check in the render
+  const [displayDropdown] = useState(false);
   const navigate = useNavigate();
   const dispatch = useDispatch();
 
@@ -84,14 +86,16 @@ const MultiMovesMoveContainer = ({ moves }) => {
           <h3>#{m.moveCode}</h3>
           {m?.orders?.orders_type === 'BLUEBARK' ? <div className={styles.specialMoves}>BLUEBARK</div> : null}
           <div className={styles.moveContainerButtons} data-testid="headerBtns">
-            <ButtonDropdownMenu
-              data-testid="downloadBtn"
-              title="Download"
-              items={dropdownMenuItems}
-              divClassName={styles.dropdownBtn}
-              onItemClick={handleDropdownItemClick}
-              outline
-            />
+            {displayDropdown ?? (
+              <ButtonDropdownMenu
+                data-testid="downloadBtn"
+                title="Download"
+                items={dropdownMenuItems}
+                divClassName={styles.dropdownBtn}
+                onItemClick={handleDropdownItemClick}
+                outline
+              />
+            )}
             <Button
               data-testid="goToMoveBtn"
               className={styles.goToMoveBtn}

--- a/src/pages/MyMove/Multi-Moves/MultiMovesMoveContainer/MultiMovesMoveContainer.test.jsx
+++ b/src/pages/MyMove/Multi-Moves/MultiMovesMoveContainer/MultiMovesMoveContainer.test.jsx
@@ -33,7 +33,8 @@ describe('MultiMovesMoveContainer', () => {
 
     expect(screen.queryByText('#SAMPLE')).toBeInTheDocument();
     expect(screen.queryByText('#EXAMPL')).toBeInTheDocument();
-    expect(screen.getAllByRole('button', { name: 'Download' })).toHaveLength(2);
+    // TODO commenting this out for now
+    // expect(screen.getAllByRole('button', { name: 'Download' })).toHaveLength(2);
   });
 
   it('expands and collapses moves correctly', () => {
@@ -65,7 +66,8 @@ describe('MultiMovesMoveContainer', () => {
     );
 
     expect(screen.getByTestId('headerBtns')).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Download' })).toBeInTheDocument();
+    // TODO commenting this out for now
+    // expect(screen.getByRole('button', { name: 'Download' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Go to Move' })).toBeInTheDocument();
   });
 
@@ -80,9 +82,10 @@ describe('MultiMovesMoveContainer', () => {
     const headerBtnsElements = screen.getAllByTestId('headerBtns');
     expect(headerBtnsElements).toHaveLength(2);
 
+    // TODO commenting these out for now
     // Check for Download buttons - there should be 2
-    const downloadButtons = screen.getAllByRole('button', { name: 'Download' });
-    expect(downloadButtons).toHaveLength(2);
+    // const downloadButtons = screen.getAllByRole('button', { name: 'Download' });
+    // expect(downloadButtons).toHaveLength(2);
 
     // Check for Go to Move buttons - there should be 2
     const goToMoveButtons = screen.getAllByRole('button', { name: 'Go to Move' });


### PR DESCRIPTION
[INTEGRATION PR](https://github.com/transcom/mymove/pull/12331)

## [Agility ticket](https://www13.v1host.com/USTRANSCOM38/assetdetail.v1?number=B-19187)

## Summary

We have some future work coming that will determine what the dropdown button displays and its functionality, so until then we will hide this sumbuck using `useState`. I didn't want to remove it entirely because it WILL be used in the future so, gonna hide it from render and comment out the checks for it in the tests. Lemon squeezy.

### How to test

1. Access MM as customer
2. Create your desired amount of moves
3. Make sure the download button is no'mo'

## Screenshots
![Screenshot 2024-03-26 at 9 15 07 AM](https://github.com/transcom/mymove/assets/136510600/97ccf28e-d50e-47bb-b502-132117b0c988)
