### PR TITLE
B-18830-Addition

### DIFF
--- a/src/components/Office/RequestAccountForm/RequestAccountForm.jsx
+++ b/src/components/Office/RequestAccountForm/RequestAccountForm.jsx
@@ -48,7 +48,7 @@ const RequestAccountForm = ({ initialValues, onSubmit, onCancel }) => {
                 onClick={() => handleSubmit()}
                 data-testid="requestOfficeAccountSubmitButton"
               >
-                Request Account
+                Submit
               </Button>
               <Button type="button" onClick={() => onCancel()} data-testid="requestOfficeAccountCancelButton">
                 Cancel

--- a/src/components/form/OfficeAccountRequestFields/OfficeAccountRequestFields.jsx
+++ b/src/components/form/OfficeAccountRequestFields/OfficeAccountRequestFields.jsx
@@ -48,7 +48,7 @@ export const OfficeAccountRequestFields = ({ render }) => {
             data-testid="officeAccountRequestEdipi"
           />
           <TextField
-            label="Other unique identifier"
+            label="Other Unique ID"
             labelHint="If not using DODID#"
             name={otherUniqueIdName}
             id="officeAccountRequestOtherUniqueId"

--- a/src/pages/SignIn/SignIn.jsx
+++ b/src/pages/SignIn/SignIn.jsx
@@ -15,6 +15,7 @@ import Alert from 'shared/Alert';
 import ConnectedEulaModal from 'components/EulaModal';
 import { isDevelopment } from 'shared/constants';
 import { useTitle } from 'hooks/custom';
+import ConnectedFlashMessage from 'containers/FlashMessage/FlashMessage';
 
 const SignIn = ({ context, showLocalDevLogin, showTestharnessList }) => {
   const location = useLocation();
@@ -67,6 +68,8 @@ const SignIn = ({ context, showLocalDevLogin, showTestharnessList }) => {
               </Alert>
             </div>
           )}
+
+          {siteName === 'office.move.mil' && <ConnectedFlashMessage />}
 
           <h1 className="align-center">Welcome to {siteName}!</h1>
           {showLoginWarning && (


### PR DESCRIPTION
[Issue ticket I-12790](https://www13.v1host.com/USTRANSCOM38/Issue.mvc/Summary?oidToken=Issue%3A939399)
[Issue ticket I-12792](https://www13.v1host.com/USTRANSCOM38/Issue.mvc/Summary?oidToken=Issue%3A939746)

## Summary
This is an extension of the fix for the `<ConnectedFlashMessage />` component in src/pages/SignIn/SignIn.jsx. This edit adds the component back to the sign in page BUT it only renders IF office is the site page. This prevent sit from trying to render when the admin page is loaded or any other page where this component is not needed. This also addresses issue I-12792 which was to just change some text.