### PR TITLE
B 18270 int

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1263,7 +1263,7 @@ jobs:
             #
             # The trailing hyphen in restore_cache seems important
             # according to the page linked above
-            - v16-spectral-lint-
+            - v17-spectral-lint-
       - run:
           name: Save Baseline Spectral Lint
           command: |
@@ -1322,7 +1322,7 @@ jobs:
             # Use the BuildNum to update the cache key so that the
             # coverage cache is always updated
             - save_cache:
-                key: v16-spectral-lint-{{ .BuildNum }}
+                key: v17-spectral-lint-{{ .BuildNum }}
                 paths:
                   - ~/transcom/mymove/spectral
       - store_artifacts:

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN apt-get install -y ca-certificates --no-install-recommends
 RUN update-ca-certificates
 
 # hadolint ignore=DL3007
-FROM gcr.io/distroless/base:latest
+FROM gcr.io/distroless/base:latest@sha256:9bc3117a99c731a41200a28774405125cb6fbda1819f4a1af88bd3bfad5dcf32
 COPY --from=build-env /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 
 COPY bin/rds-ca-rsa4096-g1.pem /bin/rds-ca-rsa4096-g1.pem

--- a/Dockerfile.dp3
+++ b/Dockerfile.dp3
@@ -1,5 +1,5 @@
 # hadolint ignore=DL3007
-FROM gcr.io/distroless/base:latest
+FROM gcr.io/distroless/base:latest@sha256:9bc3117a99c731a41200a28774405125cb6fbda1819f4a1af88bd3bfad5dcf32
 
 #AWS GovCloud RDS cert
 COPY bin/rds-ca-rsa4096-g1.pem /bin/rds-ca-rsa4096-g1.pem

--- a/Dockerfile.local
+++ b/Dockerfile.local
@@ -20,7 +20,7 @@ RUN rm -f bin/milmove && make bin/milmove
 #########
 
 # hadolint ignore=DL3007
-FROM gcr.io/distroless/base:latest
+FROM gcr.io/distroless/base:latest@sha256:9bc3117a99c731a41200a28774405125cb6fbda1819f4a1af88bd3bfad5dcf32
 
 COPY --from=builder --chown=root:root /home/circleci/project/bin/rds-ca-rsa4096-g1.pem /bin/rds-ca-rsa4096-g1.pem
 COPY --from=builder --chown=root:root /home/circleci/project/bin/rds-ca-2019-root.pem /bin/rds-ca-2019-root.pem

--- a/Dockerfile.reviewapp
+++ b/Dockerfile.reviewapp
@@ -106,7 +106,7 @@ RUN set -x \
 #########
 
 # hadolint ignore=DL3007
-FROM gcr.io/distroless/base:latest as milmove
+FROM gcr.io/distroless/base:latest@sha256:9bc3117a99c731a41200a28774405125cb6fbda1819f4a1af88bd3bfad5dcf32 as milmove
 
 COPY --from=server_builder /build/bin/rds-ca-2019-root.pem /bin/rds-ca-2019-root.pem
 COPY --from=server_builder /build/bin/milmove /bin/milmove

--- a/Dockerfile.tasks
+++ b/Dockerfile.tasks
@@ -8,7 +8,7 @@ RUN apt-get install -y ca-certificates --no-install-recommends
 RUN update-ca-certificates
 
 # hadolint ignore=DL3007
-FROM gcr.io/distroless/base:latest
+FROM gcr.io/distroless/base:latest@sha256:9bc3117a99c731a41200a28774405125cb6fbda1819f4a1af88bd3bfad5dcf32
 COPY --from=build-env /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 
 COPY config/tls/milmove-cert-bundle.p7b /config/tls/milmove-cert-bundle.p7b

--- a/Dockerfile.tasks_dp3
+++ b/Dockerfile.tasks_dp3
@@ -1,5 +1,5 @@
 # hadolint ignore=DL3007
-FROM gcr.io/distroless/base:latest
+FROM gcr.io/distroless/base:latest@sha256:9bc3117a99c731a41200a28774405125cb6fbda1819f4a1af88bd3bfad5dcf32
 
 # Demo Environment Certs
 COPY config/tls/api.demo.dp3.us.chain.der.p7b /config/tls/api.demo.dp3.us.chain.der.p7b

--- a/Dockerfile.tasks_local
+++ b/Dockerfile.tasks_local
@@ -19,7 +19,7 @@ RUN rm -f bin/milmove-tasks && make bin/milmove-tasks
 #########
 
 # hadolint ignore=DL3007
-FROM gcr.io/distroless/base:latest
+FROM gcr.io/distroless/base:latest@sha256:9bc3117a99c731a41200a28774405125cb6fbda1819f4a1af88bd3bfad5dcf32
 
 COPY --from=builder --chown=root:root /home/circleci/project/config/tls/milmove-cert-bundle.p7b /config/tls/milmove-cert-bundle.p7b
 COPY --from=builder --chown=root:root /home/circleci/project/bin/rds-ca-2019-root.pem /bin/rds-ca-2019-root.pem

--- a/pkg/services/weight_ticket_parser/weight_ticket_parser.go
+++ b/pkg/services/weight_ticket_parser/weight_ticket_parser.go
@@ -282,7 +282,7 @@ func (WeightTicketComputer *WeightTicketComputer) ParseWeightEstimatorExcelFile(
 	pagesStructs := []reflect.Value{page1Reflect, page2Reflect, page3Reflect, page4Reflect, page5Reflect, page6Reflect, page7Reflect, page8Reflect, page9Reflect, page10Reflect, page11Reflect}
 
 	// Loop through each row of the .xlsx file and read each cell. It is worth noting that excelize will skip reading any rows that are
-	// completely blank and will end a reading columns in that row when it encounters the last column to have data in it. We take this
+	// completely blank and will end reading columns in that row when it encounters the last column to have data in it. We take this
 	// into consideration when we are parsing the Weight Estimator .xlsx file.
 	for _, row := range rows {
 		currentCellCount := 1

--- a/src/components/Customer/PPM/Closeout/WeightTicketUpload/WeightTicketUpload.jsx
+++ b/src/components/Customer/PPM/Closeout/WeightTicketUpload/WeightTicketUpload.jsx
@@ -8,6 +8,7 @@ import Hint from 'components/Hint';
 import FileUpload from 'components/FileUpload/FileUpload';
 import UploadsTable from 'components/UploadsTable/UploadsTable';
 import {
+  DocumentAndImageUploadInstructions,
   SpreadsheetUploadInstructions,
   UploadDropZoneLabel,
   UploadDropZoneLabelMobile,

--- a/src/components/Customer/PPM/Closeout/WeightTicketUpload/WeightTicketUpload.jsx
+++ b/src/components/Customer/PPM/Closeout/WeightTicketUpload/WeightTicketUpload.jsx
@@ -8,7 +8,6 @@ import Hint from 'components/Hint';
 import FileUpload from 'components/FileUpload/FileUpload';
 import UploadsTable from 'components/UploadsTable/UploadsTable';
 import {
-  WeightTicketUploadInstructions,
   SpreadsheetUploadInstructions,
   UploadDropZoneLabel,
   UploadDropZoneLabelMobile,
@@ -94,7 +93,7 @@ const WeightTicketUpload = ({
   const weightTicketUploadHint = () => {
     return missingWeightTicket && !weightTicketRentalAgreement
       ? SpreadsheetUploadInstructions
-      : WeightTicketUploadInstructions;
+      : DocumentAndImageUploadInstructions;
   };
 
   return (

--- a/src/content/uploads.js
+++ b/src/content/uploads.js
@@ -6,5 +6,3 @@ export const SpreadsheetUploadInstructions = 'XLS or XLSX only. Maximum file siz
 export const UploadDropZoneLabel = 'Drag files here or <span class="filepond--label-action">choose from folder</span>';
 
 export const UploadDropZoneLabelMobile = '<span class="filepond--label-action">Upload files</span>';
-
-export const WeightTicketUploadInstructions = 'Maximum file size 25 MB. Each page must be clear and legible.';


### PR DESCRIPTION
## [B-18270](https://www13.v1host.com/USTRANSCOM38/story.mvc/Summary?oidToken=Story%3A873141)

## Summary

** This specific PR is to revert instruction text back to the original text that states the file types accepted.

When Customers don't have a weight receipt to upload they can use the official Weight Estimator excel spreadsheet as their upload for the weight receipt. We need this spreadsheet to be a part of the payment packet which is made up of PDF files. We use the Excelize library to parse the massive Weight Estimator .xlsx file and then convert the parsed data to JSON and use that to populate the newly created Weight Estimator PDF template file so we can then finally add it to the payment packet when it is generated. 

Is there anything you would like reviewers to give additional scrutiny?

Don't forget to review the weightTicketParser files, they are new files and have a lot of changes so github doesn't expand them automatically.

## Verification Steps for the Author

These are to be checked by the author.

- [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
- [ ] Have the Agility acceptance criteria been met for this change?

## Verification Steps for Reviewers

These are to be checked by a reviewer.

- [ ] Has the branch been pulled in and checked out?
- [ ] Have the BL acceptance criteria been met for this change?
- [ ] Was the CircleCI build successful?
- [ ] Has the code been reviewed from a standards and best practices point of view?

### Setup to Run the Code

- [Instructions for starting storybook](https://transcom.github.io/mymove-docs/docs/frontend/setup/storybook)
- [Instructions for starting the MilMove application](https://transcom.github.io/mymove-docs/docs/getting-started/application-setup/)
- [Instructions for running tests](https://transcom.github.io/mymove-docs/docs/getting-started/development/testing)

### How to test

To test this you will need to upload a Weight Estimator spreadsheet with data in it. You can use this one which is the same one that was put into the testdata folder and the tests will use.
[Weight Estimator Full.xlsx](https://github.com/transcom/mymove/files/14935713/Weight.Estimator.Full.xlsx)
Alternatively you can go grab a blank copy of the [Weight Estimator spreadsheet](https://www.ustranscom.mil/dp3/weightestimator.cfm) tool and fill it out and upload that. 

NOTE: Please also test that other non Weight Estimator files upload successfully. Try uploading some of these extensions .xls, .pdf, .jpg, and .xlsx that isn't the Weight Estimator template.

1. Login as a new Customer and create a new PPM shipment and submit it
2. Login as Service Counselor and approve the shipment
3. Login as a Customer and click the Upload PPM Documents button
4. Fill out the data until you get to the Upload section for Weight Tickets
5. Upload your Weight Estimator spreadsheet for either the Empty Weight or Full Weight tickets.
6. The file should be parsed successfully and you will see your filename with a .pdf extension displayed in the upload section. 
7. Now to generate a Payment Packet to verify the data was parsed correctly.
8. Easiest way is to grab the PPM shipment ID, right click in Chrome and Inspect, go to Network tab, refresh the screen if Network tab is empty, then find mto_shipments click on it, then look for ppm_shipment and expand that and copy the "id"
9. Go to the internal [API swagger page] (http://milmovelocal:3000/swagger-ui/internal.html)
10. Find the payment-packet endpoint ![image](https://github.com/transcom/mymove/assets/149000222/b4322987-7dd8-44ed-af4a-efa325a6e4e2)
11. Click the Try It Out button and then enter your PPM Shipment ID and click Execute
12. You should get a 200 response and a message about not being able to read the data, that is expected.
13. Copy the URL you are given below the curl statement, if it won't let you copy it right away give it a few seconds to finish trying to parse the response data then try to copy the link again.
14. Open that link in the browser and you should see a Payment Packet, look for the Weight Ticket pages and compare the data to the data in your uploaded .xlsx file

### Frontend

- [ ] There are no aXe warnings for UI.
- [ ] This works in [Supported Browsers and their phone views](https://transcom.github.io/mymove-docs/docs/adrs/Browser-Support/#minimum-browser-requirements) (Chrome, Firefox, Edge).
- [ ] There are no new console errors in the browser devtools.
- [ ] There are no new console errors in the test output.
- [ ] If this PR adds a new component to Storybook, it ensures the component is fully responsive, OR if it is intentionally not, a wrapping div using the `officeApp` class or custom `min-width` styling is used to hide any states the would not be visible to the user.
- [ ] This change meets the standards for [Section 
508 compliance](https://www.ssa.gov/accessibility/andi/help/install.html).

### Backend

- [ ] Code follows the guidelines for [Logging](https://transcom.github.io/mymove-docs/docs/getting-started/development/logging).
- [ ] The requirements listed in [Querying the Database Safely](https://transcom.github.io/mymove-docs/docs/backend/guides/golang-guide#querying-the-database-safely) have been satisfied.

## Screenshots
![image](https://github.com/transcom/mymove/assets/149000222/f30d1857-ad40-4699-875a-8d5fcc6fbf2e)
