### PR TITLE
B 20647 add sac 80 character limit

### DIFF
--- a/pkg/handlers/ghcapi/orders.go
+++ b/pkg/handlers/ghcapi/orders.go
@@ -186,7 +186,7 @@ func (h CreateOrderHandler) Handle(params orderop.CreateOrderParams) middleware.
 				return orderop.NewCreateOrderUnprocessableEntity(), err
 			}
 
-			if len(*payload.Sac) > SAC_LIMIT {
+			if payload.Sac != nil && len(*payload.Sac) > SAC_LIMIT {
 				err = apperror.NewBadDataError("SAC cannot be more than 80 characters.")
 				appCtx.Logger().Error(err.Error())
 				return orderop.NewCreateOrderUnprocessableEntity(), err

--- a/pkg/handlers/ghcapi/orders.go
+++ b/pkg/handlers/ghcapi/orders.go
@@ -170,6 +170,7 @@ type CreateOrderHandler struct {
 func (h CreateOrderHandler) Handle(params orderop.CreateOrderParams) middleware.Responder {
 	return h.AuditableAppContextFromRequestWithErrors(params.HTTPRequest,
 		func(appCtx appcontext.AppContext) (middleware.Responder, error) {
+			const SAC_LIMIT = 80
 			payload := params.CreateOrders
 
 			serviceMemberID, err := uuid.FromString(payload.ServiceMemberID.String())
@@ -181,6 +182,12 @@ func (h CreateOrderHandler) Handle(params orderop.CreateOrderParams) middleware.
 			serviceMember, err := models.FetchServiceMemberForUser(appCtx.DB(), appCtx.Session(), serviceMemberID)
 			if err != nil {
 				err = apperror.NewBadDataError("Service member cannot be verified")
+				appCtx.Logger().Error(err.Error())
+				return orderop.NewCreateOrderUnprocessableEntity(), err
+			}
+
+			if len(*payload.Sac) > SAC_LIMIT {
+				err = apperror.NewBadDataError("SAC cannot be more than 80 characters.")
 				appCtx.Logger().Error(err.Error())
 				return orderop.NewCreateOrderUnprocessableEntity(), err
 			}

--- a/pkg/services/order/order_updater.go
+++ b/pkg/services/order/order_updater.go
@@ -32,6 +32,7 @@ func NewOrderUpdater(moveRouter services.MoveRouter) services.OrderUpdater {
 
 // UpdateOrderAsTOO updates an order as permitted by a TOO
 func (f *orderUpdater) UpdateOrderAsTOO(appCtx appcontext.AppContext, orderID uuid.UUID, payload ghcmessages.UpdateOrderPayload, eTag string) (*models.Order, uuid.UUID, error) {
+	const SAC_LIMIT = 80
 	order, err := f.findOrder(appCtx, orderID)
 	if err != nil {
 		return &models.Order{}, uuid.Nil, err
@@ -40,6 +41,10 @@ func (f *orderUpdater) UpdateOrderAsTOO(appCtx appcontext.AppContext, orderID uu
 	existingETag := etag.GenerateEtag(order.UpdatedAt)
 	if existingETag != eTag {
 		return &models.Order{}, uuid.Nil, apperror.NewPreconditionFailedError(orderID, query.StaleIdentifierError{StaleIdentifier: eTag})
+	}
+
+	if payload.Sac.Present && payload.Sac.Value != nil && len(*payload.Sac.Value) > SAC_LIMIT {
+		return &models.Order{}, uuid.Nil, apperror.NewInvalidInputError(orderID, nil, nil, "SAC cannot be more than 80 characters")
 	}
 
 	orderToUpdate := orderFromTOOPayload(appCtx, *order, payload)

--- a/pkg/services/order/order_updater.go
+++ b/pkg/services/order/order_updater.go
@@ -54,6 +54,7 @@ func (f *orderUpdater) UpdateOrderAsTOO(appCtx appcontext.AppContext, orderID uu
 
 // UpdateOrderAsCounselor updates an order as permitted by a service counselor
 func (f *orderUpdater) UpdateOrderAsCounselor(appCtx appcontext.AppContext, orderID uuid.UUID, payload ghcmessages.CounselingUpdateOrderPayload, eTag string) (*models.Order, uuid.UUID, error) {
+	const SAC_LIMIT = 80
 	order, err := f.findOrder(appCtx, orderID)
 	if err != nil {
 		return &models.Order{}, uuid.Nil, err
@@ -62,6 +63,10 @@ func (f *orderUpdater) UpdateOrderAsCounselor(appCtx appcontext.AppContext, orde
 	existingETag := etag.GenerateEtag(order.UpdatedAt)
 	if existingETag != eTag {
 		return &models.Order{}, uuid.Nil, apperror.NewPreconditionFailedError(orderID, query.StaleIdentifierError{StaleIdentifier: eTag})
+	}
+
+	if payload.Sac.Present && payload.Sac.Value != nil && len(*payload.Sac.Value) > SAC_LIMIT {
+		return &models.Order{}, uuid.Nil, apperror.NewInvalidInputError(orderID, nil, nil, "SAC cannot be more than 80 characters")
 	}
 
 	orderToUpdate := orderFromCounselingPayload(*order, payload)

--- a/src/components/Office/OrdersDetailForm/OrdersDetailForm.jsx
+++ b/src/components/Office/OrdersDetailForm/OrdersDetailForm.jsx
@@ -116,6 +116,7 @@ const OrdersDetailForm = ({
           id="hhgSacInput"
           data-testid="hhgSacInput"
           isDisabled={formIsDisabled}
+          maxLength="80"
           optional
         />
       )}
@@ -155,6 +156,7 @@ const OrdersDetailForm = ({
           id="ntsSacInput"
           isDisabled={formIsDisabled}
           data-testid="ntsSacInput"
+          maxLength="80"
           optional
         />
       )}


### PR DESCRIPTION
## [B-20647](https://www13.v1host.com/USTRANSCOM38/story.mvc/Summary?oidToken=Story%3A982736)
### [INT PR](https://github.com/transcom/mymove/pull/13281)
## Summary

Set the SAC field character limit to 80 characters for HHG and NTS shipments.

Is there anything you would like reviewers to give additional scrutiny?
Also set backend validation so the SAC cannot be more than 80 characters. Please test using swagger by trying to create a a new Order. See instructions in test section.

## Verification Steps for the Author

These are to be checked by the author.

- [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
- [ ] Have the Agility acceptance criteria been met for this change?

## Verification Steps for Reviewers

These are to be checked by a reviewer.

- [ ] Has the branch been pulled in and checked out?
- [ ] Have the BL acceptance criteria been met for this change?
- [ ] Was the CircleCI build successful?
- [ ] Has the code been reviewed from a standards and best practices point of view?

### Setup to Run the Code

- [Instructions for starting storybook](https://transcom.github.io/mymove-docs/docs/frontend/setup/storybook)
- [Instructions for starting the MilMove application](https://transcom.github.io/mymove-docs/docs/getting-started/application-setup/)
- [Instructions for running tests](https://transcom.github.io/mymove-docs/docs/getting-started/development/testing)

### How to test

1. Access a shipment with HHG and/or NTS as Service Counselor that hasn't been approved yet
2. View the Orders for the HHG and/or NTS shipment
3. Try to enter more than 80 characters into the SAC field. Below is a sample string that is 90 characters, if you paste this into the SAC field then you should not see any 9's in the text field.

111111111122222222223333333333444444444455555555556666666666777777777788888888889999999999

4. Use swagger to try and create an Order with a SAC greater than 80 characters. This should fail with an unprocessable entity error. 
5. Adjust the SAC to be less than 80 characters and verify you get no errors.

Sample for the body for POST create Order is below just update the SAC as needed.

{
  "serviceMemberId": "eec4e65e-b328-4133-b822-c7eaba860ec9",
  "issueDate": "2024-07-22",
  "reportByDate": "2024-07-22",
  "ordersType": "PERMANENT_CHANGE_OF_STATION",
  "ordersTypeDetail": "HHG_PERMITTED",
  "hasDependents": true,
  "spouseHasProGear": true,
  "newDutyLocationId": "62e795f4-61a8-4cca-b59d-028345c07b89",
  "ordersNumber": "030-00362",
  "tac": "F8J1",
  "sac": "111111111122222222223333333333444444444455555555556666666666777777777788888888889999999999",
  "departmentIndicator": "NAVY_AND_MARINES",
  "grade": "E_1",
  "originDutyLocationId": "929ba47a-2f7d-430e-9655-157a4c80303d"
}

Sample body for the PATCH update of the order (use the eTag and id from the successful result above.

{
  "issueDate": "2024-07-22",
  "reportByDate": "2024-07-22",
  "ordersType": "PERMANENT_CHANGE_OF_STATION",
  "ordersTypeDetail": "HHG_PERMITTED",
  "newDutyLocationId": "62e795f4-61a8-4cca-b59d-028345c07b89",
  "ordersNumber": "030-00362",
  "tac": "F8J1",
  "sac": "11111111112222222222333333333344444444445555555555666666666",
  "departmentIndicator": "NAVY_AND_MARINES",
  "grade": "E_1",
  "originDutyLocationId": "929ba47a-2f7d-430e-9655-157a4c80303d"
}

### Frontend

- [ ] There are no aXe warnings for UI.
- [ ] This works in [Supported Browsers and their phone views](https://transcom.github.io/mymove-docs/docs/adrs/Browser-Support/#minimum-browser-requirements) (Chrome, Firefox, Edge).
- [ ] There are no new console errors in the browser devtools.
- [ ] There are no new console errors in the test output.
- [ ] If this PR adds a new component to Storybook, it ensures the component is fully responsive, OR if it is intentionally not, a wrapping div using the `officeApp` class or custom `min-width` styling is used to hide any states the would not be visible to the user.
- [ ] This change meets the standards for [Section 508 compliance](https://www.ssa.gov/accessibility/andi/help/install.html).

### Backend

- [ ] Code follows the guidelines for [Logging](https://transcom.github.io/mymove-docs/docs/getting-started/development/logging).
- [ ] The requirements listed in [Querying the Database Safely](https://transcom.github.io/mymove-docs/docs/backend/guides/golang-guide#querying-the-database-safely) have been satisfied.

### Database

#### Any new migrations/schema changes:

- [ ] Follows our guidelines for [Zero-Downtime Deploys](https://transcom.github.io/mymove-docs/docs/backend/setup/database-migrations#zero-downtime-migrations).
- [ ] Have been communicated to #g-database.
- [ ] Secure migrations have been tested following the instructions in our [docs](https://transcom.github.io/mymove-docs/docs/backend/setup/database-migrations#secure-migrations).

## Screenshots
