### PR TITLE
INT- B-19532-Approved Advance Bug

### DIFF
--- a/src/components/Office/ShipmentIncentiveAdvance/ShipmentIncentiveAdvance.jsx
+++ b/src/components/Office/ShipmentIncentiveAdvance/ShipmentIncentiveAdvance.jsx
@@ -15,7 +15,8 @@ const ShipmentIncentiveAdvance = ({ estimatedIncentive }) => {
   const [statusInput, , statusHelper] = useField('advanceStatus');
 
   const advanceRequested = String(advanceInput.value) === 'true';
-  const advanceRequestStatus = statusInput.value === ADVANCE_STATUSES.APPROVED.apiValue;
+  const advanceRequestStatus =
+    statusInput.value === ADVANCE_STATUSES.APPROVED.apiValue || statusInput.value === ADVANCE_STATUSES.EDITED.apiValue;
 
   const { formattedMaxAdvance, formattedIncentive } =
     calculateMaxAdvanceAndFormatAdvanceAndIncentive(estimatedIncentive);

--- a/src/components/Office/ShipmentIncentiveAdvance/ShipmentIncentiveAdvance.test.jsx
+++ b/src/components/Office/ShipmentIncentiveAdvance/ShipmentIncentiveAdvance.test.jsx
@@ -77,4 +77,15 @@ describe('components/Office/ShipmentIncentiveAdvance', () => {
     expect(screen.getByLabelText('Approve')).toBeInTheDocument();
     expect(screen.getByLabelText('Approve')).toBeChecked();
   });
+
+  it('EDITED advanceStatus should stay as APPROVED', async () => {
+    render(
+      <Formik initialValues={{ advanceRequested: 'true', advance: '500', advanceStatus: 'EDITED' }}>
+        <ShipmentIncentiveAdvance />
+      </Formik>,
+    );
+
+    expect(screen.getByLabelText('Approve')).toBeInTheDocument();
+    expect(screen.getByLabelText('Approve')).toBeChecked();
+  });
 });


### PR DESCRIPTION
## [B-19532](https://www13.v1host.com/USTRANSCOM38/story.mvc/Summary?oidToken=Story%3A940488)

## Summary

This PR fixes UI issue on Office application when amount requested is updated and APPROVE status reverts to REJECTED.

## Verification Steps for the Author

These are to be checked by the author.

- [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
- [ ] Have the Agility acceptance criteria been met for this change?

## Verification Steps for Reviewers

These are to be checked by a reviewer.

- [ ] Has the branch been pulled in and checked out?
- [ ] Have the BL acceptance criteria been met for this change?
- [ ] Was the CircleCI build successful?
- [ ] Has the code been reviewed from a standards and best practices point of view?

### Setup to Run the Code

- [Instructions for starting storybook](https://transcom.github.io/mymove-docs/docs/frontend/setup/storybook)
- [Instructions for starting the MilMove application](https://transcom.github.io/mymove-docs/docs/getting-started/application-setup/)
- [Instructions for running tests](https://transcom.github.io/mymove-docs/docs/getting-started/development/testing)

### How to test

Steps to test: 

1. Log in as Services Counselor in Office and edit shipment on PPM

2. Enter an amount for Amount Requested and select Approve and hit Save & Continue

3. Edit Shipment again and edit the Amount Requested and hit Save & Continue

4. Status must stay in APPROVE state . Bug was that status is defaulted to Reject

![936799](https://github.com/transcom/mymove/assets/148127004/63a5595d-c31c-4c40-899c-d02545497085)



### Frontend

- [ ] There are no aXe warnings for UI.
- [ ] This works in [Supported Browsers and their phone views](https://transcom.github.io/mymove-docs/docs/adrs/Browser-Support/#minimum-browser-requirements) (Chrome, Firefox, Edge).
- [ ] There are no new console errors in the browser devtools.
- [ ] There are no new console errors in the test output.
- [ ] If this PR adds a new component to Storybook, it ensures the component is fully responsive, OR if it is intentionally not, a wrapping div using the `officeApp` class or custom `min-width` styling is used to hide any states the would not be visible to the user.
- [ ] This change meets the standards for [Section 508 compliance](https://www.ssa.gov/accessibility/andi/help/install.html).
