### PR TITLE
Int b 19884 authenticate non cac user

### DIFF
--- a/pkg/gen/ghcapi/embedded_spec.go
+++ b/pkg/gen/ghcapi/embedded_spec.go
@@ -6125,7 +6125,8 @@ func init() {
           "$ref": "#/definitions/BackupContact"
         },
         "cacValidated": {
-          "type": "boolean"
+          "type": "boolean",
+          "x-nullable": true
         },
         "current_address": {
           "$ref": "#/definitions/Address"
@@ -19162,7 +19163,8 @@ func init() {
           "$ref": "#/definitions/BackupContact"
         },
         "cacValidated": {
-          "type": "boolean"
+          "type": "boolean",
+          "x-nullable": true
         },
         "current_address": {
           "$ref": "#/definitions/Address"

--- a/pkg/gen/ghcmessages/customer.go
+++ b/pkg/gen/ghcmessages/customer.go
@@ -29,7 +29,7 @@ type Customer struct {
 	BackupContact *BackupContact `json:"backup_contact,omitempty"`
 
 	// cac validated
-	CacValidated bool `json:"cacValidated,omitempty"`
+	CacValidated *bool `json:"cacValidated,omitempty"`
 
 	// current address
 	CurrentAddress *Address `json:"current_address,omitempty"`

--- a/pkg/handlers/ghcapi/internal/payloads/model_to_payload.go
+++ b/pkg/handlers/ghcapi/internal/payloads/model_to_payload.go
@@ -483,7 +483,7 @@ func Customer(customer *models.ServiceMember) *ghcmessages.Customer {
 		SecondaryTelephone: customer.SecondaryTelephone,
 		PhoneIsPreferred:   swag.BoolValue(customer.PhoneIsPreferred),
 		EmailIsPreferred:   swag.BoolValue(customer.EmailIsPreferred),
-		CacValidated:       swag.BoolValue(&customer.CacValidated),
+		CacValidated:       &customer.CacValidated,
 	}
 	return &payload
 }

--- a/src/components/DocumentViewer/Content/Content.jsx
+++ b/src/components/DocumentViewer/Content/Content.jsx
@@ -43,27 +43,3 @@ DocViewerContent.propTypes = {
 };
 
 export default DocViewerContent;
-
-/**
- * TODO
- *
- * - add className prop to file viewer
- * - add rotate left/right:
- *  <Button unstyled>
-        <RotateLeft />
-        Rotate left
-      </Button>
-      <Button unstyled>
-        <RotateRight />
-        Rotate right
-      </Button>
- * - implement pagination for multi-page PDFs & nav render prop:
- *  <div className={`${styles.docArrows}`}>
-      <Button unstyled className={`${styles.arrowButton}`}>
-        <ArrowLeft />
-      </Button>
-      <Button unstyled className={`${styles.arrowButton}`}>
-        <ArrowRight />
-      </Button>
-    </div>
-*/

--- a/src/components/Office/CustomerContactInfoForm/CustomerContactInfoForm.jsx
+++ b/src/components/Office/CustomerContactInfoForm/CustomerContactInfoForm.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Field, Formik } from 'formik';
 import * as Yup from 'yup';
 import PropTypes from 'prop-types';
-import { Checkbox, Fieldset, Radio, Grid } from '@trussworks/react-uswds';
+import { Checkbox, Radio, FormGroup, Grid } from '@trussworks/react-uswds';
 
 import styles from './CustomerContactInfoForm.module.scss';
 
@@ -15,6 +15,7 @@ import formStyles from 'styles/form.module.scss';
 import WizardNavigation from 'components/Customer/WizardNavigation/WizardNavigation';
 import { phoneSchema, requiredAddressSchema } from 'utils/validation';
 import { ResidentialAddressShape } from 'types/address';
+import Hint from 'components/Hint';
 
 const CustomerContactInfoForm = ({ initialValues, onSubmit, onBack }) => {
   const validationSchema = Yup.object().shape({
@@ -38,15 +39,15 @@ const CustomerContactInfoForm = ({ initialValues, onSubmit, onBack }) => {
       .required('Required'), // min 12 includes hyphens
     phoneIsPreferred: Yup.boolean(),
     emailIsPreferred: Yup.boolean(),
+    cacUser: Yup.boolean().required('Required'),
   });
-  console.log('initialValues: ', initialValues);
   return (
     <Grid row>
       <Grid col>
         <div className={styles.customerContactForm}>
           <h1 className={styles.title}>Customer Info</h1>
           <Formik initialValues={initialValues} onSubmit={onSubmit} validationSchema={validationSchema} validateOnMount>
-            {({ isValid, isSubmitting, handleSubmit }) => {
+            {({ isValid, handleSubmit }) => {
               return (
                 <Form className={formStyles.form}>
                   <SectionWrapper className={`${formStyles.formSection} ${styles.formSectionHeader}`}>
@@ -75,9 +76,12 @@ const CustomerContactInfoForm = ({ initialValues, onSubmit, onBack }) => {
                     <BackupContactInfoFields />
                   </SectionWrapper>
                   <SectionWrapper className={formStyles.formSection}>
-                    <h3>Non-CAC Users</h3>
-                    <Fieldset className={styles.trailerOwnershipFieldset}>
-                      <legend className="usa-label">Does the customer have a CAC?</legend>
+                    <h3>CAC Validation</h3>
+                    <FormGroup className={styles.trailerOwnershipFieldset}>
+                      <legend className="usa-label">
+                        Is the customer a non-CAC user or do they need to bypass CAC validation?
+                      </legend>
+                      <Hint>If this is checked yes, then they have already validated with CAC</Hint>
                       <div className="grid-row grid-gap">
                         <Field
                           as={Radio}
@@ -86,6 +90,7 @@ const CustomerContactInfoForm = ({ initialValues, onSubmit, onBack }) => {
                           name="cacUser"
                           value="true"
                           data-testid="cac-user-yes"
+                          type="radio"
                         />
                         <Field
                           as={Radio}
@@ -94,14 +99,15 @@ const CustomerContactInfoForm = ({ initialValues, onSubmit, onBack }) => {
                           name="cacUser"
                           value="false"
                           data-testid="cac-user-no"
+                          type="radio"
                         />
                       </div>
-                    </Fieldset>
+                    </FormGroup>
                   </SectionWrapper>
                   <div className={formStyles.formActions}>
                     <WizardNavigation
                       editMode
-                      disableNext={!isValid || isSubmitting}
+                      disableNext={!isValid}
                       onCancelClick={onBack}
                       onNextClick={handleSubmit}
                     />
@@ -128,6 +134,7 @@ CustomerContactInfoForm.propTypes = {
     telephone: PropTypes.string,
     email: PropTypes.string,
     customerAddress: ResidentialAddressShape,
+    cacUser: PropTypes.bool,
   }).isRequired,
   onSubmit: PropTypes.func,
   onBack: PropTypes.func,

--- a/src/components/Office/CustomerContactInfoForm/CustomerContactInfoForm.jsx
+++ b/src/components/Office/CustomerContactInfoForm/CustomerContactInfoForm.jsx
@@ -1,8 +1,8 @@
 import React from 'react';
-import { Formik } from 'formik';
+import { Field, Formik } from 'formik';
 import * as Yup from 'yup';
 import PropTypes from 'prop-types';
-import { Checkbox, Grid } from '@trussworks/react-uswds';
+import { Checkbox, Fieldset, Radio, Grid } from '@trussworks/react-uswds';
 
 import styles from './CustomerContactInfoForm.module.scss';
 
@@ -39,7 +39,7 @@ const CustomerContactInfoForm = ({ initialValues, onSubmit, onBack }) => {
     phoneIsPreferred: Yup.boolean(),
     emailIsPreferred: Yup.boolean(),
   });
-
+  console.log('initialValues: ', initialValues);
   return (
     <Grid row>
       <Grid col>
@@ -73,6 +73,30 @@ const CustomerContactInfoForm = ({ initialValues, onSubmit, onBack }) => {
                     <h2 className={styles.sectionHeader}>Backup contact</h2>
 
                     <BackupContactInfoFields />
+                  </SectionWrapper>
+                  <SectionWrapper className={formStyles.formSection}>
+                    <h3>Non-CAC Users</h3>
+                    <Fieldset className={styles.trailerOwnershipFieldset}>
+                      <legend className="usa-label">Does the customer have a CAC?</legend>
+                      <div className="grid-row grid-gap">
+                        <Field
+                          as={Radio}
+                          id="yesCacUser"
+                          label="Yes"
+                          name="cacUser"
+                          value="true"
+                          data-testid="cac-user-yes"
+                        />
+                        <Field
+                          as={Radio}
+                          id="NonCacUser"
+                          label="No"
+                          name="cacUser"
+                          value="false"
+                          data-testid="cac-user-no"
+                        />
+                      </div>
+                    </Fieldset>
                   </SectionWrapper>
                   <div className={formStyles.formActions}>
                     <WizardNavigation

--- a/src/components/Office/CustomerContactInfoForm/CustomerContactInfoForm.jsx
+++ b/src/components/Office/CustomerContactInfoForm/CustomerContactInfoForm.jsx
@@ -75,9 +75,9 @@ const CustomerContactInfoForm = ({ initialValues, onSubmit, onBack }) => {
 
                     <BackupContactInfoFields />
                   </SectionWrapper>
-                  <SectionWrapper className={formStyles.formSection}>
+                  <SectionWrapper className={`${formStyles.formSection} ${styles.formSectionHeader}`}>
                     <h3>CAC Validation</h3>
-                    <FormGroup className={styles.trailerOwnershipFieldset}>
+                    <FormGroup>
                       <legend className="usa-label">
                         Is the customer a non-CAC user or do they need to bypass CAC validation?
                       </legend>

--- a/src/components/Office/CustomerContactInfoForm/CustomerContactInfoForm.test.jsx
+++ b/src/components/Office/CustomerContactInfoForm/CustomerContactInfoForm.test.jsx
@@ -22,7 +22,7 @@ describe('CustomerContactInfoForm Component', () => {
     name: '',
     telephone: '',
     email: '',
-    cacUser: '',
+    cacUser: true,
   };
   const testProps = {
     initialValues,
@@ -47,7 +47,7 @@ describe('CustomerContactInfoForm Component', () => {
     name: 'joe bob',
     telephone: '855-222-1111',
     email: 'joebob@gmail.com',
-    cacUser: '',
+    cacUser: null,
   };
   const testPropsCacValidated = {
     initialValuesCacValidated,

--- a/src/components/Office/CustomerContactInfoForm/CustomerContactInfoForm.test.jsx
+++ b/src/components/Office/CustomerContactInfoForm/CustomerContactInfoForm.test.jsx
@@ -22,9 +22,35 @@ describe('CustomerContactInfoForm Component', () => {
     name: '',
     telephone: '',
     email: '',
+    cacUser: '',
   };
   const testProps = {
     initialValues,
+    onSubmit: jest.fn(),
+    onBack: jest.fn(),
+  };
+
+  const initialValuesCacValidated = {
+    firstName: 'joe',
+    middleName: 'bob',
+    lastName: 'bob',
+    suffix: 'jr',
+    customerTelephone: '855-222-1111',
+    customerEmail: 'joebob@gmail.com',
+    customerAddress: {
+      streetAddress1: '123 Happy St',
+      streetAddress2: 'Unit 4',
+      city: 'Missoula',
+      state: 'MT',
+      postalCode: '59802',
+    },
+    name: 'joe bob',
+    telephone: '855-222-1111',
+    email: 'joebob@gmail.com',
+    cacUser: '',
+  };
+  const testPropsCacValidated = {
+    initialValuesCacValidated,
     onSubmit: jest.fn(),
     onBack: jest.fn(),
   };
@@ -63,6 +89,30 @@ describe('CustomerContactInfoForm Component', () => {
       expect(screen.getByLabelText('Name')).toBeInstanceOf(HTMLInputElement);
       expect(screen.getAllByLabelText('Phone')[1]).toBeInstanceOf(HTMLInputElement);
       expect(screen.getAllByLabelText('Email')[1]).toBeInstanceOf(HTMLInputElement);
+
+      expect(screen.getByText('CAC Validation')).toBeInstanceOf(HTMLHeadingElement);
+      expect(
+        screen.getByText('Is the customer a non-CAC user or do they need to bypass CAC validation?'),
+      ).toBeInTheDocument();
+      expect(screen.getByText('If this is checked yes, then they have already validated with CAC')).toBeInTheDocument();
+      expect(screen.getByTestId('cac-user-yes')).toBeInTheDocument();
+      expect(screen.getByTestId('cac-user-no')).toBeInTheDocument();
     });
+  });
+
+  it('does not allow submission without cac_validated value', async () => {
+    render(<CustomerContactInfoForm {...testPropsCacValidated} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('CAC Validation')).toBeInstanceOf(HTMLHeadingElement);
+      expect(
+        screen.getByText('Is the customer a non-CAC user or do they need to bypass CAC validation?'),
+      ).toBeInTheDocument();
+      expect(screen.getByText('If this is checked yes, then they have already validated with CAC')).toBeInTheDocument();
+      expect(screen.getByTestId('cac-user-yes')).toBeInTheDocument();
+      expect(screen.getByTestId('cac-user-no')).toBeInTheDocument();
+    });
+    expect(screen.getByRole('button', { name: 'Save' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Save' })).toBeDisabled();
   });
 });

--- a/src/pages/Office/CreateMoveCustomerInfo/CreateMoveCustomerInfo.jsx
+++ b/src/pages/Office/CreateMoveCustomerInfo/CreateMoveCustomerInfo.jsx
@@ -11,6 +11,7 @@ import LoadingPlaceholder from 'shared/LoadingPlaceholder';
 import SomethingWentWrong from 'shared/SomethingWentWrong';
 import { useCustomerQuery } from 'hooks/queries';
 import { milmoveLogger } from 'utils/milmoveLog';
+import { formatTrueFalseInputValue } from 'utils/formatters';
 
 const CreateMoveCustomerInfo = () => {
   const { customerId } = useParams();
@@ -45,6 +46,7 @@ const CreateMoveCustomerInfo = () => {
   if (isError) return <SomethingWentWrong />;
 
   const onSubmit = (values) => {
+    const cacUser = values.cacUser === 'true';
     const {
       firstName,
       lastName,
@@ -79,6 +81,7 @@ const CreateMoveCustomerInfo = () => {
       phoneIsPreferred,
       emailIsPreferred,
       secondaryTelephone: secondaryPhone || null,
+      cac_validated: cacUser,
     };
     mutateCustomerInfo({ customerId: customerData.id, ifMatchETag: customerData.eTag, body });
   };
@@ -97,6 +100,7 @@ const CreateMoveCustomerInfo = () => {
     backupAddress: customerData?.backupAddress || '',
     emailIsPreferred: customerData?.emailIsPreferred || false,
     phoneIsPreferred: customerData?.phoneIsPreferred || false,
+    cacUser: formatTrueFalseInputValue(customerData?.cacValidated),
   };
 
   return (

--- a/src/pages/Office/CreateMoveCustomerInfo/CreateMoveCustomerInfo.test.jsx
+++ b/src/pages/Office/CreateMoveCustomerInfo/CreateMoveCustomerInfo.test.jsx
@@ -56,6 +56,7 @@ const useCustomerQueryReturnValue = {
     middle_name: 'Quincey',
     suffix: 'Jr.',
     phone: '223-444-3434',
+    cacValidated: true,
   },
 };
 

--- a/src/pages/Office/CustomerInfo/CustomerInfo.jsx
+++ b/src/pages/Office/CustomerInfo/CustomerInfo.jsx
@@ -17,6 +17,7 @@ import SomethingWentWrong from 'shared/SomethingWentWrong';
 import { CustomerShape } from 'types/order';
 
 const CustomerInfo = ({ customer, isLoading, isError, ordersId, onUpdate }) => {
+  console.log(customer);
   const navigate = useNavigate();
 
   const handleClose = () => {
@@ -47,6 +48,8 @@ const CustomerInfo = ({ customer, isLoading, isError, ordersId, onUpdate }) => {
   if (isError) return <SomethingWentWrong />;
 
   const onSubmit = (values) => {
+    const cacUser = values.cacUser === 'true';
+    console.log(cacUser);
     const {
       firstName,
       lastName,
@@ -81,7 +84,9 @@ const CustomerInfo = ({ customer, isLoading, isError, ordersId, onUpdate }) => {
       phoneIsPreferred,
       emailIsPreferred,
       secondaryTelephone: secondaryPhone,
+      cac_validated: cacUser,
     };
+    console.log(body);
     mutateCustomerInfo({ customerId: customer.id, ifMatchETag: customer.eTag, body });
   };
   const initialValues = {
@@ -99,6 +104,7 @@ const CustomerInfo = ({ customer, isLoading, isError, ordersId, onUpdate }) => {
     backupAddress: customer.backupAddress,
     emailIsPreferred: customer.emailIsPreferred,
     phoneIsPreferred: customer.phoneIsPreferred,
+    cacUser: customer.cacValidated,
   };
 
   return (

--- a/src/pages/Office/CustomerInfo/CustomerInfo.jsx
+++ b/src/pages/Office/CustomerInfo/CustomerInfo.jsx
@@ -15,9 +15,9 @@ import { updateCustomerInfo } from 'services/ghcApi';
 import LoadingPlaceholder from 'shared/LoadingPlaceholder';
 import SomethingWentWrong from 'shared/SomethingWentWrong';
 import { CustomerShape } from 'types/order';
+import { formatTrueFalseInputValue } from 'utils/formatters';
 
 const CustomerInfo = ({ customer, isLoading, isError, ordersId, onUpdate }) => {
-  console.log(customer);
   const navigate = useNavigate();
 
   const handleClose = () => {
@@ -49,7 +49,6 @@ const CustomerInfo = ({ customer, isLoading, isError, ordersId, onUpdate }) => {
 
   const onSubmit = (values) => {
     const cacUser = values.cacUser === 'true';
-    console.log(cacUser);
     const {
       firstName,
       lastName,
@@ -86,9 +85,9 @@ const CustomerInfo = ({ customer, isLoading, isError, ordersId, onUpdate }) => {
       secondaryTelephone: secondaryPhone,
       cac_validated: cacUser,
     };
-    console.log(body);
     mutateCustomerInfo({ customerId: customer.id, ifMatchETag: customer.eTag, body });
   };
+
   const initialValues = {
     firstName: customer.first_name,
     lastName: customer.last_name,
@@ -104,7 +103,7 @@ const CustomerInfo = ({ customer, isLoading, isError, ordersId, onUpdate }) => {
     backupAddress: customer.backupAddress,
     emailIsPreferred: customer.emailIsPreferred,
     phoneIsPreferred: customer.phoneIsPreferred,
-    cacUser: customer.cacValidated,
+    cacUser: formatTrueFalseInputValue(customer?.cacValidated),
   };
 
   return (

--- a/src/pages/Office/CustomerInfo/CustomerInfo.test.jsx
+++ b/src/pages/Office/CustomerInfo/CustomerInfo.test.jsx
@@ -44,6 +44,7 @@ const mockCustomer = {
   suffix: 'Jr.',
   phone: '223-444-3434',
   secondaryTelephone: '234-567-8901',
+  cacValidated: true,
 };
 
 const loadingReturnValue = {

--- a/src/utils/formatters.js
+++ b/src/utils/formatters.js
@@ -354,7 +354,7 @@ export const formatYesNoInputValue = (value) => {
   return null;
 };
 
-// Translate boolean (true/false) into "yes"/"no" string
+// Translate boolean (true/false) into "true"/"false" string
 export const formatTrueFalseInputValue = (value) => {
   if (value === true) return 'true';
   if (value === false) return 'false';

--- a/src/utils/formatters.js
+++ b/src/utils/formatters.js
@@ -354,6 +354,13 @@ export const formatYesNoInputValue = (value) => {
   return null;
 };
 
+// Translate boolean (true/false) into "yes"/"no" string
+export const formatTrueFalseInputValue = (value) => {
+  if (value === true) return 'true';
+  if (value === false) return 'false';
+  return null;
+};
+
 // Translate "yes"/"no" string into boolean (true/false)
 export const formatYesNoAPIValue = (value) => {
   if (value === 'yes') return true;

--- a/swagger-def/ghc.yaml
+++ b/swagger-def/ghc.yaml
@@ -3823,6 +3823,7 @@ definitions:
         $ref: 'definitions/Address.yaml'
       cacValidated:
         type: boolean
+        x-nullable: true
   CreatedCustomer:
     type: object
     properties:
@@ -5318,7 +5319,7 @@ definitions:
     type: object
     properties:
       movingExpenseType:
-        $ref: "definitions/OmittableMovingExpenseType.yaml"
+        $ref: 'definitions/OmittableMovingExpenseType.yaml'
       description:
         description: A brief description of the expense.
         type: string

--- a/swagger/ghc.yaml
+++ b/swagger/ghc.yaml
@@ -3974,6 +3974,7 @@ definitions:
         $ref: '#/definitions/Address'
       cacValidated:
         type: boolean
+        x-nullable: true
   CreatedCustomer:
     type: object
     properties:


### PR DESCRIPTION
## [B-19884](https://www13.v1host.com/USTRANSCOM38/assetdetail.v1?number=B-19884)

## Summary

This pull request adds the functionality for the services counselor to designate whether a customer is a cac-user or not in the edit customer info form. This will help allow a customer to login to to MilMove their first time without needing to authenticate with a CAC. 

This PR does the following:

- Updated CustomerContactInfoForm to include the Cac Validation button
- Added cacUser to body for sending to backend
- Made tests for validating proper functionality of button in form.


## Verification Steps for the Author

These are to be checked by the author.

- [v] Tested in the local environment
- [v] Have the Agility acceptance criteria been met for this change?

These are to be checked by a reviewer.

- [ ] Has the branch been pulled in and checked out?
- [ ] Have the BL acceptance criteria been met for this change?
- [ ] Was the CircleCI build successful?
- [ ] Has the code been reviewed from a standards and best practices point of view?

### How to test


1. Run server and client and login as a services counselor
2. Search for a customer and choose one then head to the edit customer info form
3. select either yes or no on the form and submit and validate the value has been updated in the database.
4. On the client side create a new user, then on services counselor side find the user and update the cacuser value to either yes or no. If value updated to yes validate user has to sign in using cac, otherwise validate they o


### Frontend

- [ ] There are no aXe warnings for UI.
- [ ] This works in [Supported Browsers and their phone views](https://transcom.github.io/mymove-docs/docs/adrs/Browser-Support/#minimum-browser-requirements) (Chrome, Firefox, Edge).
- [ ] There are no new console errors in the browser devtools.
- [ ] There are no new console errors in the test output.
- [ ] If this PR adds a new component to Storybook, it ensures the component is fully responsive, OR if it is intentionally not, a wrapping div using the `officeApp` class or custom `min-width` styling is used to hide any states the would not be visible to the user.
- [ ] This change meets the standards for [Section 508 compliance](https://www.ssa.gov/accessibility/andi/help/install.html).

### Backend

- [ ] Code follows the guidelines for [Logging](https://transcom.github.io/mymove-docs/docs/getting-started/development/logging).
- [ ] The requirements listed in [Querying the Database Safely](https://transcom.github.io/mymove-docs/docs/backend/guides/golang-guide#querying-the-database-safely) have been satisfied.

## Screenshots
![Screenshot 2024-05-23 at 2 58 57 PM](https://github.com/transcom/mymove/assets/167351500/0c5d5277-760a-431b-a221-9719ba7566e5)
