### PR TITLE
INT - B-19065 fix current bug delete docs

### DIFF
--- a/pkg/gen/internalapi/embedded_spec.go
+++ b/pkg/gen/internalapi/embedded_spec.go
@@ -3061,6 +3061,13 @@ func init() {
             "description": "ID of the order that the upload belongs to",
             "name": "orderId",
             "in": "query"
+          },
+          {
+            "type": "string",
+            "format": "uuid",
+            "description": "Optional PPM shipment ID related to the upload",
+            "name": "ppmId",
+            "in": "query"
           }
         ],
         "responses": {
@@ -10916,6 +10923,13 @@ func init() {
             "format": "uuid",
             "description": "ID of the order that the upload belongs to",
             "name": "orderId",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "format": "uuid",
+            "description": "Optional PPM shipment ID related to the upload",
+            "name": "ppmId",
             "in": "query"
           }
         ],

--- a/pkg/gen/internalapi/internaloperations/uploads/delete_upload_parameters.go
+++ b/pkg/gen/internalapi/internaloperations/uploads/delete_upload_parameters.go
@@ -36,6 +36,10 @@ type DeleteUploadParams struct {
 	  In: query
 	*/
 	OrderID *strfmt.UUID
+	/*Optional PPM shipment ID related to the upload
+	  In: query
+	*/
+	PpmID *strfmt.UUID
 	/*UUID of the upload to be deleted
 	  Required: true
 	  In: path
@@ -56,6 +60,11 @@ func (o *DeleteUploadParams) BindRequest(r *http.Request, route *middleware.Matc
 
 	qOrderID, qhkOrderID, _ := qs.GetOK("orderId")
 	if err := o.bindOrderID(qOrderID, qhkOrderID, route.Formats); err != nil {
+		res = append(res, err)
+	}
+
+	qPpmID, qhkPpmID, _ := qs.GetOK("ppmId")
+	if err := o.bindPpmID(qPpmID, qhkPpmID, route.Formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -101,6 +110,43 @@ func (o *DeleteUploadParams) bindOrderID(rawData []string, hasKey bool, formats 
 func (o *DeleteUploadParams) validateOrderID(formats strfmt.Registry) error {
 
 	if err := validate.FormatOf("orderId", "query", "uuid", o.OrderID.String(), formats); err != nil {
+		return err
+	}
+	return nil
+}
+
+// bindPpmID binds and validates parameter PpmID from query.
+func (o *DeleteUploadParams) bindPpmID(rawData []string, hasKey bool, formats strfmt.Registry) error {
+	var raw string
+	if len(rawData) > 0 {
+		raw = rawData[len(rawData)-1]
+	}
+
+	// Required: false
+	// AllowEmptyValue: false
+
+	if raw == "" { // empty values pass all other validations
+		return nil
+	}
+
+	// Format: uuid
+	value, err := formats.Parse("uuid", raw)
+	if err != nil {
+		return errors.InvalidType("ppmId", "query", "strfmt.UUID", raw)
+	}
+	o.PpmID = (value.(*strfmt.UUID))
+
+	if err := o.validatePpmID(formats); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// validatePpmID carries on validations for parameter PpmID
+func (o *DeleteUploadParams) validatePpmID(formats strfmt.Registry) error {
+
+	if err := validate.FormatOf("ppmId", "query", "uuid", o.PpmID.String(), formats); err != nil {
 		return err
 	}
 	return nil

--- a/pkg/gen/internalapi/internaloperations/uploads/delete_upload_urlbuilder.go
+++ b/pkg/gen/internalapi/internaloperations/uploads/delete_upload_urlbuilder.go
@@ -19,6 +19,7 @@ type DeleteUploadURL struct {
 	UploadID strfmt.UUID
 
 	OrderID *strfmt.UUID
+	PpmID   *strfmt.UUID
 
 	_basePath string
 	// avoid unkeyed usage
@@ -67,6 +68,14 @@ func (o *DeleteUploadURL) Build() (*url.URL, error) {
 	}
 	if orderIDQ != "" {
 		qs.Set("orderId", orderIDQ)
+	}
+
+	var ppmIDQ string
+	if o.PpmID != nil {
+		ppmIDQ = o.PpmID.String()
+	}
+	if ppmIDQ != "" {
+		qs.Set("ppmId", ppmIDQ)
 	}
 
 	_result.RawQuery = qs.Encode()

--- a/pkg/handlers/internalapi/uploads.go
+++ b/pkg/handlers/internalapi/uploads.go
@@ -122,6 +122,17 @@ func (h DeleteUploadHandler) Handle(params uploadop.DeleteUploadParams) middlewa
 				return handlers.ResponseForError(appCtx.Logger(), err), err
 			}
 
+			var ppmShipmentStatus models.PPMShipmentStatus
+
+			if params.PpmID != nil {
+				ppmShipmentId, _ := uuid.FromString(params.PpmID.String())
+				ppmShipment, err := models.FetchPPMShipmentByPPMShipmentID(appCtx.DB(), ppmShipmentId)
+				if err != nil {
+					return handlers.ResponseForError(appCtx.Logger(), err), err
+				}
+				ppmShipmentStatus = ppmShipment.Status
+			}
+
 			if params.OrderID != nil {
 				orderID, _ := uuid.FromString(params.OrderID.String())
 				move, e := models.FetchMoveByOrderID(appCtx.DB(), orderID)
@@ -157,8 +168,8 @@ func (h DeleteUploadHandler) Handle(params uploadop.DeleteUploadParams) middlewa
 				appCtx.Logger().Error("error retrieving move associated with this upload", zap.Error(err))
 			}
 
-			//If move status is not DRAFT, upload cannot be deleted
-			if *uploadInformation.MoveStatus != models.MoveStatusDRAFT {
+			//If move status is not DRAFT and customer is not uploading ppm docs, upload cannot be deleted
+			if (*uploadInformation.MoveStatus != models.MoveStatusDRAFT) && (ppmShipmentStatus != models.PPMShipmentStatusWaitingOnCustomer) {
 				return uploadop.NewDeleteUploadForbidden(), fmt.Errorf("deletion not permitted Move is not in 'DRAFT' status")
 			}
 

--- a/src/pages/MyMove/PPM/Closeout/Expenses/Expenses.jsx
+++ b/src/pages/MyMove/PPM/Closeout/Expenses/Expenses.jsx
@@ -87,7 +87,7 @@ const Expenses = () => {
   };
 
   const handleUploadDelete = (uploadId, fieldName, setFieldTouched, setFieldValue) => {
-    deleteUpload(uploadId)
+    deleteUpload(uploadId, null, mtoShipment?.ppmShipment?.id)
       .then(() => {
         const filteredUploads = mtoShipment.ppmShipment.movingExpenses[currentIndex][fieldName].uploads.filter(
           (upload) => upload.id !== uploadId,

--- a/src/pages/MyMove/PPM/Closeout/ProGear/ProGear.jsx
+++ b/src/pages/MyMove/PPM/Closeout/ProGear/ProGear.jsx
@@ -96,7 +96,7 @@ const ProGear = () => {
   };
 
   const handleUploadDelete = (uploadId, fieldName, setFieldTouched, setFieldValue) => {
-    deleteUpload(uploadId)
+    deleteUpload(uploadId, null, mtoShipment?.ppmShipment?.id)
       .then(() => {
         const filteredUploads = mtoShipment.ppmShipment.proGearWeightTickets[currentIndex][fieldName].uploads.filter(
           (upload) => upload.id !== uploadId,

--- a/src/pages/MyMove/PPM/Closeout/WeightTickets/WeightTickets.jsx
+++ b/src/pages/MyMove/PPM/Closeout/WeightTickets/WeightTickets.jsx
@@ -93,7 +93,7 @@ const WeightTickets = () => {
   };
 
   const handleUploadDelete = (uploadId, fieldName, setFieldTouched, setFieldValue) => {
-    deleteUpload(uploadId)
+    deleteUpload(uploadId, null, mtoShipment?.ppmShipment?.id)
       .then(() => {
         const filteredUploads = mtoShipment.ppmShipment.weightTickets[currentIndex][fieldName].uploads.filter(
           (upload) => upload.id !== uploadId,

--- a/src/services/internalApi.js
+++ b/src/services/internalApi.js
@@ -248,12 +248,13 @@ export async function createUploadForPPMDocument(ppmShipmentId, documentId, file
   );
 }
 
-export async function deleteUpload(uploadId, orderId) {
+export async function deleteUpload(uploadId, orderId, ppmId) {
   return makeInternalRequest(
     'uploads.deleteUpload',
     {
       uploadId,
       orderId,
+      ppmId,
     },
     {
       normalize: false,

--- a/swagger-def/internal.yaml
+++ b/swagger-def/internal.yaml
@@ -3071,6 +3071,11 @@ paths:
           type: string
           format: uuid
           description: ID of the order that the upload belongs to
+        - in: query
+          name: ppmId
+          type: string
+          format: uuid
+          description: Optional PPM shipment ID related to the upload
       responses:
         "204":
           description: deleted

--- a/swagger/internal.yaml
+++ b/swagger/internal.yaml
@@ -4362,6 +4362,11 @@ paths:
           type: string
           format: uuid
           description: ID of the order that the upload belongs to
+        - in: query
+          name: ppmId
+          type: string
+          format: uuid
+          description: Optional PPM shipment ID related to the upload
       responses:
         '204':
           description: deleted


### PR DESCRIPTION
## [B-19065](https://www13.v1host.com/USTRANSCOM38/assetdetail.v1?number=B-19065)

## Summary

This is to fix a bug where the customer cannot delete PPM documents once uploaded. The issue was due to a Move Status check in the BE where it only allowed status of `DRAFT`. This did not account for PPM shipments where the move status cannot be in `DRAFT` when uploading PPM docs.

### How to test

1. Use `HHGMoveWithPPMShipmentsReadyForCloseout` to create a move.
2. As a customer -> go to move and click "Upload PPM Documents"
3. Fill out all the information and upload documents for each weight tickets, pro-gear tickets, and expense tickets - then try deleting uploaded docs.
4. If should be able to successfully delete docs.



## Screenshots
![image](https://github.com/transcom/mymove/assets/146856854/ae9c56a7-99b5-4d9f-9128-00e6d943058c)
