### PR TITLE
removed service counselor move queue status filtering and sorting, de…

### DIFF
--- a/src/constants/queues.js
+++ b/src/constants/queues.js
@@ -29,10 +29,6 @@ export const SEARCH_QUEUE_STATUS_FILTER_OPTIONS = [
   { value: MOVE_STATUSES.SERVICE_COUNSELING_COMPLETED, label: 'Service counseling completed' },
   { value: MOVE_STATUSES.APPROVED, label: 'Move Approved' },
 ];
-export const SERVICE_COUNSELING_QUEUE_MOVE_STATUS_FILTER_OPTIONS = [
-  { value: MOVE_STATUSES.NEEDS_SERVICE_COUNSELING, label: 'Needs counseling' },
-  { value: MOVE_STATUSES.SERVICE_COUNSELING_COMPLETED, label: 'Service counseling completed' },
-];
 
 export const SERVICE_COUNSELING_MOVE_STATUS_LABELS = {
   [MOVE_STATUSES.NEEDS_SERVICE_COUNSELING]: 'Needs counseling',

--- a/src/pages/Office/ServicesCounselingQueue/ServicesCounselingQueue.jsx
+++ b/src/pages/Office/ServicesCounselingQueue/ServicesCounselingQueue.jsx
@@ -7,13 +7,11 @@ import styles from './ServicesCounselingQueue.module.scss';
 
 import { createHeader } from 'components/Table/utils';
 import { isBooleanFlagEnabled, isCounselorMoveCreateEnabled } from 'utils/featureFlags';
-import MultiSelectCheckBoxFilter from 'components/Table/Filters/MultiSelectCheckBoxFilter';
 import SelectFilter from 'components/Table/Filters/SelectFilter';
 import DateSelectFilter from 'components/Table/Filters/DateSelectFilter';
 import TableQueue from 'components/Table/TableQueue';
 import {
   SERVICE_COUNSELING_BRANCH_OPTIONS,
-  SERVICE_COUNSELING_QUEUE_MOVE_STATUS_FILTER_OPTIONS,
   SERVICE_COUNSELING_MOVE_STATUS_LABELS,
   SERVICE_COUNSELING_PPM_TYPE_OPTIONS,
   SERVICE_COUNSELING_PPM_TYPE_LABELS,
@@ -26,7 +24,7 @@ import {
   useMoveSearchQueries,
   useCustomerSearchQueries,
 } from 'hooks/queries';
-import { DATE_FORMAT_STRING } from 'shared/constants';
+import { DATE_FORMAT_STRING, MOVE_STATUSES } from 'shared/constants';
 import { formatDateFromIso, serviceMemberAgencyLabel } from 'utils/formatters';
 import LoadingPlaceholder from 'shared/LoadingPlaceholder';
 import SomethingWentWrong from 'shared/SomethingWentWrong';
@@ -84,15 +82,13 @@ const counselingColumns = (moveLockFlag) => [
   createHeader(
     'Status',
     (row) => {
-      return SERVICE_COUNSELING_MOVE_STATUS_LABELS[`${row.status}`];
+      return row.status !== MOVE_STATUSES.SERVICE_COUNSELING_COMPLETED
+        ? SERVICE_COUNSELING_MOVE_STATUS_LABELS[`${row.status}`]
+        : null;
     },
     {
       id: 'status',
-      isFilterable: true,
-      Filter: (props) => (
-        // eslint-disable-next-line react/jsx-props-no-spreading
-        <MultiSelectCheckBoxFilter options={SERVICE_COUNSELING_QUEUE_MOVE_STATUS_FILTER_OPTIONS} {...props} />
-      ),
+      disableSortBy: true,
     },
   ),
   createHeader(

--- a/src/pages/Office/ServicesCounselingQueue/ServicesCounselingQueue.test.jsx
+++ b/src/pages/Office/ServicesCounselingQueue/ServicesCounselingQueue.test.jsx
@@ -249,7 +249,6 @@ describe('ServicesCounselingQueue', () => {
       expect(wrapper.find('th[data-testid="lastName"][role="columnheader"]').prop('onClick')).not.toBe(undefined);
       expect(wrapper.find('th[data-testid="dodID"][role="columnheader"]').prop('onClick')).not.toBe(undefined);
       expect(wrapper.find('th[data-testid="locator"][role="columnheader"]').prop('onClick')).not.toBe(undefined);
-      expect(wrapper.find('th[data-testid="status"][role="columnheader"]').prop('onClick')).not.toBe(undefined);
       expect(wrapper.find('th[data-testid="requestedMoveDate"][role="columnheader"]').prop('onClick')).not.toBe(
         undefined,
       );
@@ -260,39 +259,13 @@ describe('ServicesCounselingQueue', () => {
       );
     });
 
-    it('disables sort by for origin GBLOC column', () => {
+    it('disables sort by for origin GBLOC and statues columns', () => {
       expect(wrapper.find('th[data-testid="originGBLOC"][role="columnheader"]').prop('onClick')).toBe(undefined);
+      expect(wrapper.find('th[data-testid="status"][role="columnheader"]').prop('onClick')).toBe(undefined);
     });
 
     it('omits filter input element for origin GBLOC column', () => {
       expect(wrapper.find('th[data-testid="originGBLOC"] input').exists()).toBe(false);
-    });
-  });
-
-  describe('service counseling completed moves', () => {
-    useUserQueries.mockReturnValue(serviceCounselorUser);
-    useServicesCounselingQueueQueries.mockReturnValue(serviceCounselingCompletedMoves);
-    const wrapper = mount(
-      <MockRouterProvider path={pagePath} params={{ queueType: 'counseling' }}>
-        <ServicesCounselingQueue />
-      </MockRouterProvider>,
-    );
-
-    it('displays move header with needs service counseling count', () => {
-      expect(wrapper.find('h1').text()).toBe('Moves (2)');
-    });
-
-    it('should render the table', () => {
-      expect(wrapper.find('Table').exists()).toBe(true);
-    });
-
-    it('formats the move data in rows', () => {
-      const moves = wrapper.find('tbody tr');
-      const firstMove = moves.at(0);
-      expect(firstMove.find('td.status').text()).toBe('Service counseling completed');
-
-      const secondMove = moves.at(1);
-      expect(secondMove.find('td.status').text()).toBe('Service counseling completed');
     });
   });
 

--- a/src/pages/Office/ServicesCounselingQueue/ServicesCounselingQueue.test.jsx
+++ b/src/pages/Office/ServicesCounselingQueue/ServicesCounselingQueue.test.jsx
@@ -259,7 +259,7 @@ describe('ServicesCounselingQueue', () => {
       );
     });
 
-    it('disables sort by for origin GBLOC and statues columns', () => {
+    it('disables sort by for origin GBLOC and status columns', () => {
       expect(wrapper.find('th[data-testid="originGBLOC"][role="columnheader"]').prop('onClick')).toBe(undefined);
       expect(wrapper.find('th[data-testid="status"][role="columnheader"]').prop('onClick')).toBe(undefined);
     });


### PR DESCRIPTION
## [B-19893](https://www13.v1host.com/USTRANSCOM38/story.mvc/Summary?oidToken=Story%3A947552)

## Summary

Removes the ability for a service counselor to filter their move queue status. This means that their move queue now inherits the default query which is `models.MoveStatusNeedsServiceCounseling`

### How to test

1. Login to officelocal as an SC
2. Select a move in need of counseling
3. Save the move locator and then finish counseling and submit move details
4. Navigate back to SC queue dashboard and try to find your move, it should not appear

## Screenshots
![image](https://github.com/transcom/mymove/assets/136814362/bfeb244b-dad6-4e16-8934-ff695afc0e6b)
