### PR TITLE
INT B-20012 Styling Fix

### DIFF
--- a/src/components/Office/GblocSwitcher/GblocSwitcher.module.scss
+++ b/src/components/Office/GblocSwitcher/GblocSwitcher.module.scss
@@ -10,6 +10,10 @@ div.switchGblocButton {
     background-color: $mm-blue;
     border-color: transparent;
     line-height: 1;
+
+    option {
+      background-color: $bg-white;
+    }
   }
 
   select:hover, select:focus {

--- a/src/pages/Office/ServicesCounselingQueue/ServicesCounselingQueue.jsx
+++ b/src/pages/Office/ServicesCounselingQueue/ServicesCounselingQueue.jsx
@@ -164,6 +164,9 @@ export const counselingColumns = (moveLockFlag, originLocationList, supervisor) 
         {
           id: 'originDutyLocation',
           isFilterable: true,
+          exportValue: (row) => {
+            return row.originDutyLocation?.name;
+          },
           Filter: (props) => (
             <MultiSelectTypeAheadCheckBoxFilter
               options={originLocationList}
@@ -177,6 +180,9 @@ export const counselingColumns = (moveLockFlag, originLocationList, supervisor) 
     : createHeader('Origin duty location', 'originDutyLocation.name', {
         id: 'originDutyLocation',
         isFilterable: true,
+        exportValue: (row) => {
+          return row.originDutyLocation?.name;
+        },
       }),
 ];
 export const closeoutColumns = (moveLockFlag, ppmCloseoutGBLOC, ppmCloseoutOriginLocationList, supervisor) => [
@@ -295,6 +301,9 @@ export const closeoutColumns = (moveLockFlag, ppmCloseoutGBLOC, ppmCloseoutOrigi
         {
           id: 'originDutyLocation',
           isFilterable: true,
+          exportValue: (row) => {
+            return row.originDutyLocation?.name;
+          },
           Filter: (props) => (
             <MultiSelectTypeAheadCheckBoxFilter
               options={ppmCloseoutOriginLocationList}
@@ -308,6 +317,9 @@ export const closeoutColumns = (moveLockFlag, ppmCloseoutGBLOC, ppmCloseoutOrigi
     : createHeader('Origin duty location', 'originDutyLocation.name', {
         id: 'originDutyLocation',
         isFilterable: true,
+        exportValue: (row) => {
+          return row.originDutyLocation?.name;
+        },
       }),
   createHeader('Destination duty location', 'destinationDutyLocation.name', {
     id: 'destinationDutyLocation',


### PR DESCRIPTION
## [B-20012](https://www13.v1host.com/USTRANSCOM38/assetdetail.v1?number=B-20012)
## Summary

Updates the <option> elements in the GBLOC switcher dropdown to have a background color of white, only affect Windows. 

[this article](tbd) explains more about the approach used.

## Verification Steps for the Author

These are to be checked by the author.

- [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
- [ ] Have the Agility acceptance criteria been met for this change?

## Verification Steps for Reviewers

These are to be checked by a reviewer.

- [ ] Has the branch been pulled in and checked out?
- [ ] Have the BL acceptance criteria been met for this change?
- [ ] Was the CircleCI build successful?
- [ ] Has the code been reviewed from a standards and best practices point of view?

### Setup to Run the Code

- [Instructions for starting storybook](https://transcom.github.io/mymove-docs/docs/frontend/setup/storybook)
- [Instructions for starting the MilMove application](https://transcom.github.io/mymove-docs/docs/getting-started/application-setup/)
- [Instructions for running tests](https://transcom.github.io/mymove-docs/docs/getting-started/development/testing)

### How to test

1. Access the Office app as an HQ user
2. Inspect the GBLOC switcher
3. Verify the <option> elements within it have a styling appilied to them that includes `background-color: white`

### Frontend

- [ ] There are no aXe warnings for UI.
- [ ] This works in [Supported Browsers and their phone views](https://transcom.github.io/mymove-docs/docs/adrs/Browser-Support/#minimum-browser-requirements) (Chrome, Firefox, Edge).
- [ ] There are no new console errors in the browser devtools.
- [ ] There are no new console errors in the test output.
- [ ] If this PR adds a new component to Storybook, it ensures the component is fully responsive, OR if it is intentionally not, a wrapping div using the `officeApp` class or custom `min-width` styling is used to hide any states the would not be visible to the user.
- [ ] This change meets the standards for [Section 508 compliance](https://www.ssa.gov/accessibility/andi/help/install.html).

### Backend

- [ ] Code follows the guidelines for [Logging](https://transcom.github.io/mymove-docs/docs/getting-started/development/logging).
- [ ] The requirements listed in [Querying the Database Safely](https://transcom.github.io/mymove-docs/docs/backend/guides/golang-guide#querying-the-database-safely) have been satisfied.

### Database

#### Any new migrations/schema changes:

- [ ] Follows our guidelines for [Zero-Downtime Deploys](https://transcom.github.io/mymove-docs/docs/backend/setup/database-migrations#zero-downtime-migrations).
- [ ] Have been communicated to #g-database.
- [ ] Secure migrations have been tested following the instructions in our [docs](https://transcom.github.io/mymove-docs/docs/backend/setup/database-migrations#secure-migrations).

## Screenshots
