### PR TITLE
MAIN B-19458 add linehaul service item order to service item list

### DIFF
--- a/src/components/Office/ServiceItemsTable/ServiceItemsTable.jsx
+++ b/src/components/Office/ServiceItemsTable/ServiceItemsTable.jsx
@@ -21,8 +21,19 @@ import ToolTip from 'shared/ToolTip/ToolTip';
 import { ShipmentShape } from 'types';
 
 // Sorts service items in an order preferred by the customer
-// Currently only SIT receives special sorting
+// Currently only SIT & linehauls receives special sorting
+// this current listed order goes:
+// linehaul
+// other service items
+// origin SIT
+// destination SIT
 function sortServiceItems(items) {
+  // Prioritize service items with codes 'DSH' (shorthaul) and 'DLH' (linehaul) to be at the top of the list
+  const linehaulServiceItemCodes = ['DSH', 'DLH'];
+  const linehaulServiceItems = items.filter((item) => linehaulServiceItemCodes.includes(item.code));
+  const sortedLinehaulServiceItems = linehaulServiceItems.sort(
+    (a, b) => linehaulServiceItemCodes.indexOf(a.code) - linehaulServiceItemCodes.indexOf(b.code),
+  );
   // Filter and sort destination SIT. Code index is also the sort order
   const destinationServiceItemCodes = ['DDFSIT', 'DDASIT', 'DDDSIT', 'DDSFSC'];
   const destinationServiceItems = items.filter((item) => destinationServiceItemCodes.includes(item.code));
@@ -38,10 +49,18 @@ function sortServiceItems(items) {
 
   // Filter all service items that are not specifically sorted
   const remainingServiceItems = items.filter(
-    (item) => !destinationServiceItemCodes.includes(item.code) && !originServiceItemCodes.includes(item.code),
+    (item) =>
+      !linehaulServiceItemCodes.includes(item.code) &&
+      !destinationServiceItemCodes.includes(item.code) &&
+      !originServiceItemCodes.includes(item.code),
   );
 
-  return [...remainingServiceItems, ...sortedOriginServiceItems, ...sortedDestinationServiceItems];
+  return [
+    ...sortedLinehaulServiceItems,
+    ...remainingServiceItems,
+    ...sortedOriginServiceItems,
+    ...sortedDestinationServiceItems,
+  ];
 }
 
 const ServiceItemsTable = ({

--- a/src/components/Office/ServiceItemsTable/ServiceItemsTable.jsx
+++ b/src/components/Office/ServiceItemsTable/ServiceItemsTable.jsx
@@ -21,9 +21,9 @@ import ToolTip from 'shared/ToolTip/ToolTip';
 import { ShipmentShape } from 'types';
 
 // Sorts service items in an order preferred by the customer
-// Currently only SIT & linehauls receives special sorting
+// Currently only SIT & shorthaul/linehaul receives special sorting
 // this current listed order goes:
-// linehaul
+// shorthaul & linehaul
 // other service items
 // origin SIT
 // destination SIT

--- a/src/components/Office/ServiceItemsTable/ServiceItemsTable.jsx
+++ b/src/components/Office/ServiceItemsTable/ServiceItemsTable.jsx
@@ -29,10 +29,10 @@ import { ShipmentShape } from 'types';
 // destination SIT
 function sortServiceItems(items) {
   // Prioritize service items with codes 'DSH' (shorthaul) and 'DLH' (linehaul) to be at the top of the list
-  const linehaulServiceItemCodes = ['DSH', 'DLH'];
-  const linehaulServiceItems = items.filter((item) => linehaulServiceItemCodes.includes(item.code));
-  const sortedLinehaulServiceItems = linehaulServiceItems.sort(
-    (a, b) => linehaulServiceItemCodes.indexOf(a.code) - linehaulServiceItemCodes.indexOf(b.code),
+  const haulTypeServiceItemCodes = ['DSH', 'DLH'];
+  const haulTypeServiceItems = items.filter((item) => haulTypeServiceItemCodes.includes(item.code));
+  const sortedHaulTypeServiceItems = haulTypeServiceItems.sort(
+    (a, b) => haulTypeServiceItemCodes.indexOf(a.code) - haulTypeServiceItemCodes.indexOf(b.code),
   );
   // Filter and sort destination SIT. Code index is also the sort order
   const destinationServiceItemCodes = ['DDFSIT', 'DDASIT', 'DDDSIT', 'DDSFSC'];
@@ -50,13 +50,13 @@ function sortServiceItems(items) {
   // Filter all service items that are not specifically sorted
   const remainingServiceItems = items.filter(
     (item) =>
-      !linehaulServiceItemCodes.includes(item.code) &&
+      !haulTypeServiceItemCodes.includes(item.code) &&
       !destinationServiceItemCodes.includes(item.code) &&
       !originServiceItemCodes.includes(item.code),
   );
 
   return [
-    ...sortedLinehaulServiceItems,
+    ...sortedHaulTypeServiceItems,
     ...remainingServiceItems,
     ...sortedOriginServiceItems,
     ...sortedDestinationServiceItems,


### PR DESCRIPTION
[INTEGRATION PR](https://github.com/transcom/mymove/pull/12399)

## [Agility ticket](tbd)

## Summary

Need to ensure that when a linehaul item is auto rejected & a new one created, we keep it in the same position of the list. Followed what is being done for SIT items and placing the linehaul service items (`DLH` & `DSH`) above those in the list. Lemon squeezy.

### How to test

1. Create a **LOCAL** move as a customer, set up your shipments using different ZIPs, and send it
2. Login as the service counselor and approve all of that bidness
3. Login as the TOO and approve the shipment, head over to the MTO page and you'll see a linehaul service item at the top
4. Login as the prime and request the dest address be changed to a ZIP further than 50 miles
5. Login as the TOO and approve the change as TOO
6. Navigate to the MTO page and you should see the linehaul item rejected at the bottom and the new one essentially "replaces" it at the top of the list

## Screenshots
![Screenshot 2024-04-03 at 2 45 41 PM](https://github.com/transcom/mymove/assets/136510600/d7f688ec-28d0-42d7-8fe6-945059089a7b)

