### PR TITLE
MAIN I-13010 server_test flaky test fix

### DIFF
--- a/pkg/services/office_user/customer/customer_searcher_test.go
+++ b/pkg/services/office_user/customer/customer_searcher_test.go
@@ -166,7 +166,7 @@ func (suite CustomerServiceSuite) TestCustomerSearch() {
 		})
 		suite.NoError(err)
 		suite.Len(customers, 1)
-		suite.Equal(serviceMember1.Edipi, customers[0].Edipi)
+		suite.Equal(*serviceMember1.Edipi, *customers[0].Edipi)
 		suite.Equal(2, totalCount)
 
 		// get second page
@@ -177,7 +177,7 @@ func (suite CustomerServiceSuite) TestCustomerSearch() {
 		})
 		suite.NoError(err)
 		suite.Len(customers, 1)
-		suite.Equal(serviceMember2.Edipi, customers[0].Edipi)
+		suite.Equal(*serviceMember2.Edipi, *customers[0].Edipi)
 		suite.Equal(2, totalCount)
 	})
 


### PR DESCRIPTION
[INTEGRATION PR](https://github.com/transcom/mymove/pull/13061)

## [Issue ticket](https://www13.v1host.com/USTRANSCOM38/assetdetail.v1?number=I-13010)

## Summary

There was a frequent test failure in `pkg/services/office_user/customer/customer_searcher_test.go` that was causing re-running of builds. An issue was created to fix this.

It seems the error we were getting was on the line:
```
suite.Equal(serviceMember1.Edipi, customers[0].Edipi)
```
The error:
```
    customer_searcher_test.go:180: 
                Error Trace:    /home/circleci/transcom/mymove/pkg/services/office_user/customer/customer_searcher_test.go:180
                                                        /home/circleci/go/pkg/mod/github.com/stretchr/testify@v1.9.0/suite/suite.go:115
                Error:          Not equal: 
                                expected: (*string)(0xc000b53200)
                                actual  : (*string)(0xc000727d80)
                            
                                Diff:
                Test:           TestCustomerServiceSuite/TestCustomerSearch/test_pagination
```

Not using pointers was causing differences in the memory address locations, which was causing the test to fail. 
Changing that line to use pointers dereferences those values and instead compares strings.
```
suite.Equal(*serviceMember1.Edipi, *customers[0].Edipi)
```