### PR TITLE
MAIN B-20463

### DIFF
--- a/playwright/tests/my/milmove/ppms/customerPpmTestFixture.js
+++ b/playwright/tests/my/milmove/ppms/customerPpmTestFixture.js
@@ -107,6 +107,17 @@ export class CustomerPpmPage extends CustomerPage {
   /**
    * returns {Promise<void>}
    */
+  async navigateToPPMReviewPageWithCompletePPM() {
+    await this.clickOnUploadPPMDocumentsButton();
+
+    await expect(this.page).toHaveURL(/\/moves\/[^/]+\/shipments\/[^/]/);
+
+    await expect(this.page.getByRole('heading', { name: 'Review' })).toBeVisible();
+  }
+
+  /**
+   * returns {Promise<void>}
+   */
   async navigateFromPPMReviewPageToFinalCloseoutPage() {
     await this.page.locator('a').getByText('Save & Continue').click();
     await expect(this.page).toHaveURL(/\/moves\/[^/]+\/shipments\/[^/]+\/complete/);
@@ -785,6 +796,13 @@ export class CustomerPpmPage extends CustomerPage {
   async navigateFromCloseoutReviewPageToAddExpensePage() {
     await this.page.getByRole('link', { name: 'Add Expenses' }).click();
     await this.page.waitForURL(/\/moves\/[^/]+\/shipments\/[^/]+\/expenses/);
+  }
+
+  /**
+   * returns {Promise<void>}
+   */
+  async returnToMoveHome() {
+    await this.page.getByRole('button', { name: 'Return To Homepage' }).click();
   }
 
   /**

--- a/playwright/tests/my/milmove/ppms/entireShipmentCloseout.spec.js
+++ b/playwright/tests/my/milmove/ppms/entireShipmentCloseout.spec.js
@@ -153,7 +153,10 @@ test.describe('(MultiMove) Entire PPM closeout flow (MultiMove Workflow)', () =>
 
       await customerPpmPage.signInForPPMWithMove(move);
       await customerPpmPage.navigateFromMMDashboardToMove(move);
-      await customerPpmPage.navigateToPPMReviewPage();
+      await customerPpmPage.navigateToPPMReviewPageWithCompletePPM();
+      await customerPpmPage.navigateFromPPMReviewPageToFinalCloseoutPage();
+      await customerPpmPage.returnToMoveHome();
+      await customerPpmPage.navigateToPPMReviewPageWithCompletePPM();
       await customerPpmPage.navigateFromCloseoutReviewPageToAboutPage();
       await customerPpmPage.fillOutAboutPage();
       await customerPpmPage.navigateFromCloseoutReviewPageToEditWeightTicketPage();
@@ -177,20 +180,26 @@ test.describe('(MultiMove) Entire PPM closeout flow (MultiMove Workflow)', () =>
       await customerPpmPage.signInForPPMWithMove(move);
 
       await customerPpmPage.navigateFromMMDashboardToMove(move);
-      await customerPpmPage.navigateToPPMReviewPage();
+      await customerPpmPage.navigateToPPMReviewPageWithCompletePPM();
       await customerPpmPage.verifySaveAndContinueEnabled();
 
-      // Add incomplete weight ticket
+      // Add incomplete weight ticket and exit
       await customerPpmPage.navigateFromCloseoutReviewPageToAddWeightTicketPage();
-      await customerPpmPage.cancelAddLineItemAndReturnToCloseoutReviewPage(move.id);
+      await customerPpmPage.returnToMoveHome();
 
-      // Add incomplete moving expense
+      await customerPpmPage.navigateToPPMReviewPageWithCompletePPM();
+
+      // Add incomplete moving expense and exit
       await customerPpmPage.navigateFromCloseoutReviewPageToAddExpensePage();
-      await customerPpmPage.cancelAddLineItemAndReturnToCloseoutReviewPage(move.id);
+      await customerPpmPage.returnToMoveHome();
 
-      // Add incomplete pro-gear weight ticket
+      await customerPpmPage.navigateToPPMReviewPageWithCompletePPM();
+
+      // Add incomplete pro-gear weight ticket and exit
       await customerPpmPage.navigateFromCloseoutReviewPageToAddProGearPage();
-      await customerPpmPage.cancelAddLineItemAndReturnToCloseoutReviewPage(move.id);
+      await customerPpmPage.returnToMoveHome();
+
+      await customerPpmPage.navigateToPPMReviewPageWithCompletePPM();
 
       // Now that we have incomplete line items, we cannot submit the PPM
       await customerPpmPage.verifySaveAndContinueDisabled();
@@ -218,7 +227,7 @@ test.describe('(MultiMove) Entire PPM closeout flow (MultiMove Workflow)', () =>
       await customerPpmPage.signInForPPMWithMove(move);
 
       await customerPpmPage.navigateFromMMDashboardToMove(move);
-      await customerPpmPage.navigateToPPMReviewPage();
+      await customerPpmPage.navigateToPPMReviewPageWithCompletePPM();
       await customerPpmPage.navigateFromCloseoutReviewPageToAddWeightTicketPage();
       await customerPpmPage.submitWeightTicketPage();
 
@@ -230,7 +239,7 @@ test.describe('(MultiMove) Entire PPM closeout flow (MultiMove Workflow)', () =>
         finalIncentiveAmount: '$172,795.18',
       });
       await customerPpmPage.page.getByRole('button', { name: 'Return to Homepage' }).click();
-      await customerPpmPage.navigateToPPMReviewPage();
+      await customerPpmPage.navigateToPPMReviewPageWithCompletePPM();
 
       await customerPpmPage.deleteWeightTicket(1, false);
       await customerPpmPage.navigateFromPPMReviewPageToFinalCloseoutPage();

--- a/playwright/tests/my/milmove/ppms/expenses.spec.js
+++ b/playwright/tests/my/milmove/ppms/expenses.spec.js
@@ -67,7 +67,7 @@ test.describe('(MultiMove) Expenses', () => {
       const move = await customerPpmPage.testHarness.buildApprovedMoveWithPPMMovingExpense();
       await customerPpmPage.signInForPPMWithMove(move);
       await customerPpmPage.clickOnGoToMoveButton();
-      await customerPpmPage.navigateToPPMReviewPage();
+      await customerPpmPage.navigateToPPMReviewPageWithCompletePPM();
     });
 
     test(`new expense page loads`, async ({ customerPpmPage }) => {

--- a/playwright/tests/my/milmove/ppms/finalCloseout.spec.js
+++ b/playwright/tests/my/milmove/ppms/finalCloseout.spec.js
@@ -40,7 +40,8 @@ test.describe('(MultiMove) Final Closeout', () => {
     test('can see final closeout page with final estimated incentive and shipment totals', async ({
       customerPpmPage,
     }) => {
-      await customerPpmPage.navigateToFinalCloseoutPage();
+      await customerPpmPage.navigateToPPMReviewPageWithCompletePPM();
+      await customerPpmPage.navigateFromPPMReviewPageToFinalCloseoutPage();
 
       await customerPpmPage.verifyFinalIncentiveAndTotals();
     });

--- a/playwright/tests/my/milmove/ppms/progear.spec.js
+++ b/playwright/tests/my/milmove/ppms/progear.spec.js
@@ -41,7 +41,8 @@ test.describe('(MultiMove) Progear', () => {
       const move = await customerPpmPage.testHarness.buildApprovedMoveWithPPMProgearWeightTicket();
       await customerPpmPage.signInForPPMWithMove(move);
       await customerPpmPage.clickOnGoToMoveButton();
-      await customerPpmPage.navigateToProgearPage();
+      await customerPpmPage.navigateToPPMReviewPageWithCompletePPM();
+      await customerPpmPage.navigateFromCloseoutReviewPageToProGearPage();
     });
 
     test(`progear page loads`, async ({ customerPpmPage, page }) => {

--- a/src/pages/MyMove/PPM/Closeout/ProGear/ProGear.jsx
+++ b/src/pages/MyMove/PPM/Closeout/ProGear/ProGear.jsx
@@ -5,7 +5,11 @@ import { Alert, Grid, GridContainer } from '@trussworks/react-uswds';
 
 import { isBooleanFlagEnabled } from '../../../../../utils/featureFlags';
 
-import { selectMTOShipmentById, selectProGearWeightTicketAndIndexById } from 'store/entities/selectors';
+import {
+  selectMTOShipmentById,
+  selectProGearWeightTicketAndIndexById,
+  selectServiceMemberFromLoggedInUser,
+} from 'store/entities/selectors';
 import ppmPageStyles from 'pages/MyMove/PPM/PPM.module.scss';
 import ShipmentTag from 'components/ShipmentTag/ShipmentTag';
 import { shipmentTypes } from 'constants/shipments';
@@ -17,15 +21,19 @@ import {
   patchProGearWeightTicket,
   patchMTOShipment,
   getMTOShipmentsForMove,
+  getAllMoves,
 } from 'services/internalApi';
 import LoadingPlaceholder from 'shared/LoadingPlaceholder';
 import closingPageStyles from 'pages/MyMove/PPM/Closeout/Closeout.module.scss';
 import ProGearForm from 'components/Customer/PPM/Closeout/ProGearForm/ProGearForm';
-import { updateMTOShipment } from 'store/entities/actions';
+import { updateAllMoves, updateMTOShipment } from 'store/entities/actions';
 
 const ProGear = () => {
   const dispatch = useDispatch();
   const navigate = useNavigate();
+
+  const serviceMember = useSelector((state) => selectServiceMemberFromLoggedInUser(state));
+  const serviceMemberId = serviceMember.id;
 
   const { moveId, mtoShipmentId, proGearId } = useParams();
 
@@ -73,6 +81,11 @@ const ProGear = () => {
         });
     }
   }, [proGearId, moveId, mtoShipmentId, navigate, dispatch, mtoShipment]);
+
+  useEffect(() => {
+    const moves = getAllMoves(serviceMemberId);
+    dispatch(updateAllMoves(moves));
+  }, [proGearId, moveId, mtoShipmentId, navigate, dispatch, mtoShipment, serviceMemberId]);
 
   const handleCreateUpload = async (fieldName, file, setFieldTouched) => {
     const documentId = currentProGearWeightTicket[`${fieldName}Id`];

--- a/src/pages/MyMove/PPM/Closeout/ProGear/ProGear.test.jsx
+++ b/src/pages/MyMove/PPM/Closeout/ProGear/ProGear.test.jsx
@@ -37,6 +37,7 @@ jest.mock('services/internalApi', () => ({
   deleteUpload: jest.fn(),
   patchProGearWeightTicket: jest.fn(),
   getResponseError: jest.fn(),
+  getAllMoves: jest.fn().mockImplementation(() => Promise.resolve()),
 }));
 
 const mockMTOShipment = {
@@ -109,11 +110,16 @@ const mockEntitlement = {
   proGearSpouse: 123,
 };
 
+const mockServiceMember = {
+  id: 'testId',
+};
+
 jest.mock('store/entities/selectors', () => ({
   ...jest.requireActual('store/entities/selectors'),
   selectMTOShipmentById: jest.fn(() => mockMTOShipment),
   selectProGearWeightTicketAndIndexById: jest.fn(() => mockEmptyProGearWeightTicketAndIndex),
   selectProGearEntitlements: jest.fn(() => mockEntitlement),
+  selectServiceMemberFromLoggedInUser: jest.fn(() => mockServiceMember),
 }));
 
 beforeEach(() => {

--- a/src/pages/MyMove/PPM/Closeout/Review/Review.test.jsx
+++ b/src/pages/MyMove/PPM/Closeout/Review/Review.test.jsx
@@ -232,6 +232,10 @@ const mockMTOShipmentWithExpensesDeleted = {
   },
 };
 
+const mockServiceMember = {
+  id: 'testId',
+};
+
 const mockNavigate = jest.fn();
 jest.mock('react-router-dom', () => ({
   ...jest.requireActual('react-router-dom'),
@@ -244,11 +248,13 @@ jest.mock('services/internalApi', () => ({
   deleteProGearWeightTicket: jest.fn(() => {}),
   deleteMovingExpense: jest.fn(() => {}),
   getMTOShipmentsForMove: jest.fn(),
+  getAllMoves: jest.fn().mockImplementation(() => Promise.resolve()),
 }));
 
 jest.mock('store/entities/selectors', () => ({
   ...jest.requireActual('store/entities/selectors'),
   selectMTOShipmentById: jest.fn(() => mockMTOShipment),
+  selectServiceMemberFromLoggedInUser: jest.fn(() => mockServiceMember),
 }));
 
 beforeEach(() => {

--- a/src/pages/MyMove/PPM/Closeout/WeightTickets/WeightTickets.jsx
+++ b/src/pages/MyMove/PPM/Closeout/WeightTickets/WeightTickets.jsx
@@ -5,9 +5,19 @@ import { Alert, Grid, GridContainer } from '@trussworks/react-uswds';
 
 import { isBooleanFlagEnabled } from '../../../../../utils/featureFlags';
 
-import { selectMTOShipmentById, selectWeightTicketAndIndexById } from 'store/entities/selectors';
+import {
+  selectMTOShipmentById,
+  selectServiceMemberFromLoggedInUser,
+  selectWeightTicketAndIndexById,
+} from 'store/entities/selectors';
 import { customerRoutes } from 'constants/routes';
-import { createUploadForPPMDocument, createWeightTicket, deleteUpload, patchWeightTicket } from 'services/internalApi';
+import {
+  createUploadForPPMDocument,
+  createWeightTicket,
+  deleteUpload,
+  getAllMoves,
+  patchWeightTicket,
+} from 'services/internalApi';
 import LoadingPlaceholder from 'shared/LoadingPlaceholder';
 import ppmPageStyles from 'pages/MyMove/PPM/PPM.module.scss';
 import NotificationScrollToTop from 'components/NotificationScrollToTop';
@@ -15,7 +25,7 @@ import ShipmentTag from 'components/ShipmentTag/ShipmentTag';
 import { shipmentTypes } from 'constants/shipments';
 import closingPageStyles from 'pages/MyMove/PPM/Closeout/Closeout.module.scss';
 import WeightTicketForm from 'components/Customer/PPM/Closeout/WeightTicketForm/WeightTicketForm';
-import { updateMTOShipment } from 'store/entities/actions';
+import { updateAllMoves, updateMTOShipment } from 'store/entities/actions';
 import ErrorModal from 'shared/ErrorModal/ErrorModal';
 
 const WeightTickets = () => {
@@ -30,6 +40,9 @@ const WeightTickets = () => {
   const { weightTicket: currentWeightTicket, index: currentIndex } = useSelector((state) =>
     selectWeightTicketAndIndexById(state, mtoShipmentId, weightTicketId),
   );
+
+  const serviceMember = useSelector((state) => selectServiceMemberFromLoggedInUser(state));
+  const serviceMemberId = serviceMember.id;
 
   const [isErrorModalVisible, setIsErrorModalVisible] = useState(false);
   const toggleErrorModal = () => {
@@ -67,7 +80,12 @@ const WeightTickets = () => {
           setErrorMessage('Failed to create trip record');
         });
     }
-  }, [weightTicketId, moveId, mtoShipmentId, navigate, dispatch, mtoShipment]);
+  }, [weightTicketId, moveId, mtoShipmentId, navigate, dispatch, mtoShipment, serviceMemberId]);
+
+  useEffect(() => {
+    const moves = getAllMoves(serviceMemberId);
+    dispatch(updateAllMoves(moves));
+  }, [weightTicketId, moveId, mtoShipmentId, navigate, dispatch, mtoShipment, serviceMemberId]);
 
   const handleCreateUpload = async (fieldName, file, setFieldTouched) => {
     const documentId = currentWeightTicket[`${fieldName}Id`];

--- a/src/pages/MyMove/PPM/Closeout/WeightTickets/WeightTickets.jsx
+++ b/src/pages/MyMove/PPM/Closeout/WeightTickets/WeightTickets.jsx
@@ -80,7 +80,7 @@ const WeightTickets = () => {
           setErrorMessage('Failed to create trip record');
         });
     }
-  }, [weightTicketId, moveId, mtoShipmentId, navigate, dispatch, mtoShipment, serviceMemberId]);
+  }, [weightTicketId, moveId, mtoShipmentId, navigate, dispatch, mtoShipment]);
 
   useEffect(() => {
     const moves = getAllMoves(serviceMemberId);

--- a/src/pages/MyMove/PPM/Closeout/WeightTickets/WeightTickets.test.jsx
+++ b/src/pages/MyMove/PPM/Closeout/WeightTickets/WeightTickets.test.jsx
@@ -30,6 +30,7 @@ jest.mock('services/internalApi', () => ({
   deleteUpload: jest.fn(),
   patchWeightTicket: jest.fn(),
   getResponseError: jest.fn(),
+  getAllMoves: jest.fn().mockImplementation(() => Promise.resolve()),
 }));
 
 const mockMTOShipment = {
@@ -113,10 +114,15 @@ const mockEmptyWeightTicketAndIndex = {
   index: -1,
 };
 
+const mockServiceMember = {
+  id: 'testId',
+};
+
 jest.mock('store/entities/selectors', () => ({
   ...jest.requireActual('store/entities/selectors'),
   selectMTOShipmentById: jest.fn(() => mockMTOShipment),
   selectWeightTicketAndIndexById: jest.fn(() => mockEmptyWeightTicketAndIndex),
+  selectServiceMemberFromLoggedInUser: jest.fn(() => mockServiceMember),
 }));
 
 beforeEach(() => {

--- a/src/store/entities/selectors.js
+++ b/src/store/entities/selectors.js
@@ -178,7 +178,34 @@ export const selectMTOShipmentsForCurrentMove = (state) => {
 };
 
 export function selectMTOShipmentById(state, id) {
-  return state.entities?.mtoShipments?.[`${id}`] || null;
+  // Attempt to get the shipment using the existing method
+  const mtoShipment = state.entities?.mtoShipments?.[`${id}`] || null;
+  if (mtoShipment) {
+    return mtoShipment;
+  }
+
+  // now we will check both current and previous moves for the shipment
+  const moves = state.entities.serviceMemberMoves;
+
+  const currentMove = moves.currentMove?.[0]?.mtoShipments || [];
+  const foundInCurrentMove = currentMove.find((shipment) => shipment.id === id);
+  if (foundInCurrentMove) {
+    return foundInCurrentMove;
+  }
+
+  const previousMoves = moves.previousMoves || [];
+  const foundInPreviousMoves = previousMoves.reduce((found, move) => {
+    if (found) return found;
+    const shipments = move.mtoShipments || [];
+    return shipments.find((shipment) => shipment.id === id) || null;
+  }, null);
+
+  if (foundInPreviousMoves) {
+    return foundInPreviousMoves;
+  }
+
+  // If still not found, return null
+  return null;
 }
 
 /** PPMs */


### PR DESCRIPTION
[INT PR #1](https://github.com/transcom/mymove/pull/13285)
[INT PR #2](https://github.com/transcom/mymove/pull/13308)

## [Agility ticket](https://www13.v1host.com/USTRANSCOM38/assetdetail.v1?number=B-20463)

## Summary

This ticket was created from an issue that was occurring when the customer would have more than one move and go back to their PPM shipment in an older move and try to Upload PPM docs and handle closing it out. The cause of this was when viewing a previous move, `mtoShipments` was returning `null` since the params didn't match what was stored in `state` for the CURRENT (the most recently created) move (when Truss first designed this, they did not consider multiple moves and PAST moves).

When transitioning to multiple moves, we pull a butt load of data from the `serviceMemberMoves` object in `state`. This big 'ol boy is queried when the user firsts signs in and any subsequent updates. A lot of the issue was that we weren't picking the right data from `state` when looking at a PREVIOUS moves, as well as not querying for specific data used for the weight ticket and PPM doc upload process.

This PR does the following:
- updates the query handling retrieving multiple moves to include pro gear, expense, and weight ticket data and uploads
- excludes tickets that have `deleted_at` values (comments in code explain why this has to be done with logic checks)
- updates `ProGear` & `WeightTickets` to update all moves once data/uploads are created/updated
- updated selector when picking `mtoShipment` to also include multiple moves IF it doesn't use the "old" way first
- update all relevant tests

### How to test

1. Fire up MilMove as a customer
2. Set up two moves with PPM shipments
3. Approve as service counselor
4. You should now be able to upload PPM documents and close out the PPM
5. Try to break it - make sure that you can upload docs & data for both moves separately and that data is dynamic as things change

## Screenshots
Set up two moves
![Screenshot 2024-07-19 at 11 09 41 AM](https://github.com/user-attachments/assets/784866e8-08db-451a-a4e1-9eca96f288e4)

You want your move home page to look like this for both
![Screenshot 2024-07-19 at 11 09 53 AM](https://github.com/user-attachments/assets/57d6e479-db80-427e-8b4b-414043907c68)

Add/edit/delete any of these and make sure that things change in state as you make changes
![Screenshot 2024-07-19 at 11 23 00 AM](https://github.com/user-attachments/assets/677a3017-bdc1-430d-bf7f-932042ee2d72)


