### PR TITLE
kickback B-18855 multiplier was not taking into account the different service items

### DIFF
--- a/pkg/payment_request/service_param_value_lookups/weight_billed_lookup.go
+++ b/pkg/payment_request/service_param_value_lookups/weight_billed_lookup.go
@@ -58,11 +58,13 @@ func (r WeightBilledLookup) lookup(appCtx appcontext.AppContext, keyData *Servic
 		// Check if a value is in WeightBilled
 		query := `select psip.value from payment_service_item_params psip
 		join payment_service_items psi on psip.payment_service_item_id = psi.id
+		join mto_service_items msi on msi.id = psi.mto_service_item_id
+		join re_services rs on rs.id = msi.re_service_id
 		join payment_requests pr on psi.payment_request_id = pr.id
 		join service_item_param_keys sipk on sipk.id = psip.service_item_param_key_id
-		where sipk.key = 'WeightBilled' and psi.payment_request_id = $1`
+		where sipk.key = 'WeightBilled' and psi.payment_request_id = $1 and rs.code = $2`
 
-		err := appCtx.DB().RawQuery(query, keyData.PaymentRequestID).First(&weightBilled)
+		err := appCtx.DB().RawQuery(query, keyData.PaymentRequestID, keyData.MTOServiceItem.ReService.Code).First(&weightBilled)
 
 		if err != nil && err != sql.ErrNoRows {
 			return "", err


### PR DESCRIPTION
# Agility Story: [B-18855](https://www13.v1host.com/USTRANSCOM38/assetdetail.v1?number=B-18855)

## Test steps I took to recreate
1. Use the "HHGMoveInSITEndsToday" option from the Test harness list.
2. Copy the move locator from the JSON object displayed (see Fig1 below)
3. Navigate back to the sign in page for milmove office users
4. Sign in as a Multi-role user under the KKFA GBLOC.
5. Start by clicking the Sign in button for a Prime user.
6. Search for the move by the move locator you copied earlier. Then click on that move in the list.
7. Click the "Create payment request" button.
8. You will need to create a payment request which contains 1st Day Origin SIT and Domestic origin SIT fuel surcharge service items on it. Make sure you enter between 5001 - 10000 for the Billed weight of the 1st Day Origin SIT and between 10001 - 24000 for the Billed Weight of the Domestic Origin SIT Fuel Surcharge.
9. Click the "Submit payment request" button at the bottom of the form.
10. There should be no errors at the top of the page. It should say that the payment request was submitted.
11. Switch user roles to either the TIO or TOO user and search for the move by the move locator copied from the JSON object earlier.
12. Navigate to the Payment Requests tab.
13. In order to be able to click the Review Payment Requests button you may have to first click the Review Weight button and then navigate back to the Payment Requests tab. Then click the Review Payment Requests button.
14. While viewing the Domestic Origin SIT FSC item, the FSC Multiplier should show as 0.000834.

## Fig1
![Screenshot 2024-03-25 at 2 13 29 PM](https://github.com/transcom/mymove/assets/147739091/e18e2206-9755-4d71-9a4a-8e99127cd97b)