### PR TITLE
B20449-INT-nts ntsr missing shipment num

### DIFF
--- a/src/components/Customer/Review/Summary/Summary.jsx
+++ b/src/components/Customer/Review/Summary/Summary.jsx
@@ -198,6 +198,7 @@ export class Summary extends Component {
             shipmentType={shipment.shipmentType}
             status={shipment.status}
             onIncompleteClick={this.toggleIncompleteShipmentModal}
+            shipmentLocator={shipment.shipmentLocator}
           />
         );
       }
@@ -220,6 +221,7 @@ export class Summary extends Component {
             shipmentType={shipment.shipmentType}
             status={shipment.status}
             onIncompleteClick={this.toggleIncompleteShipmentModal}
+            shipmentLocator={shipment.shipmentLocator}
           />
         );
       }


### PR DESCRIPTION
## Agility ticket
[B20449](https://www13.v1host.com/USTRANSCOM38/assetdetail.v1?number=B-20449)

## Summary
After a customer has created a move, they may review the move by clicking the "review" button at the bottom of the page.  Regardless whether the move was submitted or not, the shipment number of the shipments under the "move setup" section were empty.  The goal of the story was to fix that.

### How to test
* Customer: 
  - Create a move with an NTS and NTS-R shipment.
  - Submit the move
  - Click the "Review Request" button at the bottom
  - Scroll down to the "Move Setup" section.
  - Confirm both moves have a shipment number.

## ANDI Screenshots
![image](https://github.com/user-attachments/assets/008ea1f8-2fb7-4301-b434-e14c5e3c3609)

![image](https://github.com/user-attachments/assets/914ddd30-4011-4ac5-bf25-77e36e9f796b)

Shipment Number added to the UI has no action item.

## App Screenshots
![image](https://github.com/user-attachments/assets/5e3bdcfa-588f-4636-a0a4-0e3ae3009ecd)

![image](https://github.com/user-attachments/assets/efc564dd-78b4-47c5-9dfc-babbbffbd764)
