### PR TITLE
MAIN - closeout server error fix

### DIFF
--- a/pkg/services/ppm_closeout/ppm_closeout_test.go
+++ b/pkg/services/ppm_closeout/ppm_closeout_test.go
@@ -82,12 +82,38 @@ func (suite *PPMCloseoutSuite) TestPPMShipmentCreator() {
 				MilesLower:            2001,
 				MilesUpper:            2500,
 				PriceMillicents:       unit.Millicents(412400),
+				IsPeakPeriod:          false,
+			},
+		})
+		testdatagen.FetchOrMakeReDomesticLinehaulPrice(suite.AppContextForTest().DB(), testdatagen.Assertions{
+			ReDomesticLinehaulPrice: models.ReDomesticLinehaulPrice{
+				Contract:              originDomesticServiceArea.Contract,
+				ContractID:            originDomesticServiceArea.ContractID,
+				DomesticServiceArea:   originDomesticServiceArea,
+				DomesticServiceAreaID: originDomesticServiceArea.ID,
+				WeightLower:           unit.Pound(500),
+				WeightUpper:           unit.Pound(4999),
+				MilesLower:            2001,
+				MilesUpper:            2500,
+				PriceMillicents:       unit.Millicents(412400),
 				IsPeakPeriod:          true,
 			},
 		})
 
 		dopService := factory.BuildReServiceByCode(suite.AppContextForTest().DB(), models.ReServiceCodeDOP)
 
+		testdatagen.FetchOrMakeReDomesticServiceAreaPrice(suite.AppContextForTest().DB(), testdatagen.Assertions{
+			ReDomesticServiceAreaPrice: models.ReDomesticServiceAreaPrice{
+				ContractID:            originDomesticServiceArea.ContractID,
+				Contract:              originDomesticServiceArea.Contract,
+				ServiceID:             dopService.ID,
+				Service:               dopService,
+				DomesticServiceAreaID: originDomesticServiceArea.ID,
+				DomesticServiceArea:   originDomesticServiceArea,
+				IsPeakPeriod:          false,
+				PriceCents:            unit.Cents(404),
+			},
+		})
 		testdatagen.FetchOrMakeReDomesticServiceAreaPrice(suite.AppContextForTest().DB(), testdatagen.Assertions{
 			ReDomesticServiceAreaPrice: models.ReDomesticServiceAreaPrice{
 				ContractID:            originDomesticServiceArea.ContractID,
@@ -128,6 +154,18 @@ func (suite *PPMCloseoutSuite) TestPPMShipmentCreator() {
 				Service:               ddpService,
 				DomesticServiceAreaID: destDomesticServiceArea.ID,
 				DomesticServiceArea:   destDomesticServiceArea,
+				IsPeakPeriod:          false,
+				PriceCents:            unit.Cents(832),
+			},
+		})
+		testdatagen.FetchOrMakeReDomesticServiceAreaPrice(suite.AppContextForTest().DB(), testdatagen.Assertions{
+			ReDomesticServiceAreaPrice: models.ReDomesticServiceAreaPrice{
+				ContractID:            destDomesticServiceArea.ContractID,
+				Contract:              destDomesticServiceArea.Contract,
+				ServiceID:             ddpService.ID,
+				Service:               ddpService,
+				DomesticServiceAreaID: destDomesticServiceArea.ID,
+				DomesticServiceArea:   destDomesticServiceArea,
 				IsPeakPeriod:          true,
 				PriceCents:            unit.Cents(832),
 			},
@@ -135,6 +173,17 @@ func (suite *PPMCloseoutSuite) TestPPMShipmentCreator() {
 
 		dpkService := factory.BuildReServiceByCode(suite.AppContextForTest().DB(), models.ReServiceCodeDPK)
 
+		testdatagen.FetchOrMakeReDomesticOtherPrice(suite.AppContextForTest().DB(), testdatagen.Assertions{
+			ReDomesticOtherPrice: models.ReDomesticOtherPrice{
+				ContractID:   originDomesticServiceArea.ContractID,
+				Contract:     originDomesticServiceArea.Contract,
+				ServiceID:    dpkService.ID,
+				Service:      dpkService,
+				IsPeakPeriod: false,
+				Schedule:     3,
+				PriceCents:   7395,
+			},
+		})
 		testdatagen.FetchOrMakeReDomesticOtherPrice(suite.AppContextForTest().DB(), testdatagen.Assertions{
 			ReDomesticOtherPrice: models.ReDomesticOtherPrice{
 				ContractID:   originDomesticServiceArea.ContractID,
@@ -155,6 +204,17 @@ func (suite *PPMCloseoutSuite) TestPPMShipmentCreator() {
 				Contract:     destDomesticServiceArea.Contract,
 				ServiceID:    dupkService.ID,
 				Service:      dupkService,
+				IsPeakPeriod: false,
+				Schedule:     2,
+				PriceCents:   597,
+			},
+		})
+		testdatagen.FetchOrMakeReDomesticOtherPrice(suite.AppContextForTest().DB(), testdatagen.Assertions{
+			ReDomesticOtherPrice: models.ReDomesticOtherPrice{
+				ContractID:   destDomesticServiceArea.ContractID,
+				Contract:     destDomesticServiceArea.Contract,
+				ServiceID:    dupkService.ID,
+				Service:      dupkService,
 				IsPeakPeriod: true,
 				Schedule:     2,
 				PriceCents:   597,
@@ -163,6 +223,18 @@ func (suite *PPMCloseoutSuite) TestPPMShipmentCreator() {
 
 		dofsitService := factory.BuildReServiceByCode(suite.AppContextForTest().DB(), models.ReServiceCodeDOFSIT)
 
+		testdatagen.FetchOrMakeReDomesticServiceAreaPrice(suite.AppContextForTest().DB(), testdatagen.Assertions{
+			ReDomesticServiceAreaPrice: models.ReDomesticServiceAreaPrice{
+				ContractID:            originDomesticServiceArea.ContractID,
+				Contract:              originDomesticServiceArea.Contract,
+				ServiceID:             dofsitService.ID,
+				Service:               dofsitService,
+				DomesticServiceAreaID: originDomesticServiceArea.ID,
+				DomesticServiceArea:   originDomesticServiceArea,
+				IsPeakPeriod:          false,
+				PriceCents:            1153,
+			},
+		})
 		testdatagen.FetchOrMakeReDomesticServiceAreaPrice(suite.AppContextForTest().DB(), testdatagen.Assertions{
 			ReDomesticServiceAreaPrice: models.ReDomesticServiceAreaPrice{
 				ContractID:            originDomesticServiceArea.ContractID,
@@ -186,6 +258,18 @@ func (suite *PPMCloseoutSuite) TestPPMShipmentCreator() {
 				Service:               doasitService,
 				DomesticServiceAreaID: originDomesticServiceArea.ID,
 				DomesticServiceArea:   originDomesticServiceArea,
+				IsPeakPeriod:          false,
+				PriceCents:            46,
+			},
+		})
+		testdatagen.FetchOrMakeReDomesticServiceAreaPrice(suite.AppContextForTest().DB(), testdatagen.Assertions{
+			ReDomesticServiceAreaPrice: models.ReDomesticServiceAreaPrice{
+				ContractID:            originDomesticServiceArea.ContractID,
+				Contract:              originDomesticServiceArea.Contract,
+				ServiceID:             doasitService.ID,
+				Service:               doasitService,
+				DomesticServiceAreaID: originDomesticServiceArea.ID,
+				DomesticServiceArea:   originDomesticServiceArea,
 				IsPeakPeriod:          true,
 				PriceCents:            46,
 			},
@@ -201,6 +285,18 @@ func (suite *PPMCloseoutSuite) TestPPMShipmentCreator() {
 				Service:               ddfsitService,
 				DomesticServiceAreaID: destDomesticServiceArea.ID,
 				DomesticServiceArea:   destDomesticServiceArea,
+				IsPeakPeriod:          false,
+				PriceCents:            1612,
+			},
+		})
+		testdatagen.FetchOrMakeReDomesticServiceAreaPrice(suite.AppContextForTest().DB(), testdatagen.Assertions{
+			ReDomesticServiceAreaPrice: models.ReDomesticServiceAreaPrice{
+				ContractID:            destDomesticServiceArea.ContractID,
+				Contract:              destDomesticServiceArea.Contract,
+				ServiceID:             ddfsitService.ID,
+				Service:               ddfsitService,
+				DomesticServiceAreaID: destDomesticServiceArea.ID,
+				DomesticServiceArea:   destDomesticServiceArea,
 				IsPeakPeriod:          true,
 				PriceCents:            1612,
 			},
@@ -208,6 +304,18 @@ func (suite *PPMCloseoutSuite) TestPPMShipmentCreator() {
 
 		ddasitService := factory.BuildReServiceByCode(suite.AppContextForTest().DB(), models.ReServiceCodeDDASIT)
 
+		testdatagen.FetchOrMakeReDomesticServiceAreaPrice(suite.AppContextForTest().DB(), testdatagen.Assertions{
+			ReDomesticServiceAreaPrice: models.ReDomesticServiceAreaPrice{
+				ContractID:            destDomesticServiceArea.ContractID,
+				Contract:              destDomesticServiceArea.Contract,
+				ServiceID:             ddasitService.ID,
+				Service:               ddasitService,
+				DomesticServiceAreaID: destDomesticServiceArea.ID,
+				DomesticServiceArea:   destDomesticServiceArea,
+				IsPeakPeriod:          false,
+				PriceCents:            55,
+			},
+		})
 		testdatagen.FetchOrMakeReDomesticServiceAreaPrice(suite.AppContextForTest().DB(), testdatagen.Assertions{
 			ReDomesticServiceAreaPrice: models.ReDomesticServiceAreaPrice{
 				ContractID:            destDomesticServiceArea.ContractID,

--- a/pkg/services/ppm_closeout/ppm_closeout_test.go
+++ b/pkg/services/ppm_closeout/ppm_closeout_test.go
@@ -82,6 +82,7 @@ func (suite *PPMCloseoutSuite) TestPPMShipmentCreator() {
 				MilesLower:            2001,
 				MilesUpper:            2500,
 				PriceMillicents:       unit.Millicents(412400),
+				IsPeakPeriod:          true,
 			},
 		})
 
@@ -95,7 +96,7 @@ func (suite *PPMCloseoutSuite) TestPPMShipmentCreator() {
 				Service:               dopService,
 				DomesticServiceAreaID: originDomesticServiceArea.ID,
 				DomesticServiceArea:   originDomesticServiceArea,
-				IsPeakPeriod:          false,
+				IsPeakPeriod:          true,
 				PriceCents:            unit.Cents(404),
 			},
 		})
@@ -127,7 +128,7 @@ func (suite *PPMCloseoutSuite) TestPPMShipmentCreator() {
 				Service:               ddpService,
 				DomesticServiceAreaID: destDomesticServiceArea.ID,
 				DomesticServiceArea:   destDomesticServiceArea,
-				IsPeakPeriod:          false,
+				IsPeakPeriod:          true,
 				PriceCents:            unit.Cents(832),
 			},
 		})
@@ -140,7 +141,7 @@ func (suite *PPMCloseoutSuite) TestPPMShipmentCreator() {
 				Contract:     originDomesticServiceArea.Contract,
 				ServiceID:    dpkService.ID,
 				Service:      dpkService,
-				IsPeakPeriod: false,
+				IsPeakPeriod: true,
 				Schedule:     3,
 				PriceCents:   7395,
 			},
@@ -154,7 +155,7 @@ func (suite *PPMCloseoutSuite) TestPPMShipmentCreator() {
 				Contract:     destDomesticServiceArea.Contract,
 				ServiceID:    dupkService.ID,
 				Service:      dupkService,
-				IsPeakPeriod: false,
+				IsPeakPeriod: true,
 				Schedule:     2,
 				PriceCents:   597,
 			},
@@ -170,7 +171,7 @@ func (suite *PPMCloseoutSuite) TestPPMShipmentCreator() {
 				Service:               dofsitService,
 				DomesticServiceAreaID: originDomesticServiceArea.ID,
 				DomesticServiceArea:   originDomesticServiceArea,
-				IsPeakPeriod:          false,
+				IsPeakPeriod:          true,
 				PriceCents:            1153,
 			},
 		})
@@ -185,7 +186,7 @@ func (suite *PPMCloseoutSuite) TestPPMShipmentCreator() {
 				Service:               doasitService,
 				DomesticServiceAreaID: originDomesticServiceArea.ID,
 				DomesticServiceArea:   originDomesticServiceArea,
-				IsPeakPeriod:          false,
+				IsPeakPeriod:          true,
 				PriceCents:            46,
 			},
 		})
@@ -200,7 +201,7 @@ func (suite *PPMCloseoutSuite) TestPPMShipmentCreator() {
 				Service:               ddfsitService,
 				DomesticServiceAreaID: destDomesticServiceArea.ID,
 				DomesticServiceArea:   destDomesticServiceArea,
-				IsPeakPeriod:          false,
+				IsPeakPeriod:          true,
 				PriceCents:            1612,
 			},
 		})
@@ -215,7 +216,7 @@ func (suite *PPMCloseoutSuite) TestPPMShipmentCreator() {
 				Service:               ddasitService,
 				DomesticServiceAreaID: destDomesticServiceArea.ID,
 				DomesticServiceArea:   destDomesticServiceArea,
-				IsPeakPeriod:          false,
+				IsPeakPeriod:          true,
 				PriceCents:            55,
 			},
 		})


### PR DESCRIPTION
INT PR: https://github.com/transcom/mymove/pull/12679

## Summary

Fix for server error related to PPMCloseout.
Issue was due to `IsPeakPeriod` being changed from originally `false` to now `true` because of the current date.
The test file only accounted for when it was false and pre-loaded data only had entries with `false`.
