### PR TITLE
B-19885 Non-CAC Customers INT

### DIFF
--- a/pkg/gen/ghcapi/embedded_spec.go
+++ b/pkg/gen/ghcapi/embedded_spec.go
@@ -6034,7 +6034,7 @@ func init() {
         "backupContact": {
           "$ref": "#/definitions/BackupContact"
         },
-        "cacValidatedUser": {
+        "cacValidated": {
           "type": "boolean"
         },
         "edipi": {
@@ -18932,7 +18932,7 @@ func init() {
         "backupContact": {
           "$ref": "#/definitions/BackupContact"
         },
-        "cacValidatedUser": {
+        "cacValidated": {
           "type": "boolean"
         },
         "edipi": {

--- a/pkg/gen/ghcapi/embedded_spec.go
+++ b/pkg/gen/ghcapi/embedded_spec.go
@@ -5639,6 +5639,9 @@ func init() {
             }
           ]
         },
+        "cacUser": {
+          "type": "boolean"
+        },
         "createOktaAccount": {
           "type": "boolean"
         },
@@ -6030,6 +6033,9 @@ func init() {
         },
         "backupContact": {
           "$ref": "#/definitions/BackupContact"
+        },
+        "cacValidatedUser": {
+          "type": "boolean"
         },
         "edipi": {
           "type": "string",
@@ -18531,6 +18537,9 @@ func init() {
             }
           ]
         },
+        "cacUser": {
+          "type": "boolean"
+        },
         "createOktaAccount": {
           "type": "boolean"
         },
@@ -18922,6 +18931,9 @@ func init() {
         },
         "backupContact": {
           "$ref": "#/definitions/BackupContact"
+        },
+        "cacValidatedUser": {
+          "type": "boolean"
         },
         "edipi": {
           "type": "string",

--- a/pkg/gen/ghcmessages/create_customer_payload.go
+++ b/pkg/gen/ghcmessages/create_customer_payload.go
@@ -30,6 +30,9 @@ type CreateCustomerPayload struct {
 		Address
 	} `json:"backupMailingAddress,omitempty"`
 
+	// cac user
+	CacUser bool `json:"cacUser,omitempty"`
+
 	// create okta account
 	CreateOktaAccount bool `json:"createOktaAccount,omitempty"`
 

--- a/pkg/gen/ghcmessages/created_customer.go
+++ b/pkg/gen/ghcmessages/created_customer.go
@@ -28,8 +28,8 @@ type CreatedCustomer struct {
 	// backup contact
 	BackupContact *BackupContact `json:"backupContact,omitempty"`
 
-	// cac validated user
-	CacValidatedUser bool `json:"cacValidatedUser,omitempty"`
+	// cac validated
+	CacValidated bool `json:"cacValidated,omitempty"`
 
 	// edipi
 	Edipi *string `json:"edipi,omitempty"`

--- a/pkg/gen/ghcmessages/created_customer.go
+++ b/pkg/gen/ghcmessages/created_customer.go
@@ -28,6 +28,9 @@ type CreatedCustomer struct {
 	// backup contact
 	BackupContact *BackupContact `json:"backupContact,omitempty"`
 
+	// cac validated user
+	CacValidatedUser bool `json:"cacValidatedUser,omitempty"`
+
 	// edipi
 	Edipi *string `json:"edipi,omitempty"`
 

--- a/pkg/handlers/ghcapi/customer.go
+++ b/pkg/handlers/ghcapi/customer.go
@@ -184,9 +184,9 @@ func (h CreateCustomerWithOktaOptionHandler) Handle(params customercodeop.Create
 
 			// if the office user checked "no" to indicate the customer does NOT have a CAC, set cac_validated
 			// to true so that the customer can log in without having to authenticate with a CAC
-			var cacValidateFlag = false
+			var cacValidated = false
 			if !payload.CacUser {
-				cacValidateFlag = true
+				cacValidated = true
 			}
 
 			transactionError := appCtx.NewTransaction(func(txnAppCtx appcontext.AppContext) error {
@@ -225,7 +225,7 @@ func (h CreateCustomerWithOktaOptionHandler) Handle(params customercodeop.Create
 					EmailIsPreferred:     &payload.EmailIsPreferred,
 					ResidentialAddress:   residentialAddress,
 					BackupMailingAddress: backupMailingAddress,
-					CacValidated:         cacValidateFlag,
+					CacValidated:         cacValidated,
 				}
 
 				// create the service member and save to the db

--- a/pkg/handlers/ghcapi/customer.go
+++ b/pkg/handlers/ghcapi/customer.go
@@ -166,7 +166,7 @@ func (h CreateCustomerWithOktaOptionHandler) Handle(params customercodeop.Create
 				return customercodeop.NewCreateCustomerWithOktaOptionUnprocessableEntity().WithPayload(payload), badDataError
 			}
 
-			// delcaring okta values outside of if statements so we can use them later
+			// declaring okta values outside of if statements so we can use them later
 			var oktaSub string
 			oktaUser := &models.CreatedOktaUser{}
 
@@ -180,6 +180,13 @@ func (h CreateCustomerWithOktaOptionHandler) Handle(params customercodeop.Create
 					return customercodeop.NewCreateCustomerWithOktaOptionBadRequest(), oktaErr
 				}
 				oktaSub = oktaUser.ID
+			}
+
+			// if the office user checked "no" to indicate the customer does NOT have a CAC, set cac_validated
+			// to true so that the customer can log in without having to authenticate with a CAC
+			var cacValidateFlag = false
+			if !payload.CacUser {
+				cacValidateFlag = true
 			}
 
 			transactionError := appCtx.NewTransaction(func(txnAppCtx appcontext.AppContext) error {
@@ -218,6 +225,7 @@ func (h CreateCustomerWithOktaOptionHandler) Handle(params customercodeop.Create
 					EmailIsPreferred:     &payload.EmailIsPreferred,
 					ResidentialAddress:   residentialAddress,
 					BackupMailingAddress: backupMailingAddress,
+					CacValidated:         cacValidateFlag,
 				}
 
 				// create the service member and save to the db

--- a/pkg/handlers/ghcapi/customer_test.go
+++ b/pkg/handlers/ghcapi/customer_test.go
@@ -178,7 +178,7 @@ func (suite *HandlerSuite) TestCreateCustomerWithOktaOptionHandler() {
 			Address: backupAddress,
 		},
 		CreateOktaAccount: true,
-		// when CacUser is false, this indicates a non-CAC user so CacValidatedUser flag is set to true
+		// when CacUser is false, this indicates a non-CAC user so CacValidated is set to true
 		CacUser: false,
 	}
 
@@ -213,8 +213,8 @@ func (suite *HandlerSuite) TestCreateCustomerWithOktaOptionHandler() {
 	suite.Equal(body.BackupContact.Name, createdCustomerPayload.BackupContact.Name)
 	suite.Equal(body.BackupContact.Phone, createdCustomerPayload.BackupContact.Phone)
 	suite.Equal(body.BackupContact.Email, createdCustomerPayload.BackupContact.Email)
-	// when CacUser is false, this indicates a non-CAC user so CacValidatedUser flag is set to true
-	suite.Equal(true, createdCustomerPayload.CacValidatedUser)
+	// when CacUser is false, this indicates a non-CAC user so CacValidated is set to true
+	suite.Equal(true, createdCustomerPayload.CacValidated)
 }
 
 func (suite *HandlerSuite) TestSearchCustomersHandler() {

--- a/pkg/handlers/ghcapi/customer_test.go
+++ b/pkg/handlers/ghcapi/customer_test.go
@@ -178,6 +178,8 @@ func (suite *HandlerSuite) TestCreateCustomerWithOktaOptionHandler() {
 			Address: backupAddress,
 		},
 		CreateOktaAccount: true,
+		// when CacUser is false, this indicates a non-CAC user so CacValidatedUser flag is set to true
+		CacUser: false,
 	}
 
 	defer goth.ClearProviders()
@@ -211,6 +213,8 @@ func (suite *HandlerSuite) TestCreateCustomerWithOktaOptionHandler() {
 	suite.Equal(body.BackupContact.Name, createdCustomerPayload.BackupContact.Name)
 	suite.Equal(body.BackupContact.Phone, createdCustomerPayload.BackupContact.Phone)
 	suite.Equal(body.BackupContact.Email, createdCustomerPayload.BackupContact.Email)
+	// when CacUser is false, this indicates a non-CAC user so CacValidatedUser flag is set to true
+	suite.Equal(true, createdCustomerPayload.CacValidatedUser)
 }
 
 func (suite *HandlerSuite) TestSearchCustomersHandler() {

--- a/pkg/handlers/ghcapi/internal/payloads/model_to_payload.go
+++ b/pkg/handlers/ghcapi/internal/payloads/model_to_payload.go
@@ -501,7 +501,7 @@ func CreatedCustomer(sm *models.ServiceMember, oktaUser *models.CreatedOktaUser,
 		PhoneIsPreferred:   swag.BoolValue(sm.PhoneIsPreferred),
 		EmailIsPreferred:   swag.BoolValue(sm.EmailIsPreferred),
 		BackupContact:      bc,
-		CacValidatedUser:   swag.BoolValue(&sm.CacValidated),
+		CacValidated:       swag.BoolValue(&sm.CacValidated),
 	}
 	return &payload
 }

--- a/pkg/handlers/ghcapi/internal/payloads/model_to_payload.go
+++ b/pkg/handlers/ghcapi/internal/payloads/model_to_payload.go
@@ -501,6 +501,7 @@ func CreatedCustomer(sm *models.ServiceMember, oktaUser *models.CreatedOktaUser,
 		PhoneIsPreferred:   swag.BoolValue(sm.PhoneIsPreferred),
 		EmailIsPreferred:   swag.BoolValue(sm.EmailIsPreferred),
 		BackupContact:      bc,
+		CacValidatedUser:   swag.BoolValue(&sm.CacValidated),
 	}
 	return &payload
 }

--- a/src/pages/Office/CustomerOnboarding/CreateCustomerForm.jsx
+++ b/src/pages/Office/CustomerOnboarding/CreateCustomerForm.jsx
@@ -69,6 +69,7 @@ export const CreateCustomerForm = ({ setFlashMessage }) => {
       email: '',
     },
     create_okta_account: '',
+    cac_user: true,
   };
 
   const handleBack = () => {
@@ -78,6 +79,7 @@ export const CreateCustomerForm = ({ setFlashMessage }) => {
   const onSubmit = async (values) => {
     // Convert strings to booleans to satisfy swagger
     const createOktaAccount = values.create_okta_account === 'true';
+    const cacUser = values.cac_user === 'true';
 
     const body = {
       affiliation: values.affiliation,
@@ -99,6 +101,7 @@ export const CreateCustomerForm = ({ setFlashMessage }) => {
         phone: values[backupContactName].telephone,
       },
       createOktaAccount,
+      cacUser,
     };
 
     return createCustomerWithOktaOption({ body })
@@ -135,6 +138,7 @@ export const CreateCustomerForm = ({ setFlashMessage }) => {
     [backupAddressName]: requiredAddressSchema.required(),
     [backupContactName]: backupContactInfoSchema.required(),
     create_okta_account: Yup.boolean().required('Required'),
+    cac_user: Yup.boolean().required('Required'),
   });
 
   return (
@@ -323,6 +327,7 @@ export const CreateCustomerForm = ({ setFlashMessage }) => {
                           label="Yes"
                           name="create_okta_account"
                           value="true"
+                          data-testid="create-okta-account-yes"
                         />
                         <Field
                           as={Radio}
@@ -330,6 +335,31 @@ export const CreateCustomerForm = ({ setFlashMessage }) => {
                           label="No"
                           name="create_okta_account"
                           value="false"
+                          data-testid="create-okta-account-no"
+                        />
+                      </div>
+                    </Fieldset>
+                  </SectionWrapper>
+                  <SectionWrapper className={formStyles.formSection}>
+                    <h3>Non-CAC Users</h3>
+                    <Fieldset className={styles.trailerOwnershipFieldset}>
+                      <legend className="usa-label">Does the customer have a CAC?</legend>
+                      <div className="grid-row grid-gap">
+                        <Field
+                          as={Radio}
+                          id="yesCacUser"
+                          label="Yes"
+                          name="cac_user"
+                          value="true"
+                          data-testid="cac-user-yes"
+                        />
+                        <Field
+                          as={Radio}
+                          id="NonCacUser"
+                          label="No"
+                          name="cac_user"
+                          value="false"
+                          data-testid="cac-user-no"
                         />
                       </div>
                     </Fieldset>

--- a/src/pages/Office/CustomerOnboarding/CreateCustomerForm.test.jsx
+++ b/src/pages/Office/CustomerOnboarding/CreateCustomerForm.test.jsx
@@ -59,6 +59,7 @@ const fakePayload = {
     email: 'allOverDaPlace@mail.com',
   },
   create_okta_account: 'true',
+  cac_user: 'false',
 };
 
 const fakeResponse = {
@@ -127,6 +128,7 @@ describe('CreateCustomerForm', () => {
     expect(screen.getByText('Backup Address')).toBeInTheDocument();
     expect(screen.getByText('Backup Contact')).toBeInTheDocument();
     expect(screen.getByText('Okta Account')).toBeInTheDocument();
+    expect(screen.getByText('Non-CAC Users')).toBeInTheDocument();
 
     const saveBtn = await screen.findByRole('button', { name: 'Save' });
     expect(saveBtn).toBeInTheDocument();
@@ -235,8 +237,9 @@ describe('CreateCustomerForm', () => {
     await userEvent.type(getByRole('textbox', { name: 'Email' }), fakePayload.backup_contact.email);
     await userEvent.type(getByRole('textbox', { name: 'Phone' }), fakePayload.backup_contact.telephone);
 
-    const oktaRadioButton = getByLabelText('Yes');
-    await userEvent.click(oktaRadioButton);
+    await userEvent.type(getByTestId('create-okta-account-yes'), fakePayload.create_okta_account);
+
+    await userEvent.type(getByTestId('cac-user-no'), fakePayload.cac_user);
 
     await waitFor(() => {
       expect(saveBtn).toBeEnabled();

--- a/src/pages/Office/CustomerOnboarding/CreateCustomerForm.test.jsx
+++ b/src/pages/Office/CustomerOnboarding/CreateCustomerForm.test.jsx
@@ -185,8 +185,9 @@ describe('CreateCustomerForm', () => {
     await user.type(getByRole('textbox', { name: 'Email' }), fakePayload.backup_contact.email);
     await user.type(getByRole('textbox', { name: 'Phone' }), fakePayload.backup_contact.telephone);
 
-    const oktaRadioButton = getByLabelText('Yes');
-    await user.click(oktaRadioButton);
+    await userEvent.type(getByTestId('create-okta-account-yes'), fakePayload.create_okta_account);
+
+    await userEvent.type(getByTestId('cac-user-no'), fakePayload.cac_user);
 
     await waitFor(() => {
       expect(saveBtn).toBeEnabled();

--- a/swagger-def/ghc.yaml
+++ b/swagger-def/ghc.yaml
@@ -213,14 +213,7 @@ paths:
               sort:
                 type: string
                 x-nullable: true
-                enum:
-                  [
-                    customerName,
-                    dodID,
-                    branch,
-                    personalEmail,
-                    telephone,
-                  ]
+                enum: [customerName, dodID, branch, personalEmail, telephone]
               order:
                 type: string
                 x-nullable: true
@@ -3868,6 +3861,8 @@ definitions:
         x-nullable: true
       backupAddress:
         $ref: 'definitions/Address.yaml'
+      cacValidatedUser:
+        type: boolean
   UpdateCustomerPayload:
     type: object
     properties:
@@ -3963,6 +3958,8 @@ definitions:
         allOf:
           - $ref: 'definitions/Address.yaml'
       createOktaAccount:
+        type: boolean
+      cacUser:
         type: boolean
   SearchCustomersResult:
     type: object

--- a/swagger-def/ghc.yaml
+++ b/swagger-def/ghc.yaml
@@ -3861,7 +3861,7 @@ definitions:
         x-nullable: true
       backupAddress:
         $ref: 'definitions/Address.yaml'
-      cacValidatedUser:
+      cacValidated:
         type: boolean
   UpdateCustomerPayload:
     type: object

--- a/swagger/ghc.yaml
+++ b/swagger/ghc.yaml
@@ -4012,7 +4012,7 @@ definitions:
         x-nullable: true
       backupAddress:
         $ref: '#/definitions/Address'
-      cacValidatedUser:
+      cacValidated:
         type: boolean
   UpdateCustomerPayload:
     type: object

--- a/swagger/ghc.yaml
+++ b/swagger/ghc.yaml
@@ -4012,6 +4012,8 @@ definitions:
         x-nullable: true
       backupAddress:
         $ref: '#/definitions/Address'
+      cacValidatedUser:
+        type: boolean
   UpdateCustomerPayload:
     type: object
     properties:
@@ -4107,6 +4109,8 @@ definitions:
         allOf:
           - $ref: '#/definitions/Address'
       createOktaAccount:
+        type: boolean
+      cacUser:
         type: boolean
   SearchCustomersResult:
     type: object


### PR DESCRIPTION
## [Agility ticket](https://www13.v1host.com/USTRANSCOM38/assetdetail.v1?number=B-19885)

## Summary

As a Services counselor, I want the ability to flag a customer's profile to indicate that they do not have a CAC, so they can login to MilMove successfully without authenticating with a CAC during first login.

In order to let the customer avoid having to authenticate, when the service counselor indicates that the customer is NOT a CAC-user when creating the customer account, then we handle setting the `cac_validated` flag for that service member to `True`. This will allow the customer to access the application _without_ having to authenticate with a CAC.

### Setup to Run the Code

- [Instructions for starting storybook](https://transcom.github.io/mymove-docs/docs/frontend/setup/storybook)
- [Instructions for starting the MilMove application](https://transcom.github.io/mymove-docs/docs/getting-started/application-setup/)
- [Instructions for running tests](https://transcom.github.io/mymove-docs/docs/getting-started/development/testing)

### How to test

1. Access the office application.
2. Login as a services counselor.
3. Locate the search bar at the top of the page.
4. Search by customer name, for any string.
5. When the results are found, an "Add Customer" button should appear next to the "Search for a customer" line.
6. Click the "Add Customer" button.
7. Fill in the fields on the form.
8. At the bottom of the page, in the Non-CAC Users section, select Yes to indicate that the customer has a CAC.
9. Finish filling out the form and Save.
10. Check the database and verify that for the most recently created service member (in the `service_members` table) that the `cac_validated` value is `false`.
11. Follow the steps above again to create a new customer as the services counselor.
12. At the bottom of the page, in the Non-CAC Users section, select No to indicate that the customer does NOT have a CAC.
13. Finish filling out the form and Save.
14. Check the database and verify that for the most recently created service member (in the `service_members` table) that the `cac_validated` value is `true`.



### Frontend

- [x] There are no aXe warnings for UI.
- [x] This works in [Supported Browsers and their phone views](https://transcom.github.io/mymove-docs/docs/adrs/Browser-Support/#minimum-browser-requirements) (Chrome, Firefox, Edge).
- [x] There are no new console errors in the browser devtools.
- [x] There are no new console errors in the test output.
- [x] If this PR adds a new component to Storybook, it ensures the component is fully responsive, OR if it is intentionally not, a wrapping div using the `officeApp` class or custom `min-width` styling is used to hide any states the would not be visible to the user.
- [x] This change meets the standards for [Section 508 compliance](https://www.ssa.gov/accessibility/andi/help/install.html).

## Screenshots
![image](https://github.com/transcom/mymove/assets/147537467/1a80766c-94ef-41cc-bd48-8045f931f75a)
