### PR TITLE
MAIN B-19883 add link to search to go to cust profile

### DIFF
--- a/src/components/Office/CustomerContactInfoForm/CustomerContactInfoForm.jsx
+++ b/src/components/Office/CustomerContactInfoForm/CustomerContactInfoForm.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Formik } from 'formik';
 import * as Yup from 'yup';
 import PropTypes from 'prop-types';
-import { Checkbox } from '@trussworks/react-uswds';
+import { Checkbox, Grid } from '@trussworks/react-uswds';
 
 import styles from './CustomerContactInfoForm.module.scss';
 
@@ -41,47 +41,54 @@ const CustomerContactInfoForm = ({ initialValues, onSubmit, onBack }) => {
   });
 
   return (
-    <Formik initialValues={initialValues} onSubmit={onSubmit} validationSchema={validationSchema} validateOnMount>
-      {({ isValid, isSubmitting, handleSubmit }) => {
-        return (
-          <Form className={formStyles.form}>
-            <SectionWrapper className={`${formStyles.formSection} ${styles.formSectionHeader}`}>
-              <CustomerAltContactInfoFields
-                render={(fields) => (
-                  <>
-                    <h2>Contact info</h2>
-                    <Checkbox
-                      data-testid="useCurrentResidence"
-                      label="This is not the person named on the orders."
-                      name="useCurrentResidence"
-                      id="useCurrentResidenceCheckbox"
+    <Grid row>
+      <Grid col>
+        <div className={styles.customerContactForm}>
+          <h1 className={styles.title}>Customer Info</h1>
+          <Formik initialValues={initialValues} onSubmit={onSubmit} validationSchema={validationSchema} validateOnMount>
+            {({ isValid, isSubmitting, handleSubmit }) => {
+              return (
+                <Form className={formStyles.form}>
+                  <SectionWrapper className={`${formStyles.formSection} ${styles.formSectionHeader}`}>
+                    <CustomerAltContactInfoFields
+                      render={(fields) => (
+                        <>
+                          <h2>Contact info</h2>
+                          <Checkbox
+                            data-testid="useCurrentResidence"
+                            label="This is not the person named on the orders."
+                            name="useCurrentResidence"
+                            id="useCurrentResidenceCheckbox"
+                          />
+                          {fields}
+                        </>
+                      )}
                     />
-                    {fields}
-                  </>
-                )}
-              />
-              <h3 className={styles.sectionHeader}>Current Address</h3>
-              <AddressFields name="customerAddress" />
-              <h3 className={styles.sectionHeader}>Backup Address</h3>
-              <AddressFields name="backupAddress" />
-            </SectionWrapper>
-            <SectionWrapper className={`${formStyles.formSection} ${styles.formSectionHeader}`}>
-              <h2 className={styles.sectionHeader}>Backup contact</h2>
+                    <h3 className={styles.sectionHeader}>Current Address</h3>
+                    <AddressFields name="customerAddress" />
+                    <h3 className={styles.sectionHeader}>Backup Address</h3>
+                    <AddressFields name="backupAddress" />
+                  </SectionWrapper>
+                  <SectionWrapper className={`${formStyles.formSection} ${styles.formSectionHeader}`}>
+                    <h2 className={styles.sectionHeader}>Backup contact</h2>
 
-              <BackupContactInfoFields />
-            </SectionWrapper>
-            <div className={formStyles.formActions}>
-              <WizardNavigation
-                editMode
-                disableNext={!isValid || isSubmitting}
-                onCancelClick={onBack}
-                onNextClick={handleSubmit}
-              />
-            </div>
-          </Form>
-        );
-      }}
-    </Formik>
+                    <BackupContactInfoFields />
+                  </SectionWrapper>
+                  <div className={formStyles.formActions}>
+                    <WizardNavigation
+                      editMode
+                      disableNext={!isValid || isSubmitting}
+                      onCancelClick={onBack}
+                      onNextClick={handleSubmit}
+                    />
+                  </div>
+                </Form>
+              );
+            }}
+          </Formik>
+        </div>
+      </Grid>
+    </Grid>
   );
 };
 

--- a/src/components/Office/CustomerContactInfoForm/CustomerContactInfoForm.module.scss
+++ b/src/components/Office/CustomerContactInfoForm/CustomerContactInfoForm.module.scss
@@ -2,7 +2,14 @@
 @import 'shared/styles/_mixins';
 @import 'shared/styles/colors';
 
+.customerContactForm {
+  display: flex;
+  flex-direction: column;
+  width: 50vw;
+}
+
 .formSectionHeader {
+  width: 50vw;
   .sectionHeader {
     margin-bottom: 0;
     display: flex;

--- a/src/components/Table/SearchResultsTable.jsx
+++ b/src/components/Table/SearchResultsTable.jsx
@@ -46,7 +46,7 @@ const moveSearchColumns = (moveLockFlag, handleEditProfileClick) => [
   createHeader('  ', (row) => {
     return (
       <div className={styles.editProfile} data-label="editProfile" data-testid="editProfileBtn">
-        <Button outline type="button" onClick={() => handleEditProfileClick(row.locator)}>
+        <Button unstyled type="button" onClick={() => handleEditProfileClick(row.locator)}>
           <FontAwesomeIcon icon={['far', 'user']} />
         </Button>
       </div>

--- a/src/components/Table/SearchResultsTable.jsx
+++ b/src/components/Table/SearchResultsTable.jsx
@@ -22,7 +22,7 @@ import { servicesCounselingRoutes } from 'constants/routes';
 import { CHECK_SPECIAL_ORDERS_TYPES, SPECIAL_ORDERS_TYPES } from 'constants/orders';
 import { isBooleanFlagEnabled } from 'utils/featureFlags';
 
-const moveSearchColumns = (moveLockFlag) => [
+const moveSearchColumns = (moveLockFlag, handleEditProfileClick) => [
   createHeader(' ', (row) => {
     const now = new Date();
     // this will render a lock icon if the move is locked & if the lockExpiresAt value is after right now
@@ -42,6 +42,15 @@ const moveSearchColumns = (moveLockFlag) => [
   createHeader('DOD ID', 'dodID', {
     id: 'dodID',
     isFilterable: false,
+  }),
+  createHeader('  ', (row) => {
+    return (
+      <div className={styles.editProfile} data-label="editProfile" data-testid="editProfileBtn">
+        <Button outline type="button" onClick={() => handleEditProfileClick(row.locator)}>
+          <FontAwesomeIcon icon={['far', 'user']} />
+        </Button>
+      </div>
+    );
   }),
   createHeader(
     'Customer name',
@@ -248,6 +257,7 @@ const SearchResultsTable = (props) => {
     defaultSortedColumns,
     defaultHiddenColumns,
     handleClick,
+    handleEditProfileClick,
     useQueries,
     showFilters,
     showPagination,
@@ -293,8 +303,10 @@ const SearchResultsTable = (props) => {
 
   const tableData = useMemo(() => data, [data]);
   const tableColumns = useMemo(() => {
-    return searchType === 'customer' ? customerSearchColumns() : moveSearchColumns(moveLockFlag);
-  }, [searchType, moveLockFlag]);
+    return searchType === 'customer'
+      ? customerSearchColumns()
+      : moveSearchColumns(moveLockFlag, handleEditProfileClick);
+  }, [searchType, moveLockFlag, handleEditProfileClick]);
 
   const {
     getTableProps,

--- a/src/components/Table/SearchResultsTable.module.scss
+++ b/src/components/Table/SearchResultsTable.module.scss
@@ -30,4 +30,8 @@
     display: block;
     color: red;
   }
+
+  .editProfileText {
+    display: none;
+  }
 }

--- a/src/components/Table/SearchResultsTable.test.jsx
+++ b/src/components/Table/SearchResultsTable.test.jsx
@@ -164,6 +164,12 @@ describe('SearchResultsTable', () => {
     const createMoveButton = screen.queryByTestId('searchCreateMoveButton');
     expect(createMoveButton).not.toBeInTheDocument();
   });
+  it('renders profile button when search occurs', () => {
+    render(<SearchResultsTable handleClick={() => {}} title="Results" useQueries={mockQueries} searchType="move" />);
+
+    const editProfileBtn = screen.queryByTestId('editProfileBtn');
+    expect(editProfileBtn).toBeInTheDocument();
+  });
   it('loading', () => {
     render(
       <SearchResultsTable handleClick={() => {}} title="Results" useQueries={mockLoadingQuery} dodID="1234567890" />,

--- a/src/pages/Office/CustomerInfo/CustomerInfo.jsx
+++ b/src/pages/Office/CustomerInfo/CustomerInfo.jsx
@@ -104,7 +104,6 @@ const CustomerInfo = ({ customer, isLoading, isError, ordersId, onUpdate }) => {
   return (
     <div className={styles.customerInfoPage}>
       <GridContainer>
-        <h1>Customer Info</h1>
         <CustomerContactInfoForm initialValues={initialValues} onBack={handleClose} onSubmit={onSubmit} />
       </GridContainer>
     </div>

--- a/src/pages/Office/CustomerInfo/CustomerInfo.module.scss
+++ b/src/pages/Office/CustomerInfo/CustomerInfo.module.scss
@@ -2,4 +2,8 @@
 
 .customerInfoPage {
   background: $bg-gray;
+
+  h1 {
+    text-align: center;
+  }
 }

--- a/src/pages/Office/MoveQueue/MoveQueue.jsx
+++ b/src/pages/Office/MoveQueue/MoveQueue.jsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useState } from 'react';
-import { useNavigate, NavLink, useParams, Navigate } from 'react-router-dom';
+import { useNavigate, NavLink, useParams, Navigate, generatePath } from 'react-router-dom';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
 import styles from './MoveQueue.module.scss';
@@ -166,8 +166,19 @@ const MoveQueue = () => {
   // eslint-disable-next-line camelcase
   const showBranchFilter = office_user?.transportation_office?.gbloc !== GBLOC.USMC;
 
-  const handleClick = (values) => {
-    navigate(`/moves/${values.locator}/details`);
+  const handleEditProfileClick = (locator) => {
+    navigate(generatePath(tooRoutes.BASE_CUSTOMER_INFO_EDIT_PATH, { moveCode: locator }));
+  };
+
+  const handleClick = (values, e) => {
+    // if the user clicked the profile icon to edit, we want to route them elsewhere
+    // since we don't have innerText, we are using the data-label property
+    const editProfileDiv = e.target.closest('div[data-label="editProfile"]');
+    if (editProfileDiv) {
+      navigate(generatePath(tooRoutes.BASE_CUSTOMER_INFO_EDIT_PATH, { moveCode: values.locator }));
+    } else {
+      navigate(generatePath(tooRoutes.BASE_MOVE_VIEW_PATH, { moveCode: values.locator }));
+    }
   };
 
   if (isLoading) return <LoadingPlaceholder />;
@@ -213,6 +224,7 @@ const MoveQueue = () => {
             disableSortBy={false}
             title="Results"
             handleClick={handleClick}
+            handleEditProfileClick={handleEditProfileClick}
             useQueries={useMoveSearchQueries}
             moveCode={search.moveCode}
             dodID={search.dodID}

--- a/src/pages/Office/ServicesCounselingQueue/ServicesCounselingQueue.jsx
+++ b/src/pages/Office/ServicesCounselingQueue/ServicesCounselingQueue.jsx
@@ -268,8 +268,19 @@ const ServicesCounselingQueue = () => {
     fetchData();
   }, [setErrorState]);
 
-  const handleClick = (values) => {
-    navigate(generatePath(servicesCounselingRoutes.BASE_MOVE_VIEW_PATH, { moveCode: values.locator }));
+  const handleEditProfileClick = (locator) => {
+    navigate(generatePath(servicesCounselingRoutes.BASE_CUSTOMER_INFO_EDIT_PATH, { moveCode: locator }));
+  };
+
+  const handleClick = (values, e) => {
+    // if the user clicked the profile icon to edit, we want to route them elsewhere
+    // since we don't have innerText, we are using the data-label property
+    const editProfileDiv = e.target.closest('div[data-label="editProfile"]');
+    if (editProfileDiv) {
+      navigate(generatePath(servicesCounselingRoutes.BASE_CUSTOMER_INFO_EDIT_PATH, { moveCode: values.locator }));
+    } else {
+      navigate(generatePath(servicesCounselingRoutes.BASE_MOVE_VIEW_PATH, { moveCode: values.locator }));
+    }
   };
 
   const handleCustomerSearchClick = (values) => {
@@ -390,6 +401,7 @@ const ServicesCounselingQueue = () => {
             disableSortBy={false}
             title="Results"
             handleClick={handleClick}
+            handleEditProfileClick={handleEditProfileClick}
             useQueries={useMoveSearchQueries}
             moveCode={search.moveCode}
             dodID={search.dodID}

--- a/src/pages/Office/TXOMoveInfo/TXOMoveInfo.jsx
+++ b/src/pages/Office/TXOMoveInfo/TXOMoveInfo.jsx
@@ -3,7 +3,6 @@ import { matchPath, Navigate, Route, Routes, useLocation, useParams } from 'reac
 import { useSelector } from 'react-redux';
 
 import 'styles/office.scss';
-
 import { permissionTypes } from 'constants/permissions';
 import { qaeCSRRoutes, tioRoutes, tooRoutes } from 'constants/routes';
 import TXOTabNav from 'components/Office/TXOTabNav/TXOTabNav';
@@ -26,9 +25,9 @@ const EvaluationReports = lazy(() => import('pages/Office/EvaluationReports/Eval
 const EvaluationReport = lazy(() => import('pages/Office/EvaluationReport/EvaluationReport'));
 const EvaluationViolations = lazy(() => import('pages/Office/EvaluationViolations/EvaluationViolations'));
 const MoveHistory = lazy(() => import('pages/Office/MoveHistory/MoveHistory'));
+const CustomerInfo = lazy(() => import('pages/Office/CustomerInfo/CustomerInfo'));
 const MovePaymentRequests = lazy(() => import('pages/Office/MovePaymentRequests/MovePaymentRequests'));
 const Forbidden = lazy(() => import('pages/Office/Forbidden/Forbidden'));
-const CustomerInfo = lazy(() => import('pages/Office/CustomerInfo/CustomerInfo'));
 
 const TXOMoveInfo = () => {
   const [unapprovedShipmentCount, setUnapprovedShipmentCount] = React.useState(0);
@@ -145,6 +144,13 @@ const TXOMoveInfo = () => {
       <Suspense fallback={<LoadingPlaceholder />}>
         <Routes>
           <Route
+            path="customer"
+            end
+            element={
+              <CustomerInfo ordersId={order.id} customer={customerData} isLoading={isLoading} isError={isError} />
+            }
+          />
+          <Route
             path="details"
             end
             element={
@@ -235,15 +241,6 @@ const TXOMoveInfo = () => {
                     destinationDutyLocationPostalCode={order?.destinationDutyLocation?.address?.postalCode}
                   />
                 </Restricted>
-              }
-            />
-          )}
-          {order.grade && (
-            <Route
-              path={tooRoutes.CUSTOMER_INFO_EDIT_PATH}
-              end
-              element={
-                <CustomerInfo ordersId={order.id} customer={customerData} isLoading={isLoading} isError={isError} />
               }
             />
           )}

--- a/src/pages/Office/index.jsx
+++ b/src/pages/Office/index.jsx
@@ -8,7 +8,6 @@ import styles from './Office.module.scss';
 
 import 'styles/full_uswds.scss';
 import 'scenes/Office/office.scss';
-
 // Logger
 import { milmoveLogger } from 'utils/milmoveLog';
 import { retryPageLoading } from 'utils/retryPageLoading';
@@ -91,6 +90,7 @@ const PrimeUIShipmentUpdateDestinationAddress = lazy(() =>
 const QAECSRMoveSearch = lazy(() => import('pages/Office/QAECSRMoveSearch/QAECSRMoveSearch'));
 const CreateCustomerForm = lazy(() => import('pages/Office/CustomerOnboarding/CreateCustomerForm'));
 const CreateMoveCustomerInfo = lazy(() => import('pages/Office/CreateMoveCustomerInfo/CreateMoveCustomerInfo'));
+const CustomerInfo = lazy(() => import('pages/Office/CustomerInfo/CustomerInfo'));
 const ServicesCounselingAddOrders = lazy(() =>
   import('pages/Office/ServicesCounselingAddOrders/ServicesCounselingAddOrders'),
 );
@@ -333,6 +333,14 @@ export class OfficeApp extends Component {
                     />
 
                     {/* TOO */}
+                    <Route
+                      path={`${tooRoutes.BASE_CUSTOMERS_CUSTOMER_INFO_PATH}`}
+                      element={
+                        <PrivateRoute requiredRoles={[roleTypes.TOO]}>
+                          <CustomerInfo />
+                        </PrivateRoute>
+                      }
+                    />
                     <Route
                       key="tooEditShipmentDetailsRoute"
                       end


### PR DESCRIPTION
[INTEGRATION PR](https://github.com/transcom/mymove/pull/12738)
[ISSUE FIX PR](https://github.com/transcom/mymove/pull/12780)

## [Agility ticket](https://www13.v1host.com/USTRANSCOM38/assetdetail.v1?number=B-19883)

## Summary

We want the office users to have easy jobs and not confuse them with excessive clicks. With the addition of non-CAC users, we need the office user to be able to quickly search and have a quick icon to click to direct them to that user's customer information.

[B-19884](https://www13.v1host.com/USTRANSCOM38/assetdetail.v1?number=B-19884) should handle the additional functionality for the office users to quickly validate customers as non-CAC users.

This PR does the following:
- adds a profile icon button that displays for both TOO and SC move searches, this directs them to the `CustomerInfo` page
- some enhancements to `CustomerInfo` component to eliminate a skinny screen by putting in a fixed width and flexbox
- adding conditional logic in the `handleClick` function when a user clicks a row after searching - this was a weird one. We have to override the function by checking if the user clicked the icon by assessing the parent div

### How to test

1. Access MM as an office user (TOO/SC)
2. Perform a move search for any user
3. Should see a profile icon display next to their name
4. Click that icon and should direct you to the Customer Info page

## Screenshots

![Screenshot 2024-05-21 at 12 29 33 PM](https://github.com/transcom/mymove/assets/136510600/ec1f5725-c99f-4028-88ff-fbb056b283bc)

TOO flow
https://github.com/transcom/mymove/assets/136510600/aa5ffc53-b42f-403d-9727-aca7705061e4

SC flow
https://github.com/transcom/mymove/assets/136510600/f25e8e69-3109-4db3-920b-d32d19afef47