### PR TITLE
MAIN B-18831 admin UI add approve reject buttons and rejection input on overview page

### DIFF
--- a/pkg/gen/adminapi/doc.go
+++ b/pkg/gen/adminapi/doc.go
@@ -8,11 +8,11 @@
 //
 //	Schemes:
 //	  https
-//	Host: admin.move.mil
+//	Host: localhost
 //	BasePath: /admin/v1
 //	Version: 1.0.0
-//	License: MIT https://github.com/transcom/mymove/blob/main/LICENSE.md
-//	Contact: MilMove AppEng<support@movemil.pagerduty.com>
+//	License: MIT https://opensource.org/licenses/MIT
+//	Contact: <milmove-developers@caci.com>
 //
 //	Consumes:
 //	  - application/json

--- a/pkg/gen/adminapi/embedded_spec.go
+++ b/pkg/gen/adminapi/embedded_spec.go
@@ -32,16 +32,14 @@ func init() {
     "description": "The Admin API is a RESTful API that enables the Admin application for MilMove.\n\nAll endpoints are located under ` + "`" + `/admin/v1` + "`" + `.\n",
     "title": "MilMove Admin API",
     "contact": {
-      "name": "MilMove AppEng",
-      "email": "support@movemil.pagerduty.com"
+      "email": "milmove-developers@caci.com"
     },
     "license": {
       "name": "MIT",
-      "url": "https://github.com/transcom/mymove/blob/main/LICENSE.md"
+      "url": "https://opensource.org/licenses/MIT"
     },
     "version": "1.0.0"
   },
-  "host": "admin.move.mil",
   "basePath": "/admin/v1",
   "paths": {
     "/admin-users": {
@@ -3339,16 +3337,14 @@ func init() {
     "description": "The Admin API is a RESTful API that enables the Admin application for MilMove.\n\nAll endpoints are located under ` + "`" + `/admin/v1` + "`" + `.\n",
     "title": "MilMove Admin API",
     "contact": {
-      "name": "MilMove AppEng",
-      "email": "support@movemil.pagerduty.com"
+      "email": "milmove-developers@caci.com"
     },
     "license": {
       "name": "MIT",
-      "url": "https://github.com/transcom/mymove/blob/main/LICENSE.md"
+      "url": "https://opensource.org/licenses/MIT"
     },
     "version": "1.0.0"
   },
-  "host": "admin.move.mil",
   "basePath": "/admin/v1",
   "paths": {
     "/admin-users": {

--- a/src/constants/routes.js
+++ b/src/constants/routes.js
@@ -137,3 +137,7 @@ export const primeSimulatorRoutes = {
   CREATE_SIT_EXTENSION_REQUEST_PATH: `${BASE_PRIME_SIMULATOR_PATH}/shipments/:shipmentId/sit-extension-requests/new`,
   SHIPMENT_UPDATE_DESTINATION_ADDRESS_PATH: `${BASE_PRIME_SIMULATOR_PATH}/shipments/:shipmentId/updateDestinationAddress`,
 };
+
+export const adminRoutes = {
+  HOME_PATH: '/',
+};

--- a/src/pages/Admin/RequestedOfficeUsers/RequestedOfficeUserShow.jsx
+++ b/src/pages/Admin/RequestedOfficeUsers/RequestedOfficeUserShow.jsx
@@ -112,7 +112,7 @@ const RequestedOfficeUserActionButtons = () => {
         </Alert>
       )}
       <div className={styles.rejectionInput}>
-        <Label>Rejection reason (optional)</Label>
+        <Label>Rejection reason (required if rejecting)</Label>
         <TextInput
           label="Rejection reason"
           source="rejectionReason"

--- a/src/pages/Admin/RequestedOfficeUsers/RequestedOfficeUserShow.jsx
+++ b/src/pages/Admin/RequestedOfficeUsers/RequestedOfficeUserShow.jsx
@@ -38,13 +38,19 @@ const RequestedOfficeUserShowRoles = () => {
   );
 };
 
+// renders server and rej reason alerts
+// renders approve/reject/edit buttons
+// handles logic of approving/rejecting user
 const RequestedOfficeUserActionButtons = () => {
-  const [rejectionReason, setRejectionReason] = useState('');
   const [serverError, setServerError] = useState('');
+  const [rejectionReason, setRejectionReason] = useState('');
+  const [rejectionReasonCheck, setRejectionReasonCheck] = useState('');
   const navigate = useNavigate();
   const record = useRecordContext();
 
+  // if approved here, all values are good, but we want to change status to APPROVED
   const approve = async (user) => {
+    setRejectionReasonCheck('');
     const body = {
       edipi: user.edipi,
       firstName: user.firstName,
@@ -66,26 +72,31 @@ const RequestedOfficeUserActionButtons = () => {
       });
   };
 
+  // if rejected here, all values are good, but we want to change status to REJECTED
   const reject = async (user, rejectionReasonInput) => {
-    const body = {
-      edipi: user.edipi,
-      firstName: user.firstName,
-      middleInitials: user.middleInitials,
-      lastName: user.lastName,
-      otherUniqueId: user.otherUniqueId,
-      rejectionReason: rejectionReasonInput,
-      roles: user.roles,
-      status: 'REJECTED',
-      telephone: user.telephone,
-      transportationOfficeId: user.transportationOfficeId,
-    };
-    updateRequestedOfficeUser(record.id, body)
-      .then(() => {
-        navigate(adminRoutes.HOME_PATH);
-      })
-      .catch((error) => {
-        setServerError(error);
-      });
+    if (!rejectionReasonInput || rejectionReasonInput === '') {
+      setRejectionReasonCheck('Please provide a rejection reason.');
+    } else {
+      const body = {
+        edipi: user.edipi,
+        firstName: user.firstName,
+        middleInitials: user.middleInitials,
+        lastName: user.lastName,
+        otherUniqueId: user.otherUniqueId,
+        rejectionReason: rejectionReasonInput,
+        roles: user.roles,
+        status: 'REJECTED',
+        telephone: user.telephone,
+        transportationOfficeId: user.transportationOfficeId,
+      };
+      updateRequestedOfficeUser(record.id, body)
+        .then(() => {
+          navigate(adminRoutes.HOME_PATH);
+        })
+        .catch((error) => {
+          setServerError(error);
+        });
+    }
   };
 
   return (
@@ -95,13 +106,22 @@ const RequestedOfficeUserActionButtons = () => {
           {serverError}
         </Alert>
       )}
+      {rejectionReasonCheck && (
+        <Alert type="error" slim className={styles.error}>
+          {rejectionReasonCheck}
+        </Alert>
+      )}
       <div className={styles.rejectionInput}>
         <Label>Rejection reason (optional)</Label>
         <TextInput
           label="Rejection reason"
           source="rejectionReason"
           value={rejectionReason}
-          onChange={(e) => setRejectionReason(e.target.value)}
+          onChange={(e) => {
+            setRejectionReason(e.target.value);
+            // removing error banner if text is entered
+            setRejectionReasonCheck('');
+          }}
         />
       </div>
       <div className={styles.btnContainer}>
@@ -116,7 +136,7 @@ const RequestedOfficeUserActionButtons = () => {
         <Button
           className={styles.rejectBtn}
           onClick={async () => {
-            await reject(record);
+            await reject(record, rejectionReason);
           }}
         >
           Reject

--- a/src/pages/Admin/RequestedOfficeUsers/RequestedOfficeUserShow.module.scss
+++ b/src/pages/Admin/RequestedOfficeUsers/RequestedOfficeUserShow.module.scss
@@ -2,7 +2,7 @@
 
 .btnContainer {
     display: flex;
-    justify-content: start;
+    justify-content: flex-start;
     align-self: center;
     gap: 10px;
 

--- a/src/pages/Admin/RequestedOfficeUsers/RequestedOfficeUserShow.module.scss
+++ b/src/pages/Admin/RequestedOfficeUsers/RequestedOfficeUserShow.module.scss
@@ -1,0 +1,45 @@
+@import 'shared/styles/colors.scss';
+
+.btnContainer {
+    display: flex;
+    justify-content: start;
+    align-self: center;
+    gap: 10px;
+
+    .approveBtn {
+        width: 125px;
+        margin-left: 15px;
+        background-color: $primary;
+
+        &:active,
+        &:hover,
+        &:focus {
+          background-color:  $primary;
+          opacity: 80%;
+        }
+    }
+
+    .rejectBtn {
+        width: 125px;
+        background-color: $error;
+
+        &:active,
+        &:hover,
+        &:focus {
+          background-color:  $error;
+          opacity: 80%;
+        }
+    }
+}
+
+.rejectionInput {
+  margin-left: 15px;
+  margin-bottom: 10px;
+}
+
+.error {
+  width: auto;
+  background-color: $error;
+  margin-left: 15px;
+  margin-right: 15px;
+}

--- a/src/services/adminApi.js
+++ b/src/services/adminApi.js
@@ -1,0 +1,40 @@
+import Swagger from 'swagger-client';
+
+import { makeSwaggerRequest, requestInterceptor, responseInterceptor, makeSwaggerRequestRaw } from './swaggerRequest';
+
+let adminClient = null;
+
+// setting up the same config from Swagger/api.js
+export async function getAdminClient() {
+  if (!adminClient) {
+    adminClient = await Swagger({
+      url: '/admin/v1/swagger.yaml',
+      requestInterceptor,
+      responseInterceptor,
+    });
+  }
+  return adminClient;
+}
+
+export async function makeAdminRequest(operationPath, params = {}, options = {}) {
+  const client = await getAdminClient();
+  return makeSwaggerRequest(client, operationPath, params, options);
+}
+
+export async function makeAdminRequestRaw(operationPath, params = {}) {
+  const client = await getAdminClient();
+  return makeSwaggerRequestRaw(client, operationPath, params);
+}
+
+export async function updateRequestedOfficeUser(officeUserId, body) {
+  const operationPath = 'Requested office users.updateRequestedOfficeUser';
+
+  return makeAdminRequest(
+    operationPath,
+    {
+      officeUserId,
+      body,
+    },
+    { normalize: false },
+  );
+}

--- a/src/shared/Entities/schema.js
+++ b/src/shared/Entities/schema.js
@@ -194,3 +194,5 @@ export const evaluationReports = new schema.Array(evaluationReport);
 export const searchMove = new schema.Entity('searchMoves');
 export const searchMoves = new schema.Array(searchMove);
 export const searchMovesResult = new schema.Entity('searchMovesResult');
+
+export const officeUser = new schema.Entity('officeUser');

--- a/swagger-def/admin.yaml
+++ b/swagger-def/admin.yaml
@@ -1,19 +1,17 @@
-schemes:
-  - https
-swagger: '2.0'
-host: admin.move.mil # OpenAPI 2.x only supports a single host, while OpenAPI 3.x supports multiple server stanzas.
+swagger: "2.0"
 info:
+  contact:
+    email: milmove-developers@caci.com
   description:
     $ref: info/admin_description.md
-  version: 1.0.0
-  title: MilMove Admin API
   license:
     name: MIT
-    url: https://github.com/transcom/mymove/blob/main/LICENSE.md
-  contact: # Contact is set to Pagerduty
-    name: MilMove AppEng
-    email: support@movemil.pagerduty.com
+    url: "https://opensource.org/licenses/MIT"
+  title: MilMove Admin API
+  version: 1.0.0
 basePath: /admin/v1
+schemes:
+  - https
 consumes:
   - application/json
 produces:

--- a/swagger/admin.yaml
+++ b/swagger/admin.yaml
@@ -1,23 +1,21 @@
-schemes:
-  - https
 swagger: '2.0'
-host: admin.move.mil
 info:
+  contact:
+    email: milmove-developers@caci.com
   description: >
     The Admin API is a RESTful API that enables the Admin application for
     MilMove.
 
 
     All endpoints are located under `/admin/v1`.
-  version: 1.0.0
-  title: MilMove Admin API
   license:
     name: MIT
-    url: https://github.com/transcom/mymove/blob/main/LICENSE.md
-  contact:
-    name: MilMove AppEng
-    email: support@movemil.pagerduty.com
+    url: https://opensource.org/licenses/MIT
+  title: MilMove Admin API
+  version: 1.0.0
 basePath: /admin/v1
+schemes:
+  - https
 consumes:
   - application/json
 produces:


### PR DESCRIPTION
[INTEGRATION PR](https://github.com/transcom/mymove/pull/12302)

## [Agility ticket](https://www13.v1host.com/USTRANSCOM38/assetdetail.v1?number=B-18831)

## Summary

**NOTE** this does contain the branch of INT B-18829 https://github.com/transcom/mymove/pull/12294 in order to get the full flow of things.

When the admin user needs to view the overview of a requested office user, we want them to have some quick & dirty ways to approve/reject users that do not need any changes. 

This PR does the following for the single requested office user overview page:
- adds approve button to overview page
- adds reject button to overview page
- adds rejection reason input to overview page
- adds edit button to overview page
- added `adminApi.js` to allow for calling of the admin API from the UI
- changed swagger information to be more updated and use common format of GHC swagger docs
- added CSS where appropriate
- added `email` to payload to support future work in [B-18828](https://www13.v1host.com/USTRANSCOM38/assetdetail.v1?number=B-18828)

### How to test

1. Access MM as an admin user
2. Navigate to the requested office user list
3. If you do not see any, you'll need to update the status to `REQUESTED` of some rows in the `office_users` table
4. Click on a user
5. You should see the overview page with the added functionality of a rejection reason input and approve/reject buttons
6. When clicking approve, this updates the user to APPROVED status, vice versa for REJECTED button
7. You can provide a rejection reason if needed
8. Following testing, please ensure values update in the database

## Screenshots
![Screenshot 2024-03-21 at 3 28 35 PM](https://github.com/transcom/mymove/assets/136510600/26a55140-ec42-48ac-978e-67e4f802ce4b)

![Screenshot 2024-03-21 at 3 23 14 PM](https://github.com/transcom/mymove/assets/136510600/f6759afd-8e4a-4d94-b1e8-c8d795f597bf)
