### PR TITLE
Main B-20448 - payment request search

### DIFF
--- a/pkg/gen/ghcapi/embedded_spec.go
+++ b/pkg/gen/ghcapi/embedded_spec.go
@@ -1896,6 +1896,11 @@ func init() {
                   "description": "requested page of results",
                   "type": "integer"
                 },
+                "paymentRequestCode": {
+                  "type": "string",
+                  "x-nullable": true,
+                  "example": "9551-6199-2"
+                },
                 "perPage": {
                   "type": "integer"
                 },
@@ -11491,6 +11496,11 @@ func init() {
         "originGBLOC": {
           "$ref": "#/definitions/GBLOC"
         },
+        "paymentRequestCode": {
+          "type": "string",
+          "x-nullable": true,
+          "example": "9551-6199-2"
+        },
         "requestedDeliveryDate": {
           "type": "string",
           "format": "date",
@@ -15550,6 +15560,11 @@ func init() {
                 "page": {
                   "description": "requested page of results",
                   "type": "integer"
+                },
+                "paymentRequestCode": {
+                  "type": "string",
+                  "x-nullable": true,
+                  "example": "9551-6199-2"
                 },
                 "perPage": {
                   "type": "integer"
@@ -26111,6 +26126,11 @@ func init() {
         },
         "originGBLOC": {
           "$ref": "#/definitions/GBLOC"
+        },
+        "paymentRequestCode": {
+          "type": "string",
+          "x-nullable": true,
+          "example": "9551-6199-2"
         },
         "requestedDeliveryDate": {
           "type": "string",

--- a/pkg/gen/ghcapi/ghcoperations/move/search_moves.go
+++ b/pkg/gen/ghcapi/ghcoperations/move/search_moves.go
@@ -108,6 +108,10 @@ type SearchMovesBody struct {
 	// requested page of results
 	Page int64 `json:"page,omitempty"`
 
+	// payment request code
+	// Example: 9551-6199-2
+	PaymentRequestCode *string `json:"paymentRequestCode,omitempty"`
+
 	// per page
 	PerPage int64 `json:"perPage,omitempty"`
 

--- a/pkg/gen/ghcmessages/search_move.go
+++ b/pkg/gen/ghcmessages/search_move.go
@@ -71,6 +71,10 @@ type SearchMove struct {
 	// origin g b l o c
 	OriginGBLOC GBLOC `json:"originGBLOC,omitempty"`
 
+	// payment request code
+	// Example: 9551-6199-2
+	PaymentRequestCode *string `json:"paymentRequestCode,omitempty"`
+
 	// requested delivery date
 	// Format: date
 	RequestedDeliveryDate *strfmt.Date `json:"requestedDeliveryDate,omitempty"`

--- a/pkg/handlers/ghcapi/move.go
+++ b/pkg/handlers/ghcapi/move.go
@@ -108,6 +108,7 @@ func (h SearchMovesHandler) Handle(params moveop.SearchMovesParams) middleware.R
 				DodID:                 params.Body.DodID,
 				Emplid:                params.Body.Emplid,
 				CustomerName:          params.Body.CustomerName,
+				PaymentRequestCode:    params.Body.PaymentRequestCode,
 				DestinationPostalCode: params.Body.DestinationPostalCode,
 				OriginPostalCode:      params.Body.OriginPostalCode,
 				Status:                params.Body.Status,

--- a/pkg/services/move.go
+++ b/pkg/services/move.go
@@ -97,6 +97,7 @@ type SearchMovesParams struct {
 	DodID                 *string
 	Emplid                *string
 	CustomerName          *string
+	PaymentRequestCode    *string
 	DestinationPostalCode *string
 	OriginPostalCode      *string
 	Status                []string

--- a/src/components/MoveSearchForm/MoveSearchForm.jsx
+++ b/src/components/MoveSearchForm/MoveSearchForm.jsx
@@ -10,6 +10,7 @@ import styles from './MoveSearchForm.module.scss';
 import { Form } from 'components/form/Form';
 import TextField from 'components/form/fields/TextField/TextField';
 import formStyles from 'styles/form.module.scss';
+import { roleTypes } from 'constants/userRoles';
 
 const baseSchema = Yup.object().shape({
   searchType: Yup.string().required('searchtype error'),
@@ -44,7 +45,7 @@ const paymentRequestCodeSchema = baseSchema.concat(
   }),
 );
 
-const MoveSearchForm = ({ onSubmit }) => {
+const MoveSearchForm = ({ onSubmit, role }) => {
   const getValidationSchema = (values) => {
     switch (values.searchType) {
       case 'moveCode':
@@ -134,21 +135,23 @@ const MoveSearchForm = ({ onSubmit }) => {
                   formik.setFieldTouched('searchText', false, false);
                 }}
               />
-              <Field
-                as={Radio}
-                id="radio-picked-paymentRequestCode"
-                data-testid="paymentRequestCode"
-                type="radio"
-                name="searchType"
-                value="paymentRequestCode"
-                title="Payment Request Number"
-                label="Payment Request Number"
-                onChange={(e) => {
-                  formik.setFieldValue('searchType', e.target.value);
-                  formik.setFieldValue('searchText', '', false); // Clear TextField
-                  formik.setFieldTouched('searchText', false, false);
-                }}
-              />
+              {role !== roleTypes.SERVICES_COUNSELOR && (
+                <Field
+                  as={Radio}
+                  id="radio-picked-paymentRequestCode"
+                  data-testid="paymentRequestCode"
+                  type="radio"
+                  name="searchType"
+                  value="paymentRequestCode"
+                  title="Payment Request Number"
+                  label="Payment Request Number"
+                  onChange={(e) => {
+                    formik.setFieldValue('searchType', e.target.value);
+                    formik.setFieldValue('searchText', '', false); // Clear TextField
+                    formik.setFieldTouched('searchText', false, false);
+                  }}
+                />
+              )}
             </div>
             <div className={styles.searchBar}>
               <TextField

--- a/src/components/MoveSearchForm/MoveSearchForm.jsx
+++ b/src/components/MoveSearchForm/MoveSearchForm.jsx
@@ -118,6 +118,21 @@ const MoveSearchForm = ({ onSubmit }) => {
                   formik.setFieldTouched('searchText', false, false);
                 }}
               />
+              <Field
+                as={Radio}
+                id="radio-picked-paymentRequestCode"
+                data-testid="paymentRequestCode"
+                type="radio"
+                name="searchType"
+                value="paymentRequestCode"
+                title="Payment Request Number"
+                label="Payment Request Number"
+                onChange={(e) => {
+                  formik.setFieldValue('searchType', e.target.value);
+                  formik.setFieldValue('searchText', '', false); // Clear TextField
+                  formik.setFieldTouched('searchText', false, false);
+                }}
+              />
             </div>
             <div className={styles.searchBar}>
               <TextField

--- a/src/components/MoveSearchForm/MoveSearchForm.jsx
+++ b/src/components/MoveSearchForm/MoveSearchForm.jsx
@@ -29,6 +29,20 @@ const customerNameSchema = baseSchema.concat(
     searchText: Yup.string().trim().min(1, 'Customer search must contain a value'),
   }),
 );
+const paymentRequestCodeSchema = baseSchema.concat(
+  Yup.object().shape({
+    searchText: Yup.string()
+      .trim()
+      .length(
+        11,
+        'Payment request number must be a 11 character string (9 numbers with hyphens after every 4th number, e.g. 1234-5678-9)',
+      )
+      .matches(/(\d{4})(-{1})(\d{4})(-{1})(\d{1})/g, {
+        message:
+          'Payment request number must be a 11 character string (9 numbers with hyphens after every 4th number, e.g. 1234-5678-9)',
+      }),
+  }),
+);
 
 const MoveSearchForm = ({ onSubmit }) => {
   const getValidationSchema = (values) => {
@@ -39,6 +53,8 @@ const MoveSearchForm = ({ onSubmit }) => {
         return dodIDSchema;
       case 'customerName':
         return customerNameSchema;
+      case 'paymentRequestCode':
+        return paymentRequestCodeSchema;
       default:
         return Yup.object().shape({
           searchType: Yup.string().required('Search option must be selected'),

--- a/src/components/MoveSearchForm/MoveSearchForm.test.jsx
+++ b/src/components/MoveSearchForm/MoveSearchForm.test.jsx
@@ -79,12 +79,45 @@ describe('MoveSearchForm', () => {
       });
     });
 
+    it('can submit payment request number', async () => {
+      const onSubmit = jest.fn();
+      const { getByLabelText, getByRole } = render(<MoveSearchForm onSubmit={onSubmit} />);
+      const submitButton = getByRole('button');
+
+      await userEvent.click(getByLabelText('Payment Request Number'));
+      await userEvent.type(getByLabelText('Search'), '1234-5678-9');
+      await waitFor(() => {
+        expect(getByLabelText('Search')).toHaveValue('1234-5678-9');
+      });
+      expect(submitButton).toBeEnabled();
+      await userEvent.click(submitButton);
+      await waitFor(() => {
+        expect(onSubmit).toHaveBeenCalledWith(
+          {
+            searchText: '1234-5678-9',
+            searchType: 'paymentRequestCode',
+          },
+          expect.anything(),
+        );
+      });
+    });
+
     it('submits move code when it is 6 characters', async () => {
       const { getByLabelText, getByRole } = render(<MoveSearchForm onSubmit={jest.fn()} />);
       await userEvent.click(getByLabelText('Move Code'));
       await userEvent.type(getByLabelText('Search'), '123456');
       await waitFor(() => {
         expect(getByLabelText('Search')).toHaveValue('123456');
+      });
+      expect(getByRole('button')).toBeEnabled();
+    });
+
+    it('submits payment request code when it is in the correct format', async () => {
+      const { getByLabelText, getByRole } = render(<MoveSearchForm onSubmit={jest.fn()} />);
+      await userEvent.click(getByLabelText('Payment Request Number'));
+      await userEvent.type(getByLabelText('Search'), '1234-5678-9');
+      await waitFor(() => {
+        expect(getByLabelText('Search')).toHaveValue('1234-5678-9');
       });
       expect(getByRole('button')).toBeEnabled();
     });
@@ -120,6 +153,21 @@ describe('MoveSearchForm', () => {
       await userEvent.type(getByLabelText('Search'), '6');
       await waitFor(() => {
         expect(getByLabelText('Search')).toHaveValue('123456');
+      });
+      expect(getByRole('button')).toBeEnabled();
+    });
+
+    it('disables submit button when payment request number is not in correct format', async () => {
+      const { getByLabelText, getByRole } = render(<MoveSearchForm onSubmit={jest.fn()} />);
+      await userEvent.click(getByLabelText('Payment Request Number'));
+      await userEvent.type(getByLabelText('Search'), '1234-5678-');
+      await waitFor(() => {
+        expect(getByLabelText('Search')).toHaveValue('1234-5678-');
+      });
+      expect(getByRole('button')).toBeDisabled();
+      await userEvent.type(getByLabelText('Search'), '9');
+      await waitFor(() => {
+        expect(getByLabelText('Search')).toHaveValue('1234-5678-9');
       });
       expect(getByRole('button')).toBeEnabled();
     });

--- a/src/components/Table/SearchResultsTable.jsx
+++ b/src/components/Table/SearchResultsTable.jsx
@@ -277,6 +277,7 @@ const SearchResultsTable = (props) => {
     dodID,
     moveCode,
     customerName,
+    paymentRequestCode,
     searchType,
   } = props;
   const [paramSort, setParamSort] = useState(defaultSortedColumns);
@@ -386,8 +387,11 @@ const SearchResultsTable = (props) => {
     if (customerName) {
       filtersToAdd.push({ id: 'customerName', value: customerName });
     }
+    if (paymentRequestCode) {
+      filtersToAdd.push({ id: 'paymentRequestCode', value: paymentRequestCode });
+    }
     setParamFilters(filtersToAdd.concat(filters));
-  }, [filters, moveCode, dodID, customerName]);
+  }, [filters, moveCode, dodID, customerName, paymentRequestCode]);
 
   // this useEffect handles the fetching of feature flags
   useEffect(() => {
@@ -460,6 +464,7 @@ SearchResultsTable.propTypes = {
   moveCode: PropTypes.string,
   // customerName is the customer name search text
   customerName: PropTypes.string,
+  paymentRequestCode: PropTypes.string,
   searchType: PropTypes.string,
 };
 
@@ -474,6 +479,7 @@ SearchResultsTable.defaultProps = {
   dodID: null,
   moveCode: null,
   customerName: null,
+  paymentRequestCode: null,
   searchType: 'move',
 };
 

--- a/src/pages/Office/HeadquartersQueues/HeadquartersQueues.jsx
+++ b/src/pages/Office/HeadquartersQueues/HeadquartersQueues.jsx
@@ -41,7 +41,7 @@ import CustomerSearchForm from 'components/CustomerSearchForm/CustomerSearchForm
 const HeadquartersQueue = () => {
   const navigate = useNavigate();
   const { queueType } = useParams();
-  const [search, setSearch] = useState({ moveCode: null, dodID: null, customerName: null });
+  const [search, setSearch] = useState({ moveCode: null, dodID: null, customerName: null, paymentRequestCode: null });
   const [searchHappened, setSearchHappened] = useState(false);
   const [moveLockFlag, setMoveLockFlag] = useState(false);
   const [setErrorState] = useState({ hasError: false, error: undefined, info: undefined });
@@ -80,6 +80,7 @@ const HeadquartersQueue = () => {
       moveCode: null,
       dodID: null,
       customerName: null,
+      paymentRequestCode: null,
     };
     if (!isNullUndefinedOrWhitespace(values.searchText)) {
       if (values.searchType === 'moveCode') {
@@ -88,6 +89,8 @@ const HeadquartersQueue = () => {
         payload.dodID = values.searchText.trim();
       } else if (values.searchType === 'customerName') {
         payload.customerName = values.searchText.trim();
+      } else if (values.searchType === 'paymentRequestCode') {
+        payload.paymentRequestCode = values.searchText.trim();
       }
     }
     setSearch(payload);
@@ -184,6 +187,7 @@ const HeadquartersQueue = () => {
             useQueries={useMoveSearchQueries}
             moveCode={search.moveCode}
             dodID={search.dodID}
+            paymentRequestCode={search.paymentRequestCode}
             customerName={search.customerName}
             key="Move Search"
           />
@@ -213,6 +217,7 @@ const HeadquartersQueue = () => {
             useQueries={useCustomerSearchQueries}
             dodID={search.dodID}
             customerName={search.customerName}
+            paymentRequestCode={search.paymentRequestCode}
             searchType="customer"
             key="Customer Search"
           />

--- a/src/pages/Office/HeadquartersQueues/HeadquartersQueues.test.jsx
+++ b/src/pages/Office/HeadquartersQueues/HeadquartersQueues.test.jsx
@@ -179,7 +179,7 @@ const GetMountedComponent = (queueTypeToMount) => {
   return wrapper;
 };
 
-const SEARCH_OPTIONS = ['Move Code', 'DoD ID', 'Customer Name'];
+const SEARCH_OPTIONS = ['Move Code', 'DoD ID', 'Customer Name', 'Payment Request Number'];
 
 describe('HeadquartersQueue', () => {
   afterEach(() => {

--- a/src/pages/Office/MoveQueue/MoveQueue.jsx
+++ b/src/pages/Office/MoveQueue/MoveQueue.jsx
@@ -145,7 +145,7 @@ export const columns = (moveLockFlag, showBranchFilter = true) => [
 const MoveQueue = () => {
   const navigate = useNavigate();
   const { queueType } = useParams();
-  const [search, setSearch] = useState({ moveCode: null, dodID: null, customerName: null });
+  const [search, setSearch] = useState({ moveCode: null, dodID: null, customerName: null, paymentRequestCode: null });
   const [searchHappened, setSearchHappened] = useState(false);
   const [moveLockFlag, setMoveLockFlag] = useState(false);
 
@@ -163,6 +163,7 @@ const MoveQueue = () => {
       moveCode: null,
       dodID: null,
       customerName: null,
+      paymentRequestCode: null,
     };
     if (!isNullUndefinedOrWhitespace(values.searchText)) {
       if (values.searchType === 'moveCode') {
@@ -171,6 +172,8 @@ const MoveQueue = () => {
         payload.dodID = values.searchText.trim();
       } else if (values.searchType === 'customerName') {
         payload.customerName = values.searchText.trim();
+      } else if (values.searchType === 'paymentRequestCode') {
+        payload.paymentRequestCode = values.searchText.trim();
       }
     }
     setSearch(payload);
@@ -249,6 +252,7 @@ const MoveQueue = () => {
             moveCode={search.moveCode}
             dodID={search.dodID}
             customerName={search.customerName}
+            paymentRequestCode={search.paymentRequestCode}
             roleType={roleTypes.TOO}
           />
         )}

--- a/src/pages/Office/MoveQueue/MoveQueue.test.jsx
+++ b/src/pages/Office/MoveQueue/MoveQueue.test.jsx
@@ -96,7 +96,7 @@ const GetMountedComponent = (queueTypeToMount) => {
   );
   return wrapper;
 };
-const SEARCH_OPTIONS = ['Move Code', 'DoD ID', 'Customer Name'];
+const SEARCH_OPTIONS = ['Move Code', 'DoD ID', 'Customer Name', 'Payment Request Number'];
 describe('MoveQueue', () => {
   afterEach(() => {
     jest.restoreAllMocks();

--- a/src/pages/Office/PaymentRequestQueue/PaymentRequestQueue.jsx
+++ b/src/pages/Office/PaymentRequestQueue/PaymentRequestQueue.jsx
@@ -141,7 +141,7 @@ export const columns = (moveLockFlag, showBranchFilter = true) => [
 const PaymentRequestQueue = () => {
   const { queueType } = useParams();
   const navigate = useNavigate();
-  const [search, setSearch] = useState({ moveCode: null, dodID: null, customerName: null });
+  const [search, setSearch] = useState({ moveCode: null, dodID: null, customerName: null, paymentRequestCode: null });
   const [searchHappened, setSearchHappened] = useState(false);
   const [moveLockFlag, setMoveLockFlag] = useState(false);
 
@@ -165,6 +165,7 @@ const PaymentRequestQueue = () => {
       moveCode: null,
       dodID: null,
       customerName: null,
+      paymentRequestCode: null,
     };
     if (!isNullUndefinedOrWhitespace(values.searchText)) {
       if (values.searchType === 'moveCode') {
@@ -173,6 +174,8 @@ const PaymentRequestQueue = () => {
         payload.dodID = values.searchText;
       } else if (values.searchType === 'customerName') {
         payload.customerName = values.searchText;
+      } else if (values.searchType === 'paymentRequestCode') {
+        payload.paymentRequestCode = values.paymentRequestCode.trim();
       }
     }
     setSearch(payload);
@@ -237,6 +240,7 @@ const PaymentRequestQueue = () => {
             useQueries={useMoveSearchQueries}
             moveCode={search.moveCode}
             dodID={search.dodID}
+            paymentRequestCode={search.paymentRequestCode}
             customerName={search.customerName}
             roleType={roleTypes.TIO}
           />

--- a/src/pages/Office/PaymentRequestQueue/PaymentRequestQueue.jsx
+++ b/src/pages/Office/PaymentRequestQueue/PaymentRequestQueue.jsx
@@ -175,7 +175,7 @@ const PaymentRequestQueue = () => {
       } else if (values.searchType === 'customerName') {
         payload.customerName = values.searchText;
       } else if (values.searchType === 'paymentRequestCode') {
-        payload.paymentRequestCode = values.paymentRequestCode.trim();
+        payload.paymentRequestCode = values.searchText.trim();
       }
     }
     setSearch(payload);

--- a/src/pages/Office/PaymentRequestQueue/PaymentRequestQueue.test.jsx
+++ b/src/pages/Office/PaymentRequestQueue/PaymentRequestQueue.test.jsx
@@ -109,7 +109,7 @@ jest.mock('hooks/queries', () => ({
     };
   },
 }));
-const SEARCH_OPTIONS = ['Move Code', 'DoD ID', 'Customer Name'];
+const SEARCH_OPTIONS = ['Move Code', 'DoD ID', 'Customer Name', 'Payment Request Number'];
 
 describe('PaymentRequestQueue', () => {
   const client = new QueryClient();
@@ -299,7 +299,26 @@ describe('PaymentRequestQueue', () => {
     expect(screen.queryByText('Results (1)')).toBeInTheDocument();
     expect(screen.queryByTestId('table-queue')).toBeInTheDocument();
   });
-  it('has 3 options for searches', async () => {
+  it('searches by Move Code and displays possible filters for status', async () => {
+    reactRouterDom.useParams.mockReturnValue({ queueType: generalRoutes.QUEUE_SEARCH_PATH });
+    render(
+      <reactRouterDom.BrowserRouter>
+        <PaymentRequestQueue />
+      </reactRouterDom.BrowserRouter>,
+    );
+    // Simulate user input and form submission
+    const searchSelection = screen.getByLabelText('Payment Request Number');
+    await userEvent.click(searchSelection);
+
+    const searchInput = screen.getByTestId('searchText');
+    await userEvent.type(searchInput, '1234-5678-9');
+    await userEvent.click(screen.getByTestId('searchTextSubmit'));
+    // Assert search results are displayed
+
+    expect(screen.queryByText('Results (1)')).toBeInTheDocument();
+    expect(screen.queryByTestId('table-queue')).toBeInTheDocument();
+  });
+  it('has 4 options for searches', async () => {
     reactRouterDom.useParams.mockReturnValue({ queueType: generalRoutes.QUEUE_SEARCH_PATH });
     render(
       <reactRouterDom.BrowserRouter>

--- a/src/pages/Office/QAECSRMoveSearch/QAECSRMoveSearch.jsx
+++ b/src/pages/Office/QAECSRMoveSearch/QAECSRMoveSearch.jsx
@@ -24,6 +24,7 @@ const QAECSRMoveSearch = () => {
       moveCode: null,
       dodID: null,
       customerName: null,
+      paymentRequestCode: null,
     };
     if (!isNullUndefinedOrWhitespace(values.searchText)) {
       if (values.searchType === 'moveCode') {

--- a/src/pages/Office/QAECSRMoveSearch/QAECSRMoveSearch.jsx
+++ b/src/pages/Office/QAECSRMoveSearch/QAECSRMoveSearch.jsx
@@ -10,7 +10,7 @@ import { isNullUndefinedOrWhitespace } from 'shared/utils';
 
 const QAECSRMoveSearch = () => {
   const navigate = useNavigate();
-  const [search, setSearch] = useState({ moveCode: null, dodID: null, customerName: null });
+  const [search, setSearch] = useState({ moveCode: null, dodID: null, customerName: null, paymentRequestCode: null });
   const [searchHappened, setSearchHappened] = useState(false);
 
   const handleClick = useCallback(
@@ -32,6 +32,8 @@ const QAECSRMoveSearch = () => {
         payload.dodID = values.searchText;
       } else if (values.searchType === 'customerName') {
         payload.customerName = values.searchText;
+      } else if (values.searchType === 'paymentRequest') {
+        payload.paymentRequestCode = values.searchText;
       }
     }
 
@@ -57,6 +59,7 @@ const QAECSRMoveSearch = () => {
             moveCode={search.moveCode}
             dodID={search.dodID}
             customerName={search.customerName}
+            paymentRequestCode={search.paymentRequestCode}
           />
         )}
       </div>

--- a/src/pages/Office/QAECSRMoveSearch/QAECSRMoveSearch.jsx
+++ b/src/pages/Office/QAECSRMoveSearch/QAECSRMoveSearch.jsx
@@ -33,8 +33,8 @@ const QAECSRMoveSearch = () => {
         payload.dodID = values.searchText;
       } else if (values.searchType === 'customerName') {
         payload.customerName = values.searchText;
-      } else if (values.searchType === 'paymentRequest') {
-        payload.paymentRequestCode = values.searchText;
+      } else if (values.searchType === 'paymentRequestCode') {
+        payload.paymentRequestCode = values.searchText.trim();
       }
     }
 

--- a/src/pages/Office/ServicesCounselingQueue/ServicesCounselingQueue.jsx
+++ b/src/pages/Office/ServicesCounselingQueue/ServicesCounselingQueue.jsx
@@ -413,7 +413,7 @@ const ServicesCounselingQueue = ({ userPrivileges }) => {
     navigate(generatePath(servicesCounselingRoutes.CREATE_CUSTOMER_PATH));
   };
 
-  const [search, setSearch] = useState({ moveCode: null, dodID: null, customerName: null });
+  const [search, setSearch] = useState({ moveCode: null, dodID: null, customerName: null, paymentRequestCode: null });
   const [searchHappened, setSearchHappened] = useState(false);
   const counselorMoveCreateFeatureFlag = isBooleanFlagEnabled('counselor_move_create');
 
@@ -422,6 +422,7 @@ const ServicesCounselingQueue = ({ userPrivileges }) => {
       moveCode: null,
       dodID: null,
       customerName: null,
+      paymentRequestCode: null,
     };
     if (!isNullUndefinedOrWhitespace(values.searchText)) {
       if (values.searchType === 'moveCode') {
@@ -430,6 +431,8 @@ const ServicesCounselingQueue = ({ userPrivileges }) => {
         payload.dodID = values.searchText;
       } else if (values.searchType === 'customerName') {
         payload.customerName = values.searchText;
+      } else if (values.searchType === 'paymentRequestCode') {
+        payload.paymentRequestCode = values.paymentRequestCode.trim();
       }
     }
 
@@ -525,6 +528,7 @@ const ServicesCounselingQueue = ({ userPrivileges }) => {
             useQueries={useMoveSearchQueries}
             moveCode={search.moveCode}
             dodID={search.dodID}
+            paymentRequestCode={search.paymentRequestCode}
             customerName={search.customerName}
             roleType={roleTypes.SERVICES_COUNSELOR}
             searchType="move"
@@ -613,6 +617,7 @@ const ServicesCounselingQueue = ({ userPrivileges }) => {
             handleClick={handleCustomerSearchClick}
             useQueries={useCustomerSearchQueries}
             dodID={search.dodID}
+            paymentRequestCode={search.paymentRequestCode}
             customerName={search.customerName}
             roleType={roleTypes.SERVICES_COUNSELOR}
             searchType="customer"

--- a/src/pages/Office/ServicesCounselingQueue/ServicesCounselingQueue.jsx
+++ b/src/pages/Office/ServicesCounselingQueue/ServicesCounselingQueue.jsx
@@ -413,7 +413,7 @@ const ServicesCounselingQueue = ({ userPrivileges }) => {
     navigate(generatePath(servicesCounselingRoutes.CREATE_CUSTOMER_PATH));
   };
 
-  const [search, setSearch] = useState({ moveCode: null, dodID: null, customerName: null, paymentRequestCode: null });
+  const [search, setSearch] = useState({ moveCode: null, dodID: null, customerName: null });
   const [searchHappened, setSearchHappened] = useState(false);
   const counselorMoveCreateFeatureFlag = isBooleanFlagEnabled('counselor_move_create');
 
@@ -422,7 +422,6 @@ const ServicesCounselingQueue = ({ userPrivileges }) => {
       moveCode: null,
       dodID: null,
       customerName: null,
-      paymentRequestCode: null,
     };
     if (!isNullUndefinedOrWhitespace(values.searchText)) {
       if (values.searchType === 'moveCode') {
@@ -431,8 +430,6 @@ const ServicesCounselingQueue = ({ userPrivileges }) => {
         payload.dodID = values.searchText;
       } else if (values.searchType === 'customerName') {
         payload.customerName = values.searchText;
-      } else if (values.searchType === 'paymentRequestCode') {
-        payload.paymentRequestCode = values.paymentRequestCode.trim();
       }
     }
 
@@ -528,7 +525,6 @@ const ServicesCounselingQueue = ({ userPrivileges }) => {
             useQueries={useMoveSearchQueries}
             moveCode={search.moveCode}
             dodID={search.dodID}
-            paymentRequestCode={search.paymentRequestCode}
             customerName={search.customerName}
             roleType={roleTypes.SERVICES_COUNSELOR}
             searchType="move"
@@ -617,7 +613,6 @@ const ServicesCounselingQueue = ({ userPrivileges }) => {
             handleClick={handleCustomerSearchClick}
             useQueries={useCustomerSearchQueries}
             dodID={search.dodID}
-            paymentRequestCode={search.paymentRequestCode}
             customerName={search.customerName}
             roleType={roleTypes.SERVICES_COUNSELOR}
             searchType="customer"

--- a/swagger-def/ghc.yaml
+++ b/swagger-def/ghc.yaml
@@ -3616,6 +3616,10 @@ paths:
                 type: string
                 minLength: 1
                 x-nullable: true
+              paymentRequestCode:
+                type: string
+                example: 9551-6199-2
+                x-nullable: true
               status:
                 type: array
                 description: Filtering for the status.
@@ -6440,6 +6444,10 @@ definitions:
       dodID:
         type: string
         example: 1234567890
+        x-nullable: true
+      paymentRequestCode:
+        type: string
+        example: 9551-6199-2
         x-nullable: true
       status:
         $ref: '#/definitions/MoveStatus'

--- a/swagger/ghc.yaml
+++ b/swagger/ghc.yaml
@@ -3786,6 +3786,10 @@ paths:
                 type: string
                 minLength: 1
                 x-nullable: true
+              paymentRequestCode:
+                type: string
+                example: 9551-6199-2
+                x-nullable: true
               status:
                 type: array
                 description: Filtering for the status.
@@ -6708,6 +6712,10 @@ definitions:
       dodID:
         type: string
         example: 1234567890
+        x-nullable: true
+      paymentRequestCode:
+        type: string
+        example: 9551-6199-2
         x-nullable: true
       status:
         $ref: '#/definitions/MoveStatus'


### PR DESCRIPTION
## [Agility ticket](https://www13.v1host.com/USTRANSCOM38/assetdetail.v1?number=B-20448)

## INT PR
#13416 

## Summary

This branch adds the ability to search via the Payment Request number in the "Move Search" tab for TOO, TIO, QAE/CSR, and HQ user roles.

### How to test

1. Find the payment request number for a move, you can either go to the "Payment Requests" tab of a move and find a payment request number there, or look in the "payment_requests" table using psql or DBeaver.
2. Login as any of the roles outline above, click on "Move Search" and click the "Payment Request Number" radio button.
3. Input the payment request code exactly as shown in the app (e.g. "1234-5678-9"), and click "Search", you should see only the relevant move.
4. If you try to put in a string that is not in the format outline above, then click "Search" you should see a red error message describing the desired format.
5. Login as all other roles outline above and ensure that the search also works for them.
6. The SC role should **not** see the "Payment Request Number" radio button in their "Move Search" tab.
