### PR TITLE
INT B-19538 ppm packet download

### DIFF
--- a/src/components/Office/DefinitionLists/PPMShipmentInfoList.jsx
+++ b/src/components/Office/DefinitionLists/PPMShipmentInfoList.jsx
@@ -209,7 +209,7 @@ const PPMShipmentInfoList = ({
   const paymentPacketElement = (
     <div>
       <dt>Payment Packet</dt>
-      <dd data-testid="aoaPacketDownload">
+      <dd data-testid="paymentPacketDownload">
         <p className={styles.downloadLink}>
           <AsyncPacketDownloadLink
             id={shipment?.ppmShipment?.id}
@@ -254,8 +254,7 @@ const PPMShipmentInfoList = ({
       {hasRequestedAdvanceElement}
       {hasRequestedAdvance === true && advanceStatusElement}
       {advanceStatus === ADVANCE_STATUSES.APPROVED.apiValue && aoaPacketElement}
-      {(status === ppmShipmentStatuses.PAYMENT_APPROVED || status === ppmShipmentStatuses.WAITING_ON_CUSTOMER) &&
-        paymentPacketElement}
+      {status === ppmShipmentStatuses.PAYMENT_APPROVED && paymentPacketElement}
       {counselorRemarksElement}
     </dl>
   );


### PR DESCRIPTION
## [B-19538](https://www13.v1host.com/USTRANSCOM38/assetdetail.v1?number=B-19538)

## Summary

This fix is to only display `Download Payment Packet (PDF)` link only when the ppm status is `PAYMENT_APPROVED` and should not see it when the status is `WAITING_ON_CUSTOMER`.


### How to test

1. Use `HHGMoveWithPPMShipmentsReadyForCloseout` to create a PPM move.
2. As a SC -> Find the move and open your dev tools to find the PPM status shown in the screenshots.
3. You should not see Download payment packet link if the PPM status is `WAITING_ON_CUSTOMER`.
4. As a customer -> go to the move and upload PPM documents and submit.
5. As a closeout SC -> find the move click 'Review Documents' and approve all the items.
6. In the Move details page, check the dev tools again for the PPM status and it should show `PAYMENT_APPROVED` and you should see the `Download Payment Packet (PDF) link.


## Screenshots
![image](https://github.com/transcom/mymove/assets/146856854/f997f066-1e51-4fb1-8a37-068eb8af7c63)

![image](https://github.com/transcom/mymove/assets/146856854/edaf8335-c353-4946-a038-56d3891324da)

