### PR TITLE
B-20334 I-13046 Remove extra spaces from LOA string INT

### DIFF
--- a/src/pages/Office/Orders/Orders.jsx
+++ b/src/pages/Office/Orders/Orders.jsx
@@ -85,7 +85,10 @@ const Orders = () => {
       }
       return loa[key] || '';
     });
-    return dfasMap.join('*');
+    let longLoa = dfasMap.join('*');
+    // remove any number of spaces following an asterisk in a LOA string
+    longLoa = longLoa.replace(/\* +/g, '*');
+    return longLoa;
   };
 
   const { mutate: validateLoa } = useMutation(getLoa, {

--- a/src/pages/Office/ServicesCounselingOrders/ServicesCounselingOrders.jsx
+++ b/src/pages/Office/ServicesCounselingOrders/ServicesCounselingOrders.jsx
@@ -105,7 +105,10 @@ const ServicesCounselingOrders = ({ hasDocuments }) => {
       }
       return loa[key] || '';
     });
-    return dfasMap.join('*');
+    let longLoa = dfasMap.join('*');
+    // remove any number of spaces following an asterisk in a LOA string
+    longLoa = longLoa.replace(/\* +/g, '*');
+    return longLoa;
   };
 
   const { mutate: validateLoa } = useMutation(getLoa, {


### PR DESCRIPTION
## [Agility ticket](https://www13.v1host.com/USTRANSCOM38/assetdetail.v1?number=B-20334)

## [Issue ticket](https://www13.v1host.com/USTRANSCOM38/Issue.mvc/Summary?oidToken=Issue%3A976447)

## Summary

Cleaned up the LOA string shown in the UI. Was showing blank spaces between asterisks in the staging environment which we don't want.

![image](https://github.com/transcom/mymove/assets/147537467/81e94303-6ae6-4c82-b5fd-bd63837b419e)

The cleaned up string should match an example from a previous 858:
![image](https://github.com/transcom/mymove/assets/147537467/70b813c7-13c6-423d-b977-1482f9c9e4eb)

To test:
In the staging environment, will need to test with:
issue date = 01 May 2024
Dept Ind = Navy and Marine Corps
TAC = NAD4

It should spit out the cleaned up version of the string.