### PR TITLE
B-19124-INT weights workflows kickback

### DIFF
--- a/src/components/Office/BillableWeight/EditBillableWeight/EditBillableWeight.jsx
+++ b/src/components/Office/BillableWeight/EditBillableWeight/EditBillableWeight.jsx
@@ -18,7 +18,7 @@ function BillableWeightHintText({
   totalBillableWeight,
   isNTSRShipment,
 }) {
-  const estimatedWeightTimes110 = estimatedWeight * 1.1;
+  const estimatedWeightTimes110 = Math.round(estimatedWeight * 1.1);
 
   const showToFit = billableWeight > maxBillableWeight && billableWeight > estimatedWeightTimes110;
   // the to fit value is the max billable weight minus the total billable weight, excludes the shipment currently in view

--- a/src/pages/Office/MoveTaskOrder/MoveTaskOrder.jsx
+++ b/src/pages/Office/MoveTaskOrder/MoveTaskOrder.jsx
@@ -1065,7 +1065,7 @@ export const MoveTaskOrder = (props) => {
             <WeightDisplay
               heading="Max billable weight"
               weightValue={maxBillableWeight}
-              onEdit={handleShowWeightModal}
+              onEdit={displayMaxBillableWeight(nonPPMShipments) ? handleShowWeightModal : null}
             />
             <WeightDisplay heading="Move weight (total)" weightValue={moveWeightTotal} />
           </div>

--- a/src/pages/Office/MoveTaskOrder/MoveTaskOrder.jsx
+++ b/src/pages/Office/MoveTaskOrder/MoveTaskOrder.jsx
@@ -48,7 +48,11 @@ import LoadingPlaceholder from 'shared/LoadingPlaceholder';
 import SomethingWentWrong from 'shared/SomethingWentWrong';
 import { setFlashMessage } from 'store/flash/actions';
 import WeightDisplay from 'components/Office/WeightDisplay/WeightDisplay';
-import { calculateEstimatedWeight, calculateWeightRequested } from 'hooks/custom';
+import {
+  calculateEstimatedWeight,
+  calculateWeightRequested,
+  includedStatusesForCalculatingWeights,
+} from 'hooks/custom';
 import { SIT_EXTENSION_STATUS } from 'constants/sitExtensions';
 import FinancialReviewButton from 'components/Office/FinancialReviewButton/FinancialReviewButton';
 import FinancialReviewModal from 'components/Office/FinancialReviewModal/FinancialReviewModal';
@@ -842,10 +846,17 @@ export const MoveTaskOrder = (props) => {
   ]);
 
   /* ------------------ Utils ------------------------- */
+  // determine if max billable weight should be displayed yet
+  const displayMaxBillableWeight = (shipments) => {
+    return shipments?.some(
+      (shipment) => includedStatusesForCalculatingWeights(shipment.status) && shipment.primeEstimatedWeight,
+    );
+  };
   // Edge case of diversion shipments being counted twice
   const moveWeightTotal = calculateWeightRequested(nonPPMShipments);
   const ppmWeightTotal = calculateWeightRequested(onlyPPMShipments);
-  const maxBillableWeight = estimatedWeightTotal > 0 ? estimatedWeightTotal * 1.1 : null;
+  const maxBillableWeight = displayMaxBillableWeight(nonPPMShipments) ? order?.entitlement?.authorizedWeight : '-';
+
   /**
    * @function getSitAddressInitialValues
    * @todo ETag and Id need to be removed from response from backend or address fields needs to be in their own object
@@ -857,11 +868,13 @@ export const MoveTaskOrder = (props) => {
   -------------------------  UI -------------------------
   *
   */
+  // this should always be 110% of estimated weight regardless of allowance
+  // or max billable weight
   const estimateWeight110 = (
     <div className={moveTaskOrderStyles.childHeader}>
       <div>110% of estimated weight</div>
       <div className={moveTaskOrderStyles.value}>
-        {Number.isFinite(maxBillableWeight) ? formatWeight(maxBillableWeight) : '—'}
+        {Number.isFinite(estimatedWeightTotal) ? formatWeight(Math.round(estimatedWeightTotal * 1.1)) : '—'}
       </div>
     </div>
   );
@@ -1056,10 +1069,12 @@ export const MoveTaskOrder = (props) => {
             />
             <WeightDisplay heading="Move weight (total)" weightValue={moveWeightTotal} />
           </div>
-          <div className={moveTaskOrderStyles.secondRow} id="move-weights">
-            <WeightDisplay heading="PPM estimated weight (total)" weightValue={estimatedPPMWeightTotal} />
-            <WeightDisplay heading="Actual PPM weight (total)" weightValue={ppmWeightTotal} />
-          </div>
+          {onlyPPMShipments.length > 0 && (
+            <div className={moveTaskOrderStyles.secondRow} id="move-weights">
+              <WeightDisplay heading="PPM estimated weight (total)" weightValue={estimatedPPMWeightTotal} />
+              <WeightDisplay heading="Actual PPM weight (total)" weightValue={ppmWeightTotal} />
+            </div>
+          )}
           {mtoShipments.map((mtoShipment) => {
             if (
               mtoShipment.status !== shipmentStatuses.APPROVED &&

--- a/src/pages/Office/MoveTaskOrder/MoveTaskOrder.test.jsx
+++ b/src/pages/Office/MoveTaskOrder/MoveTaskOrder.test.jsx
@@ -112,7 +112,7 @@ describe('MoveTaskOrder', () => {
       );
 
       const weightSummaries = await screen.findAllByTestId('weight-display');
-      expect(weightSummaries[2]).toHaveTextContent('110 lbs');
+      expect(weightSummaries[2]).toHaveTextContent('8,000 lbs');
     });
 
     it('displays the estimated total weight with all weights not set', async () => {


### PR DESCRIPTION
## [Agility ticket](https://www13.v1host.com/USTRANSCOM38/assetdetail.v1?number=B-19124)
## [Previous PR](https://github.com/transcom/mymove/pull/12380)

## Summary

A couple fixes:
- 110% of estimated weight on Move Task Order screen and in the review weights workflow is now rounded properly
- Moves with no PPM shipments will have a single row of 4 boxes on their Move Task Order screen, and will NOT display the PPM estimated/actual weight boxes
- max billable weight no longer editable when being displayed as '-'

One AC was removed:
- Max billable weight on the move task order screen no longer reflects the 110% of estimated weight amount; that work has been moved to a new story

### How to test

1. Create a move with at least one HHG and no PPMs
2. Approve and submit move as a Services Counselor
3. Approve the move as a TOO, you'll be taken to the MTO screen. Confirm that the max billable weight box is not editable.
4. Login as prime and submit an estimated weight of 1333 lbs for the HHG
5. Login as a TOO and navigate to the Move task order screen. Confirm there is a single row of 4 boxes (no boxes for PPMs) and the 110% estimated weight is properly round (no decimal)

