### PR TITLE
B 19533 add spouse pro gear weights page MAIN

### DIFF
--- a/src/components/Office/PPM/ReviewShipmentWeightsTable/ReviewShipmentWeightsTable.test.jsx
+++ b/src/components/Office/PPM/ReviewShipmentWeightsTable/ReviewShipmentWeightsTable.test.jsx
@@ -21,15 +21,12 @@ const PPMProps = {
     {
       shipmentType: 'PPM',
       ppmShipment: {
-        actualMoveDate: '02-Dec-22',
         actualPickupPostalCode: '90210',
         actualDestinationPostalCode: '94611',
         hasReceivedAdvance: true,
         advanceAmountReceived: 60000,
-        proGearWeight: 1000,
-        spouseProGearWeight: 500,
         estimatedWeight: 4000,
-        expectedDepartureDate: '01-Apr-23',
+        actualMoveDate: '2023-04-01',
         weightTickets: [
           {
             emptyWeight: 1000,
@@ -37,6 +34,8 @@ const PPMProps = {
           },
         ],
       },
+      actualProGearWeight: 1000,
+      actualSpouseProGearWeight: 500,
     },
   ],
   tableConfig: PPMReviewWeightsTableConfig,
@@ -46,7 +45,7 @@ const ProGearProps = {
     {
       entitlement: {
         proGearWeight: 2000,
-        spouseProGearWeight: 500,
+        proGearWeightSpouse: 500,
       },
     },
   ],
@@ -63,7 +62,7 @@ const NonPPMProps = {
         id: 'rw01',
         weight: 3200,
       },
-      actualDeliveryDate: '04-Apr-23',
+      actualDeliveryDate: '2023-04-23',
     },
   ],
   tableConfig: nonPPMReviewWeightsTableConfig,
@@ -82,7 +81,7 @@ describe('ReviewShipmentWeight component', () => {
       expect(screen.getByText('Review Documents')).toBeInTheDocument();
       expect(screen.getByText('Review Documents').tagName).toBe('A');
       expect(screen.getByText('Pro-gear (lbs)')).toBeInTheDocument();
-      expect(screen.getByText('1,000 lbs')).toBeInTheDocument();
+      expect(screen.getByText('4,000 lbs')).toBeInTheDocument();
       expect(screen.getByText('Spouse pro-gear')).toBeInTheDocument();
       expect(screen.getByText('500 lbs')).toBeInTheDocument();
       expect(screen.getByText('Net weight')).toBeInTheDocument();
@@ -120,7 +119,7 @@ describe('ReviewShipmentWeight component', () => {
       expect(screen.getByText('Billable weight')).toBeInTheDocument();
       expect(screen.getByText('3,000 lbs')).toBeInTheDocument();
       expect(screen.getByText('Delivery date')).toBeInTheDocument();
-      expect(screen.getByText('Apr 04 2023')).toBeInTheDocument();
+      expect(screen.getByText('Apr 23 2023')).toBeInTheDocument();
     });
   });
 });

--- a/src/components/Office/PPM/ReviewShipmentWeightsTable/helpers.jsx
+++ b/src/components/Office/PPM/ReviewShipmentWeightsTable/helpers.jsx
@@ -140,7 +140,7 @@ export const PPMReviewWeightsTableColumns = [
   ),
   createHeader(
     'Pro-gear (lbs)',
-    (row) => (row.ppmShipment.proGearWeight > 0 ? formatWeight(row.ppmShipment.proGearWeight) : DASH),
+    (row) => (row.actualProGearWeight > 0 ? formatWeight(row.actualProGearWeight) : DASH),
     {
       id: 'proGear',
       isFilterable: false,
@@ -148,7 +148,7 @@ export const PPMReviewWeightsTableColumns = [
   ),
   createHeader(
     'Spouse pro-gear',
-    (row) => (row.ppmShipment.spouseProGearWeight > 0 ? formatWeight(row.ppmShipment.spouseProGearWeight) : DASH),
+    (row) => (row.actualSpouseProGearWeight > 0 ? formatWeight(row.actualSpouseProGearWeight) : DASH),
     {
       id: 'spouseProGear',
       isFilterable: false,
@@ -175,10 +175,7 @@ export const PPMReviewWeightsTableColumns = [
   ),
   createHeader(
     'Departure date',
-    (row) =>
-      row.ppmShipment.expectedDepartureDate
-        ? formatReviewShipmentWeightsDate(row.ppmShipment.expectedDepartureDate)
-        : DASH,
+    (row) => (row.ppmShipment.actualMoveDate ? formatReviewShipmentWeightsDate(row.ppmShipment.actualMoveDate) : DASH),
     {
       id: 'departureDate',
       isFilterable: false,
@@ -213,7 +210,7 @@ export const proGearTableColumns = [
   ),
   createHeader(
     'Spouse pro-gear (lbs)',
-    (row) => (row.entitlement.spouseProGearWeight > 0 ? formatWeight(row.entitlement.spouseProGearWeight) : DASH),
+    (row) => (row.entitlement.proGearWeightSpouse > 0 ? formatWeight(row.entitlement.proGearWeightSpouse) : DASH),
     {
       id: 'spouseProGear',
       isFilterable: false,

--- a/src/pages/MyMove/PPM/Closeout/ProGear/ProGear.jsx
+++ b/src/pages/MyMove/PPM/Closeout/ProGear/ProGear.jsx
@@ -15,6 +15,8 @@ import {
   createProGearWeightTicket,
   deleteUpload,
   patchProGearWeightTicket,
+  patchMTOShipment,
+  getMTOShipmentsForMove,
 } from 'services/internalApi';
 import LoadingPlaceholder from 'shared/LoadingPlaceholder';
 import closingPageStyles from 'pages/MyMove/PPM/Closeout/Closeout.module.scss';
@@ -109,9 +111,39 @@ const ProGear = () => {
       });
   };
 
-  const handleSubmit = async (values, { setSubmitting, setErrors }) => {
-    setErrorMessage(null);
-    setErrors({});
+  const updateMtoShipment = (values) => {
+    const belongsToSelf = values.belongsToSelf === 'true';
+    let proGear;
+    let spouseProGear;
+    if (belongsToSelf) {
+      proGear = values.weight;
+    }
+    if (!belongsToSelf) {
+      spouseProGear = values.weight;
+    }
+    const payload = {
+      belongsToSelf,
+      ppmShipment: {
+        id: mtoShipment.ppmShipment.id,
+      },
+      shipmentType: mtoShipment.shipmentType,
+      actualSpouseProGearWeight: parseInt(spouseProGear, 10),
+      actualProGearWeight: parseInt(proGear, 10),
+      shipmentLocator: values.shipmentLocator,
+      eTag: mtoShipment.eTag,
+    };
+
+    patchMTOShipment(mtoShipment.id, payload, payload.eTag)
+      .then((response) => {
+        navigate(generatePath(customerRoutes.SHIPMENT_PPM_REVIEW_PATH, { moveId, mtoShipmentId }));
+        dispatch(updateMTOShipment(response));
+      })
+      .catch(() => {
+        setErrorMessage('Failed to update MTO shipment due to server error.');
+      });
+  };
+
+  const updateProGearWeightTicket = (values) => {
     const hasWeightTickets = !values.missingWeightTicket;
     const belongsToSelf = values.belongsToSelf === 'true';
     const payload = {
@@ -130,15 +162,28 @@ const ProGear = () => {
       currentProGearWeightTicket.eTag,
     )
       .then((resp) => {
-        setSubmitting(false);
         mtoShipment.ppmShipment.proGearWeightTickets[currentIndex] = resp;
-        navigate(generatePath(customerRoutes.SHIPMENT_PPM_REVIEW_PATH, { moveId, mtoShipmentId }));
-        dispatch(updateMTOShipment(mtoShipment));
+        getMTOShipmentsForMove(moveId)
+          .then((response) => {
+            dispatch(updateMTOShipment(response.mtoShipments[mtoShipmentId]));
+            mtoShipment.eTag = response.mtoShipments[mtoShipmentId].eTag;
+            updateMtoShipment(values);
+            navigate(generatePath(customerRoutes.SHIPMENT_PPM_REVIEW_PATH, { moveId, mtoShipmentId }));
+          })
+          .catch(() => {
+            setErrorMessage('Failed to fetch shipment information');
+          });
       })
       .catch(() => {
-        setSubmitting(false);
         setErrorMessage('Failed to save updated trip record');
       });
+  };
+
+  const handleSubmit = async (values, { setSubmitting, setErrors }) => {
+    setErrorMessage(null);
+    setErrors({});
+    setSubmitting(false);
+    updateProGearWeightTicket(values);
   };
 
   const renderError = () => {

--- a/src/pages/MyMove/PPM/Closeout/ProGear/ProGear.test.jsx
+++ b/src/pages/MyMove/PPM/Closeout/ProGear/ProGear.test.jsx
@@ -123,14 +123,11 @@ beforeEach(() => {
 });
 
 const movePath = generatePath(customerRoutes.MOVE_HOME_PAGE);
+
 const proGearWeightTicketsEditPath = generatePath(customerRoutes.SHIPMENT_PPM_PRO_GEAR_EDIT_PATH, {
   moveId: mockMoveId,
   mtoShipmentId: mockMTOShipmentId,
   proGearId: mockProGearWeightTicketId,
-});
-const reviewPath = generatePath(customerRoutes.SHIPMENT_PPM_REVIEW_PATH, {
-  moveId: mockMoveId,
-  mtoShipmentId: mockMTOShipmentId,
 });
 
 const renderProGearPage = () => {
@@ -262,7 +259,7 @@ describe('Pro-gear page', () => {
       );
     });
 
-    expect(mockNavigate).toHaveBeenCalledWith(reviewPath);
+    expect(mockNavigate).toHaveBeenCalledWith(proGearWeightTicketsEditPath, { replace: true });
   });
 
   it('calls the delete handler when removing an existing upload', async () => {

--- a/src/types/shipment.js
+++ b/src/types/shipment.js
@@ -172,6 +172,8 @@ export const ShipmentShape = shape({
   }),
   ppmShipment: PPMShipmentShape,
   deliveryAddressUpdate: ShipmentAddressUpdateShape,
+  actual_pro_gear_weight: number,
+  actual_spouse_pro_gear_weight: number,
 });
 
 const DocumentShape = shape({

--- a/src/utils/formatters.js
+++ b/src/utils/formatters.js
@@ -316,15 +316,8 @@ export const formatAgeToDays = (age) => {
  * following format: `Dec 25 2023`.
  */
 export function formatReviewShipmentWeightsDate(date) {
-  /**
-   * @const INCOMING_DATE_FORMAT
-   * @description This is the format of the incoming `date` parameter. The
-   * reason this is passed into Moment is due to a quirk around browser
-   * support for parsing strings. Read more about *String + Format* here:
-   * <https://momentjs.com/docs/#/parsing/string/>
-   */
-  const INCOMING_DATE_FORMAT = 'DD-MMM-YY';
-  return moment(date, INCOMING_DATE_FORMAT).format('MMM DD YYYY');
+  if (!date) return DEFAULT_EMPTY_VALUE;
+  return moment(date).format('MMM DD YYYY');
 }
 // Format dates for customer app (ex. 25 Dec 2020)
 export function formatCustomerDate(date) {

--- a/src/utils/formatters.test.js
+++ b/src/utils/formatters.test.js
@@ -13,6 +13,9 @@ describe('formatters', () => {
     it('should format signature date to YYYY-MM-DD', () => {
       expect(formatters.formatSignatureDate('2020-09-27T00:00:00Z')).toBe('2020-09-27');
     });
+    it('should format review weights date MMM DD YYYY', () => {
+      expect(formatters.formatReviewShipmentWeightsDate('2020-09-27T00:00:00Z')).toBe('Sep 27 2020');
+    });
   });
 
   describe('formatYesNoInputValue', () => {


### PR DESCRIPTION
## [19533](https://www13.v1host.com/USTRANSCOM38/story.mvc/Summary?oidToken=Story%3A940551)

## Summary

Integration PR: https://github.com/transcom/mymove/pull/12835

In this PR you should now see the actual pro gear and Spouse pro gear weights, departure date, and spouse pro gear entitlements weight on the Review weights page.

## Verification Steps for Reviewers

These are to be checked by a reviewer.

- [ ] Has the branch been pulled in and checked out?
- [ ] Have the BL acceptance criteria been met for this change?
- [ ] Was the CircleCI build successful?
- [ ] Has the code been reviewed from a standards and best practices point of view?

### How to test

1. Create a Full or Partial Move with a PPM
2. Login as a SC, edit and submit move
3. Login as customer and click "Upload Documents"
4. Enter in all information and take note of actual pro gear weights and departure date
5. Sign and Save move
6. Login as a Closeout SC and click "Review Weights Page"
7. You should now see the PPM actual pro gear weights, departure date and pro gear weight entitlements

### Frontend

- [ ] There are no aXe warnings for UI.
- [ ] This works in [Supported Browsers and their phone views](https://transcom.github.io/mymove-docs/docs/adrs/Browser-Support/#minimum-browser-requirements) (Chrome, Firefox, Edge).
- [ ] There are no new console errors in the browser devtools.
- [ ] There are no new console errors in the test output.
- [ ] If this PR adds a new component to Storybook, it ensures the component is fully responsive, OR if it is intentionally not, a wrapping div using the `officeApp` class or custom `min-width` styling is used to hide any states the would not be visible to the user.
- [ ] This change meets the standards for [Section 508 compliance](https://www.ssa.gov/accessibility/andi/help/install.html).


## Screenshots
<img width="1042" alt="Screenshot 2024-05-29 at 1 56 25 PM" src="https://github.com/transcom/mymove/assets/146969726/7db78d04-8dc2-48a0-9a90-8b9d4faceab9">
