### PR TITLE
B18988 main 240410 0932 update 5 digit id in move history to be shipment locator

### DIFF
--- a/migrations/app/migrations_manifest.txt
+++ b/migrations/app/migrations_manifest.txt
@@ -917,3 +917,4 @@
 20240322144246_updateAddressesCounty.up.sql
 20240327210353_add_cac_verified_to_service_members_table.up.sql
 20240402155228_updateLongBeachGbloc.up.sql
+20240402192009_add_shipment_locator_and_shipment_seq_num.up.sql

--- a/migrations/app/schema/20240402192009_add_shipment_locator_and_shipment_seq_num.up.sql
+++ b/migrations/app/schema/20240402192009_add_shipment_locator_and_shipment_seq_num.up.sql
@@ -1,0 +1,72 @@
+ALTER TABLE moves ADD COLUMN IF NOT EXISTS shipment_seq_num INT;
+ALTER TABLE mto_shipments ADD COLUMN IF NOT EXISTS shipment_locator TEXT;
+CREATE UNIQUE INDEX IF NOT EXISTS shipment_locator_unique_idx ON mto_shipments (shipment_locator);
+
+DO $$
+BEGIN
+    -- Update existing 'mto_shipments' rows with a 'shipment_locator'
+    WITH calculated_values AS (
+        SELECT
+            s.id AS shipment_id,
+            m.id AS move_id,
+            m.locator || '-' || LPAD((COALESCE(m.shipment_seq_num, 0) + ROW_NUMBER() OVER (PARTITION BY m.id ORDER BY s.created_at))::text, 2, '0') AS new_locator
+        FROM mto_shipments s
+        JOIN moves m ON m.id = s.move_id
+        WHERE s.shipment_locator IS NULL OR s.shipment_locator = ''
+    )
+    UPDATE mto_shipments s
+    SET shipment_locator = cv.new_locator
+    FROM calculated_values cv
+    WHERE s.id = cv.shipment_id;
+
+    -- Update the 'shipment_seq_num' in the 'moves' table to reflect the highest sequence number used
+    WITH max_seq_nums AS (
+        SELECT
+            move_id,
+            MAX(SUBSTRING(shipment_locator FROM '.*-(\d+)$')::INT) AS max_seq_num
+        FROM mto_shipments
+        GROUP BY move_id
+    )
+    UPDATE moves m
+    SET shipment_seq_num = msn.max_seq_num
+    FROM max_seq_nums msn
+    WHERE m.id = msn.move_id
+    AND (m.shipment_seq_num IS NULL OR m.shipment_seq_num = 0);
+
+END $$;
+
+
+CREATE OR REPLACE FUNCTION generate_shipment_locator()
+RETURNS TRIGGER AS $$
+DECLARE
+    locator_prefix TEXT;
+	shipment_seq_num_prefix INT;
+BEGIN
+    -- Fetch the locator from the moves table
+    SELECT locator INTO locator_prefix
+	FROM moves
+	WHERE id = NEW.move_id
+	FOR UPDATE;
+
+    -- Increment the shipment_seq_num for the move and fetch the updated value
+    UPDATE moves
+	SET shipment_seq_num = COALESCE(shipment_seq_num, 0) + 1
+	WHERE id = NEW.move_id
+	RETURNING shipment_seq_num INTO shipment_seq_num_prefix;
+
+    -- Set the shipment_locator(move locator + '-' + shipment seq num) in the new shipment row
+    NEW.shipment_locator := locator_prefix || '-' || LPAD(shipment_seq_num_prefix::text, 2, '0');
+
+    -- Return the modified NEW row to be inserted
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS trigger_generate_shipment_locator ON mto_shipments;
+CREATE TRIGGER trigger_generate_shipment_locator
+BEFORE INSERT ON mto_shipments
+FOR EACH ROW
+EXECUTE FUNCTION generate_shipment_locator();
+
+COMMENT ON COLUMN mto_shipments.shipment_locator IS 'Stores the new locator for the shipment just like locator in moves table.';
+COMMENT ON COLUMN moves.shipment_seq_num IS 'Keeps track of number of shipments created for a move and use it when creating a shipment_locator.';

--- a/pkg/assets/sql_scripts/move_history_fetcher.sql
+++ b/pkg/assets/sql_scripts/move_history_fetcher.sql
@@ -25,7 +25,8 @@ WITH move AS (
 				jsonb_agg(jsonb_strip_nulls(
 					jsonb_build_object(
 						'shipment_type', move_shipments.shipment_type,
-						'shipment_id_abbr', move_shipments.shipment_id_abbr
+						'shipment_id_abbr', move_shipments.shipment_id_abbr,
+						'shipment_locator', move_shipments.shipment_locator
 					)
 				))::TEXT, '[{}]'::TEXT
 			) AS context,
@@ -40,6 +41,7 @@ WITH move AS (
 			AND NOT (audit_history.event_name = 'submitMoveForApproval' AND audit_history.changed_data = '{"status": "SUBMITTED"}')
 				-- Not including update on mto_shipment for ppm_shipment when submitted
 				-- handled on seperate event
+			AND NOT (audit_history.event_name = NULL AND audit_history.changed_data::TEXT LIKE '%shipment_locator%' AND LENGTH(audit_history.changed_data::TEXT) < 35)
 		GROUP BY audit_history.id
 	),
 	move_logs AS (
@@ -56,7 +58,11 @@ WITH move AS (
 			audit_history
 		JOIN move ON audit_history.object_id = move.id
 		JOIN jsonb_to_record(audit_history.changed_data) as c(closeout_office_id TEXT) on TRUE
-		WHERE audit_history.table_name = 'moves' group by audit_history.id
+		WHERE audit_history.table_name = 'moves'
+			-- Remove log for when shipment_seq_num updates
+			AND NOT (audit_history.event_name = NULL AND audit_history.changed_data::TEXT LIKE '%shipment_seq_num%' AND LENGTH(audit_history.changed_data::TEXT) < 25)
+		group by audit_history.id
+
 	),
 	move_orders AS (
 		SELECT
@@ -104,7 +110,8 @@ WITH move AS (
 			jsonb_agg(jsonb_build_object(
 				'name', re_services.name,
 				'shipment_type', move_shipments.shipment_type,
-				'shipment_id_abbr', move_shipments.shipment_id_abbr
+				'shipment_id_abbr', move_shipments.shipment_id_abbr,
+				'shipment_locator', move_shipments.shipment_locator
 				)
 			)::TEXT AS context,
 			NULL AS context_id
@@ -123,7 +130,8 @@ WITH move AS (
 			jsonb_agg(jsonb_build_object(
 				'name', re_services.name,
 				'shipment_type', move_shipments.shipment_type,
-				'shipment_id_abbr', move_shipments.shipment_id_abbr
+				'shipment_id_abbr', move_shipments.shipment_id_abbr,
+				'shipment_locator', move_shipments.shipment_locator
 				)
 			)::TEXT AS context
 		FROM
@@ -151,7 +159,8 @@ WITH move AS (
 			jsonb_agg(jsonb_build_object(
 				'name', re_services.name,
 				'shipment_type', move_shipments.shipment_type,
-				'shipment_id_abbr', move_shipments.shipment_id_abbr
+				'shipment_id_abbr', move_shipments.shipment_id_abbr,
+				'shipment_locator', move_shipments.shipment_locator
 				)
 			)::TEXT AS context
 		FROM
@@ -202,7 +211,8 @@ WITH move AS (
 				'status', payment_service_items.status,
 				'shipment_id', move_shipments.id::TEXT,
 				'shipment_id_abbr', move_shipments.shipment_id_abbr,
-				'shipment_type', move_shipments.shipment_type
+				'shipment_type', move_shipments.shipment_type,
+				'shipment_locator', move_shipments.shipment_locator
 				)
 			)::TEXT AS context,
 			payment_requests.id AS id,
@@ -255,7 +265,8 @@ WITH move AS (
 			mto_agents.id,
 			jsonb_agg(jsonb_build_object(
 				'shipment_type', move_shipments.shipment_type,
-				'shipment_id_abbr', move_shipments.shipment_id_abbr
+				'shipment_id_abbr', move_shipments.shipment_id_abbr,
+				'shipment_locator', move_shipments.shipment_locator
 				)
 			)::TEXT AS context
 		FROM
@@ -283,7 +294,8 @@ WITH move AS (
 			jsonb_agg(jsonb_build_object(
 				'shipment_type', move_shipments.shipment_type,
 				'shipment_id_abbr', move_shipments.shipment_id_abbr,
-				'payment_request_number', move_payment_requests.payment_request_number
+				'payment_request_number', move_payment_requests.payment_request_number,
+				'shipment_locator', move_shipments.shipment_locator
 				)
 			)::TEXT AS context
 		FROM
@@ -327,13 +339,14 @@ WITH move AS (
 		WHERE audit_history.table_name = 'service_members'
 		GROUP BY audit_history.id
 	),
-	move_addresses (address_id, address_type, shipment_type, shipment_id, service_member_id)  AS (
+	move_addresses (address_id, address_type, shipment_type, shipment_id, service_member_id, shipment_locator)  AS (
 		SELECT
 			audit_history.object_id,
 			'destinationAddress',
 			move_shipments.shipment_type,
 			move_shipments.id::TEXT,
-			NULL
+			NULL,
+			move_shipments.shipment_locator
 		FROM audit_history
 			JOIN move_shipments ON move_shipments.destination_address_id = audit_history.object_id AND audit_history."table_name" = 'addresses'
 		UNION
@@ -342,7 +355,8 @@ WITH move AS (
 			'secondaryDestinationAddress',
 			move_shipments.shipment_type,
 			move_shipments.id::TEXT,
-			NULL
+			NULL,
+			move_shipments.shipment_locator
 		FROM audit_history
 			JOIN move_shipments ON move_shipments.secondary_delivery_address_id = audit_history.object_id AND audit_history."table_name" = 'addresses'
 		UNION
@@ -351,7 +365,8 @@ WITH move AS (
 			'pickupAddress',
 			move_shipments.shipment_type,
 			move_shipments.id::TEXT,
-			NULL
+			NULL,
+			move_shipments.shipment_locator
 		FROM audit_history
 			JOIN move_shipments ON move_shipments.pickup_address_id = audit_history.object_id AND audit_history."table_name" = 'addresses'
 		UNION
@@ -360,7 +375,8 @@ WITH move AS (
 			'secondaryPickupAddress',
 			move_shipments.shipment_type,
 			move_shipments.id::TEXT,
-			NULL
+			NULL,
+			move_shipments.shipment_locator
 		FROM audit_history
 			JOIN move_shipments ON move_shipments.secondary_pickup_address_id = audit_history.object_id AND audit_history."table_name" = 'addresses'
 		UNION
@@ -369,7 +385,8 @@ WITH move AS (
 			'residentialAddress',
 			NULL,
 			NULL,
-			move_service_members.id::TEXT
+			move_service_members.id::TEXT,
+			NULL
 		FROM audit_history
 			JOIN move_service_members ON move_service_members.residential_address_id = audit_history.object_id AND audit_history."table_name" = 'addresses'
 		UNION
@@ -378,7 +395,8 @@ WITH move AS (
 			'backupMailingAddress',
 			NULL,
 			NULL,
-			move_service_members.id::TEXT
+			move_service_members.id::TEXT,
+			NULL
 		FROM audit_history
 			JOIN move_service_members ON move_service_members.backup_mailing_address_id = audit_history.object_id AND audit_history."table_name" = 'addresses'
 	),
@@ -390,7 +408,8 @@ WITH move AS (
 					jsonb_build_object(
 						'address_type', move_addresses.address_type,
 						'shipment_type', move_addresses.shipment_type,
-						'shipment_id_abbr', (CASE WHEN move_addresses.shipment_id IS NOT NULL THEN LEFT(move_addresses.shipment_id::TEXT, 5) ELSE NULL END)
+						'shipment_id_abbr', (CASE WHEN move_addresses.shipment_id IS NOT NULL THEN LEFT(move_addresses.shipment_id::TEXT, 5) ELSE NULL END),
+						'shipment_locator', move_addresses.shipment_locator
 					)
 				)
 			)::TEXT AS context,
@@ -407,7 +426,8 @@ WITH move AS (
 			audit_history.object_id,
 			move_shipments.shipment_type,
 			move_shipments.id,
-			ppm_shipments.w2_address_id
+			ppm_shipments.w2_address_id,
+			move_shipments.shipment_locator
 		FROM
 			audit_history
 		JOIN ppm_shipments ON audit_history.object_id = ppm_shipments.id
@@ -421,7 +441,8 @@ WITH move AS (
 					jsonb_build_object(
 						'shipment_type', ppms.shipment_type,
 						'shipment_id_abbr', (CASE WHEN ppms.shipment_id IS NOT NULL THEN LEFT(ppms.shipment_id::TEXT, 5) ELSE NULL END),
-						'w2_address', (SELECT row_to_json(x) FROM (SELECT * FROM addresses WHERE addresses.id = CAST(ppms.w2_address_id AS UUID)) x)::TEXT
+						'w2_address', (SELECT row_to_json(x) FROM (SELECT * FROM addresses WHERE addresses.id = CAST(ppms.w2_address_id AS UUID)) x)::TEXT,
+						'shipment_locator', ppms.shipment_locator
 					)
 				)
 			)::TEXT AS context,
@@ -433,7 +454,7 @@ WITH move AS (
 		GROUP BY
 			ppms.shipment_id, audit_history.id
 	),
-	move_sits (sit_address_updates_id, address_id, service_name, shipment_type, shipment_id, original_address_id, office_remarks, contractor_remarks)  AS (
+	move_sits (sit_address_updates_id, address_id, service_name, shipment_type, shipment_id, original_address_id, office_remarks, contractor_remarks, shipment_locator)  AS (
 		SELECT
 			audit_history.object_id,
 			sit_address_updates.new_address_id,
@@ -442,7 +463,8 @@ WITH move AS (
 			move_shipments.id,
 			move_service_items.sit_destination_original_address_id,
 			sit_address_updates.office_remarks,
-			sit_address_updates.contractor_remarks
+			sit_address_updates.contractor_remarks,
+			move_shipments.shipment_locator
 		FROM audit_history
 			JOIN sit_address_updates ON audit_history.object_id = sit_address_updates.id AND audit_history.table_name = 'sit_address_updates'
 			JOIN move_service_items ON move_service_items.id = sit_address_updates.mto_service_item_id
@@ -461,7 +483,8 @@ WITH move AS (
 						'sit_destination_address_initial', (SELECT row_to_json(x) FROM (SELECT * FROM addresses WHERE addresses.id = CAST(move_sits.original_address_id AS UUID)) x)::TEXT,
 						'office_remarks', move_sits.office_remarks,
 						'contractor_remarks', move_sits.contractor_remarks,
-						'name', move_sits.service_name
+						'name', move_sits.service_name,
+						'shipment_locator', move_sits.shipment_locator
 					)
 				)
 			)::TEXT AS context,
@@ -473,12 +496,13 @@ WITH move AS (
 		GROUP BY
 			move_sits.shipment_id, audit_history.id
 	),
-	file_uploads (user_upload_id, filename, upload_type, shipment_type, shipment_id_abbr, expense_type) AS (
+	file_uploads (user_upload_id, filename, upload_type, shipment_type, shipment_id_abbr, expense_type, shipment_locator) AS (
 		-- orders uploads have the document id the uploaded orders id column
 		SELECT
 			user_uploads.id,
 			uploads.filename,
 			'orders',
+			NULL,
 			NULL,
 			NULL,
 			NULL
@@ -494,6 +518,7 @@ WITH move AS (
 			user_uploads.id,
 			uploads.filename,
 			'amendedOrders',
+			NULL,
 			NULL,
 			NULL,
 			NULL
@@ -517,7 +542,8 @@ WITH move AS (
 			move_shipments.shipment_type::TEXT,
 			move_shipments.shipment_id_abbr,
 			CASE WHEN moving_expenses.document_id = documents.id THEN moving_expenses.moving_expense_type::text
-				 ELSE NULL END
+				ELSE NULL END,
+			move_shipments.shipment_locator
 		FROM user_uploads
 			JOIN documents ON user_uploads.document_id = documents.id
 			LEFT JOIN weight_tickets ON weight_tickets.empty_document_id = documents.id OR weight_tickets.full_document_id = documents.id OR weight_tickets.proof_of_trailer_ownership_document_id = documents.id
@@ -536,7 +562,8 @@ WITH move AS (
 					'upload_type', upload_type,
 					'shipment_type', shipment_type,
 					'shipment_id_abbr', shipment_id_abbr,
-					'moving_expense_type', expense_type
+					'moving_expense_type', expense_type,
+					'shipment_locator', shipment_locator
 				)
 			)::TEXT AS context,
 		NULL AS context_id
@@ -563,11 +590,12 @@ WITH move AS (
 	),
 	-- document_review_items grabs historical data for weight ticket, pro-gear
 	-- weight tickets, and moving expense tickets
-	document_review_items (doc_id, shipment_type, shipment_id, moving_expense_type) AS (
+	document_review_items (doc_id, shipment_type, shipment_id, moving_expense_type, shipment_locator) AS (
 		SELECT COALESCE(wt.id, pwt.id, me.id),
 			ppms.shipment_type,
 			ppms.shipment_id,
-			me.moving_expense_type
+			me.moving_expense_type,
+			ppms.shipment_locator
 		FROM audit_history ah
 		LEFT JOIN weight_tickets wt ON ah.object_id = wt.id
 		LEFT JOIN progear_weight_tickets pwt ON ah.object_id = pwt.id
@@ -582,7 +610,8 @@ WITH move AS (
 	                    jsonb_build_object(
 	                        'shipment_type', document_review_items.shipment_type,
 	                        'shipment_id_abbr', (CASE WHEN document_review_items.shipment_id IS NOT NULL THEN LEFT(document_review_items.shipment_id::TEXT, 5) ELSE NULL END),
-	                        'moving_expense_type', document_review_items.moving_expense_type
+	                        'moving_expense_type', document_review_items.moving_expense_type,
+							'shipment_locator', document_review_items.shipment_locator
 	                    )
 	                )
 	            )::TEXT AS context,

--- a/pkg/factory/mto_shipment_factory.go
+++ b/pkg/factory/mto_shipment_factory.go
@@ -207,6 +207,15 @@ func BuildMTOShipment(db *pop.Connection, customs []Customization, traits []Trai
 func BuildMTOShipmentMinimal(db *pop.Connection, customs []Customization, traits []Trait) models.MTOShipment {
 	mtoShipment := BuildBaseMTOShipment(db, customs, traits)
 
+	// Get shipment_locator from DB that was generated from shipment INSERT.
+	if db != nil {
+		var dbMtoShipment models.MTOShipment
+		err := db.Find(&dbMtoShipment, mtoShipment.ID)
+		if err == nil {
+			mtoShipment.ShipmentLocator = dbMtoShipment.ShipmentLocator
+		}
+	}
+
 	customs = setupCustomizations(customs, traits)
 
 	// Find pickup address in case it was added to customizations list

--- a/pkg/gen/ghcapi/embedded_spec.go
+++ b/pkg/gen/ghcapi/embedded_spec.go
@@ -7098,6 +7098,12 @@ func init() {
           "type": "string",
           "x-nullable": true
         },
+        "shipmentLocator": {
+          "type": "string",
+          "x-nullable": true,
+          "readOnly": true,
+          "example": "1K43AR-01"
+        },
         "shipmentType": {
           "$ref": "#/definitions/MTOShipmentType"
         },
@@ -19279,6 +19285,12 @@ func init() {
         "serviceOrderNumber": {
           "type": "string",
           "x-nullable": true
+        },
+        "shipmentLocator": {
+          "type": "string",
+          "x-nullable": true,
+          "readOnly": true,
+          "example": "1K43AR-01"
         },
         "shipmentType": {
           "$ref": "#/definitions/MTOShipmentType"

--- a/pkg/gen/ghcmessages/m_t_o_shipment.go
+++ b/pkg/gen/ghcmessages/m_t_o_shipment.go
@@ -171,6 +171,11 @@ type MTOShipment struct {
 	// service order number
 	ServiceOrderNumber *string `json:"serviceOrderNumber,omitempty"`
 
+	// shipment locator
+	// Example: 1K43AR-01
+	// Read Only: true
+	ShipmentLocator *string `json:"shipmentLocator,omitempty"`
+
 	// shipment type
 	ShipmentType MTOShipmentType `json:"shipmentType,omitempty"`
 
@@ -852,6 +857,10 @@ func (m *MTOShipment) ContextValidate(ctx context.Context, formats strfmt.Regist
 		res = append(res, err)
 	}
 
+	if err := m.contextValidateShipmentLocator(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
 	if err := m.contextValidateShipmentType(ctx, formats); err != nil {
 		res = append(res, err)
 	}
@@ -1103,6 +1112,15 @@ func (m *MTOShipment) contextValidateSecondaryPickupAddress(ctx context.Context,
 			}
 			return err
 		}
+	}
+
+	return nil
+}
+
+func (m *MTOShipment) contextValidateShipmentLocator(ctx context.Context, formats strfmt.Registry) error {
+
+	if err := validate.ReadOnly(ctx, "shipmentLocator", "body", m.ShipmentLocator); err != nil {
+		return err
 	}
 
 	return nil

--- a/pkg/gen/internalapi/embedded_spec.go
+++ b/pkg/gen/internalapi/embedded_spec.go
@@ -4292,6 +4292,12 @@ func init() {
         "secondaryPickupAddress": {
           "$ref": "#/definitions/Address"
         },
+        "shipmentLocator": {
+          "type": "string",
+          "x-nullable": true,
+          "readOnly": true,
+          "example": "1K43AR-01"
+        },
         "shipmentType": {
           "$ref": "#/definitions/MTOShipmentType"
         },
@@ -11996,6 +12002,12 @@ func init() {
         },
         "secondaryPickupAddress": {
           "$ref": "#/definitions/Address"
+        },
+        "shipmentLocator": {
+          "type": "string",
+          "x-nullable": true,
+          "readOnly": true,
+          "example": "1K43AR-01"
         },
         "shipmentType": {
           "$ref": "#/definitions/MTOShipmentType"

--- a/pkg/gen/internalmessages/m_t_o_shipment.go
+++ b/pkg/gen/internalmessages/m_t_o_shipment.go
@@ -84,6 +84,11 @@ type MTOShipment struct {
 	// secondary pickup address
 	SecondaryPickupAddress *Address `json:"secondaryPickupAddress,omitempty"`
 
+	// shipment locator
+	// Example: 1K43AR-01
+	// Read Only: true
+	ShipmentLocator *string `json:"shipmentLocator,omitempty"`
+
 	// shipment type
 	ShipmentType MTOShipmentType `json:"shipmentType,omitempty"`
 
@@ -432,6 +437,10 @@ func (m *MTOShipment) ContextValidate(ctx context.Context, formats strfmt.Regist
 		res = append(res, err)
 	}
 
+	if err := m.contextValidateShipmentLocator(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
 	if err := m.contextValidateShipmentType(ctx, formats); err != nil {
 		res = append(res, err)
 	}
@@ -618,6 +627,15 @@ func (m *MTOShipment) contextValidateSecondaryPickupAddress(ctx context.Context,
 			}
 			return err
 		}
+	}
+
+	return nil
+}
+
+func (m *MTOShipment) contextValidateShipmentLocator(ctx context.Context, formats strfmt.Registry) error {
+
+	if err := validate.ReadOnly(ctx, "shipmentLocator", "body", m.ShipmentLocator); err != nil {
+		return err
 	}
 
 	return nil

--- a/pkg/handlers/ghcapi/internal/payloads/model_to_payload.go
+++ b/pkg/handlers/ghcapi/internal/payloads/model_to_payload.go
@@ -1140,6 +1140,7 @@ func MTOShipment(storer storage.FileStorer, mtoShipment *models.MTOShipment, sit
 		StorageFacility:             StorageFacility(mtoShipment.StorageFacility),
 		PpmShipment:                 PPMShipment(storer, mtoShipment.PPMShipment),
 		DeliveryAddressUpdate:       ShipmentAddressUpdate(mtoShipment.DeliveryAddressUpdate),
+		ShipmentLocator:             handlers.FmtStringPtr(mtoShipment.ShipmentLocator),
 	}
 
 	if mtoShipment.Distance != nil {

--- a/pkg/handlers/internalapi/internal/payloads/model_to_payload.go
+++ b/pkg/handlers/internalapi/internal/payloads/model_to_payload.go
@@ -142,6 +142,7 @@ func MTOShipment(storer storage.FileStorer, mtoShipment *models.MTOShipment) *in
 		Status:                      internalmessages.MTOShipmentStatus(mtoShipment.Status),
 		PpmShipment:                 PPMShipment(storer, mtoShipment.PPMShipment),
 		ETag:                        etag.GenerateEtag(mtoShipment.UpdatedAt),
+		ShipmentLocator:             handlers.FmtStringPtr(mtoShipment.ShipmentLocator),
 	}
 	if mtoShipment.HasSecondaryPickupAddress != nil && !*mtoShipment.HasSecondaryPickupAddress {
 		payload.SecondaryPickupAddress = nil

--- a/pkg/models/move.go
+++ b/pkg/models/move.go
@@ -85,6 +85,7 @@ type Move struct {
 	CloseoutOfficeID             *uuid.UUID            `db:"closeout_office_id"`
 	CloseoutOffice               *TransportationOffice `belongs_to:"transportation_offices" fk_id:"closeout_office_id"`
 	ApprovalsRequestedAt         *time.Time            `db:"approvals_requested_at"`
+	ShipmentSeqNum               *int                  `db:"shipment_seq_num"`
 }
 
 // TableName overrides the table name used by Pop.

--- a/pkg/models/mto_shipments.go
+++ b/pkg/models/mto_shipments.go
@@ -148,6 +148,7 @@ type MTOShipment struct {
 	CreatedAt                        time.Time              `db:"created_at"`
 	UpdatedAt                        time.Time              `db:"updated_at"`
 	DeletedAt                        *time.Time             `db:"deleted_at"`
+	ShipmentLocator                  *string                `db:"shipment_locator"`
 }
 
 // TableName overrides the table name used by Pop.

--- a/pkg/services/mto_shipment/mto_shipment_creator.go
+++ b/pkg/services/mto_shipment/mto_shipment_creator.go
@@ -315,6 +315,17 @@ func (f mtoShipmentCreator) CreateMTOShipment(appCtx appcontext.AppContext, ship
 		return nil, apperror.NewQueryError("unknown", err, "")
 	}
 
+	var dbShipment models.MTOShipment
+
+	shipmentQueryFilters := []services.QueryFilter{
+		query.NewQueryFilter("id", "=", shipment.ID),
+	}
+
+	// check if Move exists
+	err = f.builder.FetchOne(appCtx, &dbShipment, shipmentQueryFilters)
+	if err == nil {
+		shipment.ShipmentLocator = dbShipment.ShipmentLocator
+	}
 	return shipment, transactionError
 }
 

--- a/pkg/services/mto_shipment/mto_shipment_creator_test.go
+++ b/pkg/services/mto_shipment/mto_shipment_creator_test.go
@@ -142,6 +142,46 @@ func (suite *MTOShipmentServiceSuite) TestCreateMTOShipment() {
 		suite.NotEmpty(createdShipment.DestinationAddressID)
 	})
 
+	suite.Run("If the shipment is created successfully it should return ShipmentLocator", func() {
+		subtestData := suite.createSubtestData(nil)
+		creator := subtestData.shipmentCreator
+
+		mtoShipment := factory.BuildMTOShipment(nil, []factory.Customization{
+			{
+				Model:    subtestData.move,
+				LinkOnly: true,
+			},
+		}, nil)
+		mtoShipment2 := factory.BuildMTOShipment(nil, []factory.Customization{
+			{
+				Model:    subtestData.move,
+				LinkOnly: true,
+			},
+		}, nil)
+
+		mtoShipmentClear := clearShipmentIDFields(&mtoShipment)
+		mtoShipmentClear.MTOServiceItems = models.MTOServiceItems{}
+		mtoShipmentClear2 := clearShipmentIDFields(&mtoShipment2)
+		mtoShipmentClear2.MTOServiceItems = models.MTOServiceItems{}
+
+		createdShipment, err := creator.CreateMTOShipment(suite.AppContextForTest(), mtoShipmentClear)
+		createdShipment2, err2 := creator.CreateMTOShipment(suite.AppContextForTest(), mtoShipmentClear2)
+
+		suite.NoError(err)
+		suite.NoError(err2)
+		suite.NotNil(createdShipment)
+		suite.NotEmpty(createdShipment.ShipmentLocator)
+
+		// ShipmentLocator = move Locator + "-" + Shipment Seq Num
+		// checks for proper structure of shipmentLocator
+		suite.Equal(subtestData.move.Locator, (*createdShipment.ShipmentLocator)[0:6])
+		suite.Equal("-", (*createdShipment.ShipmentLocator)[6:7])
+		suite.Equal("01", (*createdShipment.ShipmentLocator)[7:9])
+
+		// check if seq number is increased by 1
+		suite.Equal("02", (*createdShipment2.ShipmentLocator)[7:9])
+	})
+
 	suite.Run("If the shipment is created successfully with a destination address type it should be returned", func() {
 		destinationType := models.DestinationTypeHomeOfRecord
 		subtestData := suite.createSubtestData(nil)

--- a/pkg/services/mto_shipment/mto_shipment_updater.go
+++ b/pkg/services/mto_shipment/mto_shipment_updater.go
@@ -316,6 +316,7 @@ func (f *mtoShipmentUpdater) UpdateMTOShipment(appCtx appcontext.AppContext, mto
 		"MTOServiceItems.CustomerContacts",
 		"StorageFacility.Address",
 		"Reweigh",
+		"ShipmentLocator",
 	}
 
 	oldShipment, err := FindShipment(appCtx, mtoShipment.ID, eagerAssociations...)

--- a/pkg/services/mto_shipment/shipment_deleter_test.go
+++ b/pkg/services/mto_shipment/shipment_deleter_test.go
@@ -105,6 +105,68 @@ func (suite *MTOShipmentServiceSuite) TestShipmentDeleter() {
 		}
 	})
 
+	suite.Run("Soft deletes the shipment when it is found and check if shipment_seq_num changed", func() {
+		move := factory.BuildMove(suite.DB(), nil, nil)
+		shipmentDeleter := NewShipmentDeleter(moveTaskOrderUpdater)
+		shipment := factory.BuildMTOShipmentMinimal(suite.DB(), []factory.Customization{
+			{
+				Model:    move,
+				LinkOnly: true,
+			},
+		}, nil)
+
+		validStatuses := []struct {
+			desc   string
+			status models.MoveStatus
+		}{
+			{"Draft", models.MoveStatusDRAFT},
+			{"Needs Service Counseling", models.MoveStatusNeedsServiceCounseling},
+		}
+		for _, validStatus := range validStatuses {
+			move := shipment.MoveTaskOrder
+			move.Status = validStatus.status
+
+			var moveInDB models.Move
+			err := suite.DB().Find(&moveInDB, move.ID)
+			suite.NoError(err)
+
+			move.ShipmentSeqNum = moveInDB.ShipmentSeqNum
+
+			suite.MustSave(&move)
+
+			shipmentSeqNum := move.ShipmentSeqNum
+			session := suite.AppContextWithSessionForTest(&auth.Session{
+				ApplicationName: auth.OfficeApp,
+				OfficeUserID:    uuid.Must(uuid.NewV4()),
+			})
+			moveID, err := shipmentDeleter.DeleteShipment(session, shipment.ID)
+			suite.NoError(err)
+			// Verify that the shipment's Move ID is returned because the
+			// handler needs it to generate the TriggerEvent.
+			suite.Equal(shipment.MoveTaskOrderID, moveID)
+
+			// Verify the shipment still exists in the DB
+			var shipmentInDB models.MTOShipment
+			err = suite.DB().Find(&shipmentInDB, shipment.ID)
+			suite.NoError(err)
+
+			actualDeletedAt := shipmentInDB.DeletedAt
+			suite.WithinDuration(time.Now(), *actualDeletedAt, 2*time.Second)
+
+			// Reset the deleted_at field to nil to allow the shipment to be
+			// deleted a second time when testing the other move status (a
+			// shipment can only be deleted once)
+			shipmentInDB.DeletedAt = nil
+			suite.MustSave(&shipment)
+
+			// Get updated Move in DB
+			err = suite.DB().Find(&moveInDB, move.ID)
+			suite.NoError(err)
+
+			suite.Equal(shipmentSeqNum, moveInDB.ShipmentSeqNum)
+		}
+	})
+
 	suite.Run("Returns not found error when the shipment is already deleted", func() {
 		shipmentDeleter := NewShipmentDeleter(moveTaskOrderUpdater)
 		shipment := factory.BuildMTOShipmentMinimal(suite.DB(), nil, nil)

--- a/src/constants/MoveHistory/EventTemplates/ApproveShipment/approveShipment.jsx
+++ b/src/constants/MoveHistory/EventTemplates/ApproveShipment/approveShipment.jsx
@@ -12,7 +12,7 @@ export default {
   getEventNameDisplay: () => 'Approved shipment',
   getDetails: ({ context }) => (
     <>
-      {s[context[0]?.shipment_type]} shipment #{context[0]?.shipment_id_abbr.toUpperCase()}
+      {s[context[0]?.shipment_type]} shipment #{context[0]?.shipment_locator.toUpperCase()}
     </>
   ),
 };

--- a/src/constants/MoveHistory/EventTemplates/ApproveShipment/approveShipment.test.jsx
+++ b/src/constants/MoveHistory/EventTemplates/ApproveShipment/approveShipment.test.jsx
@@ -14,6 +14,7 @@ describe('when given an Approved shipment history record', () => {
       {
         shipment_id_abbr: '2fa5c',
         shipment_type: 'HHG',
+        shipment_locator: 'ABC123-01',
       },
     ],
   };
@@ -26,6 +27,6 @@ describe('when given an Approved shipment history record', () => {
     const template = getTemplate(historyRecord);
 
     render(template.getDetails(historyRecord));
-    expect(screen.getByText('HHG shipment #2FA5C')).toBeInTheDocument();
+    expect(screen.getByText('HHG shipment #ABC123-01')).toBeInTheDocument();
   });
 });

--- a/src/constants/MoveHistory/EventTemplates/ApproveShipment/createStandardServiceItem.jsx
+++ b/src/constants/MoveHistory/EventTemplates/ApproveShipment/createStandardServiceItem.jsx
@@ -15,7 +15,7 @@ export default {
     const shipmentLabel = getMtoShipmentLabel(historyRecord);
     return (
       <>
-        {SHIPMENT_TYPE[shipmentLabel.shipment_type]} shipment #{shipmentLabel.shipment_id_display}
+        {SHIPMENT_TYPE[shipmentLabel.shipment_type]} shipment #{shipmentLabel.shipment_locator}
         {', '}
         {shipmentLabel.service_item_name}
       </>

--- a/src/constants/MoveHistory/EventTemplates/ApproveShipment/createStandardServiceItem.test.jsx
+++ b/src/constants/MoveHistory/EventTemplates/ApproveShipment/createStandardServiceItem.test.jsx
@@ -9,6 +9,7 @@ describe('when given a Create standard service item history record', () => {
       {
         shipment_type: 'HHG',
         shipment_id_abbr: 'a1b2c',
+        shipment_locator: 'ABC123-01',
         name: 'Domestic linehaul',
       },
     ],
@@ -19,7 +20,7 @@ describe('when given a Create standard service item history record', () => {
     const template = getTemplate(historyRecord);
     render(template.getDetails(historyRecord));
     expect(template.getEventNameDisplay(template)).toEqual('Approved service item');
-    expect(screen.getByText('HHG shipment #A1B2C', { exact: false })).toBeInTheDocument();
+    expect(screen.getByText('HHG shipment #ABC123-01', { exact: false })).toBeInTheDocument();
     expect(screen.getByText('Domestic linehaul', { exact: false })).toBeInTheDocument();
   });
 });

--- a/src/constants/MoveHistory/EventTemplates/ApproveShipmentDiversion/approveShipmentDiversion.jsx
+++ b/src/constants/MoveHistory/EventTemplates/ApproveShipmentDiversion/approveShipmentDiversion.jsx
@@ -12,7 +12,7 @@ export default {
   getEventNameDisplay: () => 'Approved shipment',
   getDetails: ({ context }) => (
     <>
-      {s[context[0].shipment_type]} shipment #{context[0].shipment_id_abbr.toUpperCase()}
+      {s[context[0].shipment_type]} shipment #{context[0].shipment_locator}
     </>
   ),
 };

--- a/src/constants/MoveHistory/EventTemplates/ApproveShipmentDiversion/approveShipmentDiversion.test.jsx
+++ b/src/constants/MoveHistory/EventTemplates/ApproveShipmentDiversion/approveShipmentDiversion.test.jsx
@@ -13,6 +13,7 @@ describe('when given an Approved shipment diversion history record', () => {
       {
         shipment_id_abbr: '2fa5c',
         shipment_type: 'HHG',
+        shipment_locator: 'ABC123-01',
       },
     ],
   };
@@ -26,7 +27,7 @@ describe('when given an Approved shipment diversion history record', () => {
     const template = getTemplate(historyRecord);
 
     render(template.getDetails(historyRecord));
-    expect(screen.getByText('HHG shipment #2FA5C')).toBeInTheDocument();
+    expect(screen.getByText('HHG shipment #ABC123-01')).toBeInTheDocument();
   });
   it('displays the proper name in the event name display column', () => {
     const template = getTemplate(historyRecord);

--- a/src/constants/MoveHistory/EventTemplates/CreateMTOServiceItem/createMTOServiceItem.test.jsx
+++ b/src/constants/MoveHistory/EventTemplates/CreateMTOServiceItem/createMTOServiceItem.test.jsx
@@ -14,6 +14,7 @@ describe('when given a Create basic service item history record', () => {
       {
         name: 'Domestic uncrating',
         shipment_type: 'HHG',
+        shipment_locator: 'RQ38D4-01',
         shipment_id_abbr: 'a1b2c',
       },
     ],
@@ -30,7 +31,7 @@ describe('when given a Create basic service item history record', () => {
     it.each([
       ['service_item_name', 'Domestic uncrating'],
       ['shipment_type', 'HHG'],
-      ['shipment_id_display', 'A1B2C'],
+      ['shipment_locator', 'RQ38D4-01'],
       ['reason', 'Test'],
       ['status', 'SUBMITTED'],
     ])('for label %s it displays the proper details value %s', async (label, value) => {

--- a/src/constants/MoveHistory/EventTemplates/CreateMTOServiceItem/createMTOServiceItemCustomerContacts.test.jsx
+++ b/src/constants/MoveHistory/EventTemplates/CreateMTOServiceItem/createMTOServiceItemCustomerContacts.test.jsx
@@ -15,6 +15,7 @@ describe('when given a Create basic service item customer contacts history recor
       {
         name: 'Domestic destination 1st day SIT',
         shipment_id_abbr: 'c3a9e',
+        shipment_locator: 'RQ38D4-01',
         shipment_type: 'HHG',
       },
     ],
@@ -33,6 +34,7 @@ describe('when given a Create basic service item customer contacts history recor
       {
         name: 'Domestic destination 1st day SIT',
         shipment_id_abbr: 'c3a9e',
+        shipment_locator: 'RQ38D4-01',
         shipment_type: 'HHG',
       },
     ],
@@ -50,7 +52,7 @@ describe('when given a Create basic service item customer contacts history recor
     const template = getTemplate(firstHistoryRecord);
 
     render(template.getDetails(firstHistoryRecord));
-    expect(screen.getByText('HHG shipment #C3A9E, Domestic destination 1st day SIT'));
+    expect(screen.getByText('HHG shipment #RQ38D4-01, Domestic destination 1st day SIT'));
   });
 
   describe('when given a specific set of details', () => {

--- a/src/constants/MoveHistory/EventTemplates/CreateMTOShipment/createMTOShipment.test.jsx
+++ b/src/constants/MoveHistory/EventTemplates/CreateMTOShipment/createMTOShipment.test.jsx
@@ -17,6 +17,7 @@ describe('when given a Create mto shipment history record', () => {
     context: [
       {
         shipment_type: 'HHG',
+        shipment_locator: 'RQ38D4-01',
         shipment_id_abbr: 'a1b2c',
       },
     ],
@@ -41,7 +42,7 @@ describe('when given a Create mto shipment history record', () => {
     it('displays the correct label for shipment', () => {
       const result = getTemplate(historyRecord);
       render(result.getDetails(historyRecord));
-      expect(screen.getByText('HHG shipment #A1B2C')).toBeInTheDocument();
+      expect(screen.getByText('HHG shipment #RQ38D4-01')).toBeInTheDocument();
     });
   });
 });

--- a/src/constants/MoveHistory/EventTemplates/CreateMTOShipment/createMTOShipmentPPMDetails.test.jsx
+++ b/src/constants/MoveHistory/EventTemplates/CreateMTOShipment/createMTOShipmentPPMDetails.test.jsx
@@ -23,6 +23,7 @@ describe('When a PPM is created by the Prime and the move history is viewed', ()
     context: [
       {
         shipment_type: 'PPM',
+        shipment_locator: 'RQ38D4-01',
         shipment_id_abbr: 'a1b2c',
       },
     ],
@@ -61,7 +62,7 @@ describe('When a PPM is created by the Prime and the move history is viewed', ()
     it('displays the correct label for shipment', () => {
       const result = getTemplate(historyRecord);
       render(result.getDetails(historyRecord));
-      expect(screen.getByText('PPM shipment #A1B2C')).toBeInTheDocument();
+      expect(screen.getByText('PPM shipment #RQ38D4-01')).toBeInTheDocument();
     });
   });
 });

--- a/src/constants/MoveHistory/EventTemplates/CreateMovingExpense/CreateMovingExpense.test.jsx
+++ b/src/constants/MoveHistory/EventTemplates/CreateMovingExpense/CreateMovingExpense.test.jsx
@@ -29,6 +29,7 @@ describe('When given a created moving expense history record', () => {
     context: [
       {
         shipment_id_abbr: '125d1',
+        shipment_locator: 'RQ38D4-01',
         shipment_type: 'PPM',
       },
     ],
@@ -49,7 +50,7 @@ describe('When given a created moving expense history record', () => {
       const template = getTemplate(historyRecord);
 
       render(template.getDetails(historyRecord));
-      expect(screen.getByText(`PPM shipment #125D1, ${label}`)).toBeInTheDocument();
+      expect(screen.getByText(`PPM shipment #RQ38D4-01, ${label}`)).toBeInTheDocument();
     });
   });
 });

--- a/src/constants/MoveHistory/EventTemplates/CreatePaymentRequest/createPaymentRequest.jsx
+++ b/src/constants/MoveHistory/EventTemplates/CreatePaymentRequest/createPaymentRequest.jsx
@@ -21,7 +21,7 @@ const getPaymentRequestServices = (context) => {
         shipmentServices[shipmentId] = {
           serviceItems: serviceItem.name,
           shipmentType: serviceItem.shipment_type,
-          shipmentIdAbbr: serviceItem.shipment_id_abbr.toUpperCase(),
+          shipmentIdAbbr: serviceItem.shipment_locator,
           shipmentId,
         };
       }

--- a/src/constants/MoveHistory/EventTemplates/CreatePaymentRequest/createPaymentRequest.test.jsx
+++ b/src/constants/MoveHistory/EventTemplates/CreatePaymentRequest/createPaymentRequest.test.jsx
@@ -16,6 +16,7 @@ describe('when given a payment request is created through shipment update', () =
         shipment_id: '123',
         shipment_type: 'HHG',
         shipment_id_abbr: 'acf7b',
+        shipment_locator: 'ABC123-01',
       },
       {
         name: 'Domestic uncrating',
@@ -24,6 +25,7 @@ describe('when given a payment request is created through shipment update', () =
         shipment_id: '123',
         shipment_type: 'HHG',
         shipment_id_abbr: 'acf7b',
+        shipment_locator: 'ABC123-01',
       },
       { name: 'Move management', price: '1234', status: 'REQUESTED' },
     ],
@@ -46,7 +48,7 @@ describe('when given a payment request is created through shipment update', () =
     const template = getTemplate(historyRecord);
 
     render(template.getDetails(historyRecord));
-    expect(screen.getByText('HHG shipment #ACF7B')).toBeInTheDocument();
+    expect(screen.getByText('HHG shipment #ABC123-01')).toBeInTheDocument();
   });
 
   describe('when given a specific set of details it displays the proper labeled information in the details column', () => {

--- a/src/constants/MoveHistory/EventTemplates/CreateProGearWeightTicket/CreateProGearWeightTicket.test.jsx
+++ b/src/constants/MoveHistory/EventTemplates/CreateProGearWeightTicket/CreateProGearWeightTicket.test.jsx
@@ -23,6 +23,7 @@ describe('When given a created pro-gear set history record', () => {
     context: [
       {
         shipment_id_abbr: '125d1',
+        shipment_locator: 'RQ38D4-01',
         shipment_type: 'PPM',
       },
     ],
@@ -41,6 +42,6 @@ describe('When given a created pro-gear set history record', () => {
     const template = getTemplate(historyRecord);
 
     render(template.getDetails(historyRecord));
-    expect(screen.getByText('PPM shipment #125D1')).toBeInTheDocument();
+    expect(screen.getByText('PPM shipment #RQ38D4-01')).toBeInTheDocument();
   });
 });

--- a/src/constants/MoveHistory/EventTemplates/CreateSITRequest/CreateSITAddressUpdateRequest.test.jsx
+++ b/src/constants/MoveHistory/EventTemplates/CreateSITRequest/CreateSITAddressUpdateRequest.test.jsx
@@ -16,6 +16,7 @@ describe('When given an update Destination SIT address history record', () => {
       {
         name: 'Domestic destination SIT delivery',
         shipment_type: 'HHG',
+        shipment_locator: 'RQ38D4-01',
         shipment_id_abbr: 'e4285',
         sit_destination_address_final: `{"id":"14a265d6-95b4-4842-a2ed-e020ba7da3fb","street_address_1":"676 Destination Sit Req","street_address_2":null,"city":"Florence","state":"MT","postal_code":"59805","created_at":"2023-11-21T02:56:56.832038","updated_at":"2023-11-21T02:56:56.832038","street_address_3":null,"country":null}`,
         sit_destination_address_initial: `{"id":"ff666bfe-1a2c-45e0-b38a-18c138958f16","street_address_1":"4 Delivery address init","street_address_2":null,"city":"Great Falls","state":"MT","postal_code":"59402","created_at":"2023-11-21T02:56:08.299416","updated_at":"2023-11-21T02:56:08.299416","street_address_3":null,"country":null}`,
@@ -29,7 +30,7 @@ describe('When given an update Destination SIT address history record', () => {
     const template = getTemplate(historyRecord);
 
     render(template.getDetails(historyRecord));
-    expect(screen.getByText('HHG shipment #E4285, Domestic destination SIT delivery')).toBeInTheDocument();
+    expect(screen.getByText('HHG shipment #RQ38D4-01, Domestic destination SIT delivery')).toBeInTheDocument();
   });
 
   it('displays the status of the request', () => {

--- a/src/constants/MoveHistory/EventTemplates/CreateUpload/CreatePPMUpload.test.jsx
+++ b/src/constants/MoveHistory/EventTemplates/CreateUpload/CreatePPMUpload.test.jsx
@@ -29,6 +29,7 @@ describe('When given a created pro-gear set history record', () => {
       {
         filename: 'filename.png',
         shipment_id_abbr: '125d1',
+        shipment_locator: 'RQ38D4-01',
         shipment_type: 'PPM',
       },
     ],
@@ -62,7 +63,7 @@ describe('When given a created pro-gear set history record', () => {
       const template = getTemplate(historyRecord);
 
       render(template.getDetails(historyRecord));
-      expect(screen.getByText(`PPM shipment #125D1, ${label}`)).toBeInTheDocument();
+      expect(screen.getByText(`PPM shipment #RQ38D4-01, ${label}`)).toBeInTheDocument();
     });
   });
 });

--- a/src/constants/MoveHistory/EventTemplates/CreateWeightTicket/CreateWeightTicket.test.jsx
+++ b/src/constants/MoveHistory/EventTemplates/CreateWeightTicket/CreateWeightTicket.test.jsx
@@ -23,6 +23,7 @@ describe('When given a created trip history record', () => {
     context: [
       {
         shipment_id_abbr: '125d1',
+        shipment_locator: 'RQ38D4-01',
         shipment_type: 'PPM',
       },
     ],
@@ -41,6 +42,6 @@ describe('When given a created trip history record', () => {
     const template = getTemplate(historyRecord);
 
     render(template.getDetails(historyRecord));
-    expect(screen.getByText('PPM shipment #125D1')).toBeInTheDocument();
+    expect(screen.getByText('PPM shipment #RQ38D4-01')).toBeInTheDocument();
   });
 });

--- a/src/constants/MoveHistory/EventTemplates/DeleteMovingExpense/DeleteMovingExpense.test.jsx
+++ b/src/constants/MoveHistory/EventTemplates/DeleteMovingExpense/DeleteMovingExpense.test.jsx
@@ -17,6 +17,7 @@ describe('When given a deleted expense receipt history record', () => {
     context: [
       {
         shipment_id_abbr: '7f559',
+        shipment_locator: 'RQ38D4-01',
         shipment_type: 'PPM',
       },
     ],
@@ -37,7 +38,7 @@ describe('When given a deleted expense receipt history record', () => {
       const template = getTemplate(historyRecord);
 
       render(template.getDetails(historyRecord));
-      expect(screen.getByText(`PPM shipment #7F559, ${label}`)).toBeInTheDocument();
+      expect(screen.getByText(`PPM shipment #RQ38D4-01, ${label}`)).toBeInTheDocument();
     });
   });
 });

--- a/src/constants/MoveHistory/EventTemplates/DeleteMovingExpense/DeleteMovingExpenseUserUploads.test.jsx
+++ b/src/constants/MoveHistory/EventTemplates/DeleteMovingExpense/DeleteMovingExpenseUserUploads.test.jsx
@@ -18,6 +18,7 @@ describe('When given a deleted expense receipt upload', () => {
       {
         filename: 'expense.png',
         shipment_id_abbr: '7f559',
+        shipment_locator: 'RQ38D4-01',
         shipment_type: 'PPM',
         upload_type: 'expenseReceipt',
       },
@@ -39,7 +40,7 @@ describe('When given a deleted expense receipt upload', () => {
       const template = getTemplate(historyRecord);
 
       render(template.getDetails(historyRecord));
-      expect(screen.getByText(`PPM shipment #7F559, ${label}`)).toBeInTheDocument();
+      expect(screen.getByText(`PPM shipment #RQ38D4-01, ${label}`)).toBeInTheDocument();
     });
   });
 

--- a/src/constants/MoveHistory/EventTemplates/DeleteProGearWeightTicket/DeleteProGearWeightTicket.test.jsx
+++ b/src/constants/MoveHistory/EventTemplates/DeleteProGearWeightTicket/DeleteProGearWeightTicket.test.jsx
@@ -14,6 +14,7 @@ describe('When given a deleted pro-gear set history record', () => {
     context: [
       {
         shipment_id_abbr: '125d1',
+        shipment_locator: 'RQ38D4-01',
         shipment_type: 'PPM',
       },
     ],
@@ -32,6 +33,6 @@ describe('When given a deleted pro-gear set history record', () => {
     const template = getTemplate(historyRecord);
 
     render(template.getDetails(historyRecord));
-    expect(screen.getByText('PPM shipment #125D1')).toBeInTheDocument();
+    expect(screen.getByText('PPM shipment #RQ38D4-01')).toBeInTheDocument();
   });
 });

--- a/src/constants/MoveHistory/EventTemplates/DeleteProGearWeightTicket/DeleteProGearWeightTicketUserUploads.test.jsx
+++ b/src/constants/MoveHistory/EventTemplates/DeleteProGearWeightTicket/DeleteProGearWeightTicketUserUploads.test.jsx
@@ -16,6 +16,7 @@ describe('When given a deleted pro-gear weight ticket upload', () => {
         filename: 'pgWeight.jpg',
         moving_expense_type: '',
         shipment_id_abbr: '125d1',
+        shipment_locator: 'RQ38D4-01',
         shipment_type: 'PPM',
         upload_type: 'spouseProGearWeightTicket',
       },
@@ -35,7 +36,7 @@ describe('When given a deleted pro-gear weight ticket upload', () => {
     const template = getTemplate(historyRecord);
 
     render(template.getDetails(historyRecord));
-    expect(screen.getByText('PPM shipment #125D1')).toBeInTheDocument();
+    expect(screen.getByText('PPM shipment #RQ38D4-01')).toBeInTheDocument();
   });
 
   it('displays details the deleted document', () => {

--- a/src/constants/MoveHistory/EventTemplates/DeleteShipment/DeleteShipmentPPM.jsx
+++ b/src/constants/MoveHistory/EventTemplates/DeleteShipment/DeleteShipmentPPM.jsx
@@ -12,7 +12,7 @@ export default {
   getEventNameDisplay: () => 'Deleted shipment',
   getDetails: ({ context }) => (
     <>
-      {s[context[0].shipment_type]} shipment #{context[0].shipment_id_abbr.toUpperCase()} deleted
+      {s[context[0].shipment_type]} shipment #{context[0].shipment_locator} deleted
     </>
   ),
 };

--- a/src/constants/MoveHistory/EventTemplates/DeleteShipment/DeleteShipmentPPM.test.jsx
+++ b/src/constants/MoveHistory/EventTemplates/DeleteShipment/DeleteShipmentPPM.test.jsx
@@ -7,7 +7,7 @@ describe('When a prime deletes a shipment', () => {
   const historyRecord = {
     action: 'UPDATE',
     eventName: 'deleteMTOShipment',
-    context: [{ shipment_id_abbr: '3b475', shipment_type: 'PPM' }],
+    context: [{ shipment_id_abbr: '3b475', shipment_type: 'PPM', shipment_locator: 'ABC123-01' }],
     tableName: 'ppm_shipments',
   };
 
@@ -20,6 +20,6 @@ describe('When a prime deletes a shipment', () => {
     const template = getTemplate(historyRecord);
 
     render(template.getDetails(historyRecord));
-    expect(screen.getByText('PPM shipment #3B475 deleted')).toBeInTheDocument();
+    expect(screen.getByText('PPM shipment #ABC123-01 deleted')).toBeInTheDocument();
   });
 });

--- a/src/constants/MoveHistory/EventTemplates/DeleteShipment/deleteShipment.jsx
+++ b/src/constants/MoveHistory/EventTemplates/DeleteShipment/deleteShipment.jsx
@@ -12,7 +12,7 @@ export default {
   getEventNameDisplay: () => 'Deleted shipment',
   getDetails: ({ context }) => (
     <>
-      {s[context[0].shipment_type]} shipment #{context[0].shipment_id_abbr.toUpperCase()} deleted
+      {s[context[0].shipment_type]} shipment #{context[0].shipment_locator} deleted
     </>
   ),
 };

--- a/src/constants/MoveHistory/EventTemplates/DeleteShipment/deleteShipment.test.jsx
+++ b/src/constants/MoveHistory/EventTemplates/DeleteShipment/deleteShipment.test.jsx
@@ -7,7 +7,7 @@ describe('When a service counselor deletes a shipment', () => {
   const historyRecord = {
     action: 'UPDATE',
     eventName: 'deleteShipment',
-    context: [{ shipment_id_abbr: '3a771', shipment_type: 'HHG' }],
+    context: [{ shipment_id_abbr: '3a771', shipment_type: 'HHG', shipment_locator: 'ABC123-01' }],
     tableName: 'mto_shipments',
   };
 
@@ -20,6 +20,6 @@ describe('When a service counselor deletes a shipment', () => {
     const template = getTemplate(historyRecord);
 
     render(template.getDetails(historyRecord));
-    expect(screen.getByText('HHG shipment #3A771 deleted')).toBeInTheDocument();
+    expect(screen.getByText('HHG shipment #ABC123-01 deleted')).toBeInTheDocument();
   });
 });

--- a/src/constants/MoveHistory/EventTemplates/DeleteWeightTicket/DeleteWeightTicket.test.jsx
+++ b/src/constants/MoveHistory/EventTemplates/DeleteWeightTicket/DeleteWeightTicket.test.jsx
@@ -14,6 +14,7 @@ describe('When given a deleted trip history record', () => {
     context: [
       {
         shipment_id_abbr: '7f559',
+        shipment_locator: 'RQ38D4-01',
         shipment_type: 'PPM',
       },
     ],
@@ -32,6 +33,6 @@ describe('When given a deleted trip history record', () => {
     const template = getTemplate(historyRecord);
 
     render(template.getDetails(historyRecord));
-    expect(screen.getByText('PPM shipment #7F559')).toBeInTheDocument();
+    expect(screen.getByText('PPM shipment #RQ38D4-01')).toBeInTheDocument();
   });
 });

--- a/src/constants/MoveHistory/EventTemplates/DeleteWeightTicket/DeleteWeightTicketPPMShipments.test.jsx
+++ b/src/constants/MoveHistory/EventTemplates/DeleteWeightTicket/DeleteWeightTicketPPMShipments.test.jsx
@@ -14,6 +14,7 @@ describe('When given a deleted trip history record', () => {
     context: [
       {
         shipment_id_abbr: '7f559',
+        shipment_locator: 'RQ38D4-01',
         shipment_type: 'PPM',
       },
     ],
@@ -32,7 +33,7 @@ describe('When given a deleted trip history record', () => {
     const template = getTemplate(historyRecord);
 
     render(template.getDetails(historyRecord));
-    expect(screen.getByText('PPM shipment #7F559')).toBeInTheDocument();
+    expect(screen.getByText('PPM shipment #RQ38D4-01')).toBeInTheDocument();
   });
 
   it('displays incentive details', () => {

--- a/src/constants/MoveHistory/EventTemplates/DeleteWeightTicket/DeleteWeightTicketUserUploads.test.jsx
+++ b/src/constants/MoveHistory/EventTemplates/DeleteWeightTicket/DeleteWeightTicketUserUploads.test.jsx
@@ -16,6 +16,7 @@ describe('When given a deleted trip weight ticket upload', () => {
         filename: 'pgWeight.jpg',
         moving_expense_type: '',
         shipment_id_abbr: '125d1',
+        shipment_locator: 'RQ38D4-01',
         shipment_type: 'PPM',
       },
     ],
@@ -34,7 +35,7 @@ describe('When given a deleted trip weight ticket upload', () => {
     const template = getTemplate(historyRecord);
 
     render(template.getDetails(historyRecord));
-    expect(screen.getByText('PPM shipment #125D1')).toBeInTheDocument();
+    expect(screen.getByText('PPM shipment #RQ38D4-01')).toBeInTheDocument();
   });
 
   describe('displays details of a deleted ', () => {

--- a/src/constants/MoveHistory/EventTemplates/FinishDocumentReview/finishDocumentReview.test.jsx
+++ b/src/constants/MoveHistory/EventTemplates/FinishDocumentReview/finishDocumentReview.test.jsx
@@ -11,6 +11,7 @@ describe('When given a completed services counseling for a move', () => {
     context: [
       {
         shipment_id_abbr: 'acf7b',
+        shipment_locator: 'RQ38D4-01',
         shipment_type: 'PPM',
       },
     ],
@@ -25,7 +26,7 @@ describe('When given a completed services counseling for a move', () => {
     const template = getTemplate(historyRecord);
 
     render(template.getDetails(historyRecord));
-    expect(screen.getByText('PPM shipment #ACF7B')).toBeInTheDocument();
+    expect(screen.getByText('PPM shipment #RQ38D4-01')).toBeInTheDocument();
   });
 
   describe('When given a specific set of details for a cancelled shipment', () => {

--- a/src/constants/MoveHistory/EventTemplates/RequestShipmentCancellation/requestShipmentCancellation.jsx
+++ b/src/constants/MoveHistory/EventTemplates/RequestShipmentCancellation/requestShipmentCancellation.jsx
@@ -12,7 +12,7 @@ export default {
   getEventNameDisplay: () => 'Updated shipment',
   getDetails: ({ context }) => (
     <>
-      Requested cancellation for {s[context[0]?.shipment_type]} shipment #{context[0]?.shipment_id_abbr.toUpperCase()}
+      Requested cancellation for {s[context[0]?.shipment_type]} shipment #{context[0]?.shipment_locator}
     </>
   ),
 };

--- a/src/constants/MoveHistory/EventTemplates/RequestShipmentCancellation/requestShipmentCancellation.test.jsx
+++ b/src/constants/MoveHistory/EventTemplates/RequestShipmentCancellation/requestShipmentCancellation.test.jsx
@@ -16,6 +16,7 @@ describe('when given a Request shipment cancellation history record', () => {
       {
         shipment_id_abbr: 'acf7b',
         shipment_type: 'HHG',
+        shipment_locator: 'ABC123-01',
       },
     ],
   };
@@ -29,6 +30,6 @@ describe('when given a Request shipment cancellation history record', () => {
     const template = getTemplate(historyRecord);
 
     render(template.getDetails(historyRecord));
-    expect(screen.getByText('Requested cancellation for HHG shipment #ACF7B'));
+    expect(screen.getByText('Requested cancellation for HHG shipment #ABC123-01'));
   });
 });

--- a/src/constants/MoveHistory/EventTemplates/RequestShipmentDiversion/requestShipmentDiversion.jsx
+++ b/src/constants/MoveHistory/EventTemplates/RequestShipmentDiversion/requestShipmentDiversion.jsx
@@ -12,7 +12,7 @@ export default {
   getEventNameDisplay: () => 'Updated shipment',
   getDetails: ({ context }) => (
     <>
-      Requested diversion for {s[context[0]?.shipment_type]} shipment #{context[0].shipment_id_abbr.toUpperCase()}
+      Requested diversion for {s[context[0]?.shipment_type]} shipment #{context[0].shipment_locator}
     </>
   ),
 };

--- a/src/constants/MoveHistory/EventTemplates/RequestShipmentDiversion/requestShipmentDiversion.test.jsx
+++ b/src/constants/MoveHistory/EventTemplates/RequestShipmentDiversion/requestShipmentDiversion.test.jsx
@@ -12,6 +12,7 @@ describe('when a shipment diversion is requested', () => {
       {
         shipment_id_abbr: '2fa5c',
         shipment_type: 'HHG',
+        shipment_locator: 'ABC123-01',
       },
     ],
     tableName: 'mto_shipments',
@@ -26,6 +27,6 @@ describe('when a shipment diversion is requested', () => {
     const template = getTemplate(historyRecord);
 
     render(template.getDetails(historyRecord));
-    expect(screen.getByText('Requested diversion for HHG shipment #2FA5C')).toBeInTheDocument();
+    expect(screen.getByText('Requested diversion for HHG shipment #ABC123-01')).toBeInTheDocument();
   });
 });

--- a/src/constants/MoveHistory/EventTemplates/RequestShipmentReweigh/requestShipmentReweigh.jsx
+++ b/src/constants/MoveHistory/EventTemplates/RequestShipmentReweigh/requestShipmentReweigh.jsx
@@ -12,7 +12,7 @@ export default {
   getEventNameDisplay: () => 'Updated shipment',
   getDetails: ({ context }) => (
     <>
-      {s[context[0].shipment_type]} shipment #{context[0].shipment_id_abbr.toUpperCase()}, reweigh requested
+      {s[context[0].shipment_type]} shipment #{context[0].shipment_locator}, reweigh requested
     </>
   ),
 };

--- a/src/constants/MoveHistory/EventTemplates/RequestShipmentReweigh/requestShipmentReweigh.test.jsx
+++ b/src/constants/MoveHistory/EventTemplates/RequestShipmentReweigh/requestShipmentReweigh.test.jsx
@@ -6,7 +6,7 @@ import e from 'constants/MoveHistory/EventTemplates/RequestShipmentReweigh/reque
 describe('when given a Request shipment reweigh history record', () => {
   const historyRecord = {
     action: 'INSERT',
-    context: [{ shipment_type: 'HHG', shipment_id_abbr: 'a1b2c' }],
+    context: [{ shipment_type: 'HHG', shipment_id_abbr: 'a1b2c', shipment_locator: 'ABC123-01' }],
     eventName: 'requestShipmentReweigh',
     tableName: 'reweighs',
   };
@@ -20,6 +20,6 @@ describe('when given a Request shipment reweigh history record', () => {
     const template = getTemplate(historyRecord);
 
     render(template.getDetails(historyRecord));
-    expect(screen.getByText('HHG shipment #A1B2C, reweigh requested')).toBeInTheDocument();
+    expect(screen.getByText('HHG shipment #ABC123-01, reweigh requested')).toBeInTheDocument();
   });
 });

--- a/src/constants/MoveHistory/EventTemplates/SubmitMoveForApproval/SubmitMoveForApprovalMTOShipments.test.jsx
+++ b/src/constants/MoveHistory/EventTemplates/SubmitMoveForApproval/SubmitMoveForApprovalMTOShipments.test.jsx
@@ -16,6 +16,7 @@ describe('when given a PPM shipment update', () => {
     context: [
       {
         shipment_type: 'HHG',
+        shipment_locator: 'RQ38D4-01',
         shipment_id_abbr: '12992',
       },
     ],
@@ -24,7 +25,7 @@ describe('when given a PPM shipment update', () => {
   it('displays the correct label for shipment', () => {
     const result = getTemplate(historyRecord);
     render(result.getDetails(historyRecord));
-    expect(screen.getByText('HHG shipment #12992')).toBeInTheDocument();
+    expect(screen.getByText('HHG shipment #RQ38D4-01')).toBeInTheDocument();
   });
 
   it('displays that the shipment was submitted', () => {

--- a/src/constants/MoveHistory/EventTemplates/SubmitMoveForApproval/SubmitMoveForApprovalPPMShipments.test.jsx
+++ b/src/constants/MoveHistory/EventTemplates/SubmitMoveForApproval/SubmitMoveForApprovalPPMShipments.test.jsx
@@ -16,6 +16,7 @@ describe('when given a PPM shipment update', () => {
     context: [
       {
         shipment_type: 'PPM',
+        shipment_locator: 'RQ38D4-01',
         shipment_id_abbr: '12992',
       },
     ],
@@ -24,7 +25,7 @@ describe('when given a PPM shipment update', () => {
   it('displays the correct label for shipment', () => {
     const result = getTemplate(historyRecord);
     render(result.getDetails(historyRecord));
-    expect(screen.getByText('PPM shipment #12992')).toBeInTheDocument();
+    expect(screen.getByText('PPM shipment #RQ38D4-01')).toBeInTheDocument();
   });
 
   it('displays that the shipment was submitted', () => {

--- a/src/constants/MoveHistory/EventTemplates/SubmitPPMShipmentDocumentation/SubmitPPMShipmentDocumentation.test.jsx
+++ b/src/constants/MoveHistory/EventTemplates/SubmitPPMShipmentDocumentation/SubmitPPMShipmentDocumentation.test.jsx
@@ -16,6 +16,7 @@ describe('when given a PPM shipment update', () => {
     context: [
       {
         shipment_type: 'PPM',
+        shipment_locator: 'RQ38D4-01',
         shipment_id_abbr: '12992',
       },
     ],
@@ -24,7 +25,7 @@ describe('when given a PPM shipment update', () => {
   it('displays the correct label for shipment', () => {
     const result = getTemplate(historyRecord);
     render(result.getDetails(historyRecord));
-    expect(screen.getByText('PPM shipment #12992')).toBeInTheDocument();
+    expect(screen.getByText('PPM shipment #RQ38D4-01')).toBeInTheDocument();
   });
 
   it('displays that the shipment was submitted', () => {

--- a/src/constants/MoveHistory/EventTemplates/UpdateMTOServiceItem/updateMTOServiceItem.test.jsx
+++ b/src/constants/MoveHistory/EventTemplates/UpdateMTOServiceItem/updateMTOServiceItem.test.jsx
@@ -17,6 +17,7 @@ describe('when given a Update basic service item history record', () => {
       {
         name: 'Domestic uncrating',
         shipment_type: 'HHG',
+        shipment_locator: 'RQ38D4-01',
         shipment_id_abbr: 'a1b2c',
       },
     ],
@@ -32,7 +33,7 @@ describe('when given a Update basic service item history record', () => {
     const template = getTemplate(historyRecord);
 
     render(template.getDetails(historyRecord));
-    expect(screen.getByText('HHG shipment #A1B2C, Domestic uncrating')).toBeInTheDocument();
+    expect(screen.getByText('HHG shipment #RQ38D4-01, Domestic uncrating')).toBeInTheDocument();
   });
 
   describe('When given a specific set of details', () => {

--- a/src/constants/MoveHistory/EventTemplates/UpdateMTOShipment/UpdateMTOShipmentPPMDetails.test.jsx
+++ b/src/constants/MoveHistory/EventTemplates/UpdateMTOShipment/UpdateMTOShipmentPPMDetails.test.jsx
@@ -26,6 +26,7 @@ describe('when given a PPM shipment update', () => {
     context: [
       {
         shipment_type: 'PPM',
+        shipment_locator: 'RQ38D4-01',
         shipment_id_abbr: '12992',
       },
     ],
@@ -44,6 +45,7 @@ describe('when given a PPM shipment update', () => {
     context: [
       {
         shipment_type: 'PPM',
+        shipment_locator: 'RQ38D4-01',
         shipment_id_abbr: '12992',
       },
     ],
@@ -61,6 +63,7 @@ describe('when given a PPM shipment update', () => {
     context: [
       {
         shipment_type: 'PPM',
+        shipment_locator: 'RQ38D4-01',
         shipment_id_abbr: '12992',
       },
     ],
@@ -76,6 +79,7 @@ describe('when given a PPM shipment update', () => {
     context: [
       {
         shipment_type: 'PPM',
+        shipment_locator: 'RQ38D4-01',
         shipment_id_abbr: '12992',
       },
     ],
@@ -96,6 +100,7 @@ describe('when given a PPM shipment update', () => {
     context: [
       {
         shipment_id_abbr: '125d1',
+        shipment_locator: 'RQ38D4-01',
         shipment_type: 'PPM',
         w2_address:
           '{"id":"6c1df26c-76bc-42c4-9c7f-c626a78739d3","street_address_1":"123 Dad St","street_address_2":null,"city":"Missoula","state":"MT","postal_code":"59801","created_at":"2024-02-15T08:39:41.692044","updated_at":"2024-02-16T03:36:51.388835","street_address_3":null,"country":null}',
@@ -110,7 +115,7 @@ describe('when given a PPM shipment update', () => {
   it('displays the correct label for shipment', () => {
     const result = getTemplate(historyRecord);
     render(result.getDetails(historyRecord));
-    expect(screen.getByText('PPM shipment #12992')).toBeInTheDocument();
+    expect(screen.getByText('PPM shipment #RQ38D4-01')).toBeInTheDocument();
   });
   describe('it correctly renders the shipment details', () => {
     it.each([

--- a/src/constants/MoveHistory/EventTemplates/UpdateMTOShipment/createMTOShipmentAgent.test.jsx
+++ b/src/constants/MoveHistory/EventTemplates/UpdateMTOShipment/createMTOShipmentAgent.test.jsx
@@ -15,7 +15,7 @@ describe('when given a historyRecord that updates a receiving/releasing agent', 
       phone: '555-555-5555',
       agent_type: 'RELEASING_AGENT',
     },
-    context: [{ shipment_type: 'HHG', shipment_id_abbr: 'a1b2c' }],
+    context: [{ shipment_type: 'HHG', shipment_locator: 'RQ38D4-01', shipment_id_abbr: 'a1b2c' }],
   };
   const historyRecord2 = {
     action: 'INSERT',
@@ -28,7 +28,7 @@ describe('when given a historyRecord that updates a receiving/releasing agent', 
       phone: '999-999-9999',
       agent_type: 'RECEIVING_AGENT',
     },
-    context: [{ shipment_type: 'HHG', shipment_id_abbr: 'a1b2c' }],
+    context: [{ shipment_type: 'HHG', shipment_locator: 'RQ38D4-01', shipment_id_abbr: 'a1b2c' }],
   };
   const historyRecord3 = {
     action: 'INSERT',
@@ -41,7 +41,7 @@ describe('when given a historyRecord that updates a receiving/releasing agent', 
       phone: '555-555-5555',
       agent_type: 'RELEASING_AGENT',
     },
-    context: [{ shipment_type: 'HHG', shipment_id_abbr: 'a1b2c' }],
+    context: [{ shipment_type: 'HHG', shipment_locator: 'RQ38D4-01', shipment_id_abbr: 'a1b2c' }],
   };
   const historyRecord4 = {
     action: 'INSERT',
@@ -54,7 +54,7 @@ describe('when given a historyRecord that updates a receiving/releasing agent', 
       phone: '999-999-9999',
       agent_type: 'RECEIVING_AGENT',
     },
-    context: [{ shipment_type: 'HHG', shipment_id_abbr: 'a1b2c' }],
+    context: [{ shipment_type: 'HHG', shipment_locator: 'RQ38D4-01', shipment_id_abbr: 'a1b2c' }],
   };
   it.each([
     ['Releasing agent', ': Grace Griffin, 555-555-5555, grace@email.com', historyRecord1],
@@ -66,7 +66,7 @@ describe('when given a historyRecord that updates a receiving/releasing agent', 
     expect(template).toMatchObject(e);
 
     render(template.getDetails(historyRecord));
-    expect(screen.getByText('HHG shipment #A1B2C')).toBeInTheDocument();
+    expect(screen.getByText('HHG shipment #RQ38D4-01')).toBeInTheDocument();
     expect(screen.getByText(label)).toBeInTheDocument();
     expect(screen.getByText(value)).toBeInTheDocument();
   });

--- a/src/constants/MoveHistory/EventTemplates/UpdateMTOShipment/createReweighRequestWeightUpdate.jsx
+++ b/src/constants/MoveHistory/EventTemplates/UpdateMTOShipment/createReweighRequestWeightUpdate.jsx
@@ -12,7 +12,7 @@ export default {
   getEventNameDisplay: () => `Updated shipment`,
   getDetails: ({ context }) => {
     const shipmentType = context[0].shipment_type;
-    const shipmentIdDisplay = context[0].shipment_id_abbr.toUpperCase();
+    const shipmentIdDisplay = context[0].shipment_locator;
     return (
       <>
         {shipmentTypes[shipmentType]} shipment #{shipmentIdDisplay}, reweigh requested

--- a/src/constants/MoveHistory/EventTemplates/UpdateMTOShipment/createReweighRequestWeightUpdate.test.jsx
+++ b/src/constants/MoveHistory/EventTemplates/UpdateMTOShipment/createReweighRequestWeightUpdate.test.jsx
@@ -12,6 +12,7 @@ describe('when given an mto shipment reweigh request', () => {
       {
         shipment_type: 'PPM',
         shipment_id_abbr: 'b4b4b',
+        shipment_locator: 'ABC123-01',
       },
     ],
   };
@@ -23,6 +24,6 @@ describe('when given an mto shipment reweigh request', () => {
   it('displays the correct details component', () => {
     const result = getTemplate(historyRecord);
     render(result.getDetails(historyRecord));
-    expect(screen.getByText('PPM shipment #B4B4B, reweigh requested')).toBeInTheDocument();
+    expect(screen.getByText('PPM shipment #ABC123-01, reweigh requested')).toBeInTheDocument();
   });
 });

--- a/src/constants/MoveHistory/EventTemplates/UpdateMTOShipment/updateMTOShipment.test.jsx
+++ b/src/constants/MoveHistory/EventTemplates/UpdateMTOShipment/updateMTOShipment.test.jsx
@@ -60,6 +60,7 @@ describe('when given an mto shipment update with mto shipment table history reco
     context: [
       {
         shipment_type: 'PPM',
+        shipment_locator: 'RQ38D4-01',
         shipment_id_abbr: 'b4b4b',
       },
     ],
@@ -118,7 +119,7 @@ describe('when given an mto shipment update with mto shipment table history reco
     it('displays the correct label for shipment', () => {
       const result = getTemplate(historyRecord);
       render(result.getDetails(historyRecord));
-      expect(screen.getByText('PPM shipment #B4B4B')).toBeInTheDocument();
+      expect(screen.getByText('PPM shipment #RQ38D4-01')).toBeInTheDocument();
     });
   });
 });

--- a/src/constants/MoveHistory/EventTemplates/UpdateMTOShipment/updateMTOShipmentAgent.test.jsx
+++ b/src/constants/MoveHistory/EventTemplates/UpdateMTOShipment/updateMTOShipmentAgent.test.jsx
@@ -21,7 +21,7 @@ describe('when given an mto shipment agents update with mto agents table history
         last_name: 'Griffin',
         phone: '555-555-5551',
       },
-      context: [{ shipment_type: 'HHG', shipment_id_abbr: 'a1b2c' }],
+      context: [{ shipment_type: 'HHG', shipment_locator: 'RQ38D4-01', shipment_id_abbr: 'a1b2c' }],
     },
     RECEIVE: {
       action: 'UPDATE',
@@ -39,7 +39,7 @@ describe('when given an mto shipment agents update with mto agents table history
         last_name: 'Drew',
         phone: '555-555-5551',
       },
-      context: [{ shipment_type: 'HHG', shipment_id_abbr: 'a1b2c' }],
+      context: [{ shipment_type: 'HHG', shipment_locator: 'RQ38D4-01', shipment_id_abbr: 'a1b2c' }],
     },
   };
 
@@ -52,7 +52,7 @@ describe('when given an mto shipment agents update with mto agents table history
     it('displays the proper shipment title in the details column', () => {
       const template = getTemplate(historyRecord.RELEASE);
       render(template.getDetails(historyRecord.RELEASE));
-      expect(screen.getAllByText('HHG shipment #A1B2C'));
+      expect(screen.getAllByText('HHG shipment #RQ38D4-01'));
     });
 
     it('it displays the proper labeled details for the given releasing agent', () => {
@@ -72,7 +72,7 @@ describe('when given an mto shipment agents update with mto agents table history
     it('displays the proper shipment title in the details column', () => {
       const template = getTemplate(historyRecord.RECEIVE);
       render(template.getDetails(historyRecord.RECEIVE));
-      expect(screen.getAllByText('HHG shipment #A1B2C'));
+      expect(screen.getAllByText('HHG shipment #RQ38D4-01'));
     });
 
     it('it displays the proper labeled details for the given releasing agent', () => {

--- a/src/constants/MoveHistory/EventTemplates/UpdateMTOShipmentStatus/updateMTOShipmentStatus.test.jsx
+++ b/src/constants/MoveHistory/EventTemplates/UpdateMTOShipmentStatus/updateMTOShipmentStatus.test.jsx
@@ -11,6 +11,7 @@ describe('when Prime user cancels a shipment', () => {
     context: [
       {
         shipment_id_abbr: 'acf7b',
+        shipment_locator: 'RQ38D4-01',
         shipment_type: 'HHG',
       },
     ],
@@ -26,7 +27,7 @@ describe('when Prime user cancels a shipment', () => {
     const template = getTemplate(historyRecord);
 
     render(template.getDetails(historyRecord));
-    expect(screen.getByText('HHG shipment #ACF7B')).toBeInTheDocument();
+    expect(screen.getByText('HHG shipment #RQ38D4-01')).toBeInTheDocument();
   });
 
   describe('When given a specific set of details for a cancelled shipment', () => {

--- a/src/constants/MoveHistory/EventTemplates/UpdateMTOStatusServiceCounselingCompleted/updateMTOStatusServiceCounselingCompletedPPM.test.jsx
+++ b/src/constants/MoveHistory/EventTemplates/UpdateMTOStatusServiceCounselingCompleted/updateMTOStatusServiceCounselingCompletedPPM.test.jsx
@@ -11,6 +11,7 @@ describe('When given a completed services counseling for a move', () => {
     context: [
       {
         shipment_id_abbr: 'acf7b',
+        shipment_locator: 'RQ38D4-01',
         shipment_type: 'PPM',
       },
     ],
@@ -25,7 +26,7 @@ describe('When given a completed services counseling for a move', () => {
     const template = getTemplate(historyRecord);
 
     render(template.getDetails(historyRecord));
-    expect(screen.getByText('PPM shipment #ACF7B')).toBeInTheDocument();
+    expect(screen.getByText('PPM shipment #RQ38D4-01')).toBeInTheDocument();
   });
 
   describe('When given a specific set of details for a counseled PPM shipment', () => {

--- a/src/constants/MoveHistory/EventTemplates/UpdateMovingExpense/UpdateMovingExpense.test.jsx
+++ b/src/constants/MoveHistory/EventTemplates/UpdateMovingExpense/UpdateMovingExpense.test.jsx
@@ -16,6 +16,7 @@ describe('When given an updated expense document it', () => {
     context: [
       {
         shipment_id_abbr: '71f6f',
+        shipment_locator: 'RQ38D4-01',
         shipment_type: 'PPM',
       },
     ],
@@ -34,7 +35,7 @@ describe('When given an updated expense document it', () => {
       const template = getTemplate(expenseRecord);
 
       render(template.getDetails(expenseRecord));
-      expect(screen.getByText(`PPM shipment #71F6F, ${label}`)).toBeInTheDocument();
+      expect(screen.getByText(`PPM shipment #RQ38D4-01, ${label}`)).toBeInTheDocument();
       expect(screen.getByText(': APPROVED')).toBeInTheDocument();
       expect(screen.getByText(': $9,999.99')).toBeInTheDocument();
     });
@@ -51,7 +52,7 @@ describe('When given an updated expense document it', () => {
       const template = getTemplate(expenseRecord);
 
       render(template.getDetails(expenseRecord));
-      expect(screen.getByText(`PPM shipment #71F6F, ${label}`)).toBeInTheDocument();
+      expect(screen.getByText(`PPM shipment #RQ38D4-01, ${label}`)).toBeInTheDocument();
       expect(screen.getByText(': REJECTED')).toBeInTheDocument();
       expect(screen.getByText(': cannot read document')).toBeInTheDocument();
     });
@@ -68,7 +69,7 @@ describe('When given an updated expense document it', () => {
       const template = getTemplate(expenseRecord);
 
       render(template.getDetails(expenseRecord));
-      expect(screen.getByText(`PPM shipment #71F6F, ${label}`)).toBeInTheDocument();
+      expect(screen.getByText(`PPM shipment #RQ38D4-01, ${label}`)).toBeInTheDocument();
       expect(screen.getByText(': EXCLUDED')).toBeInTheDocument();
       expect(screen.getByText(': claim on taxes')).toBeInTheDocument();
     });

--- a/src/constants/MoveHistory/EventTemplates/UpdateReweigh/updateReweighWeight.test.jsx
+++ b/src/constants/MoveHistory/EventTemplates/UpdateReweigh/updateReweighWeight.test.jsx
@@ -7,7 +7,7 @@ describe('when given an updated reweigh weight', () => {
   const historyRecord = {
     action: 'UPDATE',
     changedValues: { weight: '9001' },
-    context: [{ shipment_type: 'HHG', shipment_id_abbr: 'a1b2c' }],
+    context: [{ shipment_type: 'HHG', shipment_locator: 'RQ38D4-01', shipment_id_abbr: 'a1b2c' }],
     eventName: 'updateReweigh',
     tableName: 'reweighs',
   };
@@ -21,7 +21,7 @@ describe('when given an updated reweigh weight', () => {
     const template = getTemplate(historyRecord);
 
     render(template.getDetails(historyRecord));
-    expect(screen.getByText('HHG shipment #A1B2C')).toBeInTheDocument();
+    expect(screen.getByText('HHG shipment #RQ38D4-01')).toBeInTheDocument();
   });
 
   describe('displays the correct labeled values in the details column', () => {

--- a/src/constants/MoveHistory/EventTemplates/UpdateSITAddress/ApproveSITAddressUpdate.test.jsx
+++ b/src/constants/MoveHistory/EventTemplates/UpdateSITAddress/ApproveSITAddressUpdate.test.jsx
@@ -16,6 +16,7 @@ describe('When given an update Destination SIT address history record', () => {
       {
         name: 'Domestic destination SIT delivery',
         shipment_type: 'HHG',
+        shipment_locator: 'RQ38D4-01',
         shipment_id_abbr: 'e4285',
         sit_destination_address_final: `{"id":"14a265d6-95b4-4842-a2ed-e020ba7da3fb","street_address_1":"676 Destination Sit Req","street_address_2":null,"city":"Florence","state":"MT","postal_code":"59805","created_at":"2023-11-21T02:56:56.832038","updated_at":"2023-11-21T02:56:56.832038","street_address_3":null,"country":null}`,
         sit_destination_address_initial: `{"id":"ff666bfe-1a2c-45e0-b38a-18c138958f16","street_address_1":"4 Delivery address init","street_address_2":null,"city":"Great Falls","state":"MT","postal_code":"59402","created_at":"2023-11-21T02:56:08.299416","updated_at":"2023-11-21T02:56:08.299416","street_address_3":null,"country":null}`,
@@ -30,7 +31,7 @@ describe('When given an update Destination SIT address history record', () => {
     const template = getTemplate(historyRecord);
 
     render(template.getDetails(historyRecord));
-    expect(screen.getByText('HHG shipment #E4285, Domestic destination SIT delivery')).toBeInTheDocument();
+    expect(screen.getByText('HHG shipment #RQ38D4-01, Domestic destination SIT delivery')).toBeInTheDocument();
   });
 
   it('displays the status of the request', () => {

--- a/src/constants/MoveHistory/EventTemplates/UpdateSITAddress/CreateSITAddressUpdate.test.jsx
+++ b/src/constants/MoveHistory/EventTemplates/UpdateSITAddress/CreateSITAddressUpdate.test.jsx
@@ -16,6 +16,7 @@ describe('When given an update Destination SIT address history record', () => {
       {
         name: 'Domestic destination SIT delivery',
         shipment_type: 'HHG',
+        shipment_locator: 'RQ38D4-01',
         shipment_id_abbr: 'e4285',
         sit_destination_address_final: `{"id":"14a265d6-95b4-4842-a2ed-e020ba7da3fb","street_address_1":"676 Destination Sit Req","street_address_2":null,"city":"Florence","state":"MT","postal_code":"59805","created_at":"2023-11-21T02:56:56.832038","updated_at":"2023-11-21T02:56:56.832038","street_address_3":null,"country":null}`,
         sit_destination_address_initial: `{"id":"ff666bfe-1a2c-45e0-b38a-18c138958f16","street_address_1":"4 Delivery address init","street_address_2":null,"city":"Great Falls","state":"MT","postal_code":"59402","created_at":"2023-11-21T02:56:08.299416","updated_at":"2023-11-21T02:56:08.299416","street_address_3":null,"country":null}`,
@@ -29,7 +30,7 @@ describe('When given an update Destination SIT address history record', () => {
     const template = getTemplate(historyRecord);
 
     render(template.getDetails(historyRecord));
-    expect(screen.getByText('HHG shipment #E4285, Domestic destination SIT delivery')).toBeInTheDocument();
+    expect(screen.getByText('HHG shipment #RQ38D4-01, Domestic destination SIT delivery')).toBeInTheDocument();
   });
 
   it('displays the status of the request', () => {

--- a/src/constants/MoveHistory/EventTemplates/UpdateSITAddress/RejectSITAddressUpdate.test.jsx
+++ b/src/constants/MoveHistory/EventTemplates/UpdateSITAddress/RejectSITAddressUpdate.test.jsx
@@ -16,6 +16,7 @@ describe('When given an update Destination SIT address history record', () => {
       {
         name: 'Domestic destination SIT delivery',
         shipment_type: 'HHG',
+        shipment_locator: 'RQ38D4-01',
         shipment_id_abbr: 'e4285',
         sit_destination_address_final: `{"id":"14a265d6-95b4-4842-a2ed-e020ba7da3fb","street_address_1":"676 Destination Sit Req","street_address_2":null,"city":"Florence","state":"MT","postal_code":"59805","created_at":"2023-11-21T02:56:56.832038","updated_at":"2023-11-21T02:56:56.832038","street_address_3":null,"country":null}`,
         sit_destination_address_initial: `{"id":"ff666bfe-1a2c-45e0-b38a-18c138958f16","street_address_1":"4 Delivery address init","street_address_2":null,"city":"Great Falls","state":"MT","postal_code":"59402","created_at":"2023-11-21T02:56:08.299416","updated_at":"2023-11-21T02:56:08.299416","street_address_3":null,"country":null}`,
@@ -30,7 +31,7 @@ describe('When given an update Destination SIT address history record', () => {
     const template = getTemplate(historyRecord);
 
     render(template.getDetails(historyRecord));
-    expect(screen.getByText('HHG shipment #E4285, Domestic destination SIT delivery')).toBeInTheDocument();
+    expect(screen.getByText('HHG shipment #RQ38D4-01, Domestic destination SIT delivery')).toBeInTheDocument();
   });
 
   it('displays the status of the request', () => {

--- a/src/constants/MoveHistory/EventTemplates/UpdateSITEntryDate/updateSitEntryDate.test.jsx
+++ b/src/constants/MoveHistory/EventTemplates/UpdateSITEntryDate/updateSitEntryDate.test.jsx
@@ -16,6 +16,7 @@ describe('when given a Update sit entry date service item history record', () =>
         name: "Domestic destination add'l SIT",
         shipment_type: 'HHG',
         shipment_id_abbr: 'a1b2c',
+        shipment_locator: 'ABC123-01',
       },
     ],
     oldValues: {
@@ -28,7 +29,7 @@ describe('when given a Update sit entry date service item history record', () =>
     const template = getTemplate(historyRecord);
 
     render(template.getDetails(historyRecord));
-    expect(screen.getByText("HHG shipment #A1B2C, Domestic destination add'l SIT")).toBeInTheDocument();
+    expect(screen.getByText("HHG shipment #ABC123-01, Domestic destination add'l SIT")).toBeInTheDocument();
   });
 
   describe('When given a specific set of details', () => {

--- a/src/constants/MoveHistory/EventTemplates/UpdateServiceItemStatus/updateServiceItemStatus.jsx
+++ b/src/constants/MoveHistory/EventTemplates/UpdateServiceItemStatus/updateServiceItemStatus.jsx
@@ -34,7 +34,7 @@ export default {
       <LabeledDetails historyRecord={formatChangedValues(historyRecord, formattedContext)} />
     ) : (
       <>
-        {s[formattedContext.shipment_type]} shipment #{formattedContext.shipment_id_display},{' '}
+        {s[formattedContext.shipment_type]} shipment #{formattedContext.shipment_locator},{' '}
         {formattedContext.service_item_name}
       </>
     );

--- a/src/constants/MoveHistory/EventTemplates/UpdateServiceItemStatus/updateServiceItemStatus.test.jsx
+++ b/src/constants/MoveHistory/EventTemplates/UpdateServiceItemStatus/updateServiceItemStatus.test.jsx
@@ -11,6 +11,7 @@ describe('when given an approved service item history record', () => {
       {
         name: 'Domestic origin price',
         shipment_type: 'HHG',
+        shipment_locator: 'RQ38D4-01',
         shipment_id_abbr: 'a1b2c',
       },
     ],
@@ -41,6 +42,7 @@ describe('when given rejected service item history record', () => {
       {
         name: 'Domestic origin price',
         shipment_type: 'HHG',
+        shipment_locator: 'RQ38D4-01',
         shipment_id_abbr: 'a1b2c',
       },
     ],
@@ -59,7 +61,7 @@ describe('when given rejected service item history record', () => {
     render(template.getEventNameDisplay(historyRecord));
     render(template.getDetails(historyRecord));
     expect(screen.getByText('Rejected service item')).toBeInTheDocument();
-    expect(screen.getByText('HHG shipment #A1B2C, Domestic origin price')).toBeInTheDocument();
+    expect(screen.getByText('HHG shipment #RQ38D4-01, Domestic origin price')).toBeInTheDocument();
   });
 
   describe('When given a specific set of details for a rejected service item', () => {

--- a/src/constants/MoveHistory/EventTemplates/UpdateServiceItemStatus/updateServiceItemStatus.test.jsx
+++ b/src/constants/MoveHistory/EventTemplates/UpdateServiceItemStatus/updateServiceItemStatus.test.jsx
@@ -30,7 +30,7 @@ describe('when given an approved service item history record', () => {
     render(template.getEventNameDisplay(historyRecord));
     render(template.getDetails(historyRecord));
     expect(screen.getByText('Approved service item')).toBeInTheDocument();
-    expect(screen.getByText('HHG shipment #A1B2C, Domestic origin price')).toBeInTheDocument();
+    expect(screen.getByText('HHG shipment #RQ38D4-01, Domestic origin price')).toBeInTheDocument();
   });
 });
 

--- a/src/constants/MoveHistory/EventTemplates/UpdateWeightTicket/UpdateWeightTicket.test.jsx
+++ b/src/constants/MoveHistory/EventTemplates/UpdateWeightTicket/UpdateWeightTicket.test.jsx
@@ -16,6 +16,7 @@ describe('When given a updated weight', () => {
     context: [
       {
         shipment_type: 'PPM',
+        shipment_locator: 'RQ38D4-01',
         shipment_id_abbr: 'f10be',
       },
     ],
@@ -35,6 +36,7 @@ describe('When given a updated weight', () => {
     context: [
       {
         shipment_type: 'PPM',
+        shipment_locator: 'RQ38D4-01',
         shipment_id_abbr: 'f10be',
       },
     ],
@@ -46,7 +48,7 @@ describe('When given a updated weight', () => {
     const template = getTemplate(netWeightRecord);
 
     render(template.getDetails(netWeightRecord));
-    expect(screen.getByText('PPM shipment #F10BE')).toBeInTheDocument();
+    expect(screen.getByText('PPM shipment #RQ38D4-01')).toBeInTheDocument();
   });
 
   it('displays an approved request', () => {

--- a/src/constants/MoveHistory/EventTemplates/UpdateWeightTicket/UpdateWeightTicketPPMShipments.test.jsx
+++ b/src/constants/MoveHistory/EventTemplates/UpdateWeightTicket/UpdateWeightTicketPPMShipments.test.jsx
@@ -14,6 +14,7 @@ describe('When given a shipment updated by updated weight', () => {
     context: [
       {
         shipment_id_abbr: '7f559',
+        shipment_locator: 'RQ38D4-01',
         shipment_type: 'PPM',
       },
     ],
@@ -32,7 +33,7 @@ describe('When given a shipment updated by updated weight', () => {
     const template = getTemplate(historyRecord);
 
     render(template.getDetails(historyRecord));
-    expect(screen.getByText('PPM shipment #7F559')).toBeInTheDocument();
+    expect(screen.getByText('PPM shipment #RQ38D4-01')).toBeInTheDocument();
   });
 
   it('displays updated incentive details', () => {

--- a/src/constants/MoveHistory/EventTemplates/UpdateWeightTicket/updateWeightTicketProGear.test.jsx
+++ b/src/constants/MoveHistory/EventTemplates/UpdateWeightTicket/updateWeightTicketProGear.test.jsx
@@ -20,6 +20,7 @@ describe('When given a updated weight', () => {
     context: [
       {
         shipment_type: 'PPM',
+        shipment_locator: 'RQ38D4-01',
         shipment_id_abbr: 'f10be',
       },
     ],
@@ -40,6 +41,7 @@ describe('When given a updated weight', () => {
     context: [
       {
         shipment_type: 'PPM',
+        shipment_locator: 'RQ38D4-01',
         shipment_id_abbr: 'f10be',
       },
     ],
@@ -51,7 +53,7 @@ describe('When given a updated weight', () => {
     const template = getTemplate(progearRecord);
 
     render(template.getDetails(progearRecord));
-    expect(screen.getByText('PPM shipment #F10BE')).toBeInTheDocument();
+    expect(screen.getByText('PPM shipment #RQ38D4-01')).toBeInTheDocument();
   });
 
   it('displays an approved request', () => {

--- a/src/pages/Office/MoveHistory/LabeledDetails.jsx
+++ b/src/pages/Office/MoveHistory/LabeledDetails.jsx
@@ -76,8 +76,8 @@ export const retrieveTextToDisplay = (fieldName, value) => {
 };
 
 // testable for code coverage //
-export const createLineItemLabel = (shipmentType, shipmentIdDisplay, serviceItemName, movingExpenseType) =>
-  [shipmentType && `${shipmentTypes[shipmentType]} shipment #${shipmentIdDisplay}`, serviceItemName, movingExpenseType]
+export const createLineItemLabel = (shipmentType, shipmentLocator, serviceItemName, movingExpenseType) =>
+  [shipmentType && `${shipmentTypes[shipmentType]} shipment #${shipmentLocator}`, serviceItemName, movingExpenseType]
     .filter((e) => e)
     .join(', ');
 
@@ -121,16 +121,11 @@ export const filterInLineItemValues = (changedValues, oldValues) =>
 const LabeledDetails = ({ historyRecord }) => {
   const { changedValues, oldValues = {} } = historyRecord;
 
-  const { shipment_type, shipment_id_display, service_item_name, moving_expense_type, ...changedValuesToUse } =
+  const { shipment_type, shipment_locator, service_item_name, moving_expense_type, ...changedValuesToUse } =
     changedValues;
 
   // Check for shipment_type to use it as a header for the row
-  const shipmentDisplay = createLineItemLabel(
-    shipment_type,
-    shipment_id_display,
-    service_item_name,
-    moving_expense_type,
-  );
+  const shipmentDisplay = createLineItemLabel(shipment_type, shipment_locator, service_item_name, moving_expense_type);
 
   const lineItems = filterInLineItemValues(changedValuesToUse, oldValues).map(([label, value]) => {
     const { displayName, displayValue } = retrieveTextToDisplay(label, value);

--- a/src/pages/Office/MoveHistory/LabeledDetails.test.jsx
+++ b/src/pages/Office/MoveHistory/LabeledDetails.test.jsx
@@ -65,13 +65,14 @@ describe('LabeledDetails', () => {
         billable_weight_cap: '200',
         billable_weight_justification: 'Test TIO Remarks',
         shipment_type: SHIPMENT_OPTIONS.NTSR,
+        shipment_locator: 'RQ38D4-01',
         shipment_id_display: 'X9Y0Z',
       },
     };
 
     render(<LabeledDetails historyRecord={historyRecord} />);
 
-    expect(screen.getByText('NTS-release shipment #X9Y0Z')).toBeInTheDocument();
+    expect(screen.getByText('NTS-release shipment #RQ38D4-01')).toBeInTheDocument();
   });
 
   it('does not render any text for changed values that are blank', async () => {

--- a/src/pages/Office/MoveHistory/LabeledDetailsWithToolTip.jsx
+++ b/src/pages/Office/MoveHistory/LabeledDetailsWithToolTip.jsx
@@ -46,7 +46,7 @@ const LabeledDetailsWithToolTip = ({ historyRecord, toolTipText, toolTipColor, t
   // Check for shipment_type to use it as a header for the row
   if ('shipment_type' in changedValuesToUse) {
     shipmentDisplay = shipmentTypes[changedValuesToUse.shipment_type];
-    shipmentDisplay += ` shipment #${changedValuesToUse.shipment_id_display}`;
+    shipmentDisplay += ` shipment #${changedValuesToUse.shipment_locator}`;
     delete changedValuesToUse.shipment_type;
   }
 

--- a/src/pages/Office/MoveHistory/LabeledDetailsWithToolTip.test.jsx
+++ b/src/pages/Office/MoveHistory/LabeledDetailsWithToolTip.test.jsx
@@ -13,6 +13,7 @@ describe('LabeledDetailsWithToolTip', () => {
         changedValues: {
           sit_entry_date: '2023-10-01',
           shipment_id_display: '1A2B3',
+          shipment_locator: 'ABC123-01',
         },
       },
     };
@@ -58,6 +59,7 @@ it('renders shipment_type as a header & SIT entry date', async () => {
     changedValues: {
       sit_entry_date: '2023-10-01',
       shipment_id_display: '1A2B3',
+      shipment_locator: 'ABC123-01',
       shipment_type: SHIPMENT_OPTIONS.HHG,
     },
     oldValues: {
@@ -67,7 +69,7 @@ it('renders shipment_type as a header & SIT entry date', async () => {
 
   render(<LabeledDetailsWithToolTip historyRecord={historyRecord} />);
 
-  expect(screen.getByText('HHG shipment #1A2B3')).toBeInTheDocument();
+  expect(screen.getByText('HHG shipment #ABC123-01')).toBeInTheDocument();
   expect(screen.getByText('SIT entry date')).toBeInTheDocument();
   expect(screen.getByText(': 01 Oct 2023')).toBeInTheDocument();
 });

--- a/src/utils/formatMtoShipment.js
+++ b/src/utils/formatMtoShipment.js
@@ -402,6 +402,9 @@ export function getMtoShipmentLabel({ context }) {
   if (context[0].name) {
     mtoShipmentLabels.service_item_name = context[0].name;
   }
+  if (context[0].shipment_locator) {
+    mtoShipmentLabels.shipment_locator = context[0].shipment_locator;
+  }
   if (context[0].moving_expense_type) {
     mtoShipmentLabels.moving_expense_type = expenseTypeLabels[context[0].moving_expense_type];
   }

--- a/swagger-def/definitions/MTOShipment.yaml
+++ b/swagger-def/definitions/MTOShipment.yaml
@@ -177,3 +177,8 @@ properties:
     $ref: 'PPMShipment.yaml'
   deliveryAddressUpdate:
     $ref: 'ShipmentAddressUpdate.yaml'
+  shipmentLocator:
+    type: string
+    x-nullable: true
+    readOnly: true
+    example: '1K43AR-01'

--- a/swagger-def/internal.yaml
+++ b/swagger-def/internal.yaml
@@ -1765,6 +1765,11 @@ definitions:
         x-omitempty: false
       eTag:
         type: string
+      shipmentLocator:
+        type: string
+        x-nullable: true
+        readOnly: true
+        example: '1K43AR-01'
   MTOShipments:
     items:
       $ref: "#/definitions/MTOShipment"

--- a/swagger/ghc.yaml
+++ b/swagger/ghc.yaml
@@ -7810,6 +7810,11 @@ definitions:
         $ref: '#/definitions/PPMShipment'
       deliveryAddressUpdate:
         $ref: '#/definitions/ShipmentAddressUpdate'
+      shipmentLocator:
+        type: string
+        x-nullable: true
+        readOnly: true
+        example: 1K43AR-01
   LOATypeNullable:
     description: The Line of accounting (TAC/SAC) type that will be used for the shipment
     type: string

--- a/swagger/internal.yaml
+++ b/swagger/internal.yaml
@@ -1792,6 +1792,11 @@ definitions:
         x-omitempty: false
       eTag:
         type: string
+      shipmentLocator:
+        type: string
+        x-nullable: true
+        readOnly: true
+        example: 1K43AR-01
   MTOShipments:
     items:
       $ref: '#/definitions/MTOShipment'


### PR DESCRIPTION
## Agility ticket
[B18988](https://www13.v1host.com/USTRANSCOM38/assetdetail.v1?number=B-18988)

## Int PR
[12507](https://github.com/transcom/mymove/pull/12507)

## Summary

In the "Move History" for a move, the shipment id (the value appearing after HHG/PPM Shipment #) was changed to "shipment locator".  Shipment locator = move locator + "-" + sequence number for the the move e.g. "ABC123-01".

### How to test

#### HHG
* create a HHG move
* login as a SC
* find the move and open it
* go to the "Move History" tab
* all occurrences of "HHG shipment #" should have move locator value + "-" + "01"

#### PPM
* as a user
  - create a PPM move
* as an officer user
  - login as a SC
  - find the move and open it
  - edit allowances
  - submit move
* as the user
  - click upload documents
  - enter vehicle info
  - add pro gear
  - add an expense
  - submit ppm documentation
* as an office user
  - login as an SC
  - go to closeout queue
  - open move
  - go to the "Move History" tab
  - all occurrences of "PPM shipment #" should have move locator value + "-" + "01"

## Screenshots
HHG
![image](https://github.com/transcom/mymove/assets/146897935/552b9aa1-cb66-4703-a9fd-18f30b7230c2)

PPM
![image](https://github.com/transcom/mymove/assets/146897935/933fddbe-16d5-4bd7-b624-36760d7616eb)
