### PR TITLE
MAIN B-20684 858 60 char limit on location names (MERGE AFTER B-20462)

### DIFF
--- a/pkg/services/invoice/ghc_payment_request_invoice_generator.go
+++ b/pkg/services/invoice/ghc_payment_request_invoice_generator.go
@@ -44,6 +44,7 @@ const dateFormat = "20060102"
 const isaDateFormat = "060102"
 const timeFormat = "1504"
 const maxCityLength = 30
+const maxLocationlength = 60
 
 // Generate method takes a payment request and returns an Invoice858C
 func (g ghcPaymentRequestInvoiceGenerator) Generate(appCtx appcontext.AppContext, paymentRequest models.PaymentRequest, sendProductionInvoice bool) (ediinvoice.Invoice858C, error) {
@@ -428,10 +429,11 @@ func (g ghcPaymentRequestInvoiceGenerator) createBuyerAndSellerOrganizationNames
 
 	header.BuyerOrganizationName = edisegment.N1{
 		EntityIdentifierCode:        "BY",
-		Name:                        originDutyLocation.Name,
+		Name:                        truncateStr(originDutyLocation.Name, maxLocationlength),
 		IdentificationCodeQualifier: "92",
 		IdentificationCode:          modifyGblocIfMarines(*orders.ServiceMember.Affiliation, *orders.OriginDutyLocationGBLOC),
 	}
+
 	// seller organization name
 	header.SellerOrganizationName = edisegment.N1{
 		EntityIdentifierCode:        "SE",
@@ -463,7 +465,7 @@ func (g ghcPaymentRequestInvoiceGenerator) createOriginAndDestinationSegments(ap
 	// destination name
 	header.DestinationName = edisegment.N1{
 		EntityIdentifierCode:        "ST",
-		Name:                        destinationDutyLocation.Name,
+		Name:                        truncateStr(destinationDutyLocation.Name, maxLocationlength),
 		IdentificationCodeQualifier: "10",
 		IdentificationCode:          modifyGblocIfMarines(*orders.ServiceMember.Affiliation, destPostalCodeToGbloc.GBLOC),
 	}
@@ -524,7 +526,7 @@ func (g ghcPaymentRequestInvoiceGenerator) createOriginAndDestinationSegments(ap
 
 	header.OriginName = edisegment.N1{
 		EntityIdentifierCode:        "SF",
-		Name:                        originDutyLocation.Name,
+		Name:                        truncateStr(originDutyLocation.Name, maxLocationlength),
 		IdentificationCodeQualifier: "10",
 		IdentificationCode:          modifyGblocIfMarines(*orders.ServiceMember.Affiliation, *orders.OriginDutyLocationGBLOC),
 	}

--- a/pkg/services/invoice/ghc_payment_request_invoice_generator_test.go
+++ b/pkg/services/invoice/ghc_payment_request_invoice_generator_test.go
@@ -786,7 +786,6 @@ func (suite *GHCInvoiceSuite) TestAllGenerateEdi() {
 		// which should match the Origin Duty location name when there is no associated transportation office.
 		n1 := result.Header.OriginName
 		suite.Equal(originDutyLocation.Name, n1.Name)
-
 	})
 
 	suite.Run("adds actual pickup date to header", func() {
@@ -930,6 +929,55 @@ func (suite *GHCInvoiceSuite) TestAllGenerateEdi() {
 		suite.NoError(phoneExpectedErr)
 		suite.Equal(phoneExpected, per.CommunicationNumber)
 	})
+
+	// suite.Run("location names get truncated to only 60 characters in N102 section", func() {
+	// 	setupTestData(nil)
+	// 	// name
+	// 	expectedDutyLocation := paymentRequest.MoveTaskOrder.Orders.OriginDutyLocation
+	// 	n1 := result.Header.OriginName
+	// 	suite.IsType(edisegment.N1{}, n1)
+	// 	suite.Equal("SF", n1.EntityIdentifierCode)
+	// 	suite.Equal(expectedDutyLocation.Name, n1.Name)
+	// 	suite.Equal("10", n1.IdentificationCodeQualifier)
+	// 	suite.Equal(expectedDutyLocation.TransportationOffice.Gbloc, n1.IdentificationCode)
+	// 	// street address
+	// 	address := expectedDutyLocation.Address
+	// 	n3Address := result.Header.OriginStreetAddress
+	// 	suite.IsType(&edisegment.N3{}, n3Address)
+	// 	n3 := *n3Address
+	// 	suite.Equal(address.StreetAddress1, n3.AddressInformation1)
+	// 	suite.Equal(*address.StreetAddress2, n3.AddressInformation2)
+	// 	// city state info
+	// 	n4 := result.Header.OriginPostalDetails
+	// 	suite.IsType(edisegment.N4{}, n4)
+	// 	if len(n4.CityName) >= maxCityLength {
+	// 		suite.Equal(address.City[:maxCityLength]+"...", n4.CityName)
+	// 	} else {
+	// 		suite.Equal(address.City, n4.CityName)
+	// 	}
+	// 	suite.Equal(address.State, n4.StateOrProvinceCode)
+	// 	suite.Equal(address.PostalCode, n4.PostalCode)
+	// 	countryCode, err := address.CountryCode()
+	// 	suite.NoError(err)
+	// 	suite.Equal(*countryCode, n4.CountryCode)
+	// 	// Office Phone
+	// 	originDutyLocationPhoneLines := expectedDutyLocation.TransportationOffice.PhoneLines
+	// 	var originPhoneLines []string
+	// 	for _, phoneLine := range originDutyLocationPhoneLines {
+	// 		if phoneLine.Type == "voice" {
+	// 			originPhoneLines = append(originPhoneLines, phoneLine.Number)
+	// 		}
+	// 	}
+	// 	phone := result.Header.OriginPhone
+	// 	suite.IsType(&edisegment.PER{}, phone)
+	// 	per := *phone
+	// 	suite.Equal("CN", per.ContactFunctionCode)
+	// 	suite.Equal("TE", per.CommunicationNumberQualifier)
+	// 	g := ghcPaymentRequestInvoiceGenerator{}
+	// 	phoneExpected, phoneExpectedErr := g.getPhoneNumberDigitsOnly(originPhoneLines[0])
+	// 	suite.NoError(phoneExpectedErr)
+	// 	suite.Equal(phoneExpected, per.CommunicationNumber)
+	// })
 
 	suite.Run("adds various service item segments", func() {
 		setupTestData(nil)
@@ -1328,14 +1376,6 @@ func (suite *GHCInvoiceSuite) TestNilValues() {
 		suite.NotPanics(panicFunc)
 		nilPaymentRequest.MoveTaskOrder.ReferenceID = oldReferenceID
 	})
-
-	// TODO: Needs some additional thought since PaymentServiceItems is loaded from the DB in Generate.
-	//suite.Run("nil PriceCents does not cause panic", func() {
-	//	oldPriceCents := nilPaymentRequest.PaymentServiceItems[0].PriceCents
-	//	nilPaymentRequest.PaymentServiceItems[0].PriceCents = nil
-	//	suite.NotPanics(panicFunc)
-	//	nilPaymentRequest.PaymentServiceItems[0].PriceCents = oldPriceCents
-	//})
 }
 
 func (suite *GHCInvoiceSuite) TestNoApprovedPaymentServiceItems() {

--- a/pkg/services/invoice/ghc_payment_request_invoice_generator_test.go
+++ b/pkg/services/invoice/ghc_payment_request_invoice_generator_test.go
@@ -946,7 +946,7 @@ func (suite *GHCInvoiceSuite) TestAllGenerateEdi() {
 	})
 
 	suite.Run("location names get truncated to only 60 characters in N102 section", func() {
-		setupTestData(nil)
+		setupTestData(nil, nil, nil, nil)
 		expectedDutyLocation := paymentRequest.MoveTaskOrder.Orders.OriginDutyLocation
 		truncatedDutyLocationName := truncateStr(*models.StringPointer(expectedDutyLocation.Name), 60)
 		n1 := result.Header.OriginName


### PR DESCRIPTION
[INT PR](https://github.com/transcom/mymove/pull/13312)

## [Agility ticket](https://www13.v1host.com/USTRANSCOM38/assetdetail.v1?number=B-20684)

## Summary

When a location name was hecka long, the 858 generation was failing due to constraints within the Go struct. This PR throws a little truncation celebration on the duty location names as well as updates those relevant tests.

### How to test

1. Find a payment request that has the status of `REVIEWED` in DBeaver in the `payment-requests` table
2. We want to change the values of the origin/destination duty location names to something longer than 60 characters to test this
3. Navigate to the orders table by flyin' through the foreign keys as follows
4. `payment_requests` -> `move_id` -> `orders_id`-> `origin_duty_location_id` -> change the `name` column to something long
5. `payment_requests` -> `move_id` -> `orders_id`-> `new_duty_location_id` -> change the `name` column to something long
6. Now go back to the `payment_requests` table on the same row you just navigated through
7. Find the column `payment_request_number`
8. In your CLI, run this command: `go run ./cmd/generate-payment-request-edi/ --payment-request-number <payment_request_number>`
9. You should see a bunch of cryptic looking numbers appear, but the ones we care about are that start with `N1` and you should see the long duty location names truncated and end with `...`

## Screenshots
<img width="1154" alt="Screenshot 2024-07-23 at 1 49 21 PM" src="https://github.com/user-attachments/assets/b105f552-cadc-41d0-af65-2720beb80a8e">
