### PR TITLE
B-19175-KB-INT Update create customer to orders workflow

### DIFF
--- a/src/components/Office/AddOrdersForm/AddOrdersForm.jsx
+++ b/src/components/Office/AddOrdersForm/AddOrdersForm.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Field, Formik } from 'formik';
 import * as Yup from 'yup';
-import { FormGroup, Label, Radio } from '@trussworks/react-uswds';
+import { FormGroup, Label, Radio, Link as USWDSLink } from '@trussworks/react-uswds';
 
 import { DatePickerInput, DropdownInput, DutyLocationInput } from 'components/form/fields';
 import { Form } from 'components/form/Form';
@@ -10,6 +10,7 @@ import SectionWrapper from 'components/Customer/SectionWrapper';
 import { ORDERS_PAY_GRADE_OPTIONS } from 'constants/orders';
 import { dropdownInputOptions } from 'utils/formatters';
 import WizardNavigation from 'components/Customer/WizardNavigation/WizardNavigation';
+import Callout from 'components/Callout';
 
 const AddOrdersForm = ({ onSubmit, ordersTypeOptions, initialValues, onBack }) => {
   const payGradeOptions = dropdownInputOptions(ORDERS_PAY_GRADE_OPTIONS);
@@ -32,7 +33,8 @@ const AddOrdersForm = ({ onSubmit, ordersTypeOptions, initialValues, onBack }) =
 
   return (
     <Formik initialValues={initialValues} validateOnMount validationSchema={validationSchema} onSubmit={onSubmit}>
-      {({ isValid, isSubmitting, handleSubmit }) => {
+      {({ values, isValid, isSubmitting, handleSubmit }) => {
+        const isRetirementOrSeparation = ['RETIREMENT', 'SEPARATION'].includes(values.ordersType);
         return (
           <Form className={`${formStyles.form}`}>
             <h1>Tell us about the orders</h1>
@@ -73,7 +75,40 @@ const AddOrdersForm = ({ onSubmit, ordersTypeOptions, initialValues, onBack }) =
                 id="originDutyLocation"
                 required
               />
-              <DutyLocationInput name="newDutyLocation" label="New duty location" required />
+
+              {isRetirementOrSeparation ? (
+                <>
+                  <h3>Where are they entitled to move?</h3>
+                  <Callout>
+                    <span>The government will pay for their move to:</span>
+                    <ul>
+                      <li>Home of record (HOR)</li>
+                      <li>Place entered active duty (PLEAD)</li>
+                    </ul>
+                    <p>
+                      It might pay for a move to their Home of selection (HOS), anywhere in CONUS. Check their orders.
+                    </p>
+                    <p>
+                      Read more about where they are entitled to move when leaving the military on{' '}
+                      <USWDSLink
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        href="https://www.militaryonesource.mil/military-life-cycle/separation-transition/military-separation-retirement/deciding-where-to-live-when-you-leave-the-military/"
+                      >
+                        Military OneSource.
+                      </USWDSLink>
+                    </p>
+                  </Callout>
+                  <DutyLocationInput
+                    name="newDutyLocation"
+                    label="HOR, PLEAD or HOS"
+                    displayAddress={false}
+                    placeholder="Enter a city or ZIP"
+                  />
+                </>
+              ) : (
+                <DutyLocationInput name="newDutyLocation" label="New duty location" required />
+              )}
               <DropdownInput label="Pay grade" name="grade" id="grade" required options={payGradeOptions} />
             </SectionWrapper>
 

--- a/src/pages/Office/CustomerOnboarding/CreateCustomerForm.jsx
+++ b/src/pages/Office/CustomerOnboarding/CreateCustomerForm.jsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { GridContainer, Grid, Alert, Label, Radio, Fieldset } from '@trussworks/react-uswds';
-import { useNavigate } from 'react-router-dom';
+import { generatePath, useNavigate } from 'react-router-dom';
 import { Field, Formik } from 'formik';
 import * as Yup from 'yup';
 import { connect } from 'react-redux';
@@ -105,9 +105,10 @@ export const CreateCustomerForm = ({ setFlashMessage }) => {
     };
 
     return createCustomerWithOktaOption({ body })
-      .then(() => {
+      .then((res) => {
+        const customerId = Object.keys(res.createdCustomer)[0];
         setFlashMessage('CUSTOMER_CREATE_SUCCESS', 'success', `Customer created successfully.`);
-        navigate(servicesCounselingRoutes.BASE_CUSTOMER_SEARCH_PATH);
+        navigate(generatePath(servicesCounselingRoutes.BASE_CUSTOMERS_ORDERS_ADD_PATH, { customerId }));
       })
       .catch((e) => {
         const { response } = e;

--- a/src/pages/Office/CustomerOnboarding/CreateCustomerForm.test.jsx
+++ b/src/pages/Office/CustomerOnboarding/CreateCustomerForm.test.jsx
@@ -1,11 +1,13 @@
 import React from 'react';
 import { render, fireEvent, waitFor, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { generatePath } from 'react-router';
 
 import { CreateCustomerForm } from './CreateCustomerForm';
 
 import { MockProviders } from 'testUtils';
 import { createCustomerWithOktaOption } from 'services/ghcApi';
+import { servicesCounselingRoutes } from 'constants/routes';
 
 const mockNavigate = jest.fn();
 jest.mock('react-router-dom', () => ({
@@ -63,53 +65,61 @@ const fakePayload = {
 };
 
 const fakeResponse = {
-  affiliation: 'string',
-  firstName: 'John',
-  lastName: 'Doe',
-  telephone: '216-421-1392',
-  personalEmail: '73sGJ6jq7cS%6@PqElR.WUzkqFNvtduyyA',
-  suffix: 'Jr.',
-  middleName: 'David',
-  residentialAddress: {
-    id: 'c56a4180-65aa-42ec-a945-5fd21dec0538',
-    streetAddress1: '123 Main Ave',
-    streetAddress2: 'Apartment 9000',
-    streetAddress3: 'Montmârtre',
-    city: 'Anytown',
-    eTag: 'string',
-    state: 'AL',
-    postalCode: '90210',
-    country: 'USA',
-  },
-  backupContact: {
-    name: 'string',
-    email: 'backupContact@mail.com',
-    phone: '381-100-5880',
-  },
-  id: 'c56a4180-65aa-42ec-a945-5fd21dec0538',
-  edipi: 'string',
-  userID: 'c56a4180-65aa-42ec-a945-5fd21dec0538',
-  oktaID: 'string',
-  oktaEmail: 'string',
-  phoneIsPreferred: true,
-  emailIsPreferred: true,
-  secondaryTelephone: '499-793-2722',
-  backupAddress: {
-    id: 'c56a4180-65aa-42ec-a945-5fd21dec0538',
-    streetAddress1: '123 Main Ave',
-    streetAddress2: 'Apartment 9000',
-    streetAddress3: 'Montmârtre',
-    city: 'Anytown',
-    eTag: 'string',
-    state: 'AL',
-    postalCode: '90210',
-    country: 'USA',
+  createdCustomer: {
+    '7575b55a-0e14-4f11-8e42-10232d22b135': {
+      affiliation: 'string',
+      firstName: 'John',
+      lastName: 'Doe',
+      telephone: '216-421-1392',
+      personalEmail: '73sGJ6jq7cS%6@PqElR.WUzkqFNvtduyyA',
+      suffix: 'Jr.',
+      middleName: 'David',
+      residentialAddress: {
+        id: 'c56a4180-65aa-42ec-a945-5fd21dec0538',
+        streetAddress1: '123 Main Ave',
+        streetAddress2: 'Apartment 9000',
+        streetAddress3: 'Montmârtre',
+        city: 'Anytown',
+        eTag: 'string',
+        state: 'AL',
+        postalCode: '90210',
+        country: 'USA',
+      },
+      backupContact: {
+        name: 'string',
+        email: 'backupContact@mail.com',
+        phone: '381-100-5880',
+      },
+      id: 'c56a4180-65aa-42ec-a945-5fd21dec0538',
+      edipi: 'string',
+      userID: 'c56a4180-65aa-42ec-a945-5fd21dec0538',
+      oktaID: 'string',
+      oktaEmail: 'string',
+      phoneIsPreferred: true,
+      emailIsPreferred: true,
+      secondaryTelephone: '499-793-2722',
+      backupAddress: {
+        id: 'c56a4180-65aa-42ec-a945-5fd21dec0538',
+        streetAddress1: '123 Main Ave',
+        streetAddress2: 'Apartment 9000',
+        streetAddress3: 'Montmârtre',
+        city: 'Anytown',
+        eTag: 'string',
+        state: 'AL',
+        postalCode: '90210',
+        country: 'USA',
+      },
+    },
   },
 };
 
 const testProps = {
   setFlashMessage: jest.fn(),
 };
+
+const ordersPath = generatePath(servicesCounselingRoutes.BASE_CUSTOMERS_ORDERS_ADD_PATH, {
+  customerId: '7575b55a-0e14-4f11-8e42-10232d22b135',
+});
 
 describe('CreateCustomerForm', () => {
   it('renders without crashing', async () => {
@@ -262,7 +272,9 @@ describe('CreateCustomerForm', () => {
 
     await userEvent.click(saveBtn);
 
-    expect(createCustomerWithOktaOption).toHaveBeenCalled();
-    expect(mockNavigate).toHaveBeenCalled();
+    await waitFor(() => {
+      expect(createCustomerWithOktaOption).toHaveBeenCalled();
+      expect(mockNavigate).toHaveBeenCalledWith(ordersPath);
+    });
   }, 10000);
 });


### PR DESCRIPTION
## [Agility ticket](https://www13.v1host.com/USTRANSCOM38/assetdetail.v1?number=B-19175)

## [First INT PR](https://github.com/transcom/mymove/pull/12526)

## Summary

Small changes to address changes requested by PO before POA
1. Create Customer now redirects to Add Orders page instead of back to Customer Search
2. SC add orders page now includes UI changes for orders of the Retirement/Separation type

### How to test

1. Login as a Services Counselor
2. In the Customer Search tab, search for a customer to make the Add Customer button appear, and click on it
3. Fill out the required information and submit, confirm you are redirected to the Add Orders page instead of back to customer search
4. Change the order type to retirement and separation and confirm the UI changes are present
