### PR TITLE
INT B-18987 update diversion msg shipment locator

### DIFF
--- a/playwright/tests/office/txo/tooFlows.spec.js
+++ b/playwright/tests/office/txo/tooFlows.spec.js
@@ -482,7 +482,7 @@ test.describe('TOO user', () => {
 
       // Check the alert message with shipment locator
       const alertText = await page.locator('[data-testid="alert"]').textContent();
-      const shipmentNumberPattern = /^Diversion successfully requested for Shipment #([A-Za-z0-9]{6}-\d{2})$/;
+      const shipmentNumberPattern = /Diversion successfully requested for Shipment #([A-Za-z0-9]{6}-\d{2})/;
       const hasValidShipmentNumber = shipmentNumberPattern.test(alertText);
       expect(hasValidShipmentNumber).toBeTruthy();
 

--- a/playwright/tests/office/txo/tooFlows.spec.js
+++ b/playwright/tests/office/txo/tooFlows.spec.js
@@ -467,6 +467,31 @@ test.describe('TOO user', () => {
       await expect(page.locator('[data-testid="alert"]')).not.toBeVisible();
     });
 
+    test('is able to request diversion for a shipment and receive alert msg', async ({ page }) => {
+      await tooFlowPage.approveAllShipments();
+
+      await page.getByTestId('MoveTaskOrder-Tab').click();
+      expect(page.url()).toContain(`/moves/${tooFlowPage.moveLocator}/mto`);
+
+      // Move Task Order page
+      await expect(page.getByTestId('ShipmentContainer')).toHaveCount(1);
+
+      await page.locator('button').getByText('Request diversion').click();
+
+      await expect(page.locator('.shipment-heading')).toContainText('diversion requested');
+
+      // Check the alert message with shipment locator
+      const alertText = await page.locator('[data-testid="alert"]').textContent();
+      const shipmentNumberPattern = /^Diversion successfully requested for Shipment #([A-Za-z0-9]{6}-\d{2})$/;
+      const hasValidShipmentNumber = shipmentNumberPattern.test(alertText);
+      expect(hasValidShipmentNumber).toBeTruthy();
+
+      // Alert should disappear if focus changes
+      await page.locator('[data-testid="rejectTextButton"]').first().click();
+      await page.locator('[data-testid="closeRejectServiceItem"]').click();
+      await expect(page.locator('[data-testid="alert"]')).not.toBeVisible();
+    });
+
     /**
      * This test is being temporarily skipped until flakiness issues
      * can be resolved. It was skipped in cypress and is not part of

--- a/src/components/Office/ShipmentAddresses/ShipmentAddresses.jsx
+++ b/src/components/Office/ShipmentAddresses/ShipmentAddresses.jsx
@@ -56,7 +56,9 @@ const ShipmentAddresses = ({
                 <Restricted to={permissionTypes.updateMTOPage}>
                   <Button
                     type="button"
-                    onClick={() => handleDivertShipment(shipmentInfo.id, shipmentInfo.eTag)}
+                    onClick={() =>
+                      handleDivertShipment(shipmentInfo.id, shipmentInfo.eTag, shipmentInfo.shipmentLocator)
+                    }
                     unstyled
                   >
                     Request diversion

--- a/src/components/Office/ShipmentAddresses/ShipmentAddresses.test.jsx
+++ b/src/components/Office/ShipmentAddresses/ShipmentAddresses.test.jsx
@@ -39,6 +39,7 @@ const testProps = {
     eTag: 'abc123',
     status: 'APPROVED',
     shipmentType: SHIPMENT_OPTIONS.HHG,
+    shipmentLocator: 'ABCDEF-01',
   },
 };
 
@@ -100,6 +101,7 @@ const cancelledShipment = {
     eTag: 'abc123',
     status: 'CANCELED',
     shipmentType: SHIPMENT_OPTIONS.HHG,
+    shipmentLocator: 'ABCDEF-01',
   },
 };
 
@@ -118,6 +120,7 @@ describe('ShipmentAddresses', () => {
       expect(testProps.handleDivertShipment).toHaveBeenCalledWith(
         testProps.shipmentInfo.id,
         testProps.shipmentInfo.eTag,
+        testProps.shipmentInfo.shipmentLocator,
       );
     });
   });

--- a/src/components/Office/ShipmentDetails/ShipmentDetailsMain.jsx
+++ b/src/components/Office/ShipmentDetails/ShipmentDetailsMain.jsx
@@ -244,6 +244,7 @@ const ShipmentDetailsMain = ({
           eTag: shipment.eTag,
           status: shipment.status,
           shipmentType: shipment.shipmentType,
+          shipmentLocator: shipment.shipmentLocator,
         }}
         handleDivertShipment={handleDivertShipment}
       />

--- a/src/pages/Office/MoveTaskOrder/MoveTaskOrder.jsx
+++ b/src/pages/Office/MoveTaskOrder/MoveTaskOrder.jsx
@@ -521,19 +521,26 @@ export const MoveTaskOrder = (props) => {
   };
 
   /* istanbul ignore next */
-  const handleDivertShipment = (mtoShipmentID, eTag) => {
+  const handleDivertShipment = (mtoShipmentID, eTag, shipmentLocator) => {
     mutateMTOShipmentStatus(
       {
         shipmentID: mtoShipmentID,
         operationPath: 'shipment.requestShipmentDiversion',
         ifMatchETag: eTag,
-        onSuccessFlashMsg: `Diversion successfully requested for Shipment #${mtoShipmentID}`,
+        onSuccessFlashMsg: `Diversion successfully requested for Shipment #${shipmentLocator}`,
+        shipmentLocator,
       },
       {
         onSuccess: (data, variables) => {
           setIsCancelModalVisible(false);
           // Must set FlashMesage after hiding the modal, since FlashMessage will disappear when focus changes
-          setMessage(`MSG_CANCEL_SUCCESS_${variables.shipmentID}`, 'success', variables.onSuccessFlashMsg, '', true);
+          setMessage(
+            `MSG_CANCEL_SUCCESS_${variables.shipmentLocator}`,
+            'success',
+            variables.onSuccessFlashMsg,
+            '',
+            true,
+          );
         },
       },
     );


### PR DESCRIPTION
## [B-18987](https://www13.v1host.com/USTRANSCOM38/assetdetail.v1?number=B-18987)

## Summary

This is to update FE diversion alert message to display the new Shipment Locator instead of Shipment ID.


### How to test

1. Create any move with a shipment that is counseled by SC (can use HHGMoveInSIT testharness).
2. As a TOO, go to the move created.
3. Under 'Move task order' tab, scroll down and find "Request diversion" link/button.
4. Click once and you should see a success alert message at the top with the new Shipment Locator. Note: Going out of focus(clicking anywhere) will review the alert message.

## Screenshots
![image](https://github.com/transcom/mymove/assets/146856854/91f681bf-bdd4-4a84-8e47-3c222ca62bd2)
