### PR TITLE
I 13243 int

### DIFF
--- a/pkg/services/mto_shipment/mto_shipment_creator.go
+++ b/pkg/services/mto_shipment/mto_shipment_creator.go
@@ -80,12 +80,7 @@ func (f mtoShipmentCreator) CreateMTOShipment(appCtx appcontext.AppContext, ship
 	isMobileHomeShipment := shipment.ShipmentType == models.MTOShipmentTypeMobileHome
 
 	// Check shipment fields that should be there or not based on shipment type.
-	if shipment.ShipmentType == models.MTOShipmentTypeHHGOutOfNTSDom {
-		if shipment.RequestedPickupDate != nil {
-			return nil, apperror.NewInvalidInputError(uuid.Nil, nil, verrs,
-				fmt.Sprintf("RequestedPickupDate should not be set when creating a %s shipment", shipment.ShipmentType))
-		}
-	} else if shipment.ShipmentType != models.MTOShipmentTypePPM && !isBoatShipment && !isMobileHomeShipment {
+	if shipment.ShipmentType != models.MTOShipmentTypePPM && shipment.ShipmentType != models.MTOShipmentTypeHHGOutOfNTSDom && !isBoatShipment && !isMobileHomeShipment {
 		// No need for a PPM to have a RequestedPickupDate
 		if shipment.RequestedPickupDate == nil || shipment.RequestedPickupDate.IsZero() {
 			return nil, apperror.NewInvalidInputError(uuid.Nil, nil, verrs,

--- a/pkg/services/mto_shipment/mto_shipment_creator_test.go
+++ b/pkg/services/mto_shipment/mto_shipment_creator_test.go
@@ -98,8 +98,8 @@ func (suite *MTOShipmentServiceSuite) TestCreateMTOShipment() {
 			{&time.Time{}, models.MTOShipmentTypeHHG, true},
 			{models.TimePointer(time.Now()), models.MTOShipmentTypeHHG, false},
 			{nil, models.MTOShipmentTypeHHGOutOfNTSDom, false},
-			{&time.Time{}, models.MTOShipmentTypeHHGOutOfNTSDom, true},
-			{models.TimePointer(time.Now()), models.MTOShipmentTypeHHGOutOfNTSDom, true},
+			{&time.Time{}, models.MTOShipmentTypeHHGOutOfNTSDom, false},
+			{models.TimePointer(time.Now()), models.MTOShipmentTypeHHGOutOfNTSDom, false},
 			{nil, models.MTOShipmentTypePPM, false},
 			{models.TimePointer(time.Now()), models.MTOShipmentTypePPM, false},
 		}


### PR DESCRIPTION
## [I-13243](https://www13.v1host.com/USTRANSCOM38/Issue.mvc/Summary?oidToken=Issue%3A1001692)

## Summary
This resolves an uncaught issue with B-20753 where TOOs cannot create NTS-Releases with requested pickup (handle out) dates due to backend validation that is not present when editing NTS-Releases or creating NTS shipments.

## Verification Steps for the Author

These are to be checked by the author.

- [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
- [ ] Have the Agility acceptance criteria been met for this change?

## Verification Steps for Reviewers

These are to be checked by a reviewer.

- [ ] Has the branch been pulled in and checked out?
- [ ] Have the BL acceptance criteria been met for this change?
- [ ] Was the CircleCI build successful?
- [ ] Has the code been reviewed from a standards and best practices point of view?

### How to test

1. Access the application as a TOO
2. Go to any move
3. Create an NTS-Release shipment with a requestedPickupDate, ensure it saves correctly
4. Ensure all tests pass.

### Backend

- [ ] Code follows the guidelines for [Logging](https://transcom.github.io/mymove-docs/docs/getting-started/development/logging).
- [ ] The requirements listed in [Querying the Database Safely](https://transcom.github.io/mymove-docs/docs/backend/guides/golang-guide#querying-the-database-safely) have been satisfied.