### PR TITLE
MAIN B-18829 admin UI show requested office user

### DIFF
--- a/pkg/gen/adminapi/adminoperations/requested_office_users/get_requested_office_user.go
+++ b/pkg/gen/adminapi/adminoperations/requested_office_users/get_requested_office_user.go
@@ -34,7 +34,7 @@ func NewGetRequestedOfficeUser(ctx *middleware.Context, handler GetRequestedOffi
 
 # Get a Requested Office User
 
-Retrieving a single office user in any status
+Retrieving a single office user in any status. This endpoint is used in the Admin UI that will allow the admin user to view the user's relevant data.
 */
 type GetRequestedOfficeUser struct {
 	Context *middleware.Context

--- a/pkg/gen/adminapi/adminoperations/requested_office_users/update_requested_office_user.go
+++ b/pkg/gen/adminapi/adminoperations/requested_office_users/update_requested_office_user.go
@@ -34,7 +34,7 @@ func NewUpdateRequestedOfficeUser(ctx *middleware.Context, handler UpdateRequest
 
 # Update a Requested Office User
 
-Updates a requested office user to include profile data and status
+Updates a requested office user to include profile data and status. This will be used in the Admin UI for approving/rejecting/updating a user.
 */
 type UpdateRequestedOfficeUser struct {
 	Context *middleware.Context

--- a/pkg/gen/adminapi/embedded_spec.go
+++ b/pkg/gen/adminapi/embedded_spec.go
@@ -1254,7 +1254,7 @@ func init() {
     },
     "/requested-office-users/{officeUserId}": {
       "get": {
-        "description": "Retrieving a single office user in any status",
+        "description": "Retrieving a single office user in any status. This endpoint is used in the Admin UI that will allow the admin user to view the user's relevant data.",
         "produces": [
           "application/json"
         ],
@@ -1294,7 +1294,7 @@ func init() {
         }
       },
       "patch": {
-        "description": "Updates a requested office user to include profile data and status",
+        "description": "Updates a requested office user to include profile data and status. This will be used in the Admin UI for approving/rejecting/updating a user.",
         "produces": [
           "application/json"
         ],
@@ -4561,7 +4561,7 @@ func init() {
     },
     "/requested-office-users/{officeUserId}": {
       "get": {
-        "description": "Retrieving a single office user in any status",
+        "description": "Retrieving a single office user in any status. This endpoint is used in the Admin UI that will allow the admin user to view the user's relevant data.",
         "produces": [
           "application/json"
         ],
@@ -4601,7 +4601,7 @@ func init() {
         }
       },
       "patch": {
-        "description": "Updates a requested office user to include profile data and status",
+        "description": "Updates a requested office user to include profile data and status. This will be used in the Admin UI for approving/rejecting/updating a user.",
         "produces": [
           "application/json"
         ],

--- a/pkg/handlers/adminapi/api.go
+++ b/pkg/handlers/adminapi/api.go
@@ -52,14 +52,16 @@ func NewAdminAPI(handlerConfig handlers.HandlerConfig) *adminops.MymoveAPI {
 		pagination.NewPagination,
 	}
 
+	userRolesCreator := usersroles.NewUsersRolesCreator()
+	newRolesFetcher := roles.NewRolesFetcher()
+
 	adminAPI.RequestedOfficeUsersGetRequestedOfficeUserHandler = GetRequestedOfficeUserHandler{
 		handlerConfig,
 		requestedofficeusers.NewRequestedOfficeUserFetcher(queryBuilder),
+		newRolesFetcher,
 		query.NewQueryFilter,
 	}
 
-	userRolesCreator := usersroles.NewUsersRolesCreator()
-	newRolesFetcher := roles.NewRolesFetcher()
 	adminAPI.RequestedOfficeUsersUpdateRequestedOfficeUserHandler = UpdateRequestedOfficeUserHandler{
 		handlerConfig,
 		requestedofficeusers.NewRequestedOfficeUserUpdater(queryBuilder),

--- a/pkg/handlers/adminapi/requested_office_users.go
+++ b/pkg/handlers/adminapi/requested_office_users.go
@@ -117,6 +117,7 @@ func (h IndexRequestedOfficeUsersHandler) Handle(params requested_office_users.I
 type GetRequestedOfficeUserHandler struct {
 	handlers.HandlerConfig
 	services.RequestedOfficeUserFetcher
+	services.RoleAssociater
 	services.NewQueryFilter
 }
 
@@ -133,6 +134,14 @@ func (h GetRequestedOfficeUserHandler) Handle(params requested_office_users.GetR
 			if err != nil {
 				return handlers.ResponseForError(appCtx.Logger(), err), err
 			}
+
+			roles, err := h.RoleAssociater.FetchRoles(appCtx, *requestedOfficeUser.UserID)
+			if err != nil {
+				appCtx.Logger().Error("Error fetching user roles", zap.Error(err))
+				return requested_office_users.NewUpdateRequestedOfficeUserInternalServerError(), err
+			}
+
+			requestedOfficeUser.User.Roles = roles
 
 			payload := payloadForRequestedOfficeUserModel(requestedOfficeUser)
 

--- a/pkg/handlers/adminapi/requested_office_users_test.go
+++ b/pkg/handlers/adminapi/requested_office_users_test.go
@@ -59,10 +59,27 @@ func (suite *HandlerSuite) TestGetRequestedOfficeUserHandler() {
 			OfficeUserID: strfmt.UUID(requestedOfficeUser.ID.String()),
 		}
 
+		mockRoleAssociator := &mocks.RoleAssociater{}
+		mockRoles := roles.Roles{
+			roles.Role{
+				ID:        uuid.Must(uuid.NewV4()),
+				RoleType:  roles.RoleTypeTOO,
+				RoleName:  "Transportation Ordering Officer",
+				CreatedAt: time.Now(),
+				UpdatedAt: time.Now(),
+			},
+		}
+		mockRoleAssociator.On(
+			"FetchRoles",
+			mock.AnythingOfType("*appcontext.appContext"),
+			mock.Anything,
+		).Return(mockRoles, nil)
+
 		queryBuilder := query.NewQueryBuilder()
 		handler := GetRequestedOfficeUserHandler{
 			suite.HandlerConfig(),
 			requestedofficeusers.NewRequestedOfficeUserFetcher(queryBuilder),
+			mockRoleAssociator,
 			query.NewQueryFilter,
 		}
 
@@ -84,9 +101,26 @@ func (suite *HandlerSuite) TestGetRequestedOfficeUserHandler() {
 			mock.AnythingOfType("*appcontext.appContext"),
 			mock.Anything,
 		).Return(requestedOfficeUser, nil).Once()
+		mockRoleAssociator := &mocks.RoleAssociater{}
+		mockRoles := roles.Roles{
+			roles.Role{
+				ID:        uuid.Must(uuid.NewV4()),
+				RoleType:  roles.RoleTypeTOO,
+				RoleName:  "Transportation Ordering Officer",
+				CreatedAt: time.Now(),
+				UpdatedAt: time.Now(),
+			},
+		}
+		mockRoleAssociator.On(
+			"FetchRoles",
+			mock.AnythingOfType("*appcontext.appContext"),
+			mock.Anything,
+		).Return(mockRoles, nil)
+
 		handler := GetRequestedOfficeUserHandler{
 			suite.HandlerConfig(),
 			requestedOfficeUserFetcher,
+			mockRoleAssociator,
 			newMockQueryFilterBuilder(&mocks.QueryFilter{}),
 		}
 
@@ -109,9 +143,27 @@ func (suite *HandlerSuite) TestGetRequestedOfficeUserHandler() {
 			mock.AnythingOfType("*appcontext.appContext"),
 			mock.Anything,
 		).Return(models.OfficeUser{}, expectedError).Once()
+
+		mockRoleAssociator := &mocks.RoleAssociater{}
+		mockRoles := roles.Roles{
+			roles.Role{
+				ID:        uuid.Must(uuid.NewV4()),
+				RoleType:  roles.RoleTypeTOO,
+				RoleName:  "Transportation Ordering Officer",
+				CreatedAt: time.Now(),
+				UpdatedAt: time.Now(),
+			},
+		}
+		mockRoleAssociator.On(
+			"FetchRoles",
+			mock.AnythingOfType("*appcontext.appContext"),
+			mock.Anything,
+		).Return(mockRoles, nil)
+
 		handler := GetRequestedOfficeUserHandler{
 			suite.HandlerConfig(),
 			requestedOfficeUserFetcher,
+			mockRoleAssociator,
 			newMockQueryFilterBuilder(&mocks.QueryFilter{}),
 		}
 

--- a/src/pages/Admin/RequestedOfficeUsers/RequestedOfficeUserShow.jsx
+++ b/src/pages/Admin/RequestedOfficeUsers/RequestedOfficeUserShow.jsx
@@ -42,7 +42,7 @@ const RequestedOfficeUserShow = () => {
         <TextField source="middleInitials" />
         <TextField source="lastName" />
         <TextField source="telephone" />
-        <TextField source="edipi" label="DoD Id" />
+        <TextField source="edipi" label="DODID#" />
         <TextField source="otherUniqueId" label="Other unique Id" />
         <RequestedOfficeUserShowRoles />
         <ReferenceField label="Transportation Office" source="transportationOfficeId" reference="offices" sortBy="name">

--- a/src/pages/Admin/RequestedOfficeUsers/RequestedOfficeUserShow.jsx
+++ b/src/pages/Admin/RequestedOfficeUsers/RequestedOfficeUserShow.jsx
@@ -42,7 +42,7 @@ const RequestedOfficeUserShow = () => {
         <TextField source="middleInitials" />
         <TextField source="lastName" />
         <TextField source="telephone" />
-        <TextField source="edipi" label="Edipi / DoD Id" />
+        <TextField source="edipi" label="DoD Id" />
         <TextField source="otherUniqueId" label="Other unique Id" />
         <RequestedOfficeUserShowRoles />
         <ReferenceField label="Transportation Office" source="transportationOfficeId" reference="offices" sortBy="name">

--- a/src/pages/Admin/RequestedOfficeUsers/RequestedOfficeUserShow.jsx
+++ b/src/pages/Admin/RequestedOfficeUsers/RequestedOfficeUserShow.jsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import {
+  ArrayField,
+  Datagrid,
+  DateField,
+  ReferenceField,
+  Show,
+  SimpleShowLayout,
+  TextField,
+  useRecordContext,
+} from 'react-admin';
+
+const RequestedOfficeUserShowTitle = () => {
+  const record = useRecordContext();
+
+  return <span>{`${record?.firstName} ${record?.lastName}`}</span>;
+};
+
+const RequestedOfficeUserShowRoles = () => {
+  const record = useRecordContext();
+  if (!record?.roles) return <p>This user has not requested any roles.</p>;
+
+  return (
+    <ArrayField source="roles">
+      <span>Requested roles:</span>
+      <Datagrid bulkActionButtons={false}>
+        <TextField source="roleName" />
+      </Datagrid>
+    </ArrayField>
+  );
+};
+
+const RequestedOfficeUserShow = () => {
+  return (
+    <Show title={<RequestedOfficeUserShowTitle />}>
+      <SimpleShowLayout>
+        <TextField source="id" />
+        <TextField source="userId" label="User Id" />
+        <TextField source="status" />
+        <TextField source="email" />
+        <TextField source="firstName" />
+        <TextField source="middleInitials" />
+        <TextField source="lastName" />
+        <TextField source="telephone" />
+        <TextField source="edipi" label="Edipi / DoD Id" />
+        <TextField source="otherUniqueId" label="Other unique Id" />
+        <RequestedOfficeUserShowRoles />
+        <ReferenceField label="Transportation Office" source="transportationOfficeId" reference="offices" sortBy="name">
+          <TextField component="pre" source="name" />
+        </ReferenceField>
+        <DateField label="Account requested at" source="createdAt" showTime />
+      </SimpleShowLayout>
+    </Show>
+  );
+};
+
+export default RequestedOfficeUserShow;

--- a/src/scenes/SystemAdmin/Home.jsx
+++ b/src/scenes/SystemAdmin/Home.jsx
@@ -41,6 +41,7 @@ import WebhookSubscriptionList from 'pages/Admin/WebhookSubscriptions/WebhookSub
 import WebhookSubscriptionShow from 'pages/Admin/WebhookSubscriptions/WebhookSubscriptionShow';
 import WebhookSubscriptionCreate from 'pages/Admin/WebhookSubscriptions/WebhookSubscriptionCreate';
 import RequestedOfficeUserList from 'pages/Admin/RequestedOfficeUsers/RequestedOfficeUserList';
+import RequestedOfficeUserShow from 'pages/Admin/RequestedOfficeUsers/RequestedOfficeUserShow';
 
 const httpClient = (url, options = {}) => {
   if (!options.headers) {
@@ -74,6 +75,8 @@ const Home = () => (
         name="requested-office-users"
         options={{ label: 'Requested Office Users' }}
         list={RequestedOfficeUserList}
+        show={RequestedOfficeUserShow}
+        edit={OfficeUserEdit}
       />
       <Resource
         name="office-users"

--- a/swagger-def/admin.yaml
+++ b/swagger-def/admin.yaml
@@ -1240,7 +1240,7 @@ paths:
       produces:
         - application/json
       summary: Get a Requested Office User
-      description: Retrieving a single office user in any status
+      description: Retrieving a single office user in any status. This endpoint is used in the Admin UI that will allow the admin user to view the user's relevant data.
       operationId: getRequestedOfficeUser
       tags:
         - Requested office users
@@ -1267,7 +1267,7 @@ paths:
       produces:
         - application/json
       summary: Update a Requested Office User
-      description: Updates a requested office user to include profile data and status
+      description: Updates a requested office user to include profile data and status. This will be used in the Admin UI for approving/rejecting/updating a user.
       operationId: updateRequestedOfficeUser
       tags:
         - Requested office users

--- a/swagger/admin.yaml
+++ b/swagger/admin.yaml
@@ -43,10 +43,6 @@ tags:
     description: Information about notifications
     externalDocs:
       url: https://transcom.github.io/mymove-docs/docs/api
-  - name: Requested office users
-    description: Information about Requested Office UI users
-    externalDocs:
-      url: https://transcom.github.io/mymove-docs/docs/api
   - name: Transportation offices
     description: Information about transportation offices
     externalDocs:
@@ -1256,7 +1252,7 @@ paths:
       produces:
         - application/json
       summary: Get a Requested Office User
-      description: Retrieving a single office user in any status. This endpoint is used in the Admin UI that will allow the admin user to view the user's relevant data.
+      description: Retrieving a single office user in any status
       operationId: getRequestedOfficeUser
       tags:
         - Requested office users
@@ -1282,10 +1278,8 @@ paths:
     patch:
       produces:
         - application/json
-      consumes:
-        - application/json
       summary: Update a Requested Office User
-      description: Updates a requested office user to include profile data and status. This will be used in the Admin UI for approving/rejecting/updating a user.
+      description: Updates a requested office user to include profile data and status
       operationId: updateRequestedOfficeUser
       tags:
         - Requested office users

--- a/swagger/admin.yaml
+++ b/swagger/admin.yaml
@@ -1252,7 +1252,10 @@ paths:
       produces:
         - application/json
       summary: Get a Requested Office User
-      description: Retrieving a single office user in any status
+      description: >-
+        Retrieving a single office user in any status. This endpoint is used in
+        the Admin UI that will allow the admin user to view the user's relevant
+        data.
       operationId: getRequestedOfficeUser
       tags:
         - Requested office users
@@ -1279,7 +1282,9 @@ paths:
       produces:
         - application/json
       summary: Update a Requested Office User
-      description: Updates a requested office user to include profile data and status
+      description: >-
+        Updates a requested office user to include profile data and status. This
+        will be used in the Admin UI for approving/rejecting/updating a user.
       operationId: updateRequestedOfficeUser
       tags:
         - Requested office users


### PR DESCRIPTION
[INTEGRATION PR](https://github.com/transcom/mymove/pull/12294)

## [Agility ticket](https://www13.v1host.com/USTRANSCOM38/assetdetail.v1?number=B-18829)

## Summary

When requested office users are requesting accounts, admin users will need to be able to see an overview of that user before approving/rejecting/editing (similar to how office users are edited in the admin UI currently).

Since the admin app uses `react-admin`, we simply throw that endpoint in there and add it to the current Requested Office Users resource.

I did make some updates to the backend to allow for passing in the roles in the `GET` request.

Also you'll see there's an `EDIT` button on this page that currently shows the edit form for an approved office user. This will be changed in [B-18832](https://www13.v1host.com/USTRANSCOM38/assetdetail.v1?number=B-18832) to show the relevant edit form for requested office users instead. The way `react-admin` works is that it only shows that edit button if there is an edit parameter in the resource.

### How to test

1. Access MM as an admin
2. Login and you should see a list of requested users
3. If you don't, you'll need to go in the database and change the `status` values of some users in the `office_users` table to `REQUESTED`
4. Once you see those users, click on one and you should see all the relevant information for that user (see screenshot)

## Screenshot
![Screenshot 2024-03-21 at 9 27 51 AM](https://github.com/transcom/mymove/assets/136510600/5a2ee858-ca6b-4466-9aa5-75583a761298)