### PR TITLE
B 19979 diversion reason for prime

### DIFF
--- a/pkg/gen/primeapi/embedded_spec.go
+++ b/pkg/gen/primeapi/embedded_spec.go
@@ -2790,6 +2790,12 @@ func init() {
           "description": "This value indicates whether or not this shipment is part of a diversion. If yes, the shipment can be either the starting or ending segment of the diversion.\n",
           "type": "boolean"
         },
+        "diversionReason": {
+          "description": "The reason the TOO provided when requesting a diversion for this shipment.\n",
+          "type": "string",
+          "x-nullable": true,
+          "readOnly": true
+        },
         "eTag": {
           "description": "A hash unique to this shipment that should be used as the \"If-Match\" header for any updates.",
           "type": "string",
@@ -7953,6 +7959,12 @@ func init() {
         "diversion": {
           "description": "This value indicates whether or not this shipment is part of a diversion. If yes, the shipment can be either the starting or ending segment of the diversion.\n",
           "type": "boolean"
+        },
+        "diversionReason": {
+          "description": "The reason the TOO provided when requesting a diversion for this shipment.\n",
+          "type": "string",
+          "x-nullable": true,
+          "readOnly": true
         },
         "eTag": {
           "description": "A hash unique to this shipment that should be used as the \"If-Match\" header for any updates.",

--- a/pkg/gen/primemessages/m_t_o_shipment_without_service_items.go
+++ b/pkg/gen/primemessages/m_t_o_shipment_without_service_items.go
@@ -97,6 +97,11 @@ type MTOShipmentWithoutServiceItems struct {
 	//
 	Diversion bool `json:"diversion,omitempty"`
 
+	// The reason the TOO provided when requesting a diversion for this shipment.
+	//
+	// Read Only: true
+	DiversionReason *string `json:"diversionReason,omitempty"`
+
 	// A hash unique to this shipment that should be used as the "If-Match" header for any updates.
 	// Read Only: true
 	ETag string `json:"eTag,omitempty"`
@@ -832,6 +837,10 @@ func (m *MTOShipmentWithoutServiceItems) ContextValidate(ctx context.Context, fo
 		res = append(res, err)
 	}
 
+	if err := m.contextValidateDiversionReason(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
 	if err := m.contextValidateETag(ctx, formats); err != nil {
 		res = append(res, err)
 	}
@@ -998,6 +1007,15 @@ func (m *MTOShipmentWithoutServiceItems) contextValidateDestinationType(ctx cont
 			}
 			return err
 		}
+	}
+
+	return nil
+}
+
+func (m *MTOShipmentWithoutServiceItems) contextValidateDiversionReason(ctx context.Context, formats strfmt.Registry) error {
+
+	if err := validate.ReadOnly(ctx, "diversionReason", "body", m.DiversionReason); err != nil {
+		return err
 	}
 
 	return nil

--- a/pkg/gen/primev2api/embedded_spec.go
+++ b/pkg/gen/primev2api/embedded_spec.go
@@ -1540,6 +1540,12 @@ func init() {
           "description": "This value indicates whether or not this shipment is part of a diversion. If yes, the shipment can be either the starting or ending segment of the diversion.\n",
           "type": "boolean"
         },
+        "diversionReason": {
+          "description": "The reason the TOO provided when requesting a diversion for this shipment.\n",
+          "type": "string",
+          "x-nullable": true,
+          "readOnly": true
+        },
         "eTag": {
           "description": "A hash unique to this shipment that should be used as the \"If-Match\" header for any updates.",
           "type": "string",
@@ -5043,6 +5049,12 @@ func init() {
         "diversion": {
           "description": "This value indicates whether or not this shipment is part of a diversion. If yes, the shipment can be either the starting or ending segment of the diversion.\n",
           "type": "boolean"
+        },
+        "diversionReason": {
+          "description": "The reason the TOO provided when requesting a diversion for this shipment.\n",
+          "type": "string",
+          "x-nullable": true,
+          "readOnly": true
         },
         "eTag": {
           "description": "A hash unique to this shipment that should be used as the \"If-Match\" header for any updates.",

--- a/pkg/gen/primev2messages/m_t_o_shipment_without_service_items.go
+++ b/pkg/gen/primev2messages/m_t_o_shipment_without_service_items.go
@@ -97,6 +97,11 @@ type MTOShipmentWithoutServiceItems struct {
 	//
 	Diversion bool `json:"diversion,omitempty"`
 
+	// The reason the TOO provided when requesting a diversion for this shipment.
+	//
+	// Read Only: true
+	DiversionReason *string `json:"diversionReason,omitempty"`
+
 	// A hash unique to this shipment that should be used as the "If-Match" header for any updates.
 	// Read Only: true
 	ETag string `json:"eTag,omitempty"`
@@ -832,6 +837,10 @@ func (m *MTOShipmentWithoutServiceItems) ContextValidate(ctx context.Context, fo
 		res = append(res, err)
 	}
 
+	if err := m.contextValidateDiversionReason(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
 	if err := m.contextValidateETag(ctx, formats); err != nil {
 		res = append(res, err)
 	}
@@ -998,6 +1007,15 @@ func (m *MTOShipmentWithoutServiceItems) contextValidateDestinationType(ctx cont
 			}
 			return err
 		}
+	}
+
+	return nil
+}
+
+func (m *MTOShipmentWithoutServiceItems) contextValidateDiversionReason(ctx context.Context, formats strfmt.Registry) error {
+
+	if err := validate.ReadOnly(ctx, "diversionReason", "body", m.DiversionReason); err != nil {
+		return err
 	}
 
 	return nil

--- a/pkg/gen/primev3api/embedded_spec.go
+++ b/pkg/gen/primev3api/embedded_spec.go
@@ -1531,6 +1531,12 @@ func init() {
           "description": "This value indicates whether or not this shipment is part of a diversion. If yes, the shipment can be either the starting or ending segment of the diversion.\n",
           "type": "boolean"
         },
+        "diversionReason": {
+          "description": "The reason the TOO provided when requesting a diversion for this shipment.\n",
+          "type": "string",
+          "x-nullable": true,
+          "readOnly": true
+        },
         "eTag": {
           "description": "A hash unique to this shipment that should be used as the \"If-Match\" header for any updates.",
           "type": "string",
@@ -5013,6 +5019,12 @@ func init() {
         "diversion": {
           "description": "This value indicates whether or not this shipment is part of a diversion. If yes, the shipment can be either the starting or ending segment of the diversion.\n",
           "type": "boolean"
+        },
+        "diversionReason": {
+          "description": "The reason the TOO provided when requesting a diversion for this shipment.\n",
+          "type": "string",
+          "x-nullable": true,
+          "readOnly": true
         },
         "eTag": {
           "description": "A hash unique to this shipment that should be used as the \"If-Match\" header for any updates.",

--- a/pkg/gen/primev3messages/m_t_o_shipment_without_service_items.go
+++ b/pkg/gen/primev3messages/m_t_o_shipment_without_service_items.go
@@ -89,6 +89,11 @@ type MTOShipmentWithoutServiceItems struct {
 	//
 	Diversion bool `json:"diversion,omitempty"`
 
+	// The reason the TOO provided when requesting a diversion for this shipment.
+	//
+	// Read Only: true
+	DiversionReason *string `json:"diversionReason,omitempty"`
+
 	// A hash unique to this shipment that should be used as the "If-Match" header for any updates.
 	// Read Only: true
 	ETag string `json:"eTag,omitempty"`
@@ -824,6 +829,10 @@ func (m *MTOShipmentWithoutServiceItems) ContextValidate(ctx context.Context, fo
 		res = append(res, err)
 	}
 
+	if err := m.contextValidateDiversionReason(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
 	if err := m.contextValidateETag(ctx, formats); err != nil {
 		res = append(res, err)
 	}
@@ -990,6 +999,15 @@ func (m *MTOShipmentWithoutServiceItems) contextValidateDestinationType(ctx cont
 			}
 			return err
 		}
+	}
+
+	return nil
+}
+
+func (m *MTOShipmentWithoutServiceItems) contextValidateDiversionReason(ctx context.Context, formats strfmt.Registry) error {
+
+	if err := validate.ReadOnly(ctx, "diversionReason", "body", m.DiversionReason); err != nil {
+		return err
 	}
 
 	return nil

--- a/pkg/handlers/primeapi/payloads/model_to_payload.go
+++ b/pkg/handlers/primeapi/payloads/model_to_payload.go
@@ -515,6 +515,7 @@ func MTOShipmentWithoutServiceItems(mtoShipment *models.MTOShipment) *primemessa
 		CounselorRemarks:                 mtoShipment.CounselorRemarks,
 		Status:                           string(mtoShipment.Status),
 		Diversion:                        bool(mtoShipment.Diversion),
+		DiversionReason:                  mtoShipment.DiversionReason,
 		DeliveryAddressUpdate:            ShipmentAddressUpdate(mtoShipment.DeliveryAddressUpdate),
 		CreatedAt:                        strfmt.DateTime(mtoShipment.CreatedAt),
 		UpdatedAt:                        strfmt.DateTime(mtoShipment.UpdatedAt),

--- a/pkg/handlers/primeapiv2/payloads/model_to_payload.go
+++ b/pkg/handlers/primeapiv2/payloads/model_to_payload.go
@@ -463,6 +463,7 @@ func MTOShipmentWithoutServiceItems(mtoShipment *models.MTOShipment) *primev2mes
 		ActualSpouseProGearWeight:        handlers.FmtPoundPtr(mtoShipment.ActualSpouseProGearWeight),
 		Status:                           string(mtoShipment.Status),
 		Diversion:                        bool(mtoShipment.Diversion),
+		DiversionReason:                  mtoShipment.DiversionReason,
 		DeliveryAddressUpdate:            ShipmentAddressUpdate(mtoShipment.DeliveryAddressUpdate),
 		CreatedAt:                        strfmt.DateTime(mtoShipment.CreatedAt),
 		UpdatedAt:                        strfmt.DateTime(mtoShipment.UpdatedAt),

--- a/pkg/handlers/primeapiv3/payloads/model_to_payload.go
+++ b/pkg/handlers/primeapiv3/payloads/model_to_payload.go
@@ -471,6 +471,7 @@ func MTOShipmentWithoutServiceItems(mtoShipment *models.MTOShipment) *primev3mes
 		CounselorRemarks:                 mtoShipment.CounselorRemarks,
 		Status:                           string(mtoShipment.Status),
 		Diversion:                        bool(mtoShipment.Diversion),
+		DiversionReason:                  mtoShipment.DiversionReason,
 		DeliveryAddressUpdate:            ShipmentAddressUpdate(mtoShipment.DeliveryAddressUpdate),
 		CreatedAt:                        strfmt.DateTime(mtoShipment.CreatedAt),
 		UpdatedAt:                        strfmt.DateTime(mtoShipment.UpdatedAt),

--- a/src/components/PrimeUI/Shipment/Shipment.jsx
+++ b/src/components/PrimeUI/Shipment/Shipment.jsx
@@ -216,8 +216,12 @@ const Shipment = ({ shipment, moveId, onDelete, mtoServiceItems }) => {
         <dd>{shipment.diversion ? 'yes' : 'no'}</dd>
       </div>
       <div className={descriptionListStyles.row}>
+        <dt>Diversion Reason:</dt>
+        <dd>{shipment.diversionReason ? shipment.diversionReason : '—'}</dd>
+      </div>
+      <div className={descriptionListStyles.row}>
         <dt>Counselor Remarks:</dt>
-        <dd>{shipment.counselorRemarks}</dd>
+        <dd>{shipment.counselorRemarks ? shipment.counselorRemarks : '—'}</dd>
       </div>
       {shipment.ppmShipment && (
         <>

--- a/src/components/PrimeUI/Shipment/Shipment.test.jsx
+++ b/src/components/PrimeUI/Shipment/Shipment.test.jsx
@@ -187,6 +187,14 @@ describe('Shipment details component', () => {
     expect(field).toBeInTheDocument();
     expect(field.nextElementSibling.textContent).toBe(shipment.approvedDate);
 
+    field = screen.getByText('Diversion:');
+    expect(field).toBeInTheDocument();
+    expect(field.nextElementSibling.textContent).toBe('no');
+
+    field = screen.getByText('Diversion Reason:');
+    expect(field).toBeInTheDocument();
+    expect(field.nextElementSibling.textContent).toBe('—');
+
     field = screen.getByText('Counselor Remarks:');
     expect(field).toBeInTheDocument();
     expect(field.nextElementSibling.textContent).toBe(shipment.counselorRemarks);
@@ -220,6 +228,30 @@ describe('Shipment details component fields and values are present', () => {
     render(mockedComponent);
     await expect(screen.getByText(shipmentField)).toBeVisible();
     await expect(screen.getByText(shipmentFieldValue)).toBeVisible();
+  });
+});
+
+const divertedShipment = {
+  ...approvedMoveTaskOrder.moveTaskOrder.mtoShipments[0],
+  diversion: true,
+  diversionReason: 'Reasonable reason',
+};
+
+describe('Shipment has been diverted', () => {
+  it('renders the component with missing reweigh error', () => {
+    render(
+      <MockProviders>
+        <Shipment shipment={divertedShipment} moveId={moveId} />
+      </MockProviders>,
+    );
+
+    let field = screen.getByText('Diversion:');
+    expect(field).toBeInTheDocument();
+    expect(field.nextElementSibling.textContent).toBe('yes');
+
+    field = screen.getByText('Diversion Reason:');
+    expect(field).toBeInTheDocument();
+    expect(field.nextElementSibling.textContent).toBe(divertedShipment.diversionReason);
   });
 });
 

--- a/swagger-def/definitions/prime/MTOShipmentWithoutServiceItems.yaml
+++ b/swagger-def/definitions/prime/MTOShipmentWithoutServiceItems.yaml
@@ -184,6 +184,12 @@ properties:
       This value indicates whether or not this shipment is part of a diversion.
       If yes, the shipment can be either the starting or ending segment of the diversion.
     type: boolean
+  diversionReason:
+    description: >
+      The reason the TOO provided when requesting a diversion for this shipment.
+    type: string
+    x-nullable: true
+    readOnly: true
   status:
     description: >
       The status of a shipment, indicating where it is in the TOO's approval process.

--- a/swagger-def/definitions/prime/v2/MTOShipmentWithoutServiceItems.yaml
+++ b/swagger-def/definitions/prime/v2/MTOShipmentWithoutServiceItems.yaml
@@ -184,6 +184,12 @@ properties:
       This value indicates whether or not this shipment is part of a diversion.
       If yes, the shipment can be either the starting or ending segment of the diversion.
     type: boolean
+  diversionReason:
+    description: >
+      The reason the TOO provided when requesting a diversion for this shipment.
+    type: string
+    x-nullable: true
+    readOnly: true
   status:
     description: >
       The status of a shipment, indicating where it is in the TOO's approval process.

--- a/swagger-def/definitions/prime/v3/MTOShipmentWithoutServiceItems.yaml
+++ b/swagger-def/definitions/prime/v3/MTOShipmentWithoutServiceItems.yaml
@@ -172,6 +172,12 @@ properties:
       This value indicates whether or not this shipment is part of a diversion.
       If yes, the shipment can be either the starting or ending segment of the diversion.
     type: boolean
+  diversionReason:
+    description: >
+      The reason the TOO provided when requesting a diversion for this shipment.
+    type: string
+    x-nullable: true
+    readOnly: true
   status:
     description: >
       The status of a shipment, indicating where it is in the TOO's approval process.

--- a/swagger/prime.yaml
+++ b/swagger/prime.yaml
@@ -4418,6 +4418,13 @@ definitions:
           diversion. If yes, the shipment can be either the starting or ending
           segment of the diversion.
         type: boolean
+      diversionReason:
+        description: >
+          The reason the TOO provided when requesting a diversion for this
+          shipment.
+        type: string
+        x-nullable: true
+        readOnly: true
       status:
         description: >
           The status of a shipment, indicating where it is in the TOO's approval

--- a/swagger/prime_v2.yaml
+++ b/swagger/prime_v2.yaml
@@ -2813,6 +2813,13 @@ definitions:
           diversion. If yes, the shipment can be either the starting or ending
           segment of the diversion.
         type: boolean
+      diversionReason:
+        description: >
+          The reason the TOO provided when requesting a diversion for this
+          shipment.
+        type: string
+        x-nullable: true
+        readOnly: true
       status:
         description: >
           The status of a shipment, indicating where it is in the TOO's approval

--- a/swagger/prime_v3.yaml
+++ b/swagger/prime_v3.yaml
@@ -2726,6 +2726,13 @@ definitions:
           diversion. If yes, the shipment can be either the starting or ending
           segment of the diversion.
         type: boolean
+      diversionReason:
+        description: >
+          The reason the TOO provided when requesting a diversion for this
+          shipment.
+        type: string
+        x-nullable: true
+        readOnly: true
       status:
         description: >
           The status of a shipment, indicating where it is in the TOO's approval


### PR DESCRIPTION
## [Agility ticket](tbd)

## Summary

Is there anything you would like reviewers to give additional scrutiny?

[this article](tbd) explains more about the approach used.

## Verification Steps for the Author

These are to be checked by the author.

- [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
- [ ] Have the Agility acceptance criteria been met for this change?

## Verification Steps for Reviewers

These are to be checked by a reviewer.

- [ ] Has the branch been pulled in and checked out?
- [ ] Have the BL acceptance criteria been met for this change?
- [ ] Was the CircleCI build successful?
- [ ] Has the code been reviewed from a standards and best practices point of view?

### Setup to Run the Code

- [Instructions for starting storybook](https://transcom.github.io/mymove-docs/docs/frontend/setup/storybook)
- [Instructions for starting the MilMove application](https://transcom.github.io/mymove-docs/docs/getting-started/application-setup/)
- [Instructions for running tests](https://transcom.github.io/mymove-docs/docs/getting-started/development/testing)

### How to test

1. Access the
2. Login as a
3.

### Frontend

- [ ] There are no aXe warnings for UI.
- [ ] This works in [Supported Browsers and their phone views](https://transcom.github.io/mymove-docs/docs/adrs/Browser-Support/#minimum-browser-requirements) (Chrome, Firefox, Edge).
- [ ] There are no new console errors in the browser devtools.
- [ ] There are no new console errors in the test output.
- [ ] If this PR adds a new component to Storybook, it ensures the component is fully responsive, OR if it is intentionally not, a wrapping div using the `officeApp` class or custom `min-width` styling is used to hide any states the would not be visible to the user.
- [ ] This change meets the standards for [Section 508 compliance](https://www.ssa.gov/accessibility/andi/help/install.html).

### Backend

- [ ] Code follows the guidelines for [Logging](https://transcom.github.io/mymove-docs/docs/getting-started/development/logging).
- [ ] The requirements listed in [Querying the Database Safely](https://transcom.github.io/mymove-docs/docs/backend/guides/golang-guide#querying-the-database-safely) have been satisfied.

### Database

#### Any new migrations/schema changes:

- [ ] Follows our guidelines for [Zero-Downtime Deploys](https://transcom.github.io/mymove-docs/docs/backend/setup/database-migrations#zero-downtime-migrations).
- [ ] Have been communicated to #g-database.
- [ ] Secure migrations have been tested following the instructions in our [docs](https://transcom.github.io/mymove-docs/docs/backend/setup/database-migrations#secure-migrations).

## Screenshots
