### PR TITLE
B-19926 split hhg and nts loas

### DIFF
--- a/src/components/Office/OrdersDetailForm/OrdersDetailForm.jsx
+++ b/src/components/Office/OrdersDetailForm/OrdersDetailForm.jsx
@@ -14,11 +14,12 @@ const OrdersDetailForm = ({
   ordersTypeOptions,
   ordersTypeDetailOptions,
   hhgTacWarning,
-  loaWarning,
+  hhgLoaWarning,
+  ntsLoaWarning,
   ntsTacWarning,
   validateHHGTac,
   validateNTSTac,
-  validateLOA,
+  validateHHGLoa,
   showDepartmentIndicator,
   showOrdersNumber,
   showOrdersTypeDetail,
@@ -26,13 +27,14 @@ const OrdersDetailForm = ({
   showHHGSac,
   showNTSTac,
   showNTSSac,
-  showLoa,
+  showHHGLoa,
+  showNTSLoa,
   showOrdersAcknowledgement,
   ordersType,
   setFieldValue,
   payGradeOptions,
   formIsDisabled,
-  longLineOfAccounting,
+  hhgLongLineOfAccounting,
 }) => {
   const [formOrdersType, setFormOrdersType] = useState(ordersType);
   const reportDateRowLabel = formatLabelReportByDate(formOrdersType);
@@ -117,6 +119,20 @@ const OrdersDetailForm = ({
           optional
         />
       )}
+      {showHHGTac && showHHGLoa && (
+        <TextField
+          name="hhgLoa"
+          label="LOA"
+          id="hhgLoaTextField"
+          mask="****"
+          inputTestId="hhgLoaTextField"
+          data-testid="hhgLoaTextField"
+          warning={hhgLoaWarning}
+          validate={validateHHGLoa}
+          value={hhgLongLineOfAccounting}
+          isDisabled
+        />
+      )}
 
       {showNTSTac && showNTSSac && <h3>NTS accounting codes</h3>}
       {showNTSTac && (
@@ -142,19 +158,17 @@ const OrdersDetailForm = ({
           optional
         />
       )}
-
-      {showLoa && <h3>Line of Accounting Preview</h3>}
-      {showLoa && (
+      {/* This is a placeholder NTS TAC holder */}
+      {/* A future ticket will be placed to add NTS lookup logic on the backend and then it will display here */}
+      {showNTSTac && showNTSLoa && (
         <TextField
-          name="loa"
+          name="ntsLoa"
           label="LOA"
-          id="loaTextField"
+          id="ntsLoaTextField"
           mask="****"
-          inputTestId="loaTextField"
-          data-testid="loaTextField"
-          warning={loaWarning}
-          validate={validateLOA}
-          value={longLineOfAccounting}
+          inputTestId="ntsLoaTextField"
+          warning={ntsLoaWarning}
+          data-testid="ntsLoaTextField"
           isDisabled
         />
       )}
@@ -179,7 +193,8 @@ OrdersDetailForm.propTypes = {
   ordersTypeDetailOptions: DropdownArrayOf,
   hhgTacWarning: string,
   ntsTacWarning: string,
-  loaWarning: string,
+  hhgLoaWarning: string,
+  ntsLoaWarning: string,
   validateHHGTac: func,
   validateNTSTac: func,
   showDepartmentIndicator: bool,
@@ -188,20 +203,22 @@ OrdersDetailForm.propTypes = {
   showHHGTac: bool,
   showHHGSac: bool,
   showNTSTac: bool,
-  showLoa: bool,
+  showHHGLoa: bool,
+  showNTSLoa: bool,
   showNTSSac: bool,
   showOrdersAcknowledgement: bool,
   ordersType: string.isRequired,
   setFieldValue: func.isRequired,
   payGradeOptions: DropdownArrayOf,
   formIsDisabled: bool,
-  longLineOfAccounting: string,
+  hhgLongLineOfAccounting: string,
 };
 
 OrdersDetailForm.defaultProps = {
   hhgTacWarning: '',
   ntsTacWarning: '',
-  loaWarning: '',
+  hhgLoaWarning: '',
+  ntsLoaWarning: '',
   deptIndicatorOptions: null,
   ordersTypeDetailOptions: null,
   validateHHGTac: null,
@@ -212,12 +229,13 @@ OrdersDetailForm.defaultProps = {
   showHHGTac: true,
   showHHGSac: true,
   showNTSTac: true,
-  showLoa: true,
+  showHHGLoa: true,
+  showNTSLoa: true,
   showNTSSac: true,
   showOrdersAcknowledgement: false,
   payGradeOptions: null,
   formIsDisabled: false,
-  longLineOfAccounting: '',
+  hhgLongLineOfAccounting: '',
 };
 
 export default OrdersDetailForm;

--- a/src/components/Office/OrdersDetailForm/OrdersDetailForm.stories.jsx
+++ b/src/components/Office/OrdersDetailForm/OrdersDetailForm.stories.jsx
@@ -92,7 +92,7 @@ export const EmptyValues = () => (
           setFieldValue={Formik.setFieldValue}
           payGrade={ORDERS_PAY_GRADE_OPTIONS.E_1}
           payGradeOptions={payGradeOptions}
-          longLineOfAccounting={longLineOfAccounting}
+          hhgLongLineOfAccounting={longLineOfAccounting}
         />
       </form>
     </Formik>

--- a/src/components/Office/OrdersDetailForm/OrdersDetailForm.test.jsx
+++ b/src/components/Office/OrdersDetailForm/OrdersDetailForm.test.jsx
@@ -53,7 +53,7 @@ const defaultProps = {
   ordersType: 'PERMANENT_CHANGE_OF_STATION',
   setFieldValue: jest.fn,
   payGradeOptions,
-  longLineOfAccounting: 'Long line of accounting is present',
+  hhgLongLineOfAccounting: 'Long line of accounting is present',
 };
 
 function renderOrdersDetailForm(props) {
@@ -102,7 +102,7 @@ describe('OrdersDetailForm', () => {
 
   it('accepts longLineOfAccounting prop', async () => {
     renderOrdersDetailForm();
-    const loaTextField = screen.getByTestId('loaTextField');
+    const loaTextField = screen.getByTestId('hhgLoaTextField');
     expect(loaTextField).toHaveValue('Long line of accounting is present');
   });
 
@@ -112,7 +112,7 @@ describe('OrdersDetailForm', () => {
   });
 
   it('shows the loa warning', async () => {
-    renderOrdersDetailForm({ loaWarning: 'Test LOA warning' });
+    renderOrdersDetailForm({ hhgLoaWarning: 'Test LOA warning' });
     expect(await screen.findByText('Test LOA warning')).toBeInTheDocument();
   });
 

--- a/src/pages/Office/Orders/Orders.jsx
+++ b/src/pages/Office/Orders/Orders.jsx
@@ -259,14 +259,14 @@ const Orders = () => {
           const hhgTacWarning = tacValidationState[LOA_TYPE.HHG].isValid ? '' : tacWarningMsg;
           const ntsTacWarning = tacValidationState[LOA_TYPE.NTS].isValid ? '' : tacWarningMsg;
           // Conditionally set the LOA warning message based on off if it is missing or just invalid
-          const isLoaMissing = loaValidationState.loa === null || loaValidationState.loa === undefined;
-          let loaWarning = '';
+          const isHHGLoaMissing = loaValidationState.loa === null || loaValidationState.loa === undefined;
+          let hhgLoaWarning = '';
           // Making a nested ternary here goes against linter rules
           // The primary warning should be if it is missing, the other warning should be if it is invalid
-          if (isLoaMissing) {
-            loaWarning = loaMissingWarningMsg;
+          if (isHHGLoaMissing) {
+            hhgLoaWarning = loaMissingWarningMsg;
           } else if (!loaValidationState.isValid) {
-            loaWarning = loaInvalidWarningMsg;
+            hhgLoaWarning = loaInvalidWarningMsg;
           }
 
           return (
@@ -311,11 +311,11 @@ const Orders = () => {
                         ntsTacWarning={ntsTacWarning}
                         validateHHGTac={handleHHGTacValidation}
                         validateNTSTac={handleNTSTacValidation}
-                        loaWarning={loaWarning}
-                        validateLOA={() =>
+                        hhgLoaWarning={hhgLoaWarning}
+                        validateHHGLoa={() =>
                           handleLoaValidation(formik.values)
                         } /* loa validation requires access to the formik values scope */
-                        longLineOfAccounting={loaValidationState.longLineOfAccounting}
+                        hhgLongLineOfAccounting={loaValidationState.longLineOfAccounting}
                         showOrdersAcknowledgement={hasAmendedOrders}
                         ordersType={order.order_type}
                         setFieldValue={formik.setFieldValue}
@@ -332,11 +332,11 @@ const Orders = () => {
                       ntsTacWarning={ntsTacWarning}
                       validateHHGTac={handleHHGTacValidation}
                       validateNTSTac={handleNTSTacValidation}
-                      loaWarning={loaWarning}
-                      validateLOA={() =>
+                      hhgLoaWarning={hhgLoaWarning}
+                      validateHHGLoa={() =>
                         handleLoaValidation(formik.values)
                       } /* loa validation requires access to the formik values scope */
-                      longLineOfAccounting={loaValidationState.longLineOfAccounting}
+                      hhgLongLineOfAccounting={loaValidationState.longLineOfAccounting}
                       showOrdersAcknowledgement={hasAmendedOrders}
                       ordersType={order.order_type}
                       setFieldValue={formik.setFieldValue}

--- a/src/pages/Office/Orders/Orders.test.jsx
+++ b/src/pages/Office/Orders/Orders.test.jsx
@@ -306,7 +306,7 @@ describe('Orders page', () => {
       const expectedLongLineOfAccounting =
         '1**20062016*1234*0000**1A*123A**00000000*********22NL***000000*HHG12345678900**12345***PERSONAL PROPERTY - PARANORMAL ACTIVITY DIVISION (OTHER)';
 
-      const loaTextField = screen.getByTestId('loaTextField');
+      const loaTextField = screen.getByTestId('hhgLoaTextField');
       expect(loaTextField).toHaveValue(expectedLongLineOfAccounting);
     });
   });

--- a/src/pages/Office/ServicesCounselingOrders/ServicesCounselingOrders.jsx
+++ b/src/pages/Office/ServicesCounselingOrders/ServicesCounselingOrders.jsx
@@ -261,14 +261,14 @@ const ServicesCounselingOrders = ({ hasDocuments }) => {
           const hhgTacWarning = tacValidationState[LOA_TYPE.HHG].isValid ? '' : tacWarningMsg;
           const ntsTacWarning = tacValidationState[LOA_TYPE.NTS].isValid ? '' : tacWarningMsg;
           // Conditionally set the LOA warning message based on off if it is missing or just invalid
-          const isLoaMissing = loaValidationState.loa === null || loaValidationState.loa === undefined;
-          let loaWarning = '';
+          const isHHGLoaMissing = loaValidationState.loa === null || loaValidationState.loa === undefined;
+          let hhgLoaWarning = '';
           // Making a nested ternary here goes against linter rules
           // The primary warning should be if it is missing, the other warning should be if it is invalid
-          if (isLoaMissing) {
-            loaWarning = loaMissingWarningMsg;
+          if (isHHGLoaMissing) {
+            hhgLoaWarning = loaMissingWarningMsg;
           } else if (!loaValidationState.isValid) {
-            loaWarning = loaInvalidWarningMsg;
+            hhgLoaWarning = loaInvalidWarningMsg;
           }
 
           return (
@@ -319,14 +319,14 @@ const ServicesCounselingOrders = ({ hasDocuments }) => {
                     setFieldValue={formik.setFieldValue}
                     hhgTacWarning={hhgTacWarning}
                     ntsTacWarning={ntsTacWarning}
-                    loaWarning={loaWarning}
+                    hhgLoaWarning={hhgLoaWarning}
                     validateHHGTac={handleHHGTacValidation}
-                    validateLOA={() =>
+                    validateHHGLoa={() =>
                       handleLoaValidation(formik.values)
                     } /* loa validation requires access to the formik values scope */
                     validateNTSTac={handleNTSTacValidation}
                     payGradeOptions={payGradeDropdownOptions}
-                    longLineOfAccounting={loaValidationState.longLineOfAccounting}
+                    hhgLongLineOfAccounting={loaValidationState.longLineOfAccounting}
                   />
                 </div>
                 <div className={styles.bottom}>

--- a/src/pages/Office/ServicesCounselingOrders/ServicesCounselingOrders.test.jsx
+++ b/src/pages/Office/ServicesCounselingOrders/ServicesCounselingOrders.test.jsx
@@ -387,7 +387,7 @@ describe('Orders page', () => {
       const expectedLongLineOfAccounting =
         '1**20062016*1234*0000**1A*123A**00000000*********22NL***000000*HHG12345678900**12345***PERSONAL PROPERTY - PARANORMAL ACTIVITY DIVISION (OTHER)';
 
-      const loaTextField = screen.getByTestId('loaTextField');
+      const loaTextField = screen.getByTestId('hhgLoaTextField');
       expect(loaTextField).toHaveValue(expectedLongLineOfAccounting);
     });
   });


### PR DESCRIPTION
## [B-19926](https://www13.v1host.com/USTRANSCOM38/story.mvc/Summary?oidToken=Story%3A948238)

> [!IMPORTANT]
> This is the second PR for B-19926. This is an enhancement based on details that were not covered via the AC, but were small enough to include for better UX
[First integration PR](https://github.com/transcom/mymove/pull/13071)

## Details
Splits NTS and HHG LOAs

## NTS and PO

The "NTS" portion of the LOA does not function at this time, and the PO is aware. Dan mentioned to seek creation of a new ticket to configure the NTS side, our service logic might already support it, but we do not know the full business logic details so we can't confirm whether or not we can just pass in "current date" into the "orders issue date" portion of the query.

Apparently NTS may just replace "Orders issue date" with "current date", if this is the case and all the rest of the business logic matches the HHG LOA, then our endpoint will already support NTS and setting up the frontend portion will be super easy.

## Screenshot
![image](https://github.com/transcom/mymove/assets/136814362/bc2f1e8b-8038-4355-a1b4-ae0698811043)


## Testing

1. Log into milmovelocal
2. Create a new move and HHG shipment
3. Write down the move locator
4. Log into officelocal as a service counselor
5. Navigate to the move -> edit orders
6. Fill out the orders like so:
7. Issue date: 2014-01-01
8. Department: ARMY
9. TAC: E12A
10. Upon filling out the above, the LOA preview at the bottom should populate (Subject to change based on randomly generated seed data)
11. Save the form if you see the LOA preview populate
12. Switch to TIO/TOO
13. Navigate to the move
14. Open edit orders -> the LOA should populate successfully without you touching anything

In order to test the error going away, please fill in ALL LOA fields within the dev db. If all fields are present (Specifically DFAS elements), then the error will also go away from the frontend after a new lookup is performed and the service object updates the isValid booleans