### PR TITLE
INT B-19226 - Customer onboarding required fields fixes

### DIFF
--- a/src/components/Customer/ContactInfoForm/index.jsx
+++ b/src/components/Customer/ContactInfoForm/index.jsx
@@ -11,7 +11,13 @@ import { contactInfoSchema } from 'utils/validation';
 
 const ContactInfoForm = ({ initialValues, onSubmit, onBack }) => {
   return (
-    <Formik initialValues={initialValues} onSubmit={onSubmit} validationSchema={contactInfoSchema} validateOnMount>
+    <Formik
+      initialValues={initialValues}
+      onSubmit={onSubmit}
+      validationSchema={contactInfoSchema}
+      validateOnMount
+      initialTouched={{ telephone: true }}
+    >
       {({ isValid, isSubmitting, handleSubmit }) => {
         return (
           <Form className={formStyles.form}>

--- a/src/components/Customer/EditContactInfoForm/EditContactInfoForm.jsx
+++ b/src/components/Customer/EditContactInfoForm/EditContactInfoForm.jsx
@@ -11,7 +11,12 @@ import SectionWrapper from 'components/Customer/SectionWrapper';
 import WizardNavigation from 'components/Customer/WizardNavigation/WizardNavigation';
 import { Form } from 'components/form/Form';
 import formStyles from 'styles/form.module.scss';
-import { backupContactInfoSchema, contactInfoSchema, requiredAddressSchema } from 'utils/validation';
+import {
+  backupContactInfoSchema,
+  contactInfoSchema,
+  requiredAddressSchema,
+  preferredContactMethodValidation,
+} from 'utils/validation';
 import { ResidentialAddressShape } from 'types/address';
 import { CustomerContactInfoFields } from 'components/form/CustomerContactInfoFields';
 import { BackupContactInfoFields } from 'components/form/BackupContactInfoFields';
@@ -22,17 +27,25 @@ export const backupAddressName = 'backup_mailing_address';
 export const backupContactName = 'backup_contact';
 
 const EditContactInfoForm = ({ initialValues, onSubmit, onCancel }) => {
-  const validationSchema = Yup.object().shape({
-    ...contactInfoSchema.fields,
-    [residentialAddressName]: requiredAddressSchema.required(),
-    [backupAddressName]: requiredAddressSchema.required(),
-    [backupContactName]: backupContactInfoSchema.required(),
-  });
+  const validationSchema = Yup.object()
+    .shape({
+      ...contactInfoSchema.fields,
+      [residentialAddressName]: requiredAddressSchema.required(),
+      [backupAddressName]: requiredAddressSchema.required(),
+      [backupContactName]: backupContactInfoSchema.required(),
+    })
+    .test('contactMethodRequired', 'Please select a preferred method of contact.', preferredContactMethodValidation);
 
   const sectionStyles = classnames(formStyles.formSection, editContactInfoFormStyle.formSection);
 
   return (
-    <Formik initialValues={initialValues} onSubmit={onSubmit} validateOnMount validationSchema={validationSchema}>
+    <Formik
+      initialValues={initialValues}
+      onSubmit={onSubmit}
+      validateOnMount
+      validationSchema={validationSchema}
+      initialTouched={{ telephone: true }}
+    >
       {({ isValid, isSubmitting, handleSubmit }) => {
         return (
           <Form className={classnames(formStyles.form, editContactInfoFormStyle.form)}>

--- a/src/components/Customer/EditOrdersForm/EditOrdersForm.jsx
+++ b/src/components/Customer/EditOrdersForm/EditOrdersForm.jsx
@@ -66,10 +66,25 @@ const EditOrdersForm = ({
 
   const payGradeOptions = dropdownInputOptions(ORDERS_PAY_GRADE_OPTIONS);
 
+  let originMeta;
+  let newDutyMeta = '';
+
   return (
-    <Formik initialValues={initialValues} onSubmit={onSubmit} validationSchema={validationSchema} validateOnMount>
+    <Formik
+      initialValues={initialValues}
+      onSubmit={onSubmit}
+      validationSchema={validationSchema}
+      validateOnMount
+      initialTouched={{ orders_type: true, issue_date: true, report_by_date: true, has_dependents: true, grade: true }}
+    >
       {({ isValid, isSubmitting, handleSubmit, values }) => {
         const isRetirementOrSeparation = ['RETIREMENT', 'SEPARATION'].includes(values.orders_type);
+
+        if (!values.origin_duty_location) originMeta = 'Required';
+        else originMeta = null;
+
+        if (!values.new_duty_location) newDutyMeta = 'Required';
+        else newDutyMeta = null;
 
         return (
           <Form className={`${formStyles.form} ${styles.EditOrdersForm}`}>
@@ -130,6 +145,7 @@ const EditOrdersForm = ({
                 name="origin_duty_location"
                 id="origin_duty_location"
                 required
+                metaOverride={originMeta}
               />
 
               {isRetirementOrSeparation ? (
@@ -161,10 +177,16 @@ const EditOrdersForm = ({
                     displayAddress={false}
                     hint="Enter the option closest to your destination. Your move counselor will identify if there might be a cost to you."
                     placeholder="Enter a city or ZIP"
+                    metaOverride={newDutyMeta}
                   />
                 </>
               ) : (
-                <DutyLocationInput name="new_duty_location" label="New duty location" displayAddress={false} />
+                <DutyLocationInput
+                  name="new_duty_location"
+                  label="New duty location"
+                  displayAddress={false}
+                  metaOverride={newDutyMeta}
+                />
               )}
               <DropdownInput label="Pay grade" name="grade" id="grade" required options={payGradeOptions} />
 

--- a/src/components/Customer/EditOrdersForm/EditOrdersForm.test.jsx
+++ b/src/components/Customer/EditOrdersForm/EditOrdersForm.test.jsx
@@ -159,6 +159,24 @@ const initialValues = {
   issue_date: '2020-11-08',
   report_by_date: '2020-11-26',
   has_dependents: 'No',
+  origin_duty_location: {
+    address: {
+      city: 'Des Moines',
+      country: 'US',
+      id: 'a4b30b99-4e82-48a6-b736-01662b499d6a',
+      postalCode: '50309',
+      state: 'IA',
+      streetAddress1: '987 Other Avenue',
+      streetAddress2: 'P.O. Box 1234',
+      streetAddress3: 'c/o Another Person',
+    },
+    address_id: 'a4b30b99-4e82-48a6-b736-01662b499d6a',
+    affiliation: 'AIR_FORCE',
+    created_at: '2020-10-19T17:01:16.114Z',
+    id: 'f9299768-16d2-4a13-ae39-7087a58b1f62',
+    name: 'Yuma AFB',
+    updated_at: '2020-10-19T17:01:16.114Z',
+  },
   new_duty_location: {
     address: {
       city: 'Des Moines',

--- a/src/components/Customer/OrdersInfoForm/OrdersInfoForm.jsx
+++ b/src/components/Customer/OrdersInfoForm/OrdersInfoForm.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Formik, Field } from 'formik';
 import * as Yup from 'yup';
-import { Radio, FormGroup, Label, Link as USWDSLink } from '@trussworks/react-uswds';
+import { Radio, FormGroup, Label, Link as USWDSLink, ErrorMessage } from '@trussworks/react-uswds';
 
 import styles from './OrdersInfoForm.module.scss';
 
@@ -18,6 +18,8 @@ import WizardNavigation from 'components/Customer/WizardNavigation/WizardNavigat
 import Callout from 'components/Callout';
 import { formatLabelReportByDate, dropdownInputOptions } from 'utils/formatters';
 
+let originMeta;
+let newDutyMeta = '';
 const OrdersInfoForm = ({ ordersTypeOptions, initialValues, onSubmit, onBack }) => {
   const payGradeOptions = dropdownInputOptions(ORDERS_PAY_GRADE_OPTIONS);
 
@@ -38,9 +40,21 @@ const OrdersInfoForm = ({ ordersTypeOptions, initialValues, onSubmit, onBack }) 
   });
 
   return (
-    <Formik initialValues={initialValues} validateOnMount validationSchema={validationSchema} onSubmit={onSubmit}>
-      {({ isValid, isSubmitting, handleSubmit, values }) => {
+    <Formik
+      initialValues={initialValues}
+      validateOnMount
+      validationSchema={validationSchema}
+      onSubmit={onSubmit}
+      initialTouched={{ orders_type: true, issue_date: true, report_by_date: true, has_dependents: true, grade: true }}
+    >
+      {({ isValid, isSubmitting, handleSubmit, values, errors }) => {
         const isRetirementOrSeparation = ['RETIREMENT', 'SEPARATION'].includes(values.orders_type);
+
+        if (!values.origin_duty_location) originMeta = 'Required';
+        else originMeta = null;
+
+        if (!values.new_duty_location) newDutyMeta = 'Required';
+        else newDutyMeta = null;
 
         return (
           <Form className={`${formStyles.form} ${styles.OrdersInfoForm}`}>
@@ -64,6 +78,7 @@ const OrdersInfoForm = ({ ordersTypeOptions, initialValues, onSubmit, onBack }) 
               <DatePickerInput name="report_by_date" label={formatLabelReportByDate(values.orders_type)} required />
               <FormGroup>
                 <Label>Are dependents included in your orders?</Label>
+                {errors.has_dependents ? <ErrorMessage>{errors.has_dependents}</ErrorMessage> : null}
                 <div>
                   <Field
                     as={Radio}
@@ -91,6 +106,7 @@ const OrdersInfoForm = ({ ordersTypeOptions, initialValues, onSubmit, onBack }) 
                 name="origin_duty_location"
                 id="origin_duty_location"
                 required
+                metaOverride={originMeta}
               />
 
               {isRetirementOrSeparation ? (
@@ -121,11 +137,17 @@ const OrdersInfoForm = ({ ordersTypeOptions, initialValues, onSubmit, onBack }) 
                     label="HOR, PLEAD or HOS"
                     displayAddress={false}
                     hint="Enter the option closest to your destination. Your move counselor will identify if there might be a cost to you."
+                    metaOverride={newDutyMeta}
                     placeholder="Enter a city or ZIP"
                   />
                 </>
               ) : (
-                <DutyLocationInput name="new_duty_location" label="New duty location" displayAddress={false} />
+                <DutyLocationInput
+                  name="new_duty_location"
+                  label="New duty location"
+                  displayAddress={false}
+                  metaOverride={newDutyMeta}
+                />
               )}
 
               <DropdownInput label="Pay grade" name="grade" id="grade" required options={payGradeOptions} />

--- a/src/components/Customer/OrdersInfoForm/OrdersInfoForm.test.jsx
+++ b/src/components/Customer/OrdersInfoForm/OrdersInfoForm.test.jsx
@@ -227,7 +227,7 @@ describe('OrdersInfoForm component', () => {
     await userEvent.click(submitBtn);
 
     await waitFor(() => {
-      expect(getAllByText('Required').length).toBe(4);
+      expect(getAllByText('Required').length).toBe(5);
     });
     expect(testProps.onSubmit).not.toHaveBeenCalled();
   });

--- a/src/components/form/CustomerAltContactInfoFields/index.jsx
+++ b/src/components/form/CustomerAltContactInfoFields/index.jsx
@@ -1,14 +1,18 @@
 import React, { useRef } from 'react';
 import { func, node, string } from 'prop-types';
 import { v4 as uuidv4 } from 'uuid';
-import { Label, Fieldset } from '@trussworks/react-uswds';
+import { Label, Fieldset, ErrorMessage } from '@trussworks/react-uswds';
+import { useFormikContext } from 'formik';
+import classnames from 'classnames';
 
+import formStyles from 'styles/form.module.scss';
 import TextField from 'components/form/fields/TextField/TextField';
 import MaskedTextField from 'components/form/fields/MaskedTextField/MaskedTextField';
 import { CheckboxField } from 'components/form/fields';
 
 export const CustomerAltContactInfoFields = ({ legend, className, render }) => {
   const CustomerAltContactInfoFieldsUUID = useRef(uuidv4());
+  const { errors } = useFormikContext();
 
   return (
     <Fieldset legend={legend} className={className}>
@@ -64,14 +68,13 @@ export const CustomerAltContactInfoFields = ({ legend, className, render }) => {
             </div>
             <div className="grid-row grid-gap">
               <Label>Preferred contact method</Label>
-              <div className="grid-col-3">
+              {errors.preferredContactMethod ? <ErrorMessage>{errors.preferredContactMethod}</ErrorMessage> : null}
+              <div className={classnames(formStyles.radioGroup, formStyles.customerPreferredContact)}>
                 <CheckboxField
                   id={`phoneIsPreferred_${CustomerAltContactInfoFieldsUUID.current}`}
                   label="Phone"
                   name="phoneIsPreferred"
                 />
-              </div>
-              <div className="grid-col-3">
                 <CheckboxField
                   id={`emailIsPreferred_ ${CustomerAltContactInfoFieldsUUID.current}`}
                   label="Email"

--- a/src/components/form/CustomerContactInfoFields/index.jsx
+++ b/src/components/form/CustomerContactInfoFields/index.jsx
@@ -1,7 +1,9 @@
 import React, { useRef } from 'react';
 import { func, node, string } from 'prop-types';
 import { v4 as uuidv4 } from 'uuid';
-import { Label, Fieldset } from '@trussworks/react-uswds';
+import { Label, Fieldset, ErrorMessage } from '@trussworks/react-uswds';
+import { useFormikContext } from 'formik';
+import classnames from 'classnames';
 
 import formStyles from 'styles/form.module.scss';
 import TextField from 'components/form/fields/TextField/TextField';
@@ -10,6 +12,8 @@ import { CheckboxField } from 'components/form/fields';
 
 export const CustomerContactInfoFields = ({ legend, className, render }) => {
   const CustomerContactInfoFieldsUUID = useRef(uuidv4());
+
+  const { errors } = useFormikContext();
 
   return (
     <Fieldset legend={legend} className={className}>
@@ -48,7 +52,8 @@ export const CustomerContactInfoFields = ({ legend, className, render }) => {
             required
           />
           <Label>Preferred contact method</Label>
-          <div className={formStyles.radioGroup}>
+          {errors.preferredContactMethod ? <ErrorMessage>{errors.preferredContactMethod}</ErrorMessage> : null}
+          <div className={classnames(formStyles.radioGroup, formStyles.customerPreferredContact)}>
             <CheckboxField
               id={`phoneIsPreferred_${CustomerContactInfoFieldsUUID.current}`}
               label="Phone"

--- a/src/styles/form.module.scss
+++ b/src/styles/form.module.scss
@@ -163,6 +163,10 @@ p + .radioGroup {
   }
 }
 
+.customerPreferredContact > div{
+  margin-top: 0;
+}
+
 .formActions {
   @include u-margin-top(3);
   @include u-margin-bottom(6);

--- a/src/utils/validation.js
+++ b/src/utils/validation.js
@@ -103,25 +103,23 @@ export const emailSchema = Yup.string().matches(
   'Must be a valid email address',
 );
 
-const validatePreferredContactMethod = (value, testContext) => {
-  return testContext.parent.phone_is_preferred || testContext.parent.email_is_preferred;
+export const preferredContactMethodValidation = (value) => {
+  return (
+    value?.phone_is_preferred ||
+    value?.email_is_preferred ||
+    new Yup.ValidationError('Please select a preferred method of contact.', null, 'preferredContactMethod')
+  );
 };
 
-export const contactInfoSchema = Yup.object().shape({
-  telephone: phoneSchema.required('Required'),
-  secondary_telephone: phoneSchema,
-  personal_email: emailSchema.required('Required'),
-  phone_is_preferred: Yup.bool().test(
-    'contactMethodRequired',
-    'Please select a preferred method of contact.',
-    validatePreferredContactMethod,
-  ),
-  email_is_preferred: Yup.bool().test(
-    'contactMethodRequired',
-    'Please select a preferred method of contact.',
-    validatePreferredContactMethod,
-  ),
-});
+export const contactInfoSchema = Yup.object()
+  .shape({
+    telephone: phoneSchema.required('Required'),
+    secondary_telephone: phoneSchema,
+    personal_email: emailSchema.required('Required'),
+    phone_is_preferred: Yup.bool(),
+    email_is_preferred: Yup.bool(),
+  })
+  .test('contactMethodRequired', 'Please select a preferred method of contact.', preferredContactMethodValidation);
 
 export const backupContactInfoSchema = Yup.object().shape({
   name: Yup.string().required('Required'),


### PR DESCRIPTION
## [Agility ticket](https://www13.v1host.com/USTRANSCOM38/assetdetail.v1?number=B-19226)

## Summary
Currently, several fields on the Customer Contact Info forms and Create/Edit Orders forms do not indicate that they are required fields, even if they are left blank and the user tries to submit. This branch fixes this issue, and changes the validation on these forms so that all fields that are required will immediately display the red "Required" warning label when the page is loaded, and will disappear as the user inputs their information. Other validation warnings such as formatting errors for phone numbers will appear once the user begins typing in their data.

### How to test

1. Login as a new customer account
2. During onboarding, when filling out customer contact info, ensure that required fields are marked as expected:
![customer_info_required](https://github.com/user-attachments/assets/7e34469c-61b4-4e0a-81ef-50ea3b03fabf)

3. Next, create a move, and on the "Tell us about your move orders" screen, verify that required fields are marked as expected:

