### PR TITLE
B 20557 payment request status updates int

### DIFF
--- a/pkg/gen/ghcapi/embedded_spec.go
+++ b/pkg/gen/ghcapi/embedded_spec.go
@@ -10466,6 +10466,11 @@ func init() {
           "format": "date-time",
           "x-nullable": true
         },
+        "sentToGexAt": {
+          "type": "string",
+          "format": "date-time",
+          "x-nullable": true
+        },
         "serviceItems": {
           "$ref": "#/definitions/PaymentServiceItems"
         },
@@ -24985,6 +24990,11 @@ func init() {
           "example": "documentation was incomplete"
         },
         "reviewedAt": {
+          "type": "string",
+          "format": "date-time",
+          "x-nullable": true
+        },
+        "sentToGexAt": {
           "type": "string",
           "format": "date-time",
           "x-nullable": true

--- a/pkg/gen/ghcmessages/payment_request.go
+++ b/pkg/gen/ghcmessages/payment_request.go
@@ -65,6 +65,10 @@ type PaymentRequest struct {
 	// Format: date-time
 	ReviewedAt *strfmt.DateTime `json:"reviewedAt,omitempty"`
 
+	// sent to gex at
+	// Format: date-time
+	SentToGexAt *strfmt.DateTime `json:"sentToGexAt,omitempty"`
+
 	// service items
 	ServiceItems PaymentServiceItems `json:"serviceItems,omitempty"`
 
@@ -101,6 +105,10 @@ func (m *PaymentRequest) Validate(formats strfmt.Registry) error {
 	}
 
 	if err := m.validateReviewedAt(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateSentToGexAt(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -208,6 +216,18 @@ func (m *PaymentRequest) validateReviewedAt(formats strfmt.Registry) error {
 	}
 
 	if err := validate.FormatOf("reviewedAt", "body", "date-time", m.ReviewedAt.String(), formats); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (m *PaymentRequest) validateSentToGexAt(formats strfmt.Registry) error {
+	if swag.IsZero(m.SentToGexAt) { // not required
+		return nil
+	}
+
+	if err := validate.FormatOf("sentToGexAt", "body", "date-time", m.SentToGexAt.String(), formats); err != nil {
 		return err
 	}
 

--- a/pkg/handlers/ghcapi/internal/payloads/model_to_payload.go
+++ b/pkg/handlers/ghcapi/internal/payloads/model_to_payload.go
@@ -1465,6 +1465,7 @@ func PaymentRequest(pr *models.PaymentRequest, storer storage.FileStorer) (*ghcm
 		ReviewedAt:                      handlers.FmtDateTimePtr(pr.ReviewedAt),
 		ProofOfServiceDocs:              serviceDocs,
 		CreatedAt:                       strfmt.DateTime(pr.CreatedAt),
+		SentToGexAt:                     (*strfmt.DateTime)(pr.SentToGexAt),
 	}, nil
 }
 

--- a/src/components/Office/PaymentRequestCard/PaymentRequestCard.jsx
+++ b/src/components/Office/PaymentRequestCard/PaymentRequestCard.jsx
@@ -21,14 +21,17 @@ const paymentRequestStatusLabel = (status) => {
   switch (status) {
     case PAYMENT_REQUEST_STATUS.PENDING:
       return 'Needs review';
-    case PAYMENT_REQUEST_STATUS.REVIEWED:
     case PAYMENT_REQUEST_STATUS.SENT_TO_GEX:
+      return 'Sent to GEX';
+    case PAYMENT_REQUEST_STATUS.REVIEWED:
     case PAYMENT_REQUEST_STATUS.RECEIVED_BY_GEX:
       return 'Reviewed';
     case PAYMENT_REQUEST_STATUS.REVIEWED_AND_ALL_SERVICE_ITEMS_REJECTED:
       return 'Rejected';
     case PAYMENT_REQUEST_STATUS.PAID:
       return 'Paid';
+    case PAYMENT_REQUEST_STATUS.EDI_ERROR:
+      return 'Error';
     default:
       return status;
   }
@@ -185,36 +188,52 @@ const PaymentRequestCard = ({
           </span>
         </div>
         <div className={styles.totalReviewed}>
-          {paymentRequest.status === PAYMENT_REQUEST_STATUS.PENDING ? (
-            <div className={styles.amountRequested}>
-              <h2>{toDollarString(formatCents(requestedAmount))}</h2>
-              <span>Requested</span>
+          {paymentRequest.status === PAYMENT_REQUEST_STATUS.SENT_TO_GEX ? (
+            <div className={styles.amountAccepted}>
+              <FontAwesomeIcon icon="check" />
+              <div>
+                <h2>{toDollarString(formatCents(approvedAmount))}</h2>
+                <span>Sent to Gex</span>
+                <span data-testid="sentToGexDate">
+                  {' '}
+                  on {formatDateFromIso(paymentRequest.sentToGexAt, 'DD MMM YYYY')}
+                </span>
+              </div>
             </div>
           ) : (
             <>
-              {approvedAmount > 0 && (
-                <div className={styles.amountAccepted}>
-                  <FontAwesomeIcon icon="check" />
-                  <div>
-                    <h2>{toDollarString(formatCents(approvedAmount))}</h2>
-                    <span>Accepted</span>
-                    <span> on {formatDateFromIso(paymentRequest.reviewedAt, 'DD MMM YYYY')}</span>
-                  </div>
+              {paymentRequest.status === PAYMENT_REQUEST_STATUS.PENDING ? (
+                <div className={styles.amountRequested}>
+                  <h2>{toDollarString(formatCents(requestedAmount))}</h2>
+                  <span>Requested</span>
                 </div>
+              ) : (
+                <>
+                  {approvedAmount > 0 && (
+                    <div className={styles.amountAccepted}>
+                      <FontAwesomeIcon icon="check" />
+                      <div>
+                        <h2>{toDollarString(formatCents(approvedAmount))}</h2>
+                        <span>Accepted</span>
+                        <span> on {formatDateFromIso(paymentRequest.reviewedAt, 'DD MMM YYYY')}</span>
+                      </div>
+                    </div>
+                  )}
+                  {rejectedAmount > 0 && (
+                    <div className={styles.amountRejected}>
+                      <FontAwesomeIcon icon="times" />
+                      <div>
+                        <h2>{toDollarString(formatCents(rejectedAmount))}</h2>
+                        <span>Rejected</span>
+                        <span> on {formatDateFromIso(paymentRequest.reviewedAt, 'DD MMM YYYY')}</span>
+                      </div>
+                    </div>
+                  )}
+                </>
               )}
-              {rejectedAmount > 0 && (
-                <div className={styles.amountRejected}>
-                  <FontAwesomeIcon icon="times" />
-                  <div>
-                    <h2>{toDollarString(formatCents(rejectedAmount))}</h2>
-                    <span>Rejected</span>
-                    <span> on {formatDateFromIso(paymentRequest.reviewedAt, 'DD MMM YYYY')}</span>
-                  </div>
-                </div>
-              )}
+              {paymentRequest.status === PAYMENT_REQUEST_STATUS.PENDING && renderReviewServiceItemsBtnForTIOandTOO()}
             </>
           )}
-          {paymentRequest.status === PAYMENT_REQUEST_STATUS.PENDING && renderReviewServiceItemsBtnForTIOandTOO()}
         </div>
         <div className={styles.footer}>
           <dl>

--- a/src/components/Office/PaymentRequestCard/PaymentRequestCard.jsx
+++ b/src/components/Office/PaymentRequestCard/PaymentRequestCard.jsx
@@ -193,10 +193,10 @@ const PaymentRequestCard = ({
               <FontAwesomeIcon icon="check" />
               <div>
                 <h2>{toDollarString(formatCents(approvedAmount))}</h2>
-                <span>Sent to Gex</span>
+                <span>Sent to GEX</span>
                 <span data-testid="sentToGexDate">
                   {' '}
-                  on {formatDateFromIso(paymentRequest.sentToGexAt, 'DD MMM YYYY')}
+                  on {paymentRequest?.sentToGexAt ? formatDateFromIso(paymentRequest.sentToGexAt, 'DD MMM YYYY') : '-'}
                 </span>
               </div>
             </div>
@@ -215,7 +215,13 @@ const PaymentRequestCard = ({
                       <div>
                         <h2>{toDollarString(formatCents(approvedAmount))}</h2>
                         <span>Accepted</span>
-                        <span> on {formatDateFromIso(paymentRequest.reviewedAt, 'DD MMM YYYY')}</span>
+                        <span>
+                          {' '}
+                          on{' '}
+                          {paymentRequest?.reviewedAt
+                            ? formatDateFromIso(paymentRequest.reviewedAt, 'DD MMM YYYY')
+                            : '-'}
+                        </span>
                       </div>
                     </div>
                   )}
@@ -225,7 +231,13 @@ const PaymentRequestCard = ({
                       <div>
                         <h2>{toDollarString(formatCents(rejectedAmount))}</h2>
                         <span>Rejected</span>
-                        <span> on {formatDateFromIso(paymentRequest.reviewedAt, 'DD MMM YYYY')}</span>
+                        <span>
+                          {' '}
+                          on{' '}
+                          {paymentRequest?.reviewedAt
+                            ? formatDateFromIso(paymentRequest.reviewedAt, 'DD MMM YYYY')
+                            : '-'}
+                        </span>
                       </div>
                     </div>
                   )}

--- a/src/components/Office/PaymentRequestCard/PaymentRequestCard.test.jsx
+++ b/src/components/Office/PaymentRequestCard/PaymentRequestCard.test.jsx
@@ -385,6 +385,21 @@ describe('PaymentRequestCard', () => {
 
       expect(wrapper.find('[data-testid="toggleDrawer"]').length).toBe(1);
     });
+
+    it('renders - for the date it was reviewed at if reviewedAt is null', () => {
+      reviewedPaymentRequest.reviewedAt = '';
+      const wrapperNoReviewedAtDate = mount(
+        <MockProviders path={tioRoutes.BASE_PAYMENT_REQUESTS_PATH} params={{ moveCode }}>
+          <PaymentRequestCard
+            hasBillableWeightIssues={false}
+            paymentRequest={reviewedPaymentRequest}
+            shipmentInfo={shipmentInfo}
+          />
+        </MockProviders>,
+      );
+      const reviewedAtDate = wrapperNoReviewedAtDate.find('.amountRejected span').at(1).text();
+      expect(reviewedAtDate).toBe(' on -');
+    });
   });
 
   describe('payment request gex statuses', () => {
@@ -426,33 +441,33 @@ describe('PaymentRequestCard', () => {
       expect(sentToGex.find({ 'data-testid': 'tag' }).contains('Error')).toBe(true);
     });
 
+    const sentToGexPaymentRequest = {
+      id: '29474c6a-69b6-4501-8e08-670a12512e5f',
+      createdAt: '2020-12-01T00:00:00.000Z',
+      moveTaskOrderID: 'f8c2f97f-99e7-4fb1-9cc4-473debd04dbc',
+      paymentRequestNumber: '1843-9061-2',
+      status: 'SENT_TO_GEX',
+      moveTaskOrder: move,
+      serviceItems: [
+        {
+          id: '09474c6a-69b6-4501-8e08-670a12512a5f',
+          createdAt: '2020-12-01T00:00:00.000Z',
+          mtoServiceItemID: 'f8c2f97f-99e7-4fb1-9cc4-473debd24dbc',
+          priceCents: 2000001,
+          status: 'DENIED',
+        },
+        {
+          id: '39474c6a-69b6-4501-8e08-670a12512a5f',
+          createdAt: '2020-12-01T00:00:00.000Z',
+          mtoServiceItemID: 'a8c2f97f-99e7-4fb1-9cc4-473debd24dbc',
+          priceCents: 4000001,
+          status: 'DENIED',
+          rejectionReason: 'duplicate charge',
+        },
+      ],
+      sentToGexAt: '2020-12-13T00:00:00.000Z',
+    };
     it('renders the Sent to GEX status tag and the date it was sent to gex for sent_to_gex', () => {
-      const sentToGexPaymentRequest = {
-        id: '29474c6a-69b6-4501-8e08-670a12512e5f',
-        createdAt: '2020-12-01T00:00:00.000Z',
-        moveTaskOrderID: 'f8c2f97f-99e7-4fb1-9cc4-473debd04dbc',
-        paymentRequestNumber: '1843-9061-2',
-        status: 'SENT_TO_GEX',
-        moveTaskOrder: move,
-        serviceItems: [
-          {
-            id: '09474c6a-69b6-4501-8e08-670a12512a5f',
-            createdAt: '2020-12-01T00:00:00.000Z',
-            mtoServiceItemID: 'f8c2f97f-99e7-4fb1-9cc4-473debd24dbc',
-            priceCents: 2000001,
-            status: 'DENIED',
-          },
-          {
-            id: '39474c6a-69b6-4501-8e08-670a12512a5f',
-            createdAt: '2020-12-01T00:00:00.000Z',
-            mtoServiceItemID: 'a8c2f97f-99e7-4fb1-9cc4-473debd24dbc',
-            priceCents: 4000001,
-            status: 'DENIED',
-            rejectionReason: 'duplicate charge',
-          },
-        ],
-        sentToGexAt: '2020-12-13T00:00:00.000Z',
-      };
       const sentToGex = mount(
         <MockProviders path={tioRoutes.BASE_PAYMENT_REQUESTS_PATH} params={{ moveCode }}>
           <PaymentRequestCard
@@ -465,6 +480,28 @@ describe('PaymentRequestCard', () => {
       expect(sentToGex.find({ 'data-testid': 'tag' }).contains('Sent to GEX')).toBe(true);
       const sentToGexAtDate = sentToGex.find({ 'data-testid': 'sentToGexDate' }).text();
       expect(sentToGexAtDate).toBe(' on 13 Dec 2020');
+    });
+
+    it('renders - for the date it was sent to gex if sentToGexAt is null', () => {
+      sentToGexPaymentRequest.sentToGexAt = '';
+      sentToGexPaymentRequest.reviewedAt = '';
+
+      const sentToGex = mount(
+        <MockProviders path={tioRoutes.BASE_PAYMENT_REQUESTS_PATH} params={{ moveCode }}>
+          <PaymentRequestCard
+            hasBillableWeightIssues={false}
+            paymentRequest={sentToGexPaymentRequest}
+            shipmentInfo={shipmentInfo}
+          />
+        </MockProviders>,
+      );
+      expect(sentToGex.find({ 'data-testid': 'tag' }).contains('Sent to GEX')).toBe(true);
+      const sentToGexAtDate = sentToGex.find({ 'data-testid': 'sentToGexDate' }).text();
+      expect(sentToGexAtDate).toBe(' on -');
+
+      // expect(sentToGex.find({ 'data-testid': 'tag' }).contains('Sent to GEX')).toBe(true);
+      // const reviewedAtDate = sentToGex.find('.amountRejected span').at(1).text();
+      // expect(reviewedAtDate).toBe('on -');
     });
 
     it('renders the reviewed status tag for received_by_gex', () => {

--- a/src/components/Office/PaymentRequestCard/PaymentRequestCard.test.jsx
+++ b/src/components/Office/PaymentRequestCard/PaymentRequestCard.test.jsx
@@ -388,13 +388,13 @@ describe('PaymentRequestCard', () => {
   });
 
   describe('payment request gex statuses', () => {
-    it('renders the reviewed status tag for sent_to_gex', () => {
+    it('renders the Error status tag for edi_error', () => {
       const sentToGexPaymentRequest = {
         id: '29474c6a-69b6-4501-8e08-670a12512e5f',
         createdAt: '2020-12-01T00:00:00.000Z',
         moveTaskOrderID: 'f8c2f97f-99e7-4fb1-9cc4-473debd04dbc',
         paymentRequestNumber: '1843-9061-2',
-        status: 'SENT_TO_GEX',
+        status: 'EDI_ERROR',
         moveTaskOrder: move,
         serviceItems: [
           {
@@ -423,7 +423,48 @@ describe('PaymentRequestCard', () => {
           />
         </MockProviders>,
       );
-      expect(sentToGex.find({ 'data-testid': 'tag' }).contains('Reviewed')).toBe(true);
+      expect(sentToGex.find({ 'data-testid': 'tag' }).contains('Error')).toBe(true);
+    });
+
+    it('renders the Sent to GEX status tag and the date it was sent to gex for sent_to_gex', () => {
+      const sentToGexPaymentRequest = {
+        id: '29474c6a-69b6-4501-8e08-670a12512e5f',
+        createdAt: '2020-12-01T00:00:00.000Z',
+        moveTaskOrderID: 'f8c2f97f-99e7-4fb1-9cc4-473debd04dbc',
+        paymentRequestNumber: '1843-9061-2',
+        status: 'SENT_TO_GEX',
+        moveTaskOrder: move,
+        serviceItems: [
+          {
+            id: '09474c6a-69b6-4501-8e08-670a12512a5f',
+            createdAt: '2020-12-01T00:00:00.000Z',
+            mtoServiceItemID: 'f8c2f97f-99e7-4fb1-9cc4-473debd24dbc',
+            priceCents: 2000001,
+            status: 'DENIED',
+          },
+          {
+            id: '39474c6a-69b6-4501-8e08-670a12512a5f',
+            createdAt: '2020-12-01T00:00:00.000Z',
+            mtoServiceItemID: 'a8c2f97f-99e7-4fb1-9cc4-473debd24dbc',
+            priceCents: 4000001,
+            status: 'DENIED',
+            rejectionReason: 'duplicate charge',
+          },
+        ],
+        sentToGexAt: '2020-12-13T00:00:00.000Z',
+      };
+      const sentToGex = mount(
+        <MockProviders path={tioRoutes.BASE_PAYMENT_REQUESTS_PATH} params={{ moveCode }}>
+          <PaymentRequestCard
+            hasBillableWeightIssues={false}
+            paymentRequest={sentToGexPaymentRequest}
+            shipmentInfo={shipmentInfo}
+          />
+        </MockProviders>,
+      );
+      expect(sentToGex.find({ 'data-testid': 'tag' }).contains('Sent to GEX')).toBe(true);
+      const sentToGexAtDate = sentToGex.find({ 'data-testid': 'sentToGexDate' }).text();
+      expect(sentToGexAtDate).toBe(' on 13 Dec 2020');
     });
 
     it('renders the reviewed status tag for received_by_gex', () => {

--- a/src/types/order.js
+++ b/src/types/order.js
@@ -135,6 +135,7 @@ export const PaymentRequestShape = PropTypes.shape({
   eTag: PropTypes.string,
   serviceItems: PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.string, PaymentServiceItemShape])),
   reviewedAt: PropTypes.string,
+  sentToGexAt: PropTypes.string,
 });
 
 export const OrdersLOAShape = PropTypes.shape({

--- a/swagger-def/ghc.yaml
+++ b/swagger-def/ghc.yaml
@@ -5463,6 +5463,10 @@ definitions:
       createdAt:
         format: date-time
         type: string
+      sentToGexAt:
+        format: date-time
+        type: string
+        x-nullable: true
     type: object
   PaymentRequests:
     items:
@@ -6765,7 +6769,7 @@ definitions:
   GBLOCs:
     type: array
     items:
-        type: string
+      type: string
   MovePayload:
     type: object
     properties:

--- a/swagger/ghc.yaml
+++ b/swagger/ghc.yaml
@@ -5677,6 +5677,10 @@ definitions:
       createdAt:
         format: date-time
         type: string
+      sentToGexAt:
+        format: date-time
+        type: string
+        x-nullable: true
     type: object
   PaymentRequests:
     items:


### PR DESCRIPTION
## [Agility ticket](https://www13.v1host.com/USTRANSCOM38/story.mvc/Summary?oidToken=Story%3A981837)

## Summary

Updated the labels for when the payment request is in EDI_ERROR or SENT_TO_GEX states.

Also brought in the sent_to_gex_at value from the database and will now display that when a payment request is in the SENT_TO_GEX status.

Added tests.
 
To test:
1. Log in as a TIO
2. Find a payment request
3. Change the status in the db to EDI_ERROR
4. Ensure you see an "ERROR" flag on the payment request
5. Change the status in the db to SENT_TO_GEX
6. Ensure you see a "SENT TO GEX" flag on the payment request
7. Also make sure it now says "Sent to GEX On" with a date that matches the sent_to_gex_at database value.
8. Change the sent_to_gex_at and make sure it changes on the frontend.

## Screenshots
Sent to Gex, includes "Sent to Gex on" with the date.
![image](https://github.com/user-attachments/assets/4654f7b9-f36d-4a35-8ee2-da097bf47ff5)

![image](https://github.com/user-attachments/assets/0c4a5fe4-51ce-4850-b6d1-f283dec24711)


When it's in the reviewed status, should say "accepted on" instead of "sent to gex on"
![image](https://github.com/user-attachments/assets/b9fe2d6a-fef5-4deb-b898-fd805ac8e8fd)
