### PR TITLE
INT B-20463 update weight and expense tickets to pull data from multi moves

### DIFF
--- a/src/pages/MyMove/PPM/Closeout/ProGear/ProGear.jsx
+++ b/src/pages/MyMove/PPM/Closeout/ProGear/ProGear.jsx
@@ -5,7 +5,11 @@ import { Alert, Grid, GridContainer } from '@trussworks/react-uswds';
 
 import { isBooleanFlagEnabled } from '../../../../../utils/featureFlags';
 
-import { selectMTOShipmentById, selectProGearWeightTicketAndIndexById } from 'store/entities/selectors';
+import {
+  selectMTOShipmentById,
+  selectProGearWeightTicketAndIndexById,
+  selectServiceMemberFromLoggedInUser,
+} from 'store/entities/selectors';
 import ppmPageStyles from 'pages/MyMove/PPM/PPM.module.scss';
 import ShipmentTag from 'components/ShipmentTag/ShipmentTag';
 import { shipmentTypes } from 'constants/shipments';
@@ -17,15 +21,19 @@ import {
   patchProGearWeightTicket,
   patchMTOShipment,
   getMTOShipmentsForMove,
+  getAllMoves,
 } from 'services/internalApi';
 import LoadingPlaceholder from 'shared/LoadingPlaceholder';
 import closingPageStyles from 'pages/MyMove/PPM/Closeout/Closeout.module.scss';
 import ProGearForm from 'components/Customer/PPM/Closeout/ProGearForm/ProGearForm';
-import { updateMTOShipment } from 'store/entities/actions';
+import { updateAllMoves, updateMTOShipment } from 'store/entities/actions';
 
 const ProGear = () => {
   const dispatch = useDispatch();
   const navigate = useNavigate();
+
+  const serviceMember = useSelector((state) => selectServiceMemberFromLoggedInUser(state));
+  const serviceMemberId = serviceMember.id;
 
   const { moveId, mtoShipmentId, proGearId } = useParams();
 
@@ -73,6 +81,11 @@ const ProGear = () => {
         });
     }
   }, [proGearId, moveId, mtoShipmentId, navigate, dispatch, mtoShipment]);
+
+  useEffect(() => {
+    const moves = getAllMoves(serviceMemberId);
+    dispatch(updateAllMoves(moves));
+  }, [proGearId, moveId, mtoShipmentId, navigate, dispatch, mtoShipment, serviceMemberId]);
 
   const handleCreateUpload = async (fieldName, file, setFieldTouched) => {
     const documentId = currentProGearWeightTicket[`${fieldName}Id`];

--- a/src/pages/MyMove/PPM/Closeout/ProGear/ProGear.test.jsx
+++ b/src/pages/MyMove/PPM/Closeout/ProGear/ProGear.test.jsx
@@ -37,6 +37,7 @@ jest.mock('services/internalApi', () => ({
   deleteUpload: jest.fn(),
   patchProGearWeightTicket: jest.fn(),
   getResponseError: jest.fn(),
+  getAllMoves: jest.fn().mockImplementation(() => Promise.resolve()),
 }));
 
 const mockMTOShipment = {
@@ -109,11 +110,16 @@ const mockEntitlement = {
   proGearSpouse: 123,
 };
 
+const mockServiceMember = {
+  id: 'testId',
+};
+
 jest.mock('store/entities/selectors', () => ({
   ...jest.requireActual('store/entities/selectors'),
   selectMTOShipmentById: jest.fn(() => mockMTOShipment),
   selectProGearWeightTicketAndIndexById: jest.fn(() => mockEmptyProGearWeightTicketAndIndex),
   selectProGearEntitlements: jest.fn(() => mockEntitlement),
+  selectServiceMemberFromLoggedInUser: jest.fn(() => mockServiceMember),
 }));
 
 beforeEach(() => {

--- a/src/pages/MyMove/PPM/Closeout/Review/Review.test.jsx
+++ b/src/pages/MyMove/PPM/Closeout/Review/Review.test.jsx
@@ -232,6 +232,10 @@ const mockMTOShipmentWithExpensesDeleted = {
   },
 };
 
+const mockServiceMember = {
+  id: 'testId',
+};
+
 const mockNavigate = jest.fn();
 jest.mock('react-router-dom', () => ({
   ...jest.requireActual('react-router-dom'),
@@ -244,11 +248,13 @@ jest.mock('services/internalApi', () => ({
   deleteProGearWeightTicket: jest.fn(() => {}),
   deleteMovingExpense: jest.fn(() => {}),
   getMTOShipmentsForMove: jest.fn(),
+  getAllMoves: jest.fn().mockImplementation(() => Promise.resolve()),
 }));
 
 jest.mock('store/entities/selectors', () => ({
   ...jest.requireActual('store/entities/selectors'),
   selectMTOShipmentById: jest.fn(() => mockMTOShipment),
+  selectServiceMemberFromLoggedInUser: jest.fn(() => mockServiceMember),
 }));
 
 beforeEach(() => {

--- a/src/pages/MyMove/PPM/Closeout/WeightTickets/WeightTickets.jsx
+++ b/src/pages/MyMove/PPM/Closeout/WeightTickets/WeightTickets.jsx
@@ -5,9 +5,19 @@ import { Alert, Grid, GridContainer } from '@trussworks/react-uswds';
 
 import { isBooleanFlagEnabled } from '../../../../../utils/featureFlags';
 
-import { selectMTOShipmentById, selectWeightTicketAndIndexById } from 'store/entities/selectors';
+import {
+  selectMTOShipmentById,
+  selectServiceMemberFromLoggedInUser,
+  selectWeightTicketAndIndexById,
+} from 'store/entities/selectors';
 import { customerRoutes } from 'constants/routes';
-import { createUploadForPPMDocument, createWeightTicket, deleteUpload, patchWeightTicket } from 'services/internalApi';
+import {
+  createUploadForPPMDocument,
+  createWeightTicket,
+  deleteUpload,
+  getAllMoves,
+  patchWeightTicket,
+} from 'services/internalApi';
 import LoadingPlaceholder from 'shared/LoadingPlaceholder';
 import ppmPageStyles from 'pages/MyMove/PPM/PPM.module.scss';
 import NotificationScrollToTop from 'components/NotificationScrollToTop';
@@ -15,7 +25,7 @@ import ShipmentTag from 'components/ShipmentTag/ShipmentTag';
 import { shipmentTypes } from 'constants/shipments';
 import closingPageStyles from 'pages/MyMove/PPM/Closeout/Closeout.module.scss';
 import WeightTicketForm from 'components/Customer/PPM/Closeout/WeightTicketForm/WeightTicketForm';
-import { updateMTOShipment } from 'store/entities/actions';
+import { updateAllMoves, updateMTOShipment } from 'store/entities/actions';
 import ErrorModal from 'shared/ErrorModal/ErrorModal';
 
 const WeightTickets = () => {
@@ -30,6 +40,9 @@ const WeightTickets = () => {
   const { weightTicket: currentWeightTicket, index: currentIndex } = useSelector((state) =>
     selectWeightTicketAndIndexById(state, mtoShipmentId, weightTicketId),
   );
+
+  const serviceMember = useSelector((state) => selectServiceMemberFromLoggedInUser(state));
+  const serviceMemberId = serviceMember.id;
 
   const [isErrorModalVisible, setIsErrorModalVisible] = useState(false);
   const toggleErrorModal = () => {
@@ -67,7 +80,12 @@ const WeightTickets = () => {
           setErrorMessage('Failed to create trip record');
         });
     }
-  }, [weightTicketId, moveId, mtoShipmentId, navigate, dispatch, mtoShipment]);
+  }, [weightTicketId, moveId, mtoShipmentId, navigate, dispatch, mtoShipment, serviceMemberId]);
+
+  useEffect(() => {
+    const moves = getAllMoves(serviceMemberId);
+    dispatch(updateAllMoves(moves));
+  }, [weightTicketId, moveId, mtoShipmentId, navigate, dispatch, mtoShipment, serviceMemberId]);
 
   const handleCreateUpload = async (fieldName, file, setFieldTouched) => {
     const documentId = currentWeightTicket[`${fieldName}Id`];

--- a/src/pages/MyMove/PPM/Closeout/WeightTickets/WeightTickets.jsx
+++ b/src/pages/MyMove/PPM/Closeout/WeightTickets/WeightTickets.jsx
@@ -80,7 +80,7 @@ const WeightTickets = () => {
           setErrorMessage('Failed to create trip record');
         });
     }
-  }, [weightTicketId, moveId, mtoShipmentId, navigate, dispatch, mtoShipment, serviceMemberId]);
+  }, [weightTicketId, moveId, mtoShipmentId, navigate, dispatch, mtoShipment]);
 
   useEffect(() => {
     const moves = getAllMoves(serviceMemberId);

--- a/src/pages/MyMove/PPM/Closeout/WeightTickets/WeightTickets.test.jsx
+++ b/src/pages/MyMove/PPM/Closeout/WeightTickets/WeightTickets.test.jsx
@@ -30,6 +30,7 @@ jest.mock('services/internalApi', () => ({
   deleteUpload: jest.fn(),
   patchWeightTicket: jest.fn(),
   getResponseError: jest.fn(),
+  getAllMoves: jest.fn().mockImplementation(() => Promise.resolve()),
 }));
 
 const mockMTOShipment = {
@@ -113,10 +114,15 @@ const mockEmptyWeightTicketAndIndex = {
   index: -1,
 };
 
+const mockServiceMember = {
+  id: 'testId',
+};
+
 jest.mock('store/entities/selectors', () => ({
   ...jest.requireActual('store/entities/selectors'),
   selectMTOShipmentById: jest.fn(() => mockMTOShipment),
   selectWeightTicketAndIndexById: jest.fn(() => mockEmptyWeightTicketAndIndex),
+  selectServiceMemberFromLoggedInUser: jest.fn(() => mockServiceMember),
 }));
 
 beforeEach(() => {

--- a/src/store/entities/selectors.js
+++ b/src/store/entities/selectors.js
@@ -178,7 +178,34 @@ export const selectMTOShipmentsForCurrentMove = (state) => {
 };
 
 export function selectMTOShipmentById(state, id) {
-  return state.entities?.mtoShipments?.[`${id}`] || null;
+  // Attempt to get the shipment using the existing method
+  const mtoShipment = state.entities?.mtoShipments?.[`${id}`] || null;
+  if (mtoShipment) {
+    return mtoShipment;
+  }
+
+  // now we will check both current and previous moves for the shipment
+  const moves = state.entities.serviceMemberMoves;
+
+  const currentMove = moves.currentMove?.[0]?.mtoShipments || [];
+  const foundInCurrentMove = currentMove.find((shipment) => shipment.id === id);
+  if (foundInCurrentMove) {
+    return foundInCurrentMove;
+  }
+
+  const previousMoves = moves.previousMoves || [];
+  const foundInPreviousMoves = previousMoves.reduce((found, move) => {
+    if (found) return found;
+    const shipments = move.mtoShipments || [];
+    return shipments.find((shipment) => shipment.id === id) || null;
+  }, null);
+
+  if (foundInPreviousMoves) {
+    return foundInPreviousMoves;
+  }
+
+  // If still not found, return null
+  return null;
 }
 
 /** PPMs */


### PR DESCRIPTION
## [Agility ticket](https://www13.v1host.com/USTRANSCOM38/assetdetail.v1?number=B-20463)

## Summary

This ticket was created from an issue that was occurring when the customer would have more than one move and go back to their PPM shipment in an older move and try to Upload PPM docs and handle closing it out. The cause of this was when viewing a previous move, `mtoShipments` was returning `null` since the params didn't match what was stored in `state` for the CURRENT (the most recently created) move (when Truss first designed this, they did not consider multiple moves and PAST moves).

When transitioning to multiple moves, we pull a butt load of data from the `serviceMemberMoves` object in `state`. This big 'ol boy is queried when the user firsts signs in and any subsequent updates. A lot of the issue was that we weren't picking the right data from `state` when looking at a PREVIOUS moves, as well as not querying for specific data used for the weight ticket and PPM doc upload process.

This PR does the following:
- updates the query handling retrieving multiple moves to include pro gear, expense, and weight ticket data and uploads
- excludes tickets that have `deleted_at` values (comments in code explain why this has to be done with logic checks)
- updates `ProGear` & `WeightTickets` to update all moves once data/uploads are created/updated
- updated selector when picking `mtoShipment` to also include multiple moves IF it doesn't use the "old" way first
- update all relevant tests

### How to test

1. Fire up MilMove as a customer
2. Set up two moves with PPM shipments
3. Approve as service counselor
4. You should now be able to upload PPM documents and close out the PPM
5. Try to break it - make sure that you can upload docs & data for both moves separately and that data is dynamic as things change

## Screenshots
Set up two moves
![Screenshot 2024-07-19 at 11 09 41 AM](https://github.com/user-attachments/assets/784866e8-08db-451a-a4e1-9eca96f288e4)

You want your move home page to look like this for both
![Screenshot 2024-07-19 at 11 09 53 AM](https://github.com/user-attachments/assets/57d6e479-db80-427e-8b4b-414043907c68)

Add/edit/delete any of these and make sure that things change in state as you make changes
![Screenshot 2024-07-19 at 11 23 00 AM](https://github.com/user-attachments/assets/677a3017-bdc1-430d-bf7f-932042ee2d72)


