### PR TITLE
B-20320 Update LOA string and validity checks INT

### DIFF
--- a/pkg/services/line_of_accounting/line_of_accounting_fetcher.go
+++ b/pkg/services/line_of_accounting/line_of_accounting_fetcher.go
@@ -94,6 +94,15 @@ func checkForValidHhgProgramCodeForLoaAndValidLoaForTac(linesOfAccounting []mode
 		if loa.LoaTnsfrDptNm == nil { // Transfer from Department (A2)
 			missingLoaFields = append(missingLoaFields, "loa.LoaTnsfrDptNm")
 		}
+		if loa.LoaBgFyTx == nil || loa.LoaEndFyTx == nil { // Ending Fiscal Year Indicator (A3)
+			// A3 is a concatenation of both LoaBgFyTx and LoaEndFyTx
+			if loa.LoaBgFyTx == nil {
+				missingLoaFields = append(missingLoaFields, "loa.LoaBgFyTx")
+			}
+			if loa.LoaEndFyTx == nil {
+				missingLoaFields = append(missingLoaFields, "loa.LoaEndFyTx")
+			}
+		}
 		if loa.LoaBafID == nil { // Basic Symbol Number (A4)
 			missingLoaFields = append(missingLoaFields, "loa.LoaBafID")
 		}
@@ -108,6 +117,9 @@ func checkForValidHhgProgramCodeForLoaAndValidLoaForTac(linesOfAccounting []mode
 		}
 		if loa.LoaAlltSnID == nil { // Allotment Serial Number (B2)
 			missingLoaFields = append(missingLoaFields, "loa.LoaAlltSnID")
+		}
+		if loa.LoaUic == nil { // Activity Address Code/UIC (B3)
+			missingLoaFields = append(missingLoaFields, "loa.LoaUic")
 		}
 		if loa.LoaPgmElmntID == nil { // Program Element (C1)
 			missingLoaFields = append(missingLoaFields, "loa.LoaPgmElmntID")
@@ -160,23 +172,11 @@ func checkForValidHhgProgramCodeForLoaAndValidLoaForTac(linesOfAccounting []mode
 		if loa.LoaLclInstlID == nil { // Local Installation Data (M1)
 			missingLoaFields = append(missingLoaFields, "loa.LoaLclInstlID")
 		}
-		if loa.LoaFmsTrnsactnID == nil { // Transaction Type (N1)
+		if loa.LoaTrnsnID == nil { // Transaction ID (N1)
+			missingLoaFields = append(missingLoaFields, "loa.LoaTrnsnID")
+		}
+		if loa.LoaFmsTrnsactnID == nil { // Transaction Type (P5)
 			missingLoaFields = append(missingLoaFields, "loa.LoaFmsTrnsactnID")
-		}
-		if loa.LoaDscTx == nil { // Foreign Military Sales (FMS) Line Item Number (P5)
-			missingLoaFields = append(missingLoaFields, "loa.LoaDscTx")
-		}
-		if loa.LoaUic == nil { // Activity Address Code/UIC (B3)
-			missingLoaFields = append(missingLoaFields, "loa.LoaUic")
-		}
-		if loa.LoaBgFyTx == nil || loa.LoaEndFyTx == nil { // Ending Fiscal Year Indicator (A3)
-			// A3 is a concatenation of both LoaBgFyTx and LoaEndFyTx
-			if loa.LoaBgFyTx == nil {
-				missingLoaFields = append(missingLoaFields, "loa.LoaBgFyTx")
-			}
-			if loa.LoaEndFyTx == nil {
-				missingLoaFields = append(missingLoaFields, "loa.LoaEndFyTx")
-			}
 		}
 
 		if missingLoaFields != nil {

--- a/pkg/services/line_of_accounting/line_of_accounting_fetcher_test.go
+++ b/pkg/services/line_of_accounting/line_of_accounting_fetcher_test.go
@@ -234,7 +234,7 @@ func (suite *LineOfAccountingServiceSuite) TestFetchOrderLineOfAccountings() {
 					LoaInstlAcntgActID:     models.StringPointer("1"),
 					LoaLclInstlID:          models.StringPointer("1"),
 					LoaFmsTrnsactnID:       models.StringPointer("1"),
-					LoaDscTx:               models.StringPointer("1"),
+					LoaTrnsnID:             models.StringPointer("1"),
 					LoaUic:                 models.StringPointer("1"),
 					LoaBgFyTx:              &loaFY,
 					LoaEndFyTx:             &loaFY,

--- a/src/pages/Office/Orders/Orders.test.jsx
+++ b/src/pages/Office/Orders/Orders.test.jsx
@@ -304,7 +304,7 @@ describe('Orders page', () => {
       await userEvent.type(hhgTacInput, '1111');
 
       const expectedLongLineOfAccounting =
-        '1**20062016*1234*0000**1A*123A**00000000*********22NL***000000*HHG12345678900**12345***PERSONAL PROPERTY - PARANORMAL ACTIVITY DIVISION (OTHER)';
+        '1**20062016*1234*0000**1A*123A**00000000*********22NL***000000*HHG12345678900**12345**B1*';
 
       const loaTextField = screen.getByTestId('hhgLoaTextField');
       expect(loaTextField).toHaveValue(expectedLongLineOfAccounting);

--- a/src/pages/Office/ServicesCounselingOrders/ServicesCounselingOrders.test.jsx
+++ b/src/pages/Office/ServicesCounselingOrders/ServicesCounselingOrders.test.jsx
@@ -385,7 +385,7 @@ describe('Orders page', () => {
       await userEvent.type(hhgTacInput, '1111');
 
       const expectedLongLineOfAccounting =
-        '1**20062016*1234*0000**1A*123A**00000000*********22NL***000000*HHG12345678900**12345***PERSONAL PROPERTY - PARANORMAL ACTIVITY DIVISION (OTHER)';
+        '1**20062016*1234*0000**1A*123A**00000000*********22NL***000000*HHG12345678900**12345**B1*';
 
       const loaTextField = screen.getByTestId('hhgLoaTextField');
       expect(loaTextField).toHaveValue(expectedLongLineOfAccounting);

--- a/src/types/lineOfAccounting.js
+++ b/src/types/lineOfAccounting.js
@@ -95,6 +95,6 @@ export const LineOfAccountingDfasElementOrder = [
   'loaClsRefID', // K6
   'loaInstlAcntgActID', // L1
   'loaLclInstlID', // M1
-  'loaFmsTrnsactnID', // N1
-  'loaDscTx', // P5
+  'loaTrnsnID', // N1
+  'loaFmsTrnsactnID', // P5
 ];


### PR DESCRIPTION
## [Agility ticket](https://www13.v1host.com/USTRANSCOM38/assetdetail.v1?number=B-20320)

## Summary

Modified the fields that get concatenated together to form the long LOA string shown on the Edit Orders page.

Previously, we were using the `loa_dsc_tx` value for the `P5 FMS Line Item Number`.
![image](https://github.com/transcom/mymove/assets/147537467/ef3b753c-d1f1-4386-85f9-09df81c98c3f)

Our PO realized this was inaccurate and provided an updated crosswalk to use as a map:
![image](https://github.com/transcom/mymove/assets/147537467/7b145670-a9cc-4504-91f8-88d29dec6f4f)

Changes:
`loa_fms_trnsactn_id`
- Previous: `N1`
- New: `P5`

`loa_dsc_tx`
- no longer part of long LOA string

`loa_trnsn_id`
- Previous: wasn't part of long LOA string
- New: `N1`, taking the place of `loa_fms_trnsactn_id`


Validity Check Changes:
The DFAS elements are all checked in order to determine whether the LOA is valid for a given TAC. I updated the fields checked to match the updated DFAS crosswalk, replacing the `loa.LoaDscTx == nil` check with `loa.LoaTrnsnID == nil`.


## To Test:
Log into officelocal as a service counselor
Navigate to the move -> edit orders
Fill out the orders like so:
Issue date: 2014-01-01
Department: ARMY
TAC: E12A
Upon filling out the above, the LOA preview at the bottom should populate

Verify in that LOA field that you no longer see any mention of "PARANORMAL ACTIVITY" or a long string like that The last few elements of the string are what changed.


Previous example string:
`'1**20062016*1234*0000**1A*123A**00000000*********22NL***000000*HHG12345678900**12345***PERSONAL PROPERTY - PARANORMAL ACTIVITY DIVISION (OTHER)'`

New example: `'1**20062016*1234*0000**1A*123A**00000000*********22NL***000000*HHG12345678900**12345**B1*'`