### PR TITLE
MAIN B-19903 unlocking a move (MERGE AFTER MAIN-B-19902)

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -129,7 +129,7 @@ export DB_SSL_MODE=disable
 export FEATURE_FLAG_MULTI_MOVE=true
 export FEATURE_FLAG_COUNSELOR_MOVE_CREATE=true
 export FEATURE_FLAG_VALIDATION_CODE_REQUIRED=false
-export FEATURE_FLAG_MOVE_LOCK=false
+export FEATURE_FLAG_MOVE_LOCK=true
 export FEATURE_FLAG_OKTA_DODID_INPUT=false
 
 # Feature flags to disable certain shipment types

--- a/.envrc
+++ b/.envrc
@@ -129,7 +129,7 @@ export DB_SSL_MODE=disable
 export FEATURE_FLAG_MULTI_MOVE=true
 export FEATURE_FLAG_COUNSELOR_MOVE_CREATE=true
 export FEATURE_FLAG_VALIDATION_CODE_REQUIRED=false
-export FEATURE_FLAG_MOVE_LOCK=true
+export FEATURE_FLAG_MOVE_LOCK=false
 export FEATURE_FLAG_OKTA_DODID_INPUT=false
 
 # Feature flags to disable certain shipment types

--- a/pkg/handlers/authentication/auth.go
+++ b/pkg/handlers/authentication/auth.go
@@ -477,10 +477,10 @@ func (h LogoutHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 	if appCtx.Session() != nil {
 		// if the user is an office user, we need to unlock any moves that they have locked
-		if appCtx.Session().IsOfficeApp() {
+		if appCtx.Session().IsOfficeApp() && appCtx.Session().OfficeUserID != uuid.Nil {
 			moveUnlocker := movelocker.NewMoveUnlocker()
 			officeUserID := appCtx.Session().OfficeUserID
-			err := moveUnlocker.CheckForUnlockedMovesAndUnlock(appCtx, officeUserID)
+			err := moveUnlocker.CheckForLockedMovesAndUnlock(appCtx, officeUserID)
 			if err != nil {
 				appCtx.Logger().Error("failed to unlock moves for office user")
 			}

--- a/pkg/handlers/authentication/auth.go
+++ b/pkg/handlers/authentication/auth.go
@@ -482,7 +482,7 @@ func (h LogoutHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			officeUserID := appCtx.Session().OfficeUserID
 			err := moveUnlocker.CheckForLockedMovesAndUnlock(appCtx, officeUserID)
 			if err != nil {
-				appCtx.Logger().Error("failed to unlock moves for office user")
+				appCtx.Logger().Error(fmt.Sprintf("failed to unlock moves for office user ID: %s", officeUserID), zap.Error(err))
 			}
 		}
 

--- a/pkg/handlers/authentication/auth.go
+++ b/pkg/handlers/authentication/auth.go
@@ -26,6 +26,7 @@ import (
 	"github.com/transcom/mymove/pkg/models/roles"
 	"github.com/transcom/mymove/pkg/notifications"
 	"github.com/transcom/mymove/pkg/services"
+	movelocker "github.com/transcom/mymove/pkg/services/lock_move"
 	"github.com/transcom/mymove/pkg/services/query"
 )
 
@@ -475,6 +476,16 @@ func (h LogoutHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if appCtx.Session() != nil {
+		// if the user is an office user, we need to unlock any moves that they have locked
+		if appCtx.Session().IsOfficeApp() {
+			moveUnlocker := movelocker.NewMoveUnlocker()
+			officeUserID := appCtx.Session().OfficeUserID
+			err := moveUnlocker.CheckForUnlockedMovesAndUnlock(appCtx, officeUserID)
+			if err != nil {
+				appCtx.Logger().Error("failed to unlock moves for office user")
+			}
+		}
+
 		sessionManager := h.SessionManagers().SessionManagerForApplication(appCtx.Session().ApplicationName)
 		if sessionManager == nil {
 			appCtx.Logger().Error("Authenticating user, cannot get session manager from request")

--- a/pkg/handlers/ghcapi/api.go
+++ b/pkg/handlers/ghcapi/api.go
@@ -471,16 +471,19 @@ func NewGhcAPIHandler(handlerConfig handlers.HandlerConfig) *ghcops.MymoveAPI {
 	ghcAPI.QueuesGetMovesQueueHandler = GetMovesQueueHandler{
 		handlerConfig,
 		order.NewOrderFetcher(),
+		movelocker.NewMoveUnlocker(),
 	}
 
 	ghcAPI.QueuesListPrimeMovesHandler = ListPrimeMovesHandler{
 		handlerConfig,
 		movetaskorder.NewMoveTaskOrderFetcher(),
+		movelocker.NewMoveUnlocker(),
 	}
 
 	ghcAPI.QueuesGetPaymentRequestsQueueHandler = GetPaymentRequestsQueueHandler{
 		handlerConfig,
 		paymentrequest.NewPaymentRequestListFetcher(),
+		movelocker.NewMoveUnlocker(),
 	}
 
 	ghcAPI.QueuesGetServicesCounselingQueueHandler = GetServicesCounselingQueueHandler{

--- a/pkg/handlers/ghcapi/api.go
+++ b/pkg/handlers/ghcapi/api.go
@@ -477,7 +477,6 @@ func NewGhcAPIHandler(handlerConfig handlers.HandlerConfig) *ghcops.MymoveAPI {
 	ghcAPI.QueuesListPrimeMovesHandler = ListPrimeMovesHandler{
 		handlerConfig,
 		movetaskorder.NewMoveTaskOrderFetcher(),
-		movelocker.NewMoveUnlocker(),
 	}
 
 	ghcAPI.QueuesGetPaymentRequestsQueueHandler = GetPaymentRequestsQueueHandler{
@@ -489,6 +488,7 @@ func NewGhcAPIHandler(handlerConfig handlers.HandlerConfig) *ghcops.MymoveAPI {
 	ghcAPI.QueuesGetServicesCounselingQueueHandler = GetServicesCounselingQueueHandler{
 		handlerConfig,
 		order.NewOrderFetcher(),
+		movelocker.NewMoveUnlocker(),
 	}
 
 	ghcAPI.TacTacValidationHandler = TacValidationHandler{

--- a/pkg/handlers/ghcapi/queues_test.go
+++ b/pkg/handlers/ghcapi/queues_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/transcom/mymove/pkg/gen/ghcmessages"
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/models/roles"
+	movelocker "github.com/transcom/mymove/pkg/services/lock_move"
 	"github.com/transcom/mymove/pkg/services/mocks"
 	movetaskorder "github.com/transcom/mymove/pkg/services/move_task_order"
 	order "github.com/transcom/mymove/pkg/services/order"
@@ -70,9 +71,11 @@ func (suite *HandlerSuite) TestGetMoveQueuesHandler() {
 		HTTPRequest: request,
 	}
 	handlerConfig := suite.HandlerConfig()
+	mockUnlocker := movelocker.NewMoveUnlocker()
 	handler := GetMovesQueueHandler{
 		handlerConfig,
 		order.NewOrderFetcher(),
+		mockUnlocker,
 	}
 
 	// Validate incoming payload: no body to validate
@@ -107,9 +110,11 @@ func (suite *HandlerSuite) TestListPrimeMovesHandler() {
 		HTTPRequest: request,
 	}
 	handlerConfig := suite.HandlerConfig()
+	mockUnlocker := movelocker.NewMoveUnlocker()
 	handler := ListPrimeMovesHandler{
 		handlerConfig,
 		movetaskorder.NewMoveTaskOrderFetcher(),
+		mockUnlocker,
 	}
 
 	// Validate incoming payload: no body to validate
@@ -192,9 +197,11 @@ func (suite *HandlerSuite) TestGetMoveQueuesHandlerMoveInfo() {
 			HTTPRequest: request,
 		}
 		handlerConfig := suite.HandlerConfig()
+		mockUnlocker := movelocker.NewMoveUnlocker()
 		handler := GetMovesQueueHandler{
 			handlerConfig,
 			&orderFetcher,
+			mockUnlocker,
 		}
 
 		// Validate incoming payload: no body to validate
@@ -263,9 +270,11 @@ func (suite *HandlerSuite) TestGetMoveQueuesBranchFilter() {
 		Branch:      models.StringPointer("AIR_FORCE"),
 	}
 	handlerConfig := suite.HandlerConfig()
+	mockUnlocker := movelocker.NewMoveUnlocker()
 	handler := GetMovesQueueHandler{
 		handlerConfig,
 		order.NewOrderFetcher(),
+		mockUnlocker,
 	}
 
 	// Validate incoming payload: no body to validate
@@ -348,9 +357,11 @@ func (suite *HandlerSuite) TestGetMoveQueuesHandlerStatuses() {
 		HTTPRequest: request,
 	}
 	handlerConfig := suite.HandlerConfig()
+	mockUnlocker := movelocker.NewMoveUnlocker()
 	handler := GetMovesQueueHandler{
 		handlerConfig,
 		order.NewOrderFetcher(),
+		mockUnlocker,
 	}
 
 	// Validate incoming payload: no body to validate
@@ -494,9 +505,11 @@ func (suite *HandlerSuite) TestGetMoveQueuesHandlerFilters() {
 	request = suite.AuthenticateOfficeRequest(request, officeUser)
 
 	handlerConfig := suite.HandlerConfig()
+	mockUnlocker := movelocker.NewMoveUnlocker()
 	handler := GetMovesQueueHandler{
 		handlerConfig,
 		order.NewOrderFetcher(),
+		mockUnlocker,
 	}
 
 	suite.Run("loads results with all STATUSes selected", func() {
@@ -748,9 +761,11 @@ func (suite *HandlerSuite) TestGetMoveQueuesHandlerCustomerInfoFilters() {
 	request = suite.AuthenticateOfficeRequest(request, officeUser)
 
 	handlerConfig := suite.HandlerConfig()
+	mockUnlocker := movelocker.NewMoveUnlocker()
 	handler := GetMovesQueueHandler{
 		handlerConfig,
 		order.NewOrderFetcher(),
+		mockUnlocker,
 	}
 
 	suite.Run("returns unfiltered results", func() {
@@ -887,9 +902,11 @@ func (suite *HandlerSuite) TestGetMoveQueuesHandlerUnauthorizedRole() {
 		HTTPRequest: request,
 	}
 	handlerConfig := suite.HandlerConfig()
+	mockUnlocker := movelocker.NewMoveUnlocker()
 	handler := GetMovesQueueHandler{
 		handlerConfig,
 		order.NewOrderFetcher(),
+		mockUnlocker,
 	}
 
 	// Validate incoming payload: no body to validate
@@ -915,9 +932,11 @@ func (suite *HandlerSuite) TestGetMoveQueuesHandlerUnauthorizedUser() {
 		HTTPRequest: request,
 	}
 	handlerConfig := suite.HandlerConfig()
+	mockUnlocker := movelocker.NewMoveUnlocker()
 	handler := GetMovesQueueHandler{
 		handlerConfig,
 		order.NewOrderFetcher(),
+		mockUnlocker,
 	}
 
 	// Validate incoming payload: no body to validate
@@ -964,9 +983,11 @@ func (suite *HandlerSuite) TestGetMoveQueuesHandlerEmptyResults() {
 		HTTPRequest: request,
 	}
 	handlerConfig := suite.HandlerConfig()
+	mockUnlocker := movelocker.NewMoveUnlocker()
 	handler := GetMovesQueueHandler{
 		handlerConfig,
 		order.NewOrderFetcher(),
+		mockUnlocker,
 	}
 
 	// Validate incoming payload: no body to validate
@@ -1010,9 +1031,11 @@ func (suite *HandlerSuite) TestGetPaymentRequestsQueueHandler() {
 		HTTPRequest: request,
 	}
 	handlerConfig := suite.HandlerConfig()
+	mockUnlocker := movelocker.NewMoveUnlocker()
 	handler := GetPaymentRequestsQueueHandler{
 		handlerConfig,
 		paymentrequest.NewPaymentRequestListFetcher(),
+		mockUnlocker,
 	}
 
 	// Validate incoming payload: no body to validate
@@ -1083,9 +1106,11 @@ func (suite *HandlerSuite) TestGetPaymentRequestsQueueSubmittedAtFilter() {
 	request = suite.AuthenticateOfficeRequest(request, officeUser)
 
 	handlerConfig := suite.HandlerConfig()
+	mockUnlocker := movelocker.NewMoveUnlocker()
 	handler := GetPaymentRequestsQueueHandler{
 		handlerConfig,
 		paymentrequest.NewPaymentRequestListFetcher(),
+		mockUnlocker,
 	}
 	suite.Run("returns unfiltered results", func() {
 		params := queues.GetPaymentRequestsQueueParams{
@@ -1160,9 +1185,11 @@ func (suite *HandlerSuite) TestGetPaymentRequestsQueueHandlerUnauthorizedRole() 
 		PerPage:     models.Int64Pointer(1),
 	}
 	handlerConfig := suite.HandlerConfig()
+	mockUnlocker := movelocker.NewMoveUnlocker()
 	handler := GetPaymentRequestsQueueHandler{
 		handlerConfig,
 		paymentrequest.NewPaymentRequestListFetcher(),
+		mockUnlocker,
 	}
 
 	// Validate incoming payload: no body to validate
@@ -1193,9 +1220,11 @@ func (suite *HandlerSuite) TestGetPaymentRequestsQueueHandlerServerError() {
 		PerPage:     models.Int64Pointer(1),
 	}
 	handlerConfig := suite.HandlerConfig()
+	mockUnlocker := movelocker.NewMoveUnlocker()
 	handler := GetPaymentRequestsQueueHandler{
 		handlerConfig,
 		&paymentRequestListFetcher,
+		mockUnlocker,
 	}
 
 	// Validate incoming payload: no body to validate
@@ -1227,9 +1256,11 @@ func (suite *HandlerSuite) TestGetPaymentRequestsQueueHandlerEmptyResults() {
 		PerPage:     models.Int64Pointer(1),
 	}
 	handlerConfig := suite.HandlerConfig()
+	mockUnlocker := movelocker.NewMoveUnlocker()
 	handler := GetPaymentRequestsQueueHandler{
 		handlerConfig,
 		&paymentRequestListFetcher,
+		mockUnlocker,
 	}
 
 	// Validate incoming payload: no body to validate

--- a/pkg/handlers/ghcapi/queues_test.go
+++ b/pkg/handlers/ghcapi/queues_test.go
@@ -110,11 +110,9 @@ func (suite *HandlerSuite) TestListPrimeMovesHandler() {
 		HTTPRequest: request,
 	}
 	handlerConfig := suite.HandlerConfig()
-	mockUnlocker := movelocker.NewMoveUnlocker()
 	handler := ListPrimeMovesHandler{
 		handlerConfig,
 		movetaskorder.NewMoveTaskOrderFetcher(),
-		mockUnlocker,
 	}
 
 	// Validate incoming payload: no body to validate
@@ -1461,9 +1459,11 @@ func (suite *HandlerSuite) makeServicesCounselingSubtestData() (subtestData *ser
 	request := httptest.NewRequest("GET", "/queues/counseling", nil)
 	subtestData.request = suite.AuthenticateOfficeRequest(request, subtestData.officeUser)
 	handlerConfig := suite.HandlerConfig()
+	mockUnlocker := movelocker.NewMoveUnlocker()
 	subtestData.handler = GetServicesCounselingQueueHandler{
 		handlerConfig,
 		order.NewOrderFetcher(),
+		mockUnlocker,
 	}
 
 	return subtestData

--- a/pkg/services/lock_move.go
+++ b/pkg/services/lock_move.go
@@ -19,5 +19,5 @@ type MoveLocker interface {
 //go:generate mockery --name MoveUnlocker
 type MoveUnlocker interface {
 	UnlockMove(appCtx appcontext.AppContext, move *models.Move, officeUserID uuid.UUID) (*models.Move, error)
-	CheckForUnlockedMovesAndUnlock(appCtx appcontext.AppContext, officeUserID uuid.UUID) error
+	CheckForLockedMovesAndUnlock(appCtx appcontext.AppContext, officeUserID uuid.UUID) error
 }

--- a/pkg/services/lock_move.go
+++ b/pkg/services/lock_move.go
@@ -13,3 +13,11 @@ import (
 type MoveLocker interface {
 	LockMove(appCtx appcontext.AppContext, move *models.Move, officeUserID uuid.UUID) (*models.Move, error)
 }
+
+// MoveUnlocker is the exported interface for unlocking moves
+//
+//go:generate mockery --name MoveUnlocker
+type MoveUnlocker interface {
+	UnlockMove(appCtx appcontext.AppContext, move *models.Move, officeUserID uuid.UUID) (*models.Move, error)
+	CheckForUnlockedMovesAndUnlock(appCtx appcontext.AppContext, officeUserID uuid.UUID) error
+}

--- a/pkg/services/lock_move/move_locker_test.go
+++ b/pkg/services/lock_move/move_locker_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/transcom/mymove/pkg/models/roles"
 )
 
-func (suite *MoveLockerServiceSuite) TestMoveFetcher() {
+func (suite *MoveLockerServiceSuite) TestLockMove() {
 	moveLocker := NewMoveLocker()
 
 	suite.Run("successfully returns move with office user values and lockExpiresAt value", func() {

--- a/pkg/services/lock_move/move_unlocker.go
+++ b/pkg/services/lock_move/move_unlocker.go
@@ -1,0 +1,99 @@
+package lockmove
+
+import (
+	"github.com/gofrs/uuid"
+
+	"github.com/transcom/mymove/pkg/appcontext"
+	"github.com/transcom/mymove/pkg/apperror"
+	"github.com/transcom/mymove/pkg/models"
+	"github.com/transcom/mymove/pkg/services"
+)
+
+type moveUnlocker struct {
+}
+
+// NewMoveLocker creates a new moveLocker service
+func NewMoveUnlocker() services.MoveUnlocker {
+	return &moveUnlocker{}
+}
+
+// UnlockMove updates a move by checking if there are values in the lock_expires_at and locked_by columns and nils them out
+// this service object is called when loading queues
+func (m moveUnlocker) UnlockMove(appCtx appcontext.AppContext, move *models.Move, officeUserID uuid.UUID) (*models.Move, error) {
+
+	if move == nil {
+		return nil, apperror.NewQueryError("Move", nil, "No move provided in request to unlock move")
+	}
+
+	if officeUserID == uuid.Nil {
+		return nil, apperror.NewQueryError("OfficeUserID", nil, "No office user provided in request to unlock move")
+	}
+
+	// nil out all of the columns since the office user is no longer in the move
+	if move.LockExpiresAt != nil {
+		move.LockExpiresAt = nil
+	}
+
+	if move.LockedByOfficeUserID != nil {
+		move.LockedByOfficeUserID = nil
+	}
+
+	if move.LockedByOfficeUser != nil {
+		move.LockedByOfficeUser = nil
+	}
+
+	transactionError := appCtx.NewTransaction(func(txnAppCtx appcontext.AppContext) error {
+		verrs, saveErr := appCtx.DB().ValidateAndSave(move)
+		if verrs != nil && verrs.HasAny() {
+			invalidInputError := apperror.NewInvalidInputError(move.ID, nil, verrs, "Could not validate move while unlocking it.")
+
+			return invalidInputError
+		}
+		if saveErr != nil {
+			return saveErr
+		}
+
+		return nil
+	})
+
+	if transactionError != nil {
+		return nil, transactionError
+	}
+
+	return move, nil
+}
+
+// CheckForUnlockedMovesAndUnlock finds moves with the officeUserID in the locked_by column for the move
+// this service object is called when a user logs out
+func (m moveUnlocker) CheckForUnlockedMovesAndUnlock(appCtx appcontext.AppContext, officeUserID uuid.UUID) error {
+
+	if officeUserID == uuid.Nil {
+		return apperror.NewQueryError("OfficeUserID", nil, "No office user provided in request to unlock move")
+	}
+
+	var moves []models.Move
+	query := appCtx.DB().Where("locked_by = ?", officeUserID)
+	err := query.Eager(
+		"LockedByOfficeUser",
+	).
+		All(&moves)
+	if err != nil {
+		return err
+	}
+
+	// iterate through each move and clear the values by using our existing function above
+	if appCtx.Session().IsOfficeUser() {
+		for _, move := range moves {
+			lockedOfficeUserID := move.LockedByOfficeUserID
+			if lockedOfficeUserID != nil && *lockedOfficeUserID == officeUserID {
+				copyOfMove := move
+				_, err := m.UnlockMove(appCtx, &copyOfMove, officeUserID)
+				if err != nil {
+					return err
+				}
+			}
+		}
+	}
+
+	return err
+}

--- a/pkg/services/lock_move/move_unlocker.go
+++ b/pkg/services/lock_move/move_unlocker.go
@@ -65,12 +65,13 @@ func (m moveUnlocker) UnlockMove(appCtx appcontext.AppContext, move *models.Move
 
 // CheckForUnlockedMovesAndUnlock finds moves with the officeUserID in the locked_by column for the move
 // this service object is called when a user logs out
-func (m moveUnlocker) CheckForUnlockedMovesAndUnlock(appCtx appcontext.AppContext, officeUserID uuid.UUID) error {
+func (m moveUnlocker) CheckForLockedMovesAndUnlock(appCtx appcontext.AppContext, officeUserID uuid.UUID) error {
 
 	if officeUserID == uuid.Nil {
 		return apperror.NewQueryError("OfficeUserID", nil, "No office user provided in request to unlock move")
 	}
 
+	// get all moves where locked_by matches officeUserID
 	var moves []models.Move
 	query := appCtx.DB().Where("locked_by = ?", officeUserID)
 	err := query.Eager(
@@ -81,7 +82,7 @@ func (m moveUnlocker) CheckForUnlockedMovesAndUnlock(appCtx appcontext.AppContex
 		return err
 	}
 
-	// iterate through each move and clear the values by using our existing function above
+	// iterate through each move and clear the values by using our existing service object above
 	if appCtx.Session().IsOfficeUser() {
 		for _, move := range moves {
 			lockedOfficeUserID := move.LockedByOfficeUserID

--- a/pkg/services/lock_move/move_unlocker_test.go
+++ b/pkg/services/lock_move/move_unlocker_test.go
@@ -1,0 +1,107 @@
+package lockmove
+
+import (
+	"github.com/transcom/mymove/pkg/auth"
+	"github.com/transcom/mymove/pkg/factory"
+	"github.com/transcom/mymove/pkg/models"
+	"github.com/transcom/mymove/pkg/models/roles"
+)
+
+func (suite *MoveLockerServiceSuite) TestMoveUnlocker() {
+	moveLocker := NewMoveLocker()
+	moveUnlocker := NewMoveUnlocker()
+
+	suite.Run("successfully returns move with no values in locked_by or lock_expires_at column", func() {
+		tooUser := factory.BuildOfficeUserWithRoles(suite.DB(), nil, []roles.RoleType{roles.RoleTypeTOO})
+		appCtx := suite.AppContextWithSessionForTest(&auth.Session{
+			ApplicationName: auth.OfficeApp,
+			Roles:           tooUser.User.Roles,
+			OfficeUserID:    tooUser.ID,
+			IDToken:         "fake_token",
+			AccessToken:     "fakeAccessToken",
+		})
+
+		// build the move so we can lock it and unlock it
+		move := factory.BuildMove(suite.DB(), nil, nil)
+
+		// lock the move first
+		lockedMove, err := moveLocker.LockMove(appCtx, &move, tooUser.ID)
+		suite.FatalNoError(err)
+		suite.Equal(move.ID, lockedMove.ID)
+		suite.Equal(lockedMove.LockedByOfficeUserID, &tooUser.ID)
+
+		// now let's unlock it
+		unlockedMove, err := moveUnlocker.UnlockMove(appCtx, lockedMove, tooUser.ID)
+		suite.FatalNoError(err)
+
+		// all values should now be nil
+		suite.Equal(move.ID, unlockedMove.ID)
+		suite.Nil(unlockedMove.LockedByOfficeUserID)
+		suite.Nil(unlockedMove.LockedByOfficeUser)
+		suite.Nil(unlockedMove.LockExpiresAt)
+	})
+}
+
+func (suite *MoveLockerServiceSuite) TestCheckForLockedMovesAndUnlock() {
+	moveLocker := NewMoveLocker()
+	moveUnlocker := NewMoveUnlocker()
+
+	suite.Run("successfully clears all moves that user has locked", func() {
+		tooUser := factory.BuildOfficeUserWithRoles(suite.DB(), nil, []roles.RoleType{roles.RoleTypeTOO})
+		appCtx := suite.AppContextWithSessionForTest(&auth.Session{
+			ApplicationName: auth.OfficeApp,
+			Roles:           tooUser.User.Roles,
+			OfficeUserID:    tooUser.ID,
+			IDToken:         "fake_token",
+			AccessToken:     "fakeAccessToken",
+		})
+
+		// build some moves so we can lock them and unlock them all
+		move := factory.BuildMove(suite.DB(), nil, nil)
+		moveTwo := factory.BuildMove(suite.DB(), nil, nil)
+		moveThree := factory.BuildMove(suite.DB(), nil, nil)
+
+		// lock the moves
+		lockedMove, err := moveLocker.LockMove(appCtx, &move, tooUser.ID)
+		suite.FatalNoError(err)
+		suite.Equal(move.ID, lockedMove.ID)
+		suite.Equal(lockedMove.LockedByOfficeUserID, &tooUser.ID)
+
+		lockedMoveTwo, err := moveLocker.LockMove(appCtx, &moveTwo, tooUser.ID)
+		suite.FatalNoError(err)
+		suite.Equal(moveTwo.ID, lockedMoveTwo.ID)
+		suite.Equal(lockedMoveTwo.LockedByOfficeUserID, &tooUser.ID)
+
+		lockedMoveThree, err := moveLocker.LockMove(appCtx, &moveThree, tooUser.ID)
+		suite.FatalNoError(err)
+		suite.Equal(moveThree.ID, lockedMoveThree.ID)
+		suite.Equal(lockedMoveThree.LockedByOfficeUserID, &tooUser.ID)
+
+		// now let's unlock them by calling CheckForUnlockedMoves
+		err = moveUnlocker.CheckForLockedMovesAndUnlock(appCtx, tooUser.ID)
+		suite.FatalNoError(err)
+
+		// all values should now be nil in all the moves
+		// find the moves in the database and verify
+		var moveInDB models.Move
+		err = suite.DB().Find(&moveInDB, move.ID)
+		suite.NoError(err)
+		suite.Nil(moveInDB.LockedByOfficeUserID)
+		suite.Nil(moveInDB.LockedByOfficeUser)
+		suite.Nil(moveInDB.LockExpiresAt)
+
+		var moveTwoInDB models.Move
+		err = suite.DB().Find(&moveTwoInDB, moveTwo.ID)
+		suite.NoError(err)
+		suite.Nil(moveTwoInDB.LockedByOfficeUserID)
+		suite.Nil(moveTwoInDB.LockedByOfficeUser)
+		suite.Nil(moveTwoInDB.LockExpiresAt)
+
+		var moveThreeInDB models.Move
+		err = suite.DB().Find(&moveThreeInDB, moveThree.ID)
+		suite.NoError(err)
+		suite.Nil(moveThreeInDB.LockedByOfficeUserID)
+		suite.Nil(moveThreeInDB.LockedByOfficeUser)
+		suite.Nil(moveThreeInDB.LockExpiresAt)
+	})
+}


### PR DESCRIPTION
[INTEGRATION PR](https://github.com/transcom/mymove/pull/12677)

FYI the files changed will be bloated until [B-19902](https://github.com/transcom/mymove/pull/12694) gets merged since this branch has that branch merged into it.

## [Agility ticket](https://www13.v1host.com/USTRANSCOM38/assetdetail.v1?number=B-19903)

## Summary

When setting up the functionality of an office user locking a move when they navigate into it, this sets the stage for when an office user needs to unlock that move. Currently there are two ways an office user can unlock a move:
1. Navigate to their respective queue (TOO -> `MovesQueue`, TIO -> `PaymentRequestQueue`, SC -> `ServicesCounselingQueue`)
2. Logout

This PR does the following:
- adds two service objects, `UnlockMove` and `CheckForLockedMovesAndUnlock` to be run for each scenario of an office user unlocking a move
- adds in logic checks to call `UnlockMove` when checks return `true` when loading up the queue list
- calls `checkForLockedMovesAndUnlock` when an office user logs out
- adds relevant tests

### How to test

This is a little tricky to test, so it is best to use two browsers that don't share cookies (I use one Chrome and one Safari - you could also do an incognito browser and one not)
1. Prior to firing up `server` & `client`, in your `envrc` change `FEATURE_FLAG_MOVE_LOCK=true`
2. Now run `make server_run` and `make client_run`
3. (OfficeUser1) Log in as an office user for each role and navigate into a move, but don't log out
4. (OfficeUser2) In your other browser log in as a different user and you should see these moves have a lock icon next to them in the queue
5. (OfficeUser1) Navigate back to your queue
6. (OfficeUser2) Refresh your screen - the lock icons should be gone
7. (OfficeUser1) Navigate back into a move
8. (OfficeUser2) Refresh your screen - lock icon should be shown next to the move
9. (OfficeUser1) Logout
10. (OfficeUser2) Refresh your screen - lock icon should be gone
