### PR TITLE
INT B-20282 fix prime sim edit styling

### DIFF
--- a/src/pages/PrimeUI/MoveTaskOrder/MoveDetails.jsx
+++ b/src/pages/PrimeUI/MoveTaskOrder/MoveDetails.jsx
@@ -214,6 +214,7 @@ const MoveDetails = ({ setFlashMessage }) => {
                       className="usa-select"
                       name="moveOrderDocumentType"
                       id="moveOrderDocumentType"
+                      title="moveOrderDocumentType"
                     >
                       <option value={MoveOrderDocumentType.ALL}>ALL</option>
                       <option value={MoveOrderDocumentType.ORDERS}>ORDERS</option>
@@ -258,7 +259,7 @@ const MoveDetails = ({ setFlashMessage }) => {
                                 <div className={styles.uploadBtn}>
                                   {SIT_SERVICE_ITEMS_ALLOWED_UPDATE.includes(serviceItem.reServiceCode) ? (
                                     <Link
-                                      className="usa-button usa-button--outline"
+                                      className={classnames(styles.editButton, 'usa-button usa-button--outline')}
                                       to={`../mto-service-items/${serviceItem.id}/update`}
                                       relative="path"
                                     >

--- a/src/pages/PrimeUI/MoveTaskOrder/MoveDetails.module.scss
+++ b/src/pages/PrimeUI/MoveTaskOrder/MoveDetails.module.scss
@@ -52,6 +52,12 @@
   :global(.usa-select) {
     width: 20%;
   }
+
+  .editButton {
+    background-color: transparent;
+    box-shadow: inset 0 0 0 2px #005ea2;
+    color: #005ea2;
+  }
 }
 
 .specialMovesLabel {


### PR DESCRIPTION
## [B-20282](https://www13.v1host.com/USTRANSCOM38/assetdetail.v1?number=B-20282)

## Summary

Fixed the styling issue in Prime Sim for the Edit buttons next to upload documents. The issue was happening when going to a move details as a TOO and then switching to Prime sim.

Before: 
![image](https://github.com/user-attachments/assets/505b51be-6406-4f4d-9cbb-7179da9283c0)

Now:
![image](https://github.com/user-attachments/assets/ebfb3682-e401-4446-8244-fbb19c315084)


## Verification Steps for Reviewers

These are to be checked by a reviewer.

- [ ] Has the branch been pulled in and checked out?
- [ ] Have the BL acceptance criteria been met for this change?
- [ ] Was the CircleCI build successful?
- [ ] Has the code been reviewed from a standards and best practices point of view?

### How to test
1. Use 'HHGMoveInSITDeparted' to create a move.
2. Start from the Prime Simulator page for the move where the 'Edit' button is showing and where the issue is supposedly present.
3. Click change user role and select TOO.
4. Click and any move and go to move details.
5. Click change user role and select prime simulator.
6. Click on the move you were on in step 2.
7. The "Edit" button should have a white background.


## Screenshots
![image](https://github.com/user-attachments/assets/2bdc3764-4731-4df9-b2b6-48de54959e13)
