### PR TITLE
INT B-19540 ppm sit not calculating correctly review documents page

### DIFF
--- a/src/components/Office/PPM/ReviewDocumentsSidePanel/ReviewDocumentsSidePanel.jsx
+++ b/src/components/Office/PPM/ReviewDocumentsSidePanel/ReviewDocumentsSidePanel.jsx
@@ -202,11 +202,10 @@ export default function ReviewDocumentsSidePanel({
                               </span>
                               <span>
                                 <dt>Total Days in SIT:</dt>
-                                <dl>
-                                  {moment(exp.sitEndDate, 'YYYY MM DD').diff(
-                                    moment(exp.sitStartDate, 'YYYY MM DD'),
-                                    'days',
-                                  )}
+                                <dl data-testid="days-in-sit">
+                                  {moment(exp.sitEndDate, 'YYYY MM DD')
+                                    .add(1, 'days')
+                                    .diff(moment(exp.sitStartDate, 'YYYY MM DD'), 'days')}
                                 </dl>
                               </span>
                               <span>

--- a/src/components/Office/PPM/ReviewExpense/ReviewExpense.jsx
+++ b/src/components/Office/PPM/ReviewExpense/ReviewExpense.jsx
@@ -122,7 +122,9 @@ export default function ReviewExpense({
 
           const daysInSIT =
             values.sitStartDate && values.sitEndDate && !errors.sitStartDate && !errors.sitEndDate
-              ? moment(values.sitEndDate, 'DD MMM YYYY').diff(moment(values.sitStartDate, 'DD MMM YYYY'), 'days')
+              ? moment(values.sitEndDate, 'DD MMM YYYY')
+                  .add(1, 'days')
+                  .diff(moment(values.sitStartDate, 'DD MMM YYYY'), 'days')
               : '##';
           return (
             <Form className={classnames(formStyles.form, styles.ReviewExpense)}>

--- a/src/components/Office/PPM/ReviewExpense/ReviewExpense.test.jsx
+++ b/src/components/Office/PPM/ReviewExpense/ReviewExpense.test.jsx
@@ -110,7 +110,7 @@ describe('ReviewExpenseForm component', () => {
     it('correctly displays days in SIT', async () => {
       render(<ReviewExpense {...defaultProps} {...storageProps} />, { wrapper: MockProviders });
       await waitFor(() => {
-        expect(screen.getByTestId('days-in-sit')).toHaveTextContent('10');
+        expect(screen.getByTestId('days-in-sit')).toHaveTextContent('11');
       });
     });
 
@@ -124,7 +124,7 @@ describe('ReviewExpenseForm component', () => {
         initialSelectionEnd: 2,
       });
       await waitFor(() => {
-        expect(screen.getByTestId('days-in-sit')).toHaveTextContent('8');
+        expect(screen.getByTestId('days-in-sit')).toHaveTextContent('9');
       });
     });
 


### PR DESCRIPTION
## [B-19540](https://www13.v1host.com/USTRANSCOM38/assetdetail.v1?number=B-19540)

## Summary

This fix is to correctly calculate "Total days in SIT" when on the Review Documents page as a Closeout SC. The SIT Days should be counting the "Start date" and "End date" (i.e. Start date of 15 Apr 24 and End date of 19 Apr 24 is 5 days of Storage.

### How to test

1. Create a new move with a PPM or use `MoveWithPPMShipmentReadyForFinalCloseoutWithSIT` testharness.
2. As a SC -> Submit/Finish Counseling the move (skip this step if used testharness).
3. As a customer -> Upload PPM documents for the move.
4. As a Closeout SC -> Find the move and click “Review Documents” under “Move details” page.
5. Approve or deny until you get to the Storage receipt and change the `Start date` to `15 Apr 24` and `End date` to `19 Apr 24`.
6. You should see `5` for Total days in SIT.
7. Go to the last page for final review and check if "Total days in SIT" is correct.

## Screenshots
![image](https://github.com/transcom/mymove/assets/146856854/956bd62a-beec-435e-93f5-6255df698646)
![image](https://github.com/transcom/mymove/assets/146856854/90b7176a-1a08-4362-93ed-5ae655e5def8)
