### PR TITLE
B 19525 i 12786 show original delivery address MAIN

### DIFF
--- a/src/components/Office/ServiceItemDetails/ServiceItemDetails.jsx
+++ b/src/components/Office/ServiceItemDetails/ServiceItemDetails.jsx
@@ -50,7 +50,6 @@ const generateDestinationSITDetailSection = (id, serviceRequestDocUploads, detai
   return (
     <div>
       <dl>
-        {console.log(details)}
         {code === 'DDFSIT'
           ? generateDetailText({
               'Original delivery address': originalDeliveryAddress

--- a/src/components/Office/ServiceItemDetails/ServiceItemDetails.jsx
+++ b/src/components/Office/ServiceItemDetails/ServiceItemDetails.jsx
@@ -50,6 +50,7 @@ const generateDestinationSITDetailSection = (id, serviceRequestDocUploads, detai
   return (
     <div>
       <dl>
+        {console.log(details)}
         {code === 'DDFSIT'
           ? generateDetailText({
               'Original delivery address': originalDeliveryAddress
@@ -79,9 +80,10 @@ const generateDestinationSITDetailSection = (id, serviceRequestDocUploads, detai
                 'Original delivery address': originalDeliveryAddress
                   ? formatCityStateAndPostalCode(originalDeliveryAddress)
                   : '-',
-                'Final delivery address': details.sitDestinationFinalAddress
-                  ? formatCityStateAndPostalCode(details.sitDestinationFinalAddress)
-                  : '-',
+                'Final delivery address':
+                  details.sitDestinationFinalAddress && details.status !== 'SUBMITTED'
+                    ? formatCityStateAndPostalCode(details.sitDestinationFinalAddress)
+                    : '-',
                 'Delivery miles out of SIT': details.sitDeliveryMiles ? details.sitDeliveryMiles : '-',
               },
               id,
@@ -93,9 +95,10 @@ const generateDestinationSITDetailSection = (id, serviceRequestDocUploads, detai
                 'Original delivery address': originalDeliveryAddress
                   ? formatCityStateAndPostalCode(originalDeliveryAddress)
                   : '-',
-                'Final delivery address': details.sitDestinationFinalAddress
-                  ? formatCityStateAndPostalCode(details.sitDestinationFinalAddress)
-                  : '-',
+                'Final delivery address':
+                  details.sitDestinationFinalAddress && details.status !== 'SUBMITTED'
+                    ? formatCityStateAndPostalCode(details.sitDestinationFinalAddress)
+                    : '-',
                 'Delivery miles out of SIT': details.sitDeliveryMiles ? details.sitDeliveryMiles : '-',
                 'Customer contacted homesafe': details.sitCustomerContacted
                   ? formatDateWithUTC(details.sitCustomerContacted, 'DD MMM YYYY')

--- a/src/components/Office/ServiceItemDetails/ServiceItemDetails.jsx
+++ b/src/components/Office/ServiceItemDetails/ServiceItemDetails.jsx
@@ -43,14 +43,17 @@ const generateDestinationSITDetailSection = (id, serviceRequestDocUploads, detai
     sitStatus &&
     sitStatus.currentSIT?.sitAllowanceEndDate &&
     formatDateWithUTC(sitStatus.currentSIT.sitAllowanceEndDate, 'DD MMM YYYY');
+  const originalDeliveryAddress = details.sitDestinationOriginalAddress
+    ? details.sitDestinationOriginalAddress
+    : shipment.destinationAddress;
 
   return (
     <div>
       <dl>
         {code === 'DDFSIT'
           ? generateDetailText({
-              'Original delivery address': details.sitDestinationOriginalAddress
-                ? formatCityStateAndPostalCode(details.sitDestinationOriginalAddress)
+              'Original delivery address': originalDeliveryAddress
+                ? formatCityStateAndPostalCode(originalDeliveryAddress)
                 : '-',
               'SIT entry date': details.sitEntryDate ? formatDateWithUTC(details.sitEntryDate, 'DD MMM YYYY') : '-',
             })
@@ -58,8 +61,8 @@ const generateDestinationSITDetailSection = (id, serviceRequestDocUploads, detai
         {code === 'DDASIT'
           ? generateDetailText(
               {
-                'Original delivery address': details.sitDestinationOriginalAddress
-                  ? formatCityStateAndPostalCode(details.sitDestinationOriginalAddress)
+                'Original delivery address': originalDeliveryAddress
+                  ? formatCityStateAndPostalCode(originalDeliveryAddress)
                   : '-',
                 "Add'l SIT Start Date": details.sitEntryDate
                   ? moment.utc(details.sitEntryDate).add(1, 'days').format('DD MMM YYYY')
@@ -73,8 +76,8 @@ const generateDestinationSITDetailSection = (id, serviceRequestDocUploads, detai
         {code === 'DDSFSC'
           ? generateDetailText(
               {
-                'Original delivery address': details.sitDestinationOriginalAddress
-                  ? formatCityStateAndPostalCode(details.sitDestinationOriginalAddress)
+                'Original delivery address': originalDeliveryAddress
+                  ? formatCityStateAndPostalCode(originalDeliveryAddress)
                   : '-',
                 'Final delivery address': details.sitDestinationFinalAddress
                   ? formatCityStateAndPostalCode(details.sitDestinationFinalAddress)
@@ -87,8 +90,8 @@ const generateDestinationSITDetailSection = (id, serviceRequestDocUploads, detai
         {code === 'DDDSIT'
           ? generateDetailText(
               {
-                'Original delivery address': details.sitDestinationOriginalAddress
-                  ? formatCityStateAndPostalCode(details.sitDestinationOriginalAddress)
+                'Original delivery address': originalDeliveryAddress
+                  ? formatCityStateAndPostalCode(originalDeliveryAddress)
                   : '-',
                 'Final delivery address': details.sitDestinationFinalAddress
                   ? formatCityStateAndPostalCode(details.sitDestinationFinalAddress)

--- a/src/components/Office/ServiceItemDetails/ServiceItemDetails.test.jsx
+++ b/src/components/Office/ServiceItemDetails/ServiceItemDetails.test.jsx
@@ -64,6 +64,58 @@ const details = {
   },
 };
 
+const submittedServiceItemDetails = {
+  description: 'some description',
+  pickupPostalCode: '90210',
+  SITPostalCode: '12345',
+  sitEntryDate: '2024-03-11T00:00:00.000Z',
+  reason: 'some reason',
+  itemDimensions: { length: 1000, width: 2500, height: 3000 },
+  crateDimensions: { length: 2000, width: 3500, height: 4000 },
+  customerContacts: [
+    { timeMilitary: '1200Z', firstAvailableDeliveryDate: '2020-09-15', dateOfContact: '2020-09-15' },
+    { timeMilitary: '2300Z', firstAvailableDeliveryDate: '2020-09-21', dateOfContact: '2020-09-21' },
+  ],
+  estimatedWeight: 2500,
+  sitCustomerContacted: '2024-03-14T00:00:00.000Z',
+  sitRequestedDelivery: '2024-03-15T00:00:00.000Z',
+  sitDepartureDate: '2024-03-16T00:00:00.000Z',
+  sitDeliveryMiles: 50,
+  sitOriginHHGOriginalAddress: {
+    city: 'Origin Original Tampa',
+    eTag: 'MjAyNC0wMy0xMlQxOTo1OTowOC41NjkxMzla',
+    id: '7fd6cb90-54cd-44d8-8735-102e28734d84',
+    postalCode: '33621',
+    state: 'FL',
+    streetAddress1: 'MacDill',
+  },
+  sitOriginHHGActualAddress: {
+    city: 'Origin Actual MacDill',
+    eTag: 'HjAyNC0wMy0xMlQxOTo1OTowOC41NjkxMzla',
+    id: '8fd6cb90-54cd-44d8-8735-102e28734d84',
+    postalCode: '33621',
+    state: 'FL',
+    streetAddress1: 'MacDill',
+  },
+  sitDestinationOriginalAddress: {
+    city: 'Destination Original Tampa',
+    eTag: 'MjAyNC0wMy0xMlQxOTo1OTowOC41NjkxMzla',
+    id: '7fd6cb90-54cd-44d8-8735-102e28734d84',
+    postalCode: '33621',
+    state: 'FL',
+    streetAddress1: 'MacDill',
+  },
+  sitDestinationFinalAddress: {
+    city: 'Destination Final MacDill',
+    eTag: 'HjAyNC0wMy0xMlQxOTo1OTowOC41NjkxMzla',
+    id: '8fd6cb90-54cd-44d8-8735-102e28734d84',
+    postalCode: '33621',
+    state: 'FL',
+    streetAddress1: 'MacDill',
+  },
+  status: 'SUBMITTED',
+};
+
 const serviceRequestDocs = [
   {
     uploads: [
@@ -134,6 +186,19 @@ describe('ServiceItemDetails Domestic Destination SIT', () => {
     expect(screen.getByText('SIT departure date:')).toBeInTheDocument();
     expect(screen.getByText('16 Mar 2024')).toBeInTheDocument();
   });
+  it('renders DDDSIT details with - for the final delivery address is service item is in submitted state', () => {
+    render(
+      <ServiceItemDetails
+        id="1"
+        code="DDDSIT"
+        details={submittedServiceItemDetails}
+        serviceRequestDocs={serviceRequestDocs}
+      />,
+    );
+
+    expect(screen.getByText('Final delivery address:')).toBeInTheDocument();
+    expect(screen.getByText('-')).toBeInTheDocument();
+  });
   it('renders DDFSIT details', () => {
     render(<ServiceItemDetails id="1" code="DDFSIT" details={details} serviceRequestDocs={serviceRequestDocs} />);
     expect(screen.getByText('Original delivery address:')).toBeInTheDocument();
@@ -149,6 +214,19 @@ describe('ServiceItemDetails Domestic Destination SIT', () => {
 
     expect(screen.getByText('Delivery miles out of SIT:')).toBeInTheDocument();
     expect(screen.getByText('50')).toBeInTheDocument();
+  });
+  it('renders DDSFSC details with - for the final delivery address is service item is in submitted state', () => {
+    render(
+      <ServiceItemDetails
+        id="1"
+        code="DDSFSC"
+        details={submittedServiceItemDetails}
+        serviceRequestDocs={serviceRequestDocs}
+      />,
+    );
+
+    expect(screen.getByText('Final delivery address:')).toBeInTheDocument();
+    expect(screen.getByText('-')).toBeInTheDocument();
   });
 });
 

--- a/src/pages/Office/MoveTaskOrder/MoveTaskOrder.jsx
+++ b/src/pages/Office/MoveTaskOrder/MoveTaskOrder.jsx
@@ -159,6 +159,7 @@ export const MoveTaskOrder = (props) => {
         sitCustomerContacted: item.sitCustomerContacted,
         sitRequestedDelivery: item.sitRequestedDelivery,
         sitDeliveryMiles: item.sitDeliveryMiles,
+        status: item.status,
       };
 
       if (serviceItemsForShipment[`${newItem.mtoShipmentID}`]) {

--- a/src/types/serviceItems.js
+++ b/src/types/serviceItems.js
@@ -54,6 +54,7 @@ export const ServiceItemDetailsShape = PropTypes.shape({
     crateDimensions: MTOServiceItemDimensionShape,
     customerContacts: PropTypes.arrayOf(MTOServiceItemCustomerContactShape),
     estimatedWeight: PropTypes.number,
+    status: PropTypes.string,
   }),
   sitAddressUpdates: PropTypes.arrayOf(SitAddressUpdatesShape),
 });


### PR DESCRIPTION
## [Integration PR](https://github.com/transcom/mymove/pull/12494)

## [Agility ticket](https://www13.v1host.com/USTRANSCOM38/assetdetail.v1?number=B-19525)
## [I-12786](https://www13.v1host.com/USTRANSCOM38/issue.mvc/summary?oidToken=Issue%3A938897)

At the time SIT is requested, we still treat it as a non-SIT (direct delivery) shipment. We only store the original delivery/destination address at the service item level when the service item is APPROVED. This story was to show an address on that field while the service item is only requested.

Added a ternary to conditionally show either the shipment destination address (while SIT is only requested) and then after it's approved, show the service item value for the sitDestinationOriginalAddress which will be populated on SIT approval.

Also added a conditional to not show a value for the Final delivery address while the service item is in the requested state.

1. Request destination SIT on a shipment as prime.
2. As TOO, view the dest SIT service items in the requested state.
3. Verify that you see an address rather than `-` for the `Original delivery address` fields.
![image](https://github.com/transcom/mymove/assets/147537467/d7fd74d8-9275-44d0-bd08-80581400a4d8)
4. Verify you see `-` instead of address for the `Final delivery address` fields.
![image](https://github.com/transcom/mymove/assets/147537467/bcf46a5e-d4d1-4559-b142-d42068bcfe42)
5. Approve all of the destination SIT service items.
6. Verify that for the Domestic destination SIT delivery and Domestic destination SIT fuel surcharge, you now see the `Final delivery address` field populated with an address value.
![image](https://github.com/transcom/mymove/assets/147537467/1ef8678b-5053-4fdf-bbf4-5694260eea2a)