### PR TITLE
B-19763 fixed logic to the code that was changed works

### DIFF
--- a/pkg/payment_request/service_param_value_lookups/distance_zip_lookup.go
+++ b/pkg/payment_request/service_param_value_lookups/distance_zip_lookup.go
@@ -22,6 +22,7 @@ type DistanceZipLookup struct {
 func (r DistanceZipLookup) lookup(appCtx appcontext.AppContext, keyData *ServiceItemParamKeyData) (string, error) {
 	planner := keyData.planner
 	db := appCtx.DB()
+	var distanceMiles int
 
 	// Make sure there's an MTOShipment since that's nullable
 	mtoShipmentID := keyData.mtoShipmentID
@@ -40,6 +41,11 @@ func (r DistanceZipLookup) lookup(appCtx appcontext.AppContext, keyData *Service
 		}
 	}
 
+	err = appCtx.DB().EagerPreload("DeliveryAddressUpdate", "DeliveryAddressUpdate.OriginalAddress", "DeliveryAddressUpdate.NewAddress", "MTOServiceItems", "Distance").Find(&mtoShipment, mtoShipment.ID)
+	if err != nil {
+		return "", err
+	}
+
 	// Now calculate the distance between zips
 	pickupZip := r.PickupAddress.PostalCode
 	destinationZip := r.DestinationAddress.PostalCode
@@ -55,11 +61,6 @@ func (r DistanceZipLookup) lookup(appCtx appcontext.AppContext, keyData *Service
 	serviceCode := keyData.MTOServiceItem.ReService.Code
 	switch serviceCode {
 	case models.ReServiceCodeDLH, models.ReServiceCodeDSH, models.ReServiceCodeFSC:
-		err := appCtx.DB().EagerPreload("DeliveryAddressUpdate", "DeliveryAddressUpdate.OriginalAddress", "DeliveryAddressUpdate.NewAddress", "MTOServiceItems", "Distance").Find(&mtoShipment, mtoShipment.ID)
-		if err != nil {
-			return "", err
-		}
-
 		for _, si := range mtoShipment.MTOServiceItems {
 			siCopy := si
 			err := appCtx.DB().EagerPreload("ReService", "ApprovedAt").Find(&siCopy, siCopy.ID)
@@ -78,13 +79,20 @@ func (r DistanceZipLookup) lookup(appCtx appcontext.AppContext, keyData *Service
 				}
 			}
 		}
+
+		if mtoShipment.DeliveryAddressUpdate != nil && mtoShipment.DeliveryAddressUpdate.Status == models.ShipmentAddressUpdateStatusApproved {
+			distanceMiles, err = planner.ZipTransitDistance(appCtx, pickupZip, mtoShipment.DeliveryAddressUpdate.NewAddress.PostalCode)
+			if err != nil {
+				return "", err
+			}
+			return strconv.Itoa(distanceMiles), nil
+		}
 	}
 
 	if mtoShipment.Distance != nil && mtoShipment.ShipmentType != models.MTOShipmentTypePPM {
 		return strconv.Itoa(mtoShipment.Distance.Int()), nil
 	}
 
-	var distanceMiles int
 	if pickupZip == destinationZip {
 		distanceMiles = 1
 	} else {


### PR DESCRIPTION
There was a minor code change that cause some functionality of the previous code changes to not work. Please test these steps:

1. Make a HHG move as basic user and approve/send as SC.
2. Approve the move as TOO.
3. As Prime, update the shipment so that you have dates and shipment weights.
4. As Prime, create payment requests for Linehaul and FSC.
5. As TOO or TIO review the Payment Request (destination ZIP and mileage).
6. As Prime, update the destination address of the shipment.
7. As TOO approve the updated destination address of the shipment.
8. As Prime, create a new Payment Request for Linehaul and FSC.
9. As TOO or TIO review the newly created Payment Request to have a new Destination ZIP as well as mileage to reflect the changed shipment address.