### PR TITLE
add csr to roles table

### DIFF
--- a/migrations/app/migrations_manifest.txt
+++ b/migrations/app/migrations_manifest.txt
@@ -937,3 +937,4 @@
 20240515164336_ignore_locked_columns_in_moves_table_for_history_log.up.sql
 20240516143952_add_pricing_estimate_to_mto_service_items.up.sql
 20240516184021_import_pricing_data_ghc.up.sql
+20240522124339_add_csr_to_roles.up.sql

--- a/migrations/app/schema/20240522124339_add_csr_to_roles.up.sql
+++ b/migrations/app/schema/20240522124339_add_csr_to_roles.up.sql
@@ -1,0 +1,9 @@
+-- Insert CSR as a separate role as part of the feature to split QAE/CSR into two separate roles
+INSERT INTO roles (id, role_type, created_at, updated_at, role_name)
+VALUES (
+        '72432922-BF2E-45DE-8837-1A458F5D1011',
+        'customer_service_representative',
+        now(),
+        now(),
+        'Customer Service Representative'
+    );


### PR DESCRIPTION
## [B-19824](https://www13.v1host.com/USTRANSCOM38/story.mvc/Summary?oidToken=Story%3A946535)

## Summary

Adding CSR as a new role so that we can split QAE/CSR respectively. UUID was generated with CLI `uuidgen`.

### Note
As this is an insert and not a db mod, no tracker changes are necessary.