### PR TITLE
MAIN B-20447 Customer Search Sorting Fixes

### DIFF
--- a/pkg/handlers/ghcapi/customer_test.go
+++ b/pkg/handlers/ghcapi/customer_test.go
@@ -229,7 +229,7 @@ func (suite *HandlerSuite) TestSearchCustomersHandler() {
 	suite.Run("Successful customer search by DOD ID", func() {
 		req := setupTestData()
 		customer := factory.BuildServiceMember(suite.DB(), nil, nil)
-		customers := models.ServiceMembers{customer}
+		customers := models.ServiceMemberSearchResults{customer.ToSearchResult()}
 
 		mockSearcher := mocks.CustomerSearcher{}
 
@@ -264,7 +264,7 @@ func (suite *HandlerSuite) TestSearchCustomersHandler() {
 	suite.Run("Successful customer search by name", func() {
 		req := setupTestData()
 		customer := factory.BuildServiceMember(suite.DB(), nil, nil)
-		customers := models.ServiceMembers{customer}
+		customers := models.ServiceMemberSearchResults{customer.ToSearchResult()}
 
 		mockSearcher := mocks.CustomerSearcher{}
 

--- a/pkg/handlers/ghcapi/internal/payloads/model_to_payload.go
+++ b/pkg/handlers/ghcapi/internal/payloads/model_to_payload.go
@@ -2151,7 +2151,7 @@ func ShipmentsPaymentSITBalance(shipmentsSITBalance []services.ShipmentPaymentSI
 	return payload
 }
 
-func SearchCustomers(customers models.ServiceMembers) *ghcmessages.SearchCustomers {
+func SearchCustomers(customers models.ServiceMemberSearchResults) *ghcmessages.SearchCustomers {
 	searchCustomers := make(ghcmessages.SearchCustomers, len(customers))
 	for i, customer := range customers {
 		searchCustomers[i] = &ghcmessages.SearchCustomer{

--- a/pkg/models/service_member.go
+++ b/pkg/models/service_member.go
@@ -102,6 +102,35 @@ func (s ServiceMember) TableName() string {
 	return "service_members"
 }
 
+// Convenience function to convert to search result type, used in go tests
+func (s ServiceMember) ToSearchResult() ServiceMemberSearchResult {
+	return ServiceMemberSearchResult{
+		ID:                     s.ID,
+		CreatedAt:              s.CreatedAt,
+		UpdatedAt:              s.UpdatedAt,
+		UserID:                 s.UserID,
+		User:                   s.User,
+		Edipi:                  s.Edipi,
+		Emplid:                 s.Emplid,
+		Affiliation:            s.Affiliation,
+		FirstName:              s.FirstName,
+		LastName:               s.LastName,
+		Suffix:                 s.Suffix,
+		Telephone:              s.Telephone,
+		SecondaryTelephone:     s.SecondaryTelephone,
+		PersonalEmail:          s.PersonalEmail,
+		EmailIsPreferred:       s.EmailIsPreferred,
+		ResidentialAddressID:   s.ResidentialAddressID,
+		ResidentialAddress:     s.ResidentialAddress,
+		BackupMailingAddressID: s.BackupMailingAddressID,
+		BackupMailingAddress:   s.BackupMailingAddress,
+		Orders:                 s.Orders,
+		BackupContacts:         s.BackupContacts,
+		CacValidated:           s.CacValidated,
+		TotalSim:               nil,
+	}
+}
+
 type ServiceMembers []ServiceMember
 type ServiceMemberSearchResults []ServiceMemberSearchResult
 

--- a/pkg/models/service_member.go
+++ b/pkg/models/service_member.go
@@ -67,12 +67,43 @@ type ServiceMember struct {
 	CacValidated           bool                      `json:"cac_validated" db:"cac_validated"`
 }
 
+// This model should be used whenever the customer name search is used. Had to create new struct so that Pop is aware of the "total_sim" field used in search queries.
+// Since this isn't an actual column, but one created by a subquery, couldn't add it to original ServiceMember struct without errors.
+type ServiceMemberSearchResult struct {
+	ID                     uuid.UUID                 `json:"id" db:"id"`
+	CreatedAt              time.Time                 `json:"created_at" db:"created_at"`
+	UpdatedAt              time.Time                 `json:"updated_at" db:"updated_at"`
+	UserID                 uuid.UUID                 `json:"user_id" db:"user_id"`
+	User                   User                      `belongs_to:"user" fk_id:"user_id"`
+	Edipi                  *string                   `json:"edipi" db:"edipi"`
+	Emplid                 *string                   `json:"emplid" db:"emplid"`
+	Affiliation            *ServiceMemberAffiliation `json:"affiliation" db:"affiliation"`
+	FirstName              *string                   `json:"first_name" db:"first_name"`
+	MiddleName             *string                   `json:"middle_name" db:"middle_name"`
+	LastName               *string                   `json:"last_name" db:"last_name"`
+	Suffix                 *string                   `json:"suffix" db:"suffix"`
+	Telephone              *string                   `json:"telephone" db:"telephone"`
+	SecondaryTelephone     *string                   `json:"secondary_telephone" db:"secondary_telephone"`
+	PersonalEmail          *string                   `json:"personal_email" db:"personal_email"`
+	PhoneIsPreferred       *bool                     `json:"phone_is_preferred" db:"phone_is_preferred"`
+	EmailIsPreferred       *bool                     `json:"email_is_preferred" db:"email_is_preferred"`
+	ResidentialAddressID   *uuid.UUID                `json:"residential_address_id" db:"residential_address_id"`
+	ResidentialAddress     *Address                  `belongs_to:"address" fk_id:"residential_address_id"`
+	BackupMailingAddressID *uuid.UUID                `json:"backup_mailing_address_id" db:"backup_mailing_address_id"`
+	BackupMailingAddress   *Address                  `belongs_to:"address" fk_id:"backup_mailing_address_id"`
+	Orders                 Orders                    `has_many:"orders" fk_id:"service_member_id" order_by:"created_at desc" `
+	BackupContacts         BackupContacts            `has_many:"backup_contacts" fk_id:"service_member_id"`
+	CacValidated           bool                      `json:"cac_validated" db:"cac_validated"`
+	TotalSim               *float32                  `db:"total_sim"`
+}
+
 // TableName overrides the table name used by Pop.
 func (s ServiceMember) TableName() string {
 	return "service_members"
 }
 
 type ServiceMembers []ServiceMember
+type ServiceMemberSearchResults []ServiceMemberSearchResult
 
 // Validate gets run every time you call a "pop.Validate*" (pop.ValidateAndSave, pop.ValidateAndCreate, pop.ValidateAndUpdate) method.
 func (s *ServiceMember) Validate(_ *pop.Connection) (*validate.Errors, error) {

--- a/pkg/services/customer.go
+++ b/pkg/services/customer.go
@@ -23,7 +23,7 @@ type CustomerUpdater interface {
 
 //go:generate mockery --name CustomerSearcher
 type CustomerSearcher interface {
-	SearchCustomers(appCtx appcontext.AppContext, params *SearchCustomersParams) (models.ServiceMembers, int, error)
+	SearchCustomers(appCtx appcontext.AppContext, params *SearchCustomersParams) (models.ServiceMemberSearchResults, int, error)
 }
 
 type SearchCustomersParams struct {

--- a/pkg/services/mocks/CustomerSearcher.go
+++ b/pkg/services/mocks/CustomerSearcher.go
@@ -17,20 +17,20 @@ type CustomerSearcher struct {
 }
 
 // SearchCustomers provides a mock function with given fields: appCtx, params
-func (_m *CustomerSearcher) SearchCustomers(appCtx appcontext.AppContext, params *services.SearchCustomersParams) (models.ServiceMembers, int, error) {
+func (_m *CustomerSearcher) SearchCustomers(appCtx appcontext.AppContext, params *services.SearchCustomersParams) (models.ServiceMemberSearchResults, int, error) {
 	ret := _m.Called(appCtx, params)
 
-	var r0 models.ServiceMembers
+	var r0 models.ServiceMemberSearchResults
 	var r1 int
 	var r2 error
-	if rf, ok := ret.Get(0).(func(appcontext.AppContext, *services.SearchCustomersParams) (models.ServiceMembers, int, error)); ok {
+	if rf, ok := ret.Get(0).(func(appcontext.AppContext, *services.SearchCustomersParams) (models.ServiceMemberSearchResults, int, error)); ok {
 		return rf(appCtx, params)
 	}
-	if rf, ok := ret.Get(0).(func(appcontext.AppContext, *services.SearchCustomersParams) models.ServiceMembers); ok {
+	if rf, ok := ret.Get(0).(func(appcontext.AppContext, *services.SearchCustomersParams) models.ServiceMemberSearchResults); ok {
 		r0 = rf(appCtx, params)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(models.ServiceMembers)
+			r0 = ret.Get(0).(models.ServiceMemberSearchResults)
 		}
 	}
 

--- a/pkg/services/office_user/customer/customer_searcher.go
+++ b/pkg/services/office_user/customer/customer_searcher.go
@@ -138,7 +138,7 @@ func customerNameSearch(customerName *string) QueryOption {
 }
 
 var parameters = map[string]string{
-	"customerName":  "distinct_customers.last_name, distinct_customers.first_name",
+	"customerName":  "distinct_customers.last_name",
 	"dodID":         "distinct_customers.edipi",
 	"emplid":        "distinct_customers.emplid",
 	"branch":        "distinct_customers.affiliation",

--- a/pkg/services/office_user/customer/customer_searcher.go
+++ b/pkg/services/office_user/customer/customer_searcher.go
@@ -96,7 +96,7 @@ func (s customerSearcher) SearchCustomers(appCtx appcontext.AppContext, params *
 			sortTerm := parameters[*params.Sort]
 			rawquery += ` ORDER BY ` + sortTerm + ` ` + *params.Order
 		} else {
-			rawquery += ` ORDER BY distinct_customers.last_name ASC`
+			rawquery += ` ORDER BY f_unaccent(lower($1)) <-> searchable_full_name(first_name, last_name) `
 		}
 		query = appCtx.DB().RawQuery(rawquery, params.CustomerName)
 	}


### PR DESCRIPTION
## [Agility ticket](https://www13.v1host.com/USTRANSCOM38/assetdetail.v1?number=B-20447)

## INT PRs
#13381
#13403

## Summary


This branch fixes two problems that existed on the "Customer Search" tab (as well as other places where customer search was allowed):

1. Names weren't sorted by closest match, i.e. a search for "Ted" would have a user with the last name, first name of "Submitted, HHG" appear at the top, several spots above a user with the name "Marine, Ted". Exact matches now appear at the top of the search results.
2. Sorting on the customer name field was a combination of last name and first name, which led to changing the sort from ascending to descending not actually doing much. For example if you were to have this list in an descending sort:

- Submitted, HHG
- Submitted, PPM
- Unsubmitted, PPM

Instead of "Unsubmitted" going to the top like you might expect when you change to ascending sort, it would instead reverse the sort inside of the last name groups like this:

- Submitted, PPM
- Submitted, HHG
- Unsubmitted, PPM

Now, first name has been removed from the sort consideration, and the expected sort result occurs.

Also, matches were originally calculating match between first and last name separately, which led to some incorrect results. Now, it takes the similarity of the search string with both fields and gets the sum, ensuring that the closest match is always at the top.

Finally, sorting by Branch, phone, etc, would override the exact name matches in the name column, i.e.; results with Air Force branch would always come first regardless of match similarity with the given name search string. PO clarified that exact matches should still take precedent even when sorting via another column.

So, the search SQL query has been edited to always take match similarity into account first, i.e. if a result from the "Navy" branch is a closer match than a result from "Air Force", the "Navy" one should show up at the top anyway. The sort will instead affect the groups where match similarity is the same.


### How to test

Instructions available in both INT PRs for the relevant changes in each.