### PR TITLE
Duplicate key fix int

### DIFF
--- a/migrations/app/schema/20240410154749_add_safety_privilege.up.sql
+++ b/migrations/app/schema/20240410154749_add_safety_privilege.up.sql
@@ -1,1 +1,1 @@
-INSERT INTO privileges VALUES ('43f77473-2ecd-4b06-920a-e1e003f63c18', 'safety', now(), now(), 'Safety');
+INSERT INTO privileges VALUES ('43f77473-2ecd-4b06-920a-e1e003f63c18', 'safety', now(), now(), 'Safety') ON CONFLICT DO NOTHING;


### PR DESCRIPTION
## Summary

Fix for duplicate id error when switching branches.
![image (1)](https://github.com/transcom/mymove/assets/149000222/0af7d1e5-c987-43c8-9e64-4a9e2d3d1b26)

## Verification Steps for the Author

These are to be checked by the author.

- [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
- [ ] Have the Agility acceptance criteria been met for this change?

## Verification Steps for Reviewers

These are to be checked by a reviewer.

- [ ] Has the branch been pulled in and checked out?
- [ ] Have the BL acceptance criteria been met for this change?
- [ ] Was the CircleCI build successful?
- [ ] Has the code been reviewed from a standards and best practices point of view?

### Setup to Run the Code

- [Instructions for starting storybook](https://transcom.github.io/mymove-docs/docs/frontend/setup/storybook)
- [Instructions for starting the MilMove application](https://transcom.github.io/mymove-docs/docs/getting-started/application-setup/)
- [Instructions for running tests](https://transcom.github.io/mymove-docs/docs/getting-started/development/testing)

### How to test

1. Run make server_run on a branch
2. Switch to this PR branch
3.Run make server_run again 
4. Verify you don't see the error in the above screenshot

### Database

#### Any new migrations/schema changes:

- [ ] Follows our guidelines for [Zero-Downtime Deploys](https://transcom.github.io/mymove-docs/docs/backend/setup/database-migrations#zero-downtime-migrations).
- [ ] Have been communicated to #g-database.
- [ ] Secure migrations have been tested following the instructions in our [docs](https://transcom.github.io/mymove-docs/docs/backend/setup/database-migrations#secure-migrations).

## Screenshots
