### PR TITLE
added tio, too checkbox validation policy to RequestAccountForm

### DIFF
--- a/src/components/Office/AllowancesDetailForm/AllowancesDetailForm.test.jsx
+++ b/src/components/Office/AllowancesDetailForm/AllowancesDetailForm.test.jsx
@@ -25,6 +25,13 @@ jest.mock('formik', () => ({
             onChange: jest.fn(),
             onBlur: jest.fn(),
           },
+          {
+            touched: false,
+          },
+          {
+            setValue: jest.fn(),
+            setTouched: jest.fn(),
+          },
         ];
       }
 

--- a/src/components/Office/RequestAccountForm/RequestAccountForm.test.jsx
+++ b/src/components/Office/RequestAccountForm/RequestAccountForm.test.jsx
@@ -145,5 +145,30 @@ describe('RequestAccountForm component', () => {
     expect(testProps.onSubmit).toHaveBeenCalled();
   });
 
+  it('shows policy error when both TOO and TIO checkboxes are both selected, and goes away after unselecting one of them', async () => {
+    renderWithRouter(<RequestAccountForm {...testProps} />);
+
+    const tooCheckbox = screen.getByTestId('transportationOrderingOfficerCheckBox');
+    const tioCheckbox = screen.getByTestId('transportationInvoicingOfficerCheckBox');
+
+    // Click both the TOO and TIO role checkboxes
+    await userEvent.click(tooCheckbox);
+    await userEvent.click(tioCheckbox);
+
+    // Check that the validation error appears
+    const policyVerrs = await screen.findAllByText(
+      'You cannot select both Transportation Ordering Officer and Transportation Invoicing Officer. This is a policy managed by USTRANSCOM.',
+    );
+    expect(policyVerrs.length).toBeGreaterThan(0);
+
+    // Check that it goes away after unselecting either TIO or TOO checkbox
+    await userEvent.click(tioCheckbox);
+    expect(
+      screen.queryByText(
+        'You cannot select both Transportation Ordering Officer and Transportation Invoicing Officer. This is a policy managed by USTRANSCOM.',
+      ),
+    ).not.toBeInTheDocument();
+  });
+
   afterEach(jest.resetAllMocks);
 });

--- a/src/components/form/fields/CheckboxField.jsx
+++ b/src/components/form/fields/CheckboxField.jsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import classnames from 'classnames';
 import { Field, useField } from 'formik';
-import { Checkbox } from '@trussworks/react-uswds';
+import { FormGroup, Checkbox, ErrorMessage } from '@trussworks/react-uswds';
 
 import './CheckboxField.module.scss';
 
@@ -15,23 +16,77 @@ import './CheckboxField.module.scss';
  * ReactUSWDS components directly.
  */
 
-export const CheckboxField = ({ name, id, label, isDisabled, ...inputProps }) => {
-  const [fieldProps] = useField({ name, type: 'checkbox' });
+export const CheckboxField = ({
+  name,
+  id,
+  validate,
+  type,
+  warning,
+  error,
+  errorMessage,
+  errorClassName,
+  isDisabled,
+  ...inputProps
+}) => {
+  const [fieldProps, metaProps, helperProps] = useField({ name, validate, type });
+  const showError = (metaProps.touched && !!metaProps.error) || error;
+  const showWarning = !showError && warning;
+
+  const formGroupClasses = classnames({
+    warning: showWarning,
+  });
+
+  // This immediately triggers state change for the yup validation errors
+  // If this is not present and blur is not triggered, then only after a user clicks again
+  // outside of the checkbox (blur) then it will trigger errors. We want to enforce
+  // errors appearing immediately on click and prior to form submission.
+  const handleClick = () => {
+    helperProps.setValue(!metaProps.value);
+    helperProps.setTouched(true);
+  };
 
   return (
-    /* eslint-disable-next-line react/jsx-props-no-spreading */
-    <Field id={id} as={Checkbox} name={name} label={label} disabled={isDisabled} {...fieldProps} {...inputProps} />
+    <FormGroup className={formGroupClasses} error={showError}>
+      {showError && (
+        <ErrorMessage display={showError} className={errorClassName}>
+          {metaProps.error ? metaProps.error : errorMessage}
+        </ErrorMessage>
+      )}
+      <Field
+        id={id}
+        as={Checkbox}
+        name={name}
+        disabled={isDisabled}
+        onClick={handleClick}
+        onBlur={() => helperProps.setTouched(true)}
+        /* eslint-disable-next-line react/jsx-props-no-spreading */
+        {...fieldProps}
+        /* eslint-disable-next-line react/jsx-props-no-spreading */
+        {...inputProps}
+      />
+    </FormGroup>
   );
 };
 
 CheckboxField.propTypes = {
   id: PropTypes.string.isRequired,
   name: PropTypes.string.isRequired,
-  label: PropTypes.node.isRequired,
+  warning: PropTypes.string,
+  validate: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
+  type: PropTypes.string,
+  error: PropTypes.bool,
+  errorMessage: PropTypes.string,
+  errorClassName: PropTypes.string,
   isDisabled: PropTypes.bool,
 };
 
 CheckboxField.defaultProps = {
+  warning: '',
+  validate: undefined,
+  type: 'checkbox',
+  error: false,
+  errorMessage: '',
+  errorClassName: '',
   isDisabled: false,
 };
 

--- a/src/pages/Office/RequestAccount/RequestAccount.test.jsx
+++ b/src/pages/Office/RequestAccount/RequestAccount.test.jsx
@@ -91,9 +91,6 @@ describe('RequestAccount page', () => {
     const tooCheckbox = screen.getByTestId('transportationOrderingOfficerCheckBox');
     await userEvent.click(tooCheckbox);
 
-    const tioCheckbox = screen.getByTestId('transportationInvoicingOfficerCheckBox');
-    await userEvent.click(tioCheckbox);
-
     const saveBtn = screen.getByTestId('requestOfficeAccountSubmitButton');
     await userEvent.click(saveBtn);
 

--- a/src/utils/validation.js
+++ b/src/utils/validation.js
@@ -205,7 +205,15 @@ const validateEdipi = (value, testContext) => {
   return false;
 };
 
-// checking request office account form
+// It is TRANSCOM policy that an individual person may only be either a TIO or TOO, never both.
+const validateOnlyOneTransportationOfficerRole = (value, testContext) => {
+  const { transportationOrderingOfficerCheckBox, transportationInvoicingOfficerCheckBox } = testContext.parent;
+  if (transportationOrderingOfficerCheckBox && transportationInvoicingOfficerCheckBox) {
+    return false;
+  }
+  return true;
+};
+
 export const officeAccountRequestSchema = Yup.object().shape({
   officeAccountRequestFirstName: Yup.string()
     .matches(/^[A-Za-z]+$/, noNumericAllowedErrorMsg)
@@ -227,16 +235,20 @@ export const officeAccountRequestSchema = Yup.object().shape({
   officeAccountRequestTelephone: phoneSchema.required('Required'),
   officeAccountRequestEmail: emailSchema.required('Required'),
   officeAccountTransportationOffice: Yup.object().required('Required'),
-  transportationOrderingOfficerCheckBox: Yup.bool().test(
-    'roleRequestedRequired',
-    'You must select at least one role.',
-    validateRoleRequestedMethod,
-  ),
-  transportationInvoicingOfficerCheckBox: Yup.bool().test(
-    'roleRequestedRequired',
-    'You must select at least one role.',
-    validateRoleRequestedMethod,
-  ),
+  transportationOrderingOfficerCheckBox: Yup.bool()
+    .test('roleRequestedRequired', 'You must select at least one role.', validateRoleRequestedMethod)
+    .test(
+      'onlyOneTransportationOfficerRole',
+      'You cannot select both Transportation Ordering Officer and Transportation Invoicing Officer. This is a policy managed by USTRANSCOM.',
+      validateOnlyOneTransportationOfficerRole,
+    ),
+  transportationInvoicingOfficerCheckBox: Yup.bool()
+    .test('roleRequestedRequired', 'You must select at least one role.', validateRoleRequestedMethod)
+    .test(
+      'onlyOneTransportationOfficerRole',
+      'You cannot select both Transportation Ordering Officer and Transportation Invoicing Officer. This is a policy managed by USTRANSCOM.',
+      validateOnlyOneTransportationOfficerRole,
+    ),
   servicesCounselorCheckBox: Yup.bool().test(
     'roleRequestedRequired',
     'You must select at least one role.',


### PR DESCRIPTION
## [B-19922](https://www13.v1host.com/USTRANSCOM38/story.mvc/Summary?oidToken=Story%3A948234)

## Summary

Creates a new validation rule that only one or the other of roles "TOO"/"TIO" may be selected when requesting an account. Included is an expansion of the CheckBox component where it will not display errors properly as well as it will auto-blur on click to trigger yup errors to display, if any.

## Verification Steps for Reviewers

These are to be checked by a reviewer.

- [ ] Does this validation work?
- [ ] Does this validation properly display an error?
- [ ] Have the BL acceptance criteria been met for this change?
- [ ] Was the CircleCI build successful?
- [ ] Has the code been reviewed from a standards and best practices point of view?

### How to test

1. Access [officelocal](http://officelocal:3000/)
2. Select to "Request Account" in the top right
3. Check both "TOO" and "TIO" roles to verify validation error
4. Uncheck one of them to ensure that the error goes away

## Screenshots
Violating the validation
![image](https://github.com/transcom/mymove/assets/136814362/78ca9cd4-73c1-4535-8bcc-b220097e78a7)

Making the validation happy
![image](https://github.com/transcom/mymove/assets/136814362/748ec346-ae2b-480f-984e-a898732e7c9c)

