### PR TITLE
MAIN B-20316 - Pro Gear Weights in Prime V3 API

### DIFF
--- a/pkg/gen/primev3api/embedded_spec.go
+++ b/pkg/gen/primev3api/embedded_spec.go
@@ -1480,6 +1480,18 @@ func init() {
           "x-nullable": true,
           "x-omitempty": false
         },
+        "actualProGearWeight": {
+          "description": "The actual weight of any pro gear being shipped.\n",
+          "type": "integer",
+          "x-nullable": true,
+          "x-omitempty": false
+        },
+        "actualSpouseProGearWeight": {
+          "description": "The actual weight of any spouse pro gear being shipped.\n",
+          "type": "integer",
+          "x-nullable": true,
+          "x-omitempty": false
+        },
         "agents": {
           "$ref": "#/definitions/MTOAgents"
         },
@@ -4984,6 +4996,18 @@ func init() {
           "description": "The date when the Prime contractor actually picked up the shipment. Updated after-the-fact.",
           "type": "string",
           "format": "date",
+          "x-nullable": true,
+          "x-omitempty": false
+        },
+        "actualProGearWeight": {
+          "description": "The actual weight of any pro gear being shipped.\n",
+          "type": "integer",
+          "x-nullable": true,
+          "x-omitempty": false
+        },
+        "actualSpouseProGearWeight": {
+          "description": "The actual weight of any spouse pro gear being shipped.\n",
+          "type": "integer",
           "x-nullable": true,
           "x-omitempty": false
         },

--- a/pkg/gen/primev3messages/m_t_o_shipment_without_service_items.go
+++ b/pkg/gen/primev3messages/m_t_o_shipment_without_service_items.go
@@ -28,6 +28,14 @@ type MTOShipmentWithoutServiceItems struct {
 	// Format: date
 	ActualPickupDate *strfmt.Date `json:"actualPickupDate"`
 
+	// The actual weight of any pro gear being shipped.
+	//
+	ActualProGearWeight *int64 `json:"actualProGearWeight"`
+
+	// The actual weight of any spouse pro gear being shipped.
+	//
+	ActualSpouseProGearWeight *int64 `json:"actualSpouseProGearWeight"`
+
 	// agents
 	Agents MTOAgents `json:"agents,omitempty"`
 

--- a/pkg/handlers/primeapiv3/payloads/model_to_payload.go
+++ b/pkg/handlers/primeapiv3/payloads/model_to_payload.go
@@ -476,6 +476,8 @@ func MTOShipmentWithoutServiceItems(mtoShipment *models.MTOShipment) *primev3mes
 		ShipmentType:                     primev3messages.MTOShipmentType(mtoShipment.ShipmentType),
 		CustomerRemarks:                  mtoShipment.CustomerRemarks,
 		CounselorRemarks:                 mtoShipment.CounselorRemarks,
+		ActualProGearWeight:              handlers.FmtPoundPtr(mtoShipment.ActualProGearWeight),
+		ActualSpouseProGearWeight:        handlers.FmtPoundPtr(mtoShipment.ActualSpouseProGearWeight),
 		Status:                           string(mtoShipment.Status),
 		Diversion:                        bool(mtoShipment.Diversion),
 		DiversionReason:                  mtoShipment.DiversionReason,

--- a/swagger-def/definitions/prime/v3/MTOShipmentWithoutServiceItems.yaml
+++ b/swagger-def/definitions/prime/v3/MTOShipmentWithoutServiceItems.yaml
@@ -130,6 +130,18 @@ properties:
     example: handle with care
     x-nullable: true
     readOnly: true
+  actualProGearWeight:
+    description: |
+      The actual weight of any pro gear being shipped.
+    type: integer
+    x-nullable: true
+    x-omitempty: false
+  actualSpouseProGearWeight:
+    description: |
+      The actual weight of any spouse pro gear being shipped.
+    type: integer
+    x-nullable: true
+    x-omitempty: false
   agents:
     $ref: '../MTOAgents.yaml'
   sitExtensions:

--- a/swagger/prime_v3.yaml
+++ b/swagger/prime_v3.yaml
@@ -2689,6 +2689,18 @@ definitions:
         example: handle with care
         x-nullable: true
         readOnly: true
+      actualProGearWeight:
+        description: |
+          The actual weight of any pro gear being shipped.
+        type: integer
+        x-nullable: true
+        x-omitempty: false
+      actualSpouseProGearWeight:
+        description: |
+          The actual weight of any spouse pro gear being shipped.
+        type: integer
+        x-nullable: true
+        x-omitempty: false
       agents:
         $ref: '#/definitions/MTOAgents'
       sitExtensions:


### PR DESCRIPTION
## [B-20316](https://www13.v1host.com/USTRANSCOM38/assetdetail.v1?number=B-20316)
### [INT PR](https://github.com/transcom/mymove/pull/13330)

## Summary
Pro Gear Weights were getting added to the Prime V1 and Prime V2 APIs at the same time Prime V3 was getting created. That timing caused those fields to not make it into Prime V3. Later, the Simulator was updated to use Prime V3 in places that used Pro Gear Weights and this issue became much more noticeable. <- All of this was in tasks assigned to our team.

[Brooklyn noticed this issue and fixed Prime V3 to accept and persist Pro Gear Weights](https://github.com/transcom/mymove/pull/12826/commits/7c5d8eaa848de5dc8c2798a75c5db533dfa7b63c). This ticket returns those stored values.

I was eager to move this to PI 24.5 so it could be fixed before Home Safe switches to V3.

## Verification Steps for the Author

These are to be checked by the author.

- [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
- [ ] Have the Agility acceptance criteria been met for this change?

## Verification Steps for Reviewers

These are to be checked by a reviewer.

- [ ] Has the branch been pulled in and checked out?
- [ ] Have the BL acceptance criteria been met for this change?
- [ ] Was the CircleCI build successful?
- [ ] Has the code been reviewed from a standards and best practices point of view?

### Setup to Run the Code

- [Instructions for starting storybook](https://transcom.github.io/mymove-docs/docs/frontend/setup/storybook)
- [Instructions for starting the MilMove application](https://transcom.github.io/mymove-docs/docs/getting-started/application-setup/)
- [Instructions for running tests](https://transcom.github.io/mymove-docs/docs/getting-started/development/testing)

### How to test

1. Access the
2. Login as a
3.

### Frontend

- [ ] There are no aXe warnings for UI.
- [ ] This works in [Supported Browsers and their phone views](https://transcom.github.io/mymove-docs/docs/adrs/Browser-Support/#minimum-browser-requirements) (Chrome, Firefox, Edge).
- [ ] There are no new console errors in the browser devtools.
- [ ] There are no new console errors in the test output.
- [ ] If this PR adds a new component to Storybook, it ensures the component is fully responsive, OR if it is intentionally not, a wrapping div using the `officeApp` class or custom `min-width` styling is used to hide any states the would not be visible to the user.
- [ ] This change meets the standards for [Section 508 compliance](https://www.ssa.gov/accessibility/andi/help/install.html).

### Backend

- [ ] Code follows the guidelines for [Logging](https://transcom.github.io/mymove-docs/docs/getting-started/development/logging).
- [ ] The requirements listed in [Querying the Database Safely](https://transcom.github.io/mymove-docs/docs/backend/guides/golang-guide#querying-the-database-safely) have been satisfied.

### Database

#### Any new migrations/schema changes:

- [ ] Follows our guidelines for [Zero-Downtime Deploys](https://transcom.github.io/mymove-docs/docs/backend/setup/database-migrations#zero-downtime-migrations).
- [ ] Have been communicated to #g-database.
- [ ] Secure migrations have been tested following the instructions in our [docs](https://transcom.github.io/mymove-docs/docs/backend/setup/database-migrations#secure-migrations).

## Screenshots
