### PR TITLE
INT-B-19980 Fixed issue with editable advance amount on PPM Closeout screen not updating "Remaining Incentive" value.

### DIFF
--- a/pkg/services/ppm_closeout/ppm_closeout.go
+++ b/pkg/services/ppm_closeout/ppm_closeout.go
@@ -73,7 +73,7 @@ func (p *ppmCloseoutFetcher) GetPPMCloseout(appCtx appcontext.AppContext, ppmShi
 		return &models.PPMCloseout{}, err
 	}
 	if ppmShipment.FinalIncentive != nil {
-		if *ppmShipment.HasRequestedAdvance && ppmShipment.AdvanceAmountReceived != nil {
+		if *ppmShipment.HasReceivedAdvance && ppmShipment.AdvanceAmountReceived != nil {
 			remainingIncentive = *ppmShipment.FinalIncentive - *ppmShipment.AdvanceAmountReceived
 		} else {
 			remainingIncentive = *ppmShipment.FinalIncentive


### PR DESCRIPTION
## [Agility ticket](https://www13.v1host.com/USTRANSCOM38/assetdetail.v1?number=B-19980)

## Related INT PR
#12959 

## Summary
The "Remaining Incentive" field on the PPM Closeout review screen was not being updated when the SC edited the "Amount Received" value, but only if the user did *not* request the advance during move setup. This is because the backend was checking for if the "advanceRequested" flag was true, but since a new PR has added this editable field, it is still possible for an advance to be given, even if the user did not request it.

It now checks for the "AdvanceReceived" flag instead.


### How to test
Follow the steps laid out in the INT PR above, but check that editing the "Advance Received" field forces a recalculation of the "Remaining Incentive" field 