### PR TITLE
B-20121 corrected label for non-FSC items

### DIFF
--- a/playwright/tests/office/txo/tioFlows.spec.js
+++ b/playwright/tests/office/txo/tioFlows.spec.js
@@ -411,7 +411,7 @@ test.describe('TIO user', () => {
       // Confirm TIO can view the calculations
       await page.getByText('Show calculations').click();
       await expect(page.locator('[data-testid="ServiceItemCalculations"]')).toContainText('Calculations');
-      await expect(page.locator('[data-testid="ServiceItemCalculations"]')).toContainText('Fuel rate adjustment');
+      await expect(page.locator('[data-testid="ServiceItemCalculations"]')).toContainText('Total:');
       await expect(page.locator('[data-testid="ServiceItemCalculations"]')).toContainText('Service schedule: 2');
 
       // Confirm TIO can hide the calculations. This ensures there's
@@ -432,7 +432,7 @@ test.describe('TIO user', () => {
       // Confirm TIO can view the calculations
       await page.getByText('Show calculations').click();
       await expect(page.locator('[data-testid="ServiceItemCalculations"]')).toContainText('Calculations');
-      await expect(page.locator('[data-testid="ServiceItemCalculations"]')).toContainText('Fuel rate adjustment');
+      await expect(page.locator('[data-testid="ServiceItemCalculations"]')).toContainText('Total:');
       await expect(page.locator('[data-testid="ServiceItemCalculations"]')).toContainText('Dimensions: 12x3x10 in');
 
       // Confirm TIO can hide the calculations. This ensures there's no scrolling weirdness before the next action

--- a/src/components/Office/ServiceItemCalculations/ServiceItemCalculations.jsx
+++ b/src/components/Office/ServiceItemCalculations/ServiceItemCalculations.jsx
@@ -97,14 +97,12 @@ const ServiceItemCalculations = ({
                     return (
                       <div data-testid="details" className={styles.row}>
                         <small>
-                          {detail.text.includes(SERVICE_ITEM_CALCULATION_LABELS.FSCPriceDifferenceInCents) ||
-                          checkItemCode(calc.itemCode)
+                          {detail.text.includes(SERVICE_ITEM_CALCULATION_LABELS.Total) || checkItemCode(calc.itemCode)
                             ? `${detail.text.substring(0, detail.text.indexOf(':'))}:`
                             : checkForEmptyString(detail.text)}
                         </small>
                         <small>
-                          {detail.text.includes(SERVICE_ITEM_CALCULATION_LABELS.FSCPriceDifferenceInCents) ||
-                          checkItemCode(calc.itemCode)
+                          {detail.text.includes(SERVICE_ITEM_CALCULATION_LABELS.Total) || checkItemCode(calc.itemCode)
                             ? detail.text.substring(detail.text.indexOf(':') + 1)
                             : ''}
                         </small>

--- a/src/components/Office/ServiceItemCalculations/ServiceItemCalculations.test.jsx
+++ b/src/components/Office/ServiceItemCalculations/ServiceItemCalculations.test.jsx
@@ -107,27 +107,22 @@ describe('ServiceItemCalculations DLH', () => {
     {
       value: '85 cwt',
       label: 'Billable weight (cwt)',
-      details: ['Original: 8,500 lbs', 'Estimated: 8,000 lbs'],
     },
     {
       value: '210',
       label: 'Mileage',
-      details: ['ZIP 32210 to ZIP 91910'],
     },
     {
       value: '1.71',
       label: 'Baseline linehaul price',
-      details: ['Domestic non-peak', 'Origin service area: 176', 'Requested pickup: 09 Mar 2020'],
     },
     {
       value: '1.033',
       label: 'Price escalation factor',
-      details: ['Base year: 2'],
     },
     {
       value: '$10.00',
-      label: 'Fuel rate adjustment',
-      details: [],
+      label: 'Total:',
     },
   ];
   testServiceItemCalculation([SERVICE_ITEM_CODES.DLH, testParams.DomesticLongHaul, {}, expectedOutput]);
@@ -197,22 +192,18 @@ describe('ServiceItemCalculations DCRT', () => {
     {
       value: '4.00',
       label: 'Crating size (cu ft)',
-      details: ['Description: Grand piano', 'Dimensions: 3x10x6 in'],
     },
     {
       value: '1.71',
       label: 'Crating price (per cu ft)',
-      details: ['Service schedule: 3', 'Crating date: 09 Mar 2020', 'Domestic'],
     },
     {
       value: '1.033',
       label: 'Price escalation factor',
-      details: [],
     },
     {
       value: '$10.00',
-      label: 'Fuel rate adjustment',
-      details: [''],
+      label: 'Total:',
     },
   ];
   testServiceItemCalculation([
@@ -287,22 +278,18 @@ describe('ServiceItemCalculations DUCRT', () => {
     {
       value: '4.00',
       label: 'Crating size (cu ft)',
-      details: ['Description: Grand piano', 'Dimensions: 3x10x6 in'],
     },
     {
       value: '1.71',
       label: 'Uncrating price (per cu ft)',
-      details: ['Service schedule: 3', 'Uncrating date: 09 Mar 2020', 'Domestic'],
     },
     {
       value: '1.033',
       label: 'Price escalation factor',
-      details: [],
     },
     {
       value: '$10.00',
-      label: 'Fuel rate adjustment',
-      details: [''],
+      label: 'Total',
     },
   ];
   testServiceItemCalculation([

--- a/src/components/Office/ServiceItemCalculations/helpers.js
+++ b/src/components/Office/ServiceItemCalculations/helpers.js
@@ -616,10 +616,9 @@ const cratingSize = (params, mtoParams) => {
   return calculation(value, label, formatDetail(description), formatDetail(formattedDimensions));
 };
 
-// totalAmountRequested is not a service item param
 const totalAmountRequested = (totalAmount) => {
   const value = toDollarString(formatCents(totalAmount));
-  const label = SERVICE_ITEM_CALCULATION_LABELS.FuelRateAdjustment;
+  const label = `${SERVICE_ITEM_CALCULATION_LABELS.Total}:`;
   const detail = '';
 
   return calculation(value, label, formatDetail(detail));

--- a/src/components/Office/ServiceItemCalculations/helpers.test.js
+++ b/src/components/Office/ServiceItemCalculations/helpers.test.js
@@ -3,30 +3,128 @@ import testParams from './serviceItemTestParams';
 
 import { SHIPMENT_OPTIONS } from 'shared/constants';
 
+function testData(code) {
+  let result;
+  if (code === 'DCRT' || code === 'DUCRT') {
+    result = {
+      ...result,
+      'Crating size (cu ft)': '4.00',
+    };
+  }
+  if (code === 'DCRT') {
+    result = {
+      ...result,
+      'Crating price (per cu ft)': '1.71',
+    };
+  } else if (code === 'DUCRT') {
+    result = {
+      ...result,
+      'Uncrating price (per cu ft)': '1.71',
+    };
+  } else {
+    result = {
+      ...result,
+      'Billable weight (cwt)': '85 cwt',
+    };
+  }
+  if (code === 'DDDSIT') {
+    result = {
+      ...result,
+      Mileage: '51',
+      'SIT delivery price': '1.71',
+    };
+  } else if (code === 'DDDSITb') {
+    result = {
+      ...result,
+      Mileage: '3',
+      'SIT delivery price': '1.71',
+    };
+  } else if (code === 'DDDSITc') {
+    result = {
+      ...result,
+      'SIT delivery price': '1.71',
+    };
+  } else if (code !== 'DOFSIT' && code !== 'DDFSIT' && code !== 'DOPSIT' && code.includes('SIT')) {
+    result = {
+      ...result,
+      'SIT days invoiced': '2',
+      'Additional day SIT price': '1.71',
+    };
+  }
+  if (code === 'DOPSIT') {
+    result = {
+      ...result,
+      Mileage: '29',
+      'SIT pickup price': '1.71',
+    };
+  } else if (code === 'DLH') {
+    result = {
+      ...result,
+      Mileage: '210',
+      'Baseline linehaul price': '1.71',
+    };
+  } else if (code === 'DSH') {
+    result = {
+      ...result,
+      Mileage: '210',
+      'Baseline shorthaul price': '1.71',
+    };
+  }
+  if (code === 'DOP' || code === 'DOFSIT') {
+    result = {
+      ...result,
+      'Origin price': '1.71',
+    };
+  } else if (code === 'DDP') {
+    result = {
+      ...result,
+      'Destination price': '1.71',
+    };
+  }
+  if (!code.includes('FSC')) {
+    result = {
+      ...result,
+      'Price escalation factor': '1.033',
+    };
+  }
+  if (code.includes('FSC')) {
+    result = {
+      ...result,
+      'Total:': '$999.98',
+    };
+  } else {
+    result = {
+      ...result,
+      'Total:': '$999.99',
+    };
+  }
+
+  return result;
+}
+
+function testAB(a, b) {
+  const keys = Object.keys(b);
+  for (let j = 0; j < keys.length; j += 1) {
+    for (let i = 0; i < a.length; i += 1) {
+      if (i < a.length - 1) {
+        if (a[i].label === keys[j]) {
+          expect(a[i].value).toEqual(b[keys[j]]);
+          break;
+        }
+      } else {
+        expect(a[i].value).toEqual(b[keys[j]]);
+        break;
+      }
+    }
+  }
+}
+
 describe('makeCalculations', () => {
   it('returns correct data for DomesticLongHaul', () => {
     const result = makeCalculations('DLH', 99999, testParams.DomesticLongHaul, testParams.additionalCratingDataDCRT);
-    for (let i = 0; i < result.length; i += 1) {
-      switch (result[i].label) {
-        case 'Billable weight (cwt)':
-          expect(result[i].value).toEqual('85 cwt');
-          break;
-        case 'Mileage':
-          expect(result[i].details).toEqual([{ text: 'ZIP 32210 to ZIP 91910', styles: {} }]);
-          break;
-        case 'Baseline linehaul price':
-          expect(result[i].value).toEqual('1.71');
-          break;
-        case 'Price escalation factor':
-          expect(result[i].value).toEqual('1.033');
-          break;
-        case 'Fuel rate adjustment':
-          expect(result[i].value).toEqual('$999.99');
-          break;
-        default:
-          break;
-      }
-    }
+    const expected = testData('DLH');
+
+    testAB(result, expected);
   });
 
   it('returns correct data for DomesticLongHaul for NTS-release', () => {
@@ -37,27 +135,9 @@ describe('makeCalculations', () => {
       testParams.additionalCratingDataDCRT,
       SHIPMENT_OPTIONS.NTSR,
     );
-    for (let i = 0; i < result.length; i += 1) {
-      switch (result[i].label) {
-        case 'Billable weight (cwt)':
-          expect(result[i].value).toEqual('85 cwt');
-          break;
-        case 'Mileage':
-          expect(result[i].details).toEqual([{ text: 'ZIP 32210 to ZIP 91910', styles: {} }]);
-          break;
-        case 'Baseline linehaul price':
-          expect(result[i].value).toEqual('1.71');
-          break;
-        case 'Price escalation factor':
-          expect(result[i].value).toEqual('1.033');
-          break;
-        case 'Fuel rate adjustment':
-          expect(result[i].value).toEqual('$999.99');
-          break;
-        default:
-          break;
-      }
-    }
+    const expected = testData('DLH');
+
+    testAB(result, expected);
   });
 
   it('returns correct data for DomesticLongHaul with reweigh weight', () => {
@@ -67,27 +147,9 @@ describe('makeCalculations', () => {
       testParams.DomesticLongHaulWithReweigh,
       testParams.additionalCratingDataDCRT,
     );
-    for (let i = 0; i < result.length; i += 1) {
-      switch (result[i].label) {
-        case 'Billable weight (cwt)':
-          expect(result[i].value).toEqual('85 cwt');
-          break;
-        case 'Mileage':
-          expect(result[i].details).toEqual([{ text: 'ZIP 32210 to ZIP 91910', styles: {} }]);
-          break;
-        case 'Baseline linehaul price':
-          expect(result[i].value).toEqual('1.71');
-          break;
-        case 'Price escalation factor':
-          expect(result[i].value).toEqual('1.033');
-          break;
-        case 'Fuel rate adjustment':
-          expect(result[i].value).toEqual('$999.99');
-          break;
-        default:
-          break;
-      }
-    }
+    const expected = testData('DLH');
+
+    testAB(result, expected);
   });
 
   it('returns correct data for DomesticLongHaul weigh reweigh and adjusted weight', () => {
@@ -97,27 +159,9 @@ describe('makeCalculations', () => {
       testParams.DomesticLongHaulWeightWithAdjustedAndReweigh,
       testParams.additionalCratingDataDCRT,
     );
-    for (let i = 0; i < result.length; i += 1) {
-      switch (result[i].label) {
-        case 'Billable weight (cwt)':
-          expect(result[i].value).toEqual('85 cwt');
-          break;
-        case 'Mileage':
-          expect(result[i].details).toEqual([{ text: 'ZIP 32210 to ZIP 91910', styles: {} }]);
-          break;
-        case 'Baseline linehaul price':
-          expect(result[i].value).toEqual('1.71');
-          break;
-        case 'Price escalation factor':
-          expect(result[i].value).toEqual('1.033');
-          break;
-        case 'Fuel rate adjustment':
-          expect(result[i].value).toEqual('$999.99');
-          break;
-        default:
-          break;
-      }
-    }
+    const expected = testData('DLH');
+
+    testAB(result, expected);
   });
 
   it('returns correct data for DomesticLongHaul with no reweigh but billable weight adjusted', () => {
@@ -127,457 +171,136 @@ describe('makeCalculations', () => {
       testParams.DomesticLongHaulWithAdjusted,
       testParams.additionalCratingDataDCRT,
     );
-    for (let i = 0; i < result.length; i += 1) {
-      switch (result[i].label) {
-        case 'Billable weight (cwt)':
-          expect(result[i].value).toEqual('85 cwt');
-          break;
-        case 'Mileage':
-          expect(result[i].details).toEqual([{ text: 'ZIP 32210 to ZIP 91910', styles: {} }]);
-          break;
-        case 'Baseline linehaul price':
-          expect(result[i].value).toEqual('1.71');
-          break;
-        case 'Price escalation factor':
-          expect(result[i].value).toEqual('1.033');
-          break;
-        case 'Fuel rate adjustment':
-          expect(result[i].value).toEqual('$999.99');
-          break;
-        default:
-          break;
-      }
-    }
+    const expected = testData('DLH');
+
+    testAB(result, expected);
   });
 
   it('returns correct data for DomesticShortHaul', () => {
     const result = makeCalculations('DSH', 99999, testParams.DomesticShortHaul);
-    for (let i = 0; i < result.length; i += 1) {
-      switch (result[i].label) {
-        case 'Billable weight (cwt)':
-          expect(result[i].value).toEqual('85 cwt');
-          break;
-        case 'Mileage':
-          expect(result[i].details).toEqual([{ text: 'ZIP 32210 to ZIP 91910', styles: {} }]);
-          break;
-        case 'Baseline linehaul price':
-          expect(result[i].value).toEqual('1.71');
-          break;
-        case 'Price escalation factor':
-          expect(result[i].value).toEqual('1.033');
-          break;
-        case 'Fuel rate adjustment':
-          expect(result[i].value).toEqual('$999.99');
-          break;
-        default:
-          break;
-      }
-    }
+    const expected = testData('DSH');
+
+    testAB(result, expected);
   });
 
   it('returns correct data for DomesticOriginPrice', () => {
-    const result = makeCalculations('DOP', 99998, testParams.DomesticOriginPrice);
-    for (let i = 0; i < result.length; i += 1) {
-      switch (result[i].label) {
-        case 'Billable weight (cwt)':
-          expect(result[i].value).toEqual('85 cwt');
-          break;
-        case 'Origin price':
-          expect(result[i].value).toEqual('1.71');
-          break;
-        case 'Baseline linehaul price':
-          expect(result[i].value).toEqual('1.71');
-          break;
-        case 'Price escalation factor':
-          expect(result[i].value).toEqual('1.033');
-          break;
-        case 'Fuel rate adjustment':
-          expect(result[i].value).toEqual('$999.98');
-          break;
-        default:
-          break;
-      }
-    }
+    const result = makeCalculations('DOP', 99999, testParams.DomesticOriginPrice);
+    const expected = testData('DOP');
+
+    testAB(result, expected);
   });
 
   it('returns correct data for DomesticDestinationPrice', () => {
     const result = makeCalculations('DDP', 99999, testParams.DomesticDestinationPrice);
-    for (let i = 0; i < result.length; i += 1) {
-      switch (result[i].label) {
-        case 'Billable weight (cwt)':
-          expect(result[i].value).toEqual('85 cwt');
-          break;
-        case 'Destination price':
-          expect(result[i].value).toEqual('1.71');
-          break;
-        case 'Baseline linehaul price':
-          expect(result[i].value).toEqual('1.71');
-          break;
-        case 'Price escalation factor':
-          expect(result[i].value).toEqual('1.033');
-          break;
-        case 'Fuel rate adjustment':
-          expect(result[i].value).toEqual('$999.99');
-          break;
-        default:
-          break;
-      }
-    }
+    const expected = testData('DDP');
+
+    testAB(result, expected);
   });
 
   it('returns correct data for DomesticOrigin1stSIT', () => {
     const result = makeCalculations('DOFSIT', 99999, testParams.DomesticOrigin1stSIT);
-    for (let i = 0; i < result.length; i += 1) {
-      switch (result[i].label) {
-        case 'Billable weight (cwt)':
-          expect(result[i].value).toEqual('85 cwt');
-          break;
-        case 'Origin price':
-          expect(result[i].value).toEqual('1.71');
-          break;
-        case 'Baseline linehaul price':
-          expect(result[i].value).toEqual('1.71');
-          break;
-        case 'Price escalation factor':
-          expect(result[i].value).toEqual('1.033');
-          break;
-        case 'Fuel rate adjustment':
-          expect(result[i].value).toEqual('$999.99');
-          break;
-        default:
-          break;
-      }
-    }
+    const expected = testData('DOFSIT');
+
+    testAB(result, expected);
   });
 
   it('returns correct data for DomesticDestination1stSIT', () => {
     const result = makeCalculations('DDFSIT', 99999, testParams.DomesticDestination1stSIT);
-    for (let i = 0; i < result.length; i += 1) {
-      switch (result[i].label) {
-        case 'Billable weight (cwt)':
-          expect(result[i].value).toEqual('85 cwt');
-          break;
-        case 'Destination price':
-          expect(result[i].value).toEqual('1.71');
-          break;
-        case 'Baseline linehaul price':
-          expect(result[i].value).toEqual('1.71');
-          break;
-        case 'Price escalation factor':
-          expect(result[i].value).toEqual('1.033');
-          break;
-        case 'Fuel rate adjustment':
-          expect(result[i].value).toEqual('$999.99');
-          break;
-        default:
-          break;
-      }
-    }
+    const expected = testData('DDFSIT');
+
+    testAB(result, expected);
   });
 
   it('returns correct data for DomesticOriginAdditionalSIT', () => {
     const result = makeCalculations('DOASIT', 99999, testParams.DomesticOriginAdditionalSIT);
-    for (let i = 0; i < result.length; i += 1) {
-      switch (result[i].label) {
-        case 'Billable weight (cwt)':
-          expect(result[i].value).toEqual('85 cwt');
-          break;
-        case 'SIT days invoiced':
-          expect(result[i].value).toEqual('2');
-          break;
-        case 'Additional day SIT price':
-          expect(result[i].value).toEqual('1.71');
-          break;
-        case 'Price escalation factor':
-          expect(result[i].value).toEqual('1.033');
-          break;
-        case 'Fuel rate adjustment':
-          expect(result[i].value).toEqual('$999.99');
-          break;
-        default:
-          break;
-      }
-    }
+    const expected = testData('DOASIT');
+
+    testAB(result, expected);
   });
 });
 describe('returns correct data for DomesticDestinationAdditionalSIT', () => {
   const result = makeCalculations('DDASIT', 99999, testParams.DomesticDestinationAdditionalSIT);
-  for (let i = 0; i < result.length; i += 1) {
-    switch (result[i].label) {
-      case 'Billable weight (cwt)':
-        expect(result[i].value).toEqual('85 cwt');
-        break;
-      case 'SIT days invoiced':
-        expect(result[i].value).toEqual('2');
-        break;
-      case 'Additional day SIT price':
-        expect(result[i].value).toEqual('1.71');
-        break;
-      case 'Price escalation factor':
-        expect(result[i].value).toEqual('1.033');
-        break;
-      case 'Fuel rate adjustment':
-        expect(result[i].value).toEqual('$999.99');
-        break;
-      default:
-        break;
-    }
-  }
+  const expected = testData('DDASIT');
+
+  testAB(result, expected);
 });
 
 it('returns correct data for DomesticOriginSITPickup', () => {
   const result = makeCalculations('DOPSIT', 99999, testParams.DomesticOriginSITPickup);
-  for (let i = 0; i < result.length; i += 1) {
-    switch (result[i].label) {
-      case 'Billable weight (cwt)':
-        expect(result[i].value).toEqual('85 cwt');
-        break;
-      case 'Mileage':
-        expect(result[i].value).toEqual('29');
-        break;
-      case 'SIT pickup price':
-        expect(result[i].value).toEqual('1.71');
-        break;
-      case 'Price escalation factor':
-        expect(result[i].value).toEqual('1.033');
-        break;
-      case 'Fuel rate adjustment':
-        expect(result[i].value).toEqual('$999.99');
-        break;
-      default:
-        break;
-    }
-  }
+  const expected = testData('DOPSIT');
+
+  testAB(result, expected);
 });
 
 describe('DomesticDestinationSITDelivery', () => {
   it('returns the correct data for mileage above 50', () => {
     const result = makeCalculations('DDDSIT', 99999, testParams.DomesticDestinationSITDeliveryLonghaul);
-    for (let i = 0; i < result.length; i += 1) {
-      switch (result[i].label) {
-        case 'Billable weight (cwt)':
-          expect(result[i].value).toEqual('85 cwt');
-          break;
-        case 'Mileage':
-          expect(result[i].value).toEqual('51');
-          break;
-        case 'SIT pickup price':
-          expect(result[i].value).toEqual('1.71');
-          break;
-        case 'Price escalation factor':
-          expect(result[i].value).toEqual('1.033');
-          break;
-        case 'Fuel rate adjustment':
-          expect(result[i].value).toEqual('$999.99');
-          break;
-        default:
-          break;
-      }
-    }
+    const expected = testData('DDDSIT');
+
+    testAB(result, expected);
   });
 
   it('returns the correct data for mileage below 50 with matching ZIP3s', () => {
     const result = makeCalculations('DDDSIT', 99999, testParams.DomesticDestinationSITDeliveryMatchingZip3);
-    for (let i = 0; i < result.length; i += 1) {
-      switch (result[i].label) {
-        case 'Billable weight (cwt)':
-          expect(result[i].value).toEqual('85 cwt');
-          break;
-        case 'Mileage':
-          expect(result[i].value).toEqual('3');
-          break;
-        case 'SIT delivery price':
-          expect(result[i].value).toEqual('1.71');
-          break;
-        case 'Price escalation factor':
-          expect(result[i].value).toEqual('1.033');
-          break;
-        case 'Fuel rate adjustment':
-          expect(result[i].value).toEqual('$999.99');
-          break;
-        default:
-          break;
-      }
-    }
+    const expected = testData('DDDSITb');
+
+    testAB(result, expected);
   });
 
   it('returns the correct data for mileage below 50 with non-matching ZIP3s', () => {
     const result = makeCalculations('DDDSIT', 99999, testParams.DomesticDestinationSITDelivery);
-    for (let i = 0; i < result.length; i += 1) {
-      switch (result[i].label) {
-        case 'Billable weight (cwt)':
-          expect(result[i].value).toEqual('85 cwt');
-          break;
-        case 'SIT delivery price':
-          expect(result[i].value).toEqual('1.71');
-          break;
-        case 'Price escalation factor':
-          expect(result[i].value).toEqual('1.033');
-          break;
-        case 'Fuel rate adjustment':
-          expect(result[i].value).toEqual('$999.99');
-          break;
-        default:
-          break;
-      }
-    }
+    const expected = testData('DDDSITc');
+
+    testAB(result, expected);
   });
 
   it('returns correct data for DomesticPacking', () => {
     const result = makeCalculations('DPK', 99999, testParams.DomesticPacking);
-    for (let i = 0; i < result.length; i += 1) {
-      switch (result[i].label) {
-        case 'Billable weight (cwt)':
-          expect(result[i].value).toEqual('85 cwt');
-          break;
-        case 'Pack price':
-          expect(result[i].value).toEqual('1.71');
-          break;
-        case 'Price escalation factor':
-          expect(result[i].value).toEqual('1.033');
-          break;
-        case 'Fuel rate adjustment':
-          expect(result[i].value).toEqual('$999.99');
-          break;
-        default:
-          break;
-      }
-    }
+    const expected = testData('DPK');
+
+    testAB(result, expected);
   });
 
   it('returns correct data for DomesticNTSPacking', () => {
     const result = makeCalculations('DNPK', 99999, testParams.DomesticNTSPacking);
-    for (let i = 0; i < result.length; i += 1) {
-      switch (result[i].label) {
-        case 'Billable weight (cwt)':
-          expect(result[i].value).toEqual('85 cwt');
-          break;
-        case 'Pack price':
-          expect(result[i].value).toEqual('1.71');
-          break;
-        case 'NTS packing factor':
-          expect(result[i].value).toEqual('1.35');
-          break;
-        case 'Price escalation factor':
-          expect(result[i].value).toEqual('1.033');
-          break;
-        case 'Fuel rate adjustment':
-          expect(result[i].value).toEqual('$999.99');
-          break;
-        default:
-          break;
-      }
-    }
+    const expected = testData('DNPK');
+
+    testAB(result, expected);
   });
 
   it('returns correct data for DomesticUnpacking', () => {
     const result = makeCalculations('DUPK', 99999, testParams.DomesticUnpacking);
-    for (let i = 0; i < result.length; i += 1) {
-      switch (result[i].label) {
-        case 'Billable weight (cwt)':
-          expect(result[i].value).toEqual('85 cwt');
-          break;
-        case 'Unpack price':
-          expect(result[i].value).toEqual('1.71');
-          break;
-        case 'Price escalation factor':
-          expect(result[i].value).toEqual('1.033');
-          break;
-        case 'Fuel rate adjustment':
-          expect(result[i].value).toEqual('$999.99');
-          break;
-        default:
-          break;
-      }
-    }
+    const expected = testData('DUPK');
+
+    testAB(result, expected);
   });
 
   it('returns correct data for DomesticCrating', () => {
     const result = makeCalculations('DCRT', 99999, testParams.DomesticCrating, testParams.additionalCratingDataDCRT);
-    for (let i = 0; i < result.length; i += 1) {
-      switch (result[i].label) {
-        case 'Crating size (cu ft)':
-          expect(result[i].value).toEqual('4.00');
-          break;
-        case 'Crating price (per cu ft)':
-          expect(result[i].value).toEqual('1.71');
-          break;
-        case 'Price escalation factor':
-          expect(result[i].value).toEqual('1.033');
-          break;
-        case 'Fuel rate adjustment':
-          expect(result[i].value).toEqual('$999.99');
-          break;
-        default:
-          break;
-      }
-    }
+    const expected = testData('DCRT');
+
+    testAB(result, expected);
   });
 
   it('returns correct data for DomesticUncrating', () => {
     const result = makeCalculations('DUCRT', 99999, testParams.DomesticUncrating, testParams.additionalCratingDataDCRT);
-    for (let i = 0; i < result.length; i += 1) {
-      switch (result[i].label) {
-        case 'Crating size (cu ft)':
-          expect(result[i].value).toEqual('4.00');
-          break;
-        case 'Uncrating price (per cu ft)':
-          expect(result[i].value).toEqual('1.71');
-          break;
-        case 'Price escalation factor':
-          expect(result[i].value).toEqual('1.033');
-          break;
-        case 'Fuel rate adjustment':
-          expect(result[i].value).toEqual('$999.99');
-          break;
-        default:
-          break;
-      }
-    }
+    const expected = testData('DUCRT');
+
+    testAB(result, expected);
   });
 
   it('returns correct data for DomesticOriginShuttleService', () => {
     const result = makeCalculations('DOSHUT', 99999, testParams.DomesticOriginShuttleService);
-    for (let i = 0; i < result.length; i += 1) {
-      switch (result[i].label) {
-        case 'Billable weight (cwt)':
-          expect(result[i].value).toEqual('85 cwt');
-          break;
-        case 'Origin price':
-          expect(result[i].value).toEqual('1.71');
-          break;
-        case 'Price escalation factor':
-          expect(result[i].value).toEqual('1.033');
-          break;
-        case 'Fuel rate adjustment':
-          expect(result[i].value).toEqual('$999.99');
-          break;
-        default:
-          break;
-      }
-    }
+    const expected = testData('DOSHUT');
+
+    testAB(result, expected);
   });
 
   it('returns correct data for DomesticDestinationShuttleService', () => {
     const result = makeCalculations('DDSHUT', 99999, testParams.DomesticDestinationShuttleService);
-    for (let i = 0; i < result.length; i += 1) {
-      switch (result[i].label) {
-        case 'Billable weight (cwt)':
-          expect(result[i].value).toEqual('85 cwt');
-          break;
-        case 'Destination price':
-          expect(result[i].value).toEqual('1.71');
-          break;
-        case 'Price escalation factor':
-          expect(result[i].value).toEqual('1.033');
-          break;
-        case 'Fuel rate adjustment':
-          expect(result[i].value).toEqual('$999.99');
-          break;
-        default:
-          break;
-      }
-    }
+    const expected = testData('DDSHUT');
+
+    testAB(result, expected);
   });
 
   it('returns correct data for NonStandardHHG', () => {
@@ -591,66 +314,24 @@ describe('DomesticDestinationSITDelivery', () => {
   });
 
   it('FuelSurcharge returns correct data for FSC', () => {
-    const result = makeCalculations('FSC', 99999, testParams.FuelSurchage);
-    for (let i = 0; i < result.length; i += 1) {
-      switch (result[i].label) {
-        case 'Billable weight (cwt)':
-          expect(result[i].value).toEqual('85 cwt');
-          break;
-        case 'Fuel surcharge price (per mi)':
-          expect(result[i].value).toEqual('0.1');
-          break;
-        case 'Fuel rate adjustment':
-          expect(result[i].value).toEqual('$999.99');
-          break;
-        default:
-          break;
-      }
-    }
+    const result = makeCalculations('FSC', 99998, testParams.FuelSurchage);
+    const expected = testData('FSC');
+
+    testAB(result, expected);
   });
 
   it('FuelSurcharge returns correct data for DOSFSC', () => {
-    const result = makeCalculations('DOSFSC', 99999, testParams.DomesticOriginSITFuelSurchage);
-    for (let i = 0; i < result.length; i += 1) {
-      switch (result[i].label) {
-        case 'Billable weight (cwt)':
-          expect(result[i].value).toEqual('85 cwt');
-          break;
-        case 'Mileage into SIT':
-          expect(result[i].value).toEqual('29');
-          break;
-        case 'SIT mileage factor':
-          expect(result[i].value).toEqual('0.012');
-          break;
-        case 'Fuel rate adjustment':
-          expect(result[i].value).toEqual('$999.99');
-          break;
-        default:
-          break;
-      }
-    }
+    const result = makeCalculations('DOSFSC', 99998, testParams.DomesticOriginSITFuelSurchage);
+    const expected = testData('DOSFSC');
+
+    testAB(result, expected);
   });
 
   it('FuelSurcharge returns correct data for DDSFSC', () => {
-    const result = makeCalculations('DDSFSC', 99999, testParams.DomesticDestinationSITFuelSurchage);
-    for (let i = 0; i < result.length; i += 1) {
-      switch (result[i].label) {
-        case 'Billable weight (cwt)':
-          expect(result[i].value).toEqual('85 cwt');
-          break;
-        case 'Mileage into SIT':
-          expect(result[i].value).toEqual('29');
-          break;
-        case 'SIT fuel surcharge price (per mi)':
-          expect(result[i].value).toEqual('0.0');
-          break;
-        case 'Fuel rate adjustment':
-          expect(result[i].value).toEqual('$999.99');
-          break;
-        default:
-          break;
-      }
-    }
+    const result = makeCalculations('DDSFSC', 99998, testParams.DomesticDestinationSITFuelSurchage);
+    const expected = testData('DDSFSC');
+
+    testAB(result, expected);
   });
 
   // it('returns correct data for DomesticMobileHomeFactor', () => {

--- a/src/constants/serviceItems.js
+++ b/src/constants/serviceItems.js
@@ -37,6 +37,7 @@ const SERVICE_ITEM_PARAM_KEYS = {
   SITScheduleOrigin: 'SITScheduleOrigin',
   SITServiceAreaDest: 'SITServiceAreaDest',
   SITServiceAreaOrigin: 'SITServiceAreaOrigin',
+  Total: 'TotalAmountRequested',
   WeightAdjusted: 'WeightAdjusted',
   WeightOriginal: 'WeightOriginal',
   WeightBilled: 'WeightBilled',
@@ -70,6 +71,7 @@ const SERVICE_ITEM_CALCULATION_LABELS = {
   [SERVICE_ITEM_PARAM_KEYS.SITScheduleOrigin]: 'Origin SIT schedule',
   [SERVICE_ITEM_PARAM_KEYS.SITServiceAreaDest]: 'SIT destination service area',
   [SERVICE_ITEM_PARAM_KEYS.SITServiceAreaOrigin]: 'SIT origin service area',
+  [SERVICE_ITEM_PARAM_KEYS.Total]: 'Total',
   [SERVICE_ITEM_PARAM_KEYS.WeightAdjusted]: 'Adjusted',
   [SERVICE_ITEM_PARAM_KEYS.WeightOriginal]: 'Original',
   [SERVICE_ITEM_PARAM_KEYS.WeightBilled]: 'Shipment weight',
@@ -110,6 +112,7 @@ const SERVICE_ITEM_CALCULATION_LABELS = {
   UncratingDate: 'Uncrating date',
   UncratingPrice: 'Uncrating price (per cu ft)',
   SITFuelSurchargePrice: 'SIT mileage factor',
+  Total: 'Total',
 };
 
 const SERVICE_ITEM_CODES = {


### PR DESCRIPTION
## Previous PR #12600 into INT

## [B-20121](https://www13.v1host.com/USTRANSCOM38/assetdetail.v1?number=B-20121)

## Steps I took to test
1. Create test harness move with 'HHGMoveInSITEndsToday'.
- Copy Move Locator
2. Log in as Prime office user
3. Find the move by it's Move Locator and open it
4. Create a Payment Request for either Destination or Origin FSC
5. Switch user role to TIO or TOO office user
6. Find the move by it's Move Locator and open it
7. Review the Payment Requests
- You may have to click the Review Weights button and navigate back to the Payment Request Review page
8. You should no longer see "Fuel Rate Adjustment" at the bottom as the label of the total. It should now read "Total:"