### PR TITLE
INT I-12882 potential fix for B-19883

### DIFF
--- a/src/components/Table/SearchResultsTable.jsx
+++ b/src/components/Table/SearchResultsTable.jsx
@@ -46,7 +46,7 @@ const moveSearchColumns = (moveLockFlag, handleEditProfileClick) => [
   createHeader('  ', (row) => {
     return (
       <div className={styles.editProfile} data-label="editProfile" data-testid="editProfileBtn">
-        <Button outline type="button" onClick={() => handleEditProfileClick(row.locator)}>
+        <Button unstyled type="button" onClick={() => handleEditProfileClick(row.locator)}>
           <FontAwesomeIcon icon={['far', 'user']} />
         </Button>
       </div>


### PR DESCRIPTION
## [Agility ticket](https://www13.v1host.com/USTRANSCOM38/assetdetail.v1?number=B-19883)
## [Issue ticket](https://www13.v1host.com/USTRANSCOM38/assetdetail.v1?number=I-12937)

## Summary

An issue was opened when using the search and nothing was showing but a blue box
![BAD BUTTON](https://github.com/transcom/mymove/assets/136510600/ebae6cc1-533d-4fe1-8b2d-c3f57da71f65)

I think this might be because the button styling is hitting before the icon and so trying to see if setting the button to `unstyled` will fix this issue.

![Screenshot 2024-05-24 at 9 09 36 AM](https://github.com/transcom/mymove/assets/136510600/9744a396-a4f2-4407-9ffe-75bc9ebace89)
