### PR TITLE
Fix flaky happy path with edits and backs test in PPM closeout flow #2

### DIFF
--- a/playwright/tests/my/milmove/ppms/customerPpmTestFixture.js
+++ b/playwright/tests/my/milmove/ppms/customerPpmTestFixture.js
@@ -870,7 +870,6 @@ export class CustomerPpmPage extends CustomerPage {
    */
   async navigateFromCloseoutReviewPageToExpensesPage() {
     await this.page.getByRole('link', { name: 'Add Expenses' }).click();
-    await this.page.waitForURL(/\/moves\/[^/]+\/shipments\/[^/]+\/expenses/);
   }
 
   /**


### PR DESCRIPTION
Trying one more small fix, but think the problem could also be related to https://github.com/microsoft/playwright/issues/12182.

The `happy path with edits and backs` for the `PPM closeout flow` passed, but the  `flows through happy path for existing shipment` test failed. Trying another small fix, very slight performance increase. Locally, running `npx playwright test --workers=1 --shard=3/10` passes even when failing on circle, so still not sure this'll fix it.

Failed test:
![image](https://github.com/transcom/mymove/assets/147537467/aecac6c6-b824-467a-bda1-8be371f44d46)

Before change, running `npx playwright test --workers=1 --shard=3/10`:
![image](https://github.com/transcom/mymove/assets/147537467/a0c02995-1784-4cb1-a40c-1653a01fcc45)

After:
![image](https://github.com/transcom/mymove/assets/147537467/7af9cd31-93ad-4804-9fc4-1ae76f38635b)
