### PR TITLE
B19228 int 20240618 - Fix sidebar text spilling paste in the page in MTO page

### DIFF
--- a/src/components/Office/ShipmentDetails/ShipmentDetails.module.scss
+++ b/src/components/Office/ShipmentDetails/ShipmentDetails.module.scss
@@ -24,6 +24,7 @@
 }
 .ShipmentDetailsSidebar {
   flex-grow: 1;
+  min-width: 260px;
 
   > section {
     @include u-margin-bottom(1.5);

--- a/src/components/Office/ShipmentDetails/ShipmentDetailsSidebar.jsx
+++ b/src/components/Office/ShipmentDetails/ShipmentDetailsSidebar.jsx
@@ -189,7 +189,7 @@ const ShipmentDetailsSidebar = ({
           border
         >
           {tacType && tac && <div>TAC: {formatAccountingCode(tac, tacType)}</div>}
-          {sacType && sac && <div>SAC: {formatAccountingCode(sac, sacType)}</div>}
+          {sacType && sac && <div className={styles.accounting_code}>SAC: {formatAccountingCode(sac, sacType)}</div>}
         </SimpleSection>
       )}
 

--- a/src/components/Office/ShipmentDetails/ShipmentDetailsSidebar.module.scss
+++ b/src/components/Office/ShipmentDetails/ShipmentDetailsSidebar.module.scss
@@ -10,3 +10,7 @@
 .MtoAgentSection {
   word-break: break-all;
 }
+
+.accounting_code {
+  overflow-wrap: anywhere;
+}


### PR DESCRIPTION
## Agility ticket
[B19228](https://www13.v1host.com/USTRANSCOM38/assetdetail.v1?number=B-19228)

## Summary

In "Review Documents" page in the "Summary", “Authorized Receipt Total” was changed to “Accepted Receipt Totals”.

### How to test

* Customer:  create a PPM move.
* SC: login and approve it.
* Customer: Upload PPM documents.  Upload expense receipts.
* SC: Review Documents.  Get to the summary screen.  Will see “Accepted Receipt Totals”.

## Screenshots
![image](https://github.com/transcom/mymove/assets/146897935/e79a2d09-59d3-45c0-8160-ef4b5ac2b7f1)