### PR TITLE
MAIN B-19045 Hide Request Diversion when Cancellation is Requested

### DIFF
--- a/src/components/Office/ShipmentAddresses/ShipmentAddresses.jsx
+++ b/src/components/Office/ShipmentAddresses/ShipmentAddresses.jsx
@@ -53,6 +53,7 @@ const ShipmentAddresses = ({
           'Authorized addresses',
           <div className={styles.rightAlignButtonWrapper}>
             {shipmentInfo.status !== shipmentStatuses.CANCELED &&
+              shipmentInfo.status !== shipmentStatuses.CANCELLATION_REQUESTED &&
               shipmentInfo.shipmentType !== SHIPMENT_OPTIONS.PPM && (
                 <Restricted to={permissionTypes.createShipmentDiversionRequest}>
                   <Restricted to={permissionTypes.updateMTOPage}>

--- a/src/components/Office/ShipmentAddresses/ShipmentAddresses.jsx
+++ b/src/components/Office/ShipmentAddresses/ShipmentAddresses.jsx
@@ -62,7 +62,7 @@ const ShipmentAddresses = ({
                       unstyled
                       disabled={isMoveLocked}
                     >
-                      Request diversion
+                      Request Diversion
                     </Button>
                   </Restricted>
                 </Restricted>

--- a/src/components/Office/ShipmentAddresses/ShipmentAddresses.test.jsx
+++ b/src/components/Office/ShipmentAddresses/ShipmentAddresses.test.jsx
@@ -106,6 +106,17 @@ const canceledShipment = {
   },
 };
 
+const cancellationRequestedShipment = {
+  ...canceledShipment,
+  shipmentInfo: {
+    id: '456',
+    eTag: 'abc123',
+    status: 'CANCELLATION_REQUESTED',
+    shipmentType: SHIPMENT_OPTIONS.HHG,
+    shipmentLocator: 'ABCDEF-01',
+  },
+};
+
 describe('ShipmentAddresses', () => {
   it('calls props.handleShowDiversionModal on request diversion button click', async () => {
     render(
@@ -128,7 +139,20 @@ describe('ShipmentAddresses', () => {
         <ShipmentAddresses {...canceledShipment} />
       </MockProviders>,
     );
-    const requestDiversionBtn = screen.queryByRole('button', { name: 'Request diversion' });
+    const requestDiversionBtn = screen.queryByRole('button', { name: 'Request Diversion' });
+
+    await waitFor(() => {
+      expect(requestDiversionBtn).toBeNull();
+    });
+  });
+
+  it('hides the request diversion button for a cancelation requested shipment', async () => {
+    render(
+      <MockProviders permissions={[permissionTypes.createShipmentDiversionRequest, permissionTypes.updateMTOPage]}>
+        <ShipmentAddresses {...cancellationRequestedShipment} />
+      </MockProviders>,
+    );
+    const requestDiversionBtn = screen.queryByRole('button', { name: 'Request Diversion' });
 
     await waitFor(() => {
       expect(requestDiversionBtn).toBeNull();

--- a/src/components/Office/ShipmentAddresses/ShipmentAddresses.test.jsx
+++ b/src/components/Office/ShipmentAddresses/ShipmentAddresses.test.jsx
@@ -71,7 +71,7 @@ const ppmShipment = {
   },
 };
 
-const cancelledShipment = {
+const canceledShipment = {
   pickupAddress: {
     city: 'Fairfax',
     state: 'VA',
@@ -113,7 +113,7 @@ describe('ShipmentAddresses', () => {
         <ShipmentAddresses {...testProps} />
       </MockProviders>,
     );
-    const requestDiversionBtn = screen.getByRole('button', { name: 'Request diversion' });
+    const requestDiversionBtn = screen.getByRole('button', { name: 'Request Diversion' });
 
     await userEvent.click(requestDiversionBtn);
     await waitFor(() => {
@@ -125,7 +125,7 @@ describe('ShipmentAddresses', () => {
   it('hides the request diversion button for a cancelled shipment', async () => {
     render(
       <MockProviders permissions={[permissionTypes.createShipmentDiversionRequest, permissionTypes.updateMTOPage]}>
-        <ShipmentAddresses {...cancelledShipment} />
+        <ShipmentAddresses {...canceledShipment} />
       </MockProviders>,
     );
     const requestDiversionBtn = screen.queryByRole('button', { name: 'Request diversion' });
@@ -136,8 +136,8 @@ describe('ShipmentAddresses', () => {
   });
 
   it('hides the request diversion button when user does not have permissions', async () => {
-    render(<ShipmentAddresses {...cancelledShipment} />);
-    const requestDiversionBtn = screen.queryByRole('button', { name: 'Request diversion' });
+    render(<ShipmentAddresses {...canceledShipment} />);
+    const requestDiversionBtn = screen.queryByRole('button', { name: 'Request Diversion' });
 
     await waitFor(() => {
       expect(requestDiversionBtn).toBeNull();
@@ -147,10 +147,10 @@ describe('ShipmentAddresses', () => {
   it('hides the request diversion button when user does not have updateMTOPage permissions', async () => {
     render(
       <MockProviders permissions={[permissionTypes.createShipmentDiversionRequest]}>
-        <ShipmentAddresses {...cancelledShipment} />
+        <ShipmentAddresses {...canceledShipment} />
       </MockProviders>,
     );
-    const requestDiversionBtn = screen.queryByRole('button', { name: 'Request diversion' });
+    const requestDiversionBtn = screen.queryByRole('button', { name: 'Request Diversion' });
 
     await waitFor(() => {
       expect(requestDiversionBtn).toBeNull();
@@ -196,7 +196,7 @@ describe('ShipmentAddresses', () => {
       </MockProviders>,
     );
 
-    expect(screen.queryByText('Request diversion')).not.toBeInTheDocument();
+    expect(screen.queryByText('Request Diversion')).not.toBeInTheDocument();
   });
 
   it('renders with disabled request diversion button', async () => {
@@ -206,7 +206,7 @@ describe('ShipmentAddresses', () => {
         <ShipmentAddresses {...testProps} isMoveLocked={isMoveLocked} />
       </MockProviders>,
     );
-    const requestDiversionBtn = screen.getByRole('button', { name: 'Request diversion' });
+    const requestDiversionBtn = screen.getByRole('button', { name: 'Request Diversion' });
     expect(requestDiversionBtn).toBeDisabled();
   });
 });

--- a/src/components/Office/ShipmentHeading/ShipmentHeading.jsx
+++ b/src/components/Office/ShipmentHeading/ShipmentHeading.jsx
@@ -23,7 +23,8 @@ function formatDestinationAddress(address) {
 function ShipmentHeading({ shipmentInfo, handleShowCancellationModal, isMoveLocked }) {
   const { shipmentStatus } = shipmentInfo;
   // cancelation modal is visible if shipment is not already canceled, AND if shipment cancellation hasn't already been requested
-  const isCancelModalVisible = shipmentStatus !== shipmentStatuses.CANCELED || shipmentStatuses.CANCELLATION_REQUESTED;
+  const showRequestCancellation =
+    shipmentStatus !== shipmentStatuses.CANCELED && shipmentStatus !== shipmentStatuses.CANCELLATION_REQUESTED;
   const isCancellationRequested = shipmentStatus === shipmentStatuses.CANCELLATION_REQUESTED;
 
   return (
@@ -44,7 +45,7 @@ function ShipmentHeading({ shipmentInfo, handleShowCancellationModal, isMoveLock
           {`${shipmentInfo.originCity}, ${shipmentInfo.originState} ${shipmentInfo.originPostalCode} to
         ${formatDestinationAddress(shipmentInfo.destinationAddress)} on ${shipmentInfo.scheduledPickupDate}`}
         </small>
-        {isCancelModalVisible && (
+        {showRequestCancellation && (
           <Restricted to={permissionTypes.createShipmentCancellation}>
             <Restricted to={permissionTypes.updateMTOPage}>
               <Button

--- a/src/components/Office/ShipmentHeading/ShipmentHeading.test.jsx
+++ b/src/components/Office/ShipmentHeading/ShipmentHeading.test.jsx
@@ -99,11 +99,13 @@ describe('Shipment Heading with diversion requested shipment', () => {
 
 describe('Shipment Heading with cancelled shipment', () => {
   const wrapper = mount(
-    <ShipmentHeading
-      shipmentInfo={{ isDiversion: false, ...headingInfo, shipmentStatus: 'CANCELED' }}
-      handleUpdateMTOShipmentStatus={jest.fn()}
-      handleShowCancellationModal={jest.fn()}
-    />,
+    <MockProviders permissions={[permissionTypes.createShipmentCancellation, permissionTypes.updateMTOPage]}>
+      <ShipmentHeading
+        shipmentInfo={{ isDiversion: false, ...headingInfo, shipmentStatus: 'CANCELED' }}
+        handleUpdateMTOShipmentStatus={jest.fn()}
+        handleShowCancellationModal={jest.fn()}
+      />
+    </MockProviders>,
   );
 
   it('renders the cancelled tag next to the shipment type', () => {
@@ -111,25 +113,27 @@ describe('Shipment Heading with cancelled shipment', () => {
   });
 
   it('hides the request cancellation button', () => {
-    expect(wrapper.find('button').length).toBeFalsy();
+    expect(wrapper.find({ 'data-testid': 'requestCancellationBtn' }).length).toBeFalsy();
   });
 });
 
 describe('Shipment Heading with shipment cancellation requested', () => {
   const wrapper = mount(
-    <ShipmentHeading
-      shipmentInfo={{ isDiversion: false, ...headingInfo, shipmentStatus: shipmentStatuses.CANCELLATION_REQUESTED }}
-      handleUpdateMTOShipmentStatus={jest.fn()}
-      handleShowCancellationModal={jest.fn()}
-    />,
+    <MockProviders permissions={[permissionTypes.createShipmentCancellation, permissionTypes.updateMTOPage]}>
+      <ShipmentHeading
+        shipmentInfo={{ isDiversion: false, ...headingInfo, shipmentStatus: shipmentStatuses.CANCELLATION_REQUESTED }}
+        handleUpdateMTOShipmentStatus={jest.fn()}
+        handleShowCancellationModal={jest.fn()}
+      />
+    </MockProviders>,
   );
 
   it('renders the cancellation requested tag next to the shipment type', () => {
     expect(wrapper.find({ 'data-testid': 'tag' }).text()).toEqual('Cancellation Requested');
   });
 
-  it('hides the request cancellation button', () => {
-    expect(wrapper.find('button').length).toBeFalsy();
+  it('hides the request cancellation button', async () => {
+    expect(wrapper.find({ 'data-testid': 'requestCancellationBtn' }).length).toBeFalsy();
   });
 });
 
@@ -149,7 +153,7 @@ describe('Shipment Heading shows cancellation button with permissions', () => {
   });
 });
 
-describe('Shipment Heading hides cancellation button without permissions', () => {
+describe('Shipment Heading hides cancellation button without any permissions', () => {
   const wrapper = mount(
     <ShipmentHeading
       shipmentInfo={headingInfo}
@@ -158,13 +162,13 @@ describe('Shipment Heading hides cancellation button without permissions', () =>
     />,
   );
 
-  it('renders withour request shipment cancellation when user does not have permission', () => {
+  it('renders without request shipment cancellation when user does not have any permissions', () => {
     expect(wrapper.find('button').length).toBeFalsy();
   });
 });
 
-describe('Shipment Heading hides cancellation button without updateMTOPage permission', () => {
-  const wrapper = mount(
+describe('Shipment Heading hides cancellation button when user is missing permission(s)', () => {
+  let wrapper = mount(
     <MockProviders permissions={[permissionTypes.createShipmentCancellation]}>
       <ShipmentHeading
         shipmentInfo={headingInfo}
@@ -174,8 +178,22 @@ describe('Shipment Heading hides cancellation button without updateMTOPage permi
     </MockProviders>,
   );
 
-  it('renders withour request shipment cancellation when user does not have permission', () => {
-    expect(wrapper.find('button').length).toBeFalsy();
+  it('renders withour request shipment cancellation when user is missing one permissions', () => {
+    expect(wrapper.find({ 'data-testid': 'requestCancellationBtn' }).length).toBeFalsy();
+  });
+
+  wrapper = mount(
+    <MockProviders permissions={[permissionTypes.updateMTOPage]}>
+      <ShipmentHeading
+        shipmentInfo={headingInfo}
+        handleUpdateMTOShipmentStatus={jest.fn()}
+        handleShowCancellationModal={jest.fn()}
+      />
+    </MockProviders>,
+  );
+
+  it('renders withour request shipment cancellation when user does not have both permissions', () => {
+    expect(wrapper.find({ 'data-testid': 'requestCancellationBtn' }).length).toBeFalsy();
   });
 });
 


### PR DESCRIPTION
## [B-19045](https://www13.v1host.com/USTRANSCOM38/assetdetail.v1?number=B-19045)
### [INT PR](https://github.com/transcom/mymove/pull/13270)

## Summary

Is there anything you would like reviewers to give additional scrutiny?

[this article](tbd) explains more about the approach used.

## Verification Steps for the Author

These are to be checked by the author.

- [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
- [ ] Have the Agility acceptance criteria been met for this change?

## Verification Steps for Reviewers

These are to be checked by a reviewer.

- [ ] Has the branch been pulled in and checked out?
- [ ] Have the BL acceptance criteria been met for this change?
- [ ] Was the CircleCI build successful?
- [ ] Has the code been reviewed from a standards and best practices point of view?

### Setup to Run the Code

- [Instructions for starting storybook](https://transcom.github.io/mymove-docs/docs/frontend/setup/storybook)
- [Instructions for starting the MilMove application](https://transcom.github.io/mymove-docs/docs/getting-started/application-setup/)
- [Instructions for running tests](https://transcom.github.io/mymove-docs/docs/getting-started/development/testing)

### How to test

1. Access the
2. Login as a
3.

### Frontend

- [ ] There are no aXe warnings for UI.
- [ ] This works in [Supported Browsers and their phone views](https://transcom.github.io/mymove-docs/docs/adrs/Browser-Support/#minimum-browser-requirements) (Chrome, Firefox, Edge).
- [ ] There are no new console errors in the browser devtools.
- [ ] There are no new console errors in the test output.
- [ ] If this PR adds a new component to Storybook, it ensures the component is fully responsive, OR if it is intentionally not, a wrapping div using the `officeApp` class or custom `min-width` styling is used to hide any states the would not be visible to the user.
- [ ] This change meets the standards for [Section 508 compliance](https://www.ssa.gov/accessibility/andi/help/install.html).

### Backend

- [ ] Code follows the guidelines for [Logging](https://transcom.github.io/mymove-docs/docs/getting-started/development/logging).
- [ ] The requirements listed in [Querying the Database Safely](https://transcom.github.io/mymove-docs/docs/backend/guides/golang-guide#querying-the-database-safely) have been satisfied.

### Database

#### Any new migrations/schema changes:

- [ ] Follows our guidelines for [Zero-Downtime Deploys](https://transcom.github.io/mymove-docs/docs/backend/setup/database-migrations#zero-downtime-migrations).
- [ ] Have been communicated to #g-database.
- [ ] Secure migrations have been tested following the instructions in our [docs](https://transcom.github.io/mymove-docs/docs/backend/setup/database-migrations#secure-migrations).

## Screenshots
