### PR TITLE
B-20292: Customer's Profile | Contact info not updating the Alt. phone

### DIFF
--- a/pkg/gen/internalapi/embedded_spec.go
+++ b/pkg/gen/internalapi/embedded_spec.go
@@ -4025,7 +4025,7 @@ func init() {
           "type": "string",
           "format": "telephone",
           "title": "Alternate phone",
-          "pattern": "^[2-9]\\d{2}-\\d{3}-\\d{4}$",
+          "pattern": "^([2-9]\\d{2}-\\d{3}-\\d{4})?$",
           "x-nullable": true,
           "example": "212-555-5555"
         },
@@ -6468,7 +6468,7 @@ func init() {
           "type": "string",
           "format": "telephone",
           "title": "Alternate Phone",
-          "pattern": "^[2-9]\\d{2}-\\d{3}-\\d{4}$",
+          "pattern": "^([2-9]\\d{2}-\\d{3}-\\d{4})?$",
           "x-nullable": true,
           "example": "212-555-5555"
         },
@@ -6944,7 +6944,7 @@ func init() {
           "type": "string",
           "format": "telephone",
           "title": "Secondary Phone",
-          "pattern": "^[2-9]\\d{2}-\\d{3}-\\d{4}$",
+          "pattern": "^([2-9]\\d{2}-\\d{3}-\\d{4})?$",
           "x-nullable": true,
           "example": "212-555-5555"
         },
@@ -12805,7 +12805,7 @@ func init() {
           "type": "string",
           "format": "telephone",
           "title": "Alternate phone",
-          "pattern": "^[2-9]\\d{2}-\\d{3}-\\d{4}$",
+          "pattern": "^([2-9]\\d{2}-\\d{3}-\\d{4})?$",
           "x-nullable": true,
           "example": "212-555-5555"
         },
@@ -15252,7 +15252,7 @@ func init() {
           "type": "string",
           "format": "telephone",
           "title": "Alternate Phone",
-          "pattern": "^[2-9]\\d{2}-\\d{3}-\\d{4}$",
+          "pattern": "^([2-9]\\d{2}-\\d{3}-\\d{4})?$",
           "x-nullable": true,
           "example": "212-555-5555"
         },
@@ -15730,7 +15730,7 @@ func init() {
           "type": "string",
           "format": "telephone",
           "title": "Secondary Phone",
-          "pattern": "^[2-9]\\d{2}-\\d{3}-\\d{4}$",
+          "pattern": "^([2-9]\\d{2}-\\d{3}-\\d{4})?$",
           "x-nullable": true,
           "example": "212-555-5555"
         },

--- a/pkg/gen/internalmessages/create_service_member_payload.go
+++ b/pkg/gen/internalmessages/create_service_member_payload.go
@@ -68,7 +68,7 @@ type CreateServiceMemberPayload struct {
 
 	// Alternate phone
 	// Example: 212-555-5555
-	// Pattern: ^[2-9]\d{2}-\d{3}-\d{4}$
+	// Pattern: ^([2-9]\d{2}-\d{3}-\d{4})?$
 	SecondaryTelephone *string `json:"secondary_telephone,omitempty"`
 
 	// Suffix
@@ -261,7 +261,7 @@ func (m *CreateServiceMemberPayload) validateSecondaryTelephone(formats strfmt.R
 		return nil
 	}
 
-	if err := validate.Pattern("secondary_telephone", "body", *m.SecondaryTelephone, `^[2-9]\d{2}-\d{3}-\d{4}$`); err != nil {
+	if err := validate.Pattern("secondary_telephone", "body", *m.SecondaryTelephone, `^([2-9]\d{2}-\d{3}-\d{4})?$`); err != nil {
 		return err
 	}
 

--- a/pkg/gen/internalmessages/patch_service_member_payload.go
+++ b/pkg/gen/internalmessages/patch_service_member_payload.go
@@ -72,7 +72,7 @@ type PatchServiceMemberPayload struct {
 
 	// Alternate Phone
 	// Example: 212-555-5555
-	// Pattern: ^[2-9]\d{2}-\d{3}-\d{4}$
+	// Pattern: ^([2-9]\d{2}-\d{3}-\d{4})?$
 	SecondaryTelephone *string `json:"secondary_telephone,omitempty"`
 
 	// Suffix
@@ -266,7 +266,7 @@ func (m *PatchServiceMemberPayload) validateSecondaryTelephone(formats strfmt.Re
 		return nil
 	}
 
-	if err := validate.Pattern("secondary_telephone", "body", *m.SecondaryTelephone, `^[2-9]\d{2}-\d{3}-\d{4}$`); err != nil {
+	if err := validate.Pattern("secondary_telephone", "body", *m.SecondaryTelephone, `^([2-9]\d{2}-\d{3}-\d{4})?$`); err != nil {
 		return err
 	}
 

--- a/pkg/gen/internalmessages/service_member_payload.go
+++ b/pkg/gen/internalmessages/service_member_payload.go
@@ -95,7 +95,7 @@ type ServiceMemberPayload struct {
 
 	// Secondary Phone
 	// Example: 212-555-5555
-	// Pattern: ^[2-9]\d{2}-\d{3}-\d{4}$
+	// Pattern: ^([2-9]\d{2}-\d{3}-\d{4})?$
 	SecondaryTelephone *string `json:"secondary_telephone,omitempty"`
 
 	// Suffix
@@ -411,7 +411,7 @@ func (m *ServiceMemberPayload) validateSecondaryTelephone(formats strfmt.Registr
 		return nil
 	}
 
-	if err := validate.Pattern("secondary_telephone", "body", *m.SecondaryTelephone, `^[2-9]\d{2}-\d{3}-\d{4}$`); err != nil {
+	if err := validate.Pattern("secondary_telephone", "body", *m.SecondaryTelephone, `^([2-9]\d{2}-\d{3}-\d{4})?$`); err != nil {
 		return err
 	}
 

--- a/pkg/handlers/internalapi/service_members.go
+++ b/pkg/handlers/internalapi/service_members.go
@@ -235,9 +235,8 @@ func (h PatchServiceMemberHandler) patchServiceMemberWithPayload(serviceMember *
 	if payload.Telephone != nil {
 		serviceMember.Telephone = payload.Telephone
 	}
-	if payload.SecondaryTelephone != nil {
-		serviceMember.SecondaryTelephone = payload.SecondaryTelephone
-	}
+	// Need to be able to accept a nil value for this optional field
+	serviceMember.SecondaryTelephone = payload.SecondaryTelephone
 	if payload.PersonalEmail != nil {
 		serviceMember.PersonalEmail = payload.PersonalEmail
 	}

--- a/src/pages/MyMove/Profile/EditContactInfo.jsx
+++ b/src/pages/MyMove/Profile/EditContactInfo.jsx
@@ -75,9 +75,7 @@ export const EditContactInfo = ({
       backup_mailing_address: values[backupAddressName.toString()],
     };
 
-    if (values?.secondary_telephone) {
-      serviceMemberPayload.secondary_telephone = values?.secondary_telephone;
-    }
+    serviceMemberPayload.secondary_telephone = values?.secondary_telephone;
 
     const backupContactPayload = {
       id: currentBackupContacts[0].id,

--- a/src/pages/Office/CustomerOnboarding/CreateCustomerForm.jsx
+++ b/src/pages/Office/CustomerOnboarding/CreateCustomerForm.jsx
@@ -41,6 +41,7 @@ export const CreateCustomerForm = ({ userPrivileges, setFlashMessage }) => {
   const backupContactName = 'backup_contact';
 
   const [isSafetyMoveFF, setSafetyMoveFF] = useState(false);
+  const [secondaryTelephoneNum, setSecondaryTelephoneNum] = useState('');
 
   useEffect(() => {
     isBooleanFlagEnabled('safety_move')?.then((enabled) => {
@@ -189,6 +190,16 @@ export const CreateCustomerForm = ({ userPrivileges, setFlashMessage }) => {
         <Grid col desktop={{ col: 8 }} className={styles.nameForm}>
           <Formik initialValues={initialValues} validateOnMount validationSchema={validationSchema} onSubmit={onSubmit}>
             {({ isValid, handleSubmit, setValues, values, handleChange }) => {
+              const handleSubmitNext = () => {
+                setValues({
+                  ...values,
+                  secondary_telephone: secondaryTelephoneNum,
+                });
+                handleSubmit();
+              };
+              const handlePhoneNumChange = (value) => {
+                setSecondaryTelephoneNum(value);
+              };
               const handleIsSafetyMove = (e) => {
                 const { value } = e.target;
                 if (value === 'true') {
@@ -305,6 +316,7 @@ export const CreateCustomerForm = ({ userPrivileges, setFlashMessage }) => {
                       type="tel"
                       minimum="12"
                       mask="000{-}000{-}0000"
+                      onChange={handlePhoneNumChange}
                     />
                     <TextField label="Personal email" id="personalEmail" name="personal_email" required />
                     <Label>Preferred contact method (optional)</Label>
@@ -479,7 +491,7 @@ export const CreateCustomerForm = ({ userPrivileges, setFlashMessage }) => {
                       editMode
                       onCancelClick={handleBack}
                       disableNext={!isValid}
-                      onNextClick={handleSubmit}
+                      onNextClick={handleSubmitNext}
                     />
                   </div>
                 </Form>

--- a/swagger-def/internal.yaml
+++ b/swagger-def/internal.yaml
@@ -709,7 +709,7 @@ definitions:
       secondary_telephone:
         type: string
         format: telephone
-        pattern: '^[2-9]\d{2}-\d{3}-\d{4}$'
+        pattern: '^([2-9]\d{2}-\d{3}-\d{4})?$'
         example: 212-555-5555
         x-nullable: true
         title: Secondary Phone
@@ -803,7 +803,7 @@ definitions:
       secondary_telephone:
         type: string
         format: telephone
-        pattern: '^[2-9]\d{2}-\d{3}-\d{4}$'
+        pattern: '^([2-9]\d{2}-\d{3}-\d{4})?$'
         example: 212-555-5555
         x-nullable: true
         title: Alternate phone
@@ -887,7 +887,7 @@ definitions:
       secondary_telephone:
         type: string
         format: telephone
-        pattern: '^[2-9]\d{2}-\d{3}-\d{4}$'
+        pattern: '^([2-9]\d{2}-\d{3}-\d{4})?$'
         example: 212-555-5555
         x-nullable: true
         title: Alternate Phone

--- a/swagger/internal.yaml
+++ b/swagger/internal.yaml
@@ -730,7 +730,7 @@ definitions:
       secondary_telephone:
         type: string
         format: telephone
-        pattern: ^[2-9]\d{2}-\d{3}-\d{4}$
+        pattern: ^([2-9]\d{2}-\d{3}-\d{4})?$
         example: 212-555-5555
         x-nullable: true
         title: Secondary Phone
@@ -824,7 +824,7 @@ definitions:
       secondary_telephone:
         type: string
         format: telephone
-        pattern: ^[2-9]\d{2}-\d{3}-\d{4}$
+        pattern: ^([2-9]\d{2}-\d{3}-\d{4})?$
         example: 212-555-5555
         x-nullable: true
         title: Alternate phone
@@ -908,7 +908,7 @@ definitions:
       secondary_telephone:
         type: string
         format: telephone
-        pattern: ^[2-9]\d{2}-\d{3}-\d{4}$
+        pattern: ^([2-9]\d{2}-\d{3}-\d{4})?$
         example: 212-555-5555
         x-nullable: true
         title: Alternate Phone


### PR DESCRIPTION
## [Agility ticket B-20292](https://www13.v1host.com/USTRANSCOM38/assetdetail.v1?number=B-20292)
## Steps to test
### For customer role
Note: it may help to have the dev tools open on the Network section to verify that the customer object either has or does not have the secondary_telephone property on it.
1. Create a new customer account and start entering in information.
2. When you get to the section that asks for "Best contact phone", "Alt. phone", "Personal email", as well as "Preferred contact method," you should enter all the required information as well as an "Alt. phone".
3. Click the form's "Next" button to navigate to the next section.
4. Click the form's "Back" button to navigate back to the previous section that showed phone numbers and an email address field. At this point you should see all of the previously entered information.
5. Now erase the value of the "Alt. phone" field.
6. Click the form's "Next" button.
7. Click the form's "Back" button. You should see no value in the "Alt. phone" field.
8. Now complete the creation of this customer account.
9. Once the account has been created, you should be able to select the Account icon at the top-right.
![Screenshot 2024-08-27 at 3 01 11 PM](https://github.com/user-attachments/assets/220fb64f-aba2-4bf5-b586-22fb3840a008)
10. From this Account Details screen, you should copy the value of the "Personal email" shown.
11. Now perform a SQL query to verify that the secondary_telephone field of the customer account returns null.
```
select secondary_telephone from service_members sm where personal_email = '<<Copied Personal email here>>'
```
<img width="266" alt="Screenshot 2024-08-27 at 3 04 01 PM" src="https://github.com/user-attachments/assets/0d231b29-54c9-471c-a5c4-05b7ba0f4675">

12. Before proceeding, observe that the "Alt. phone" field on the "Contact info" card doesn't show a phone number value.. it should show a '–' in stead.
13. Now click the "Edit" option at the top-right of the "Contact info" card.
14. Change the value of the field associated with the "Alt. phone" to a valid phone number and client the form's "Save" button at the bottom.
15. Verify that the number has been saved to the DB by executing the following SQL query. You should observe the value shows up.
```
select secondary_telephone from service_members sm where personal_email = '<<Copied Personal email here>>'
```
### For SC role
Note: as a prerequisite, make sure you have copied the user's personal email address or name.
1. In the DB, run the following SQL query to get the user's name if you don't already have it.
```
select last_name, first_name from service_members sm where personal_email = '<<customer's copied email address>>'
```
2. As an SC user, search for the customer by name then click on the customer item from the search results.
![Screenshot 2024-08-27 at 3 25 32 PM](https://github.com/user-attachments/assets/f8bc75e6-4bfc-42b2-b2d3-3bd854342de1)
3. Remove the value from the form's "Alternate Phone" field and click the "Save" button at the bottom.
Note: at this time, you may have to enter in other move/shipment information. If so, enter it and click the "Next" button.
4. Verify that the secondary_telephone field returns null by executing the following SQL query in the DB. Make sure to replace <<Copied Personal email here>> with the user's personal email address.
```
select secondary_telephone from service_members sm where personal_email = '<<Copied Personal email here>>'
```
5. Now click the "Edit customer info" button towards the bottom of the page, on the "Customer info" card.
6. Enter a valid phone number in the "Alternate Phone" field on this form, then click the "Save" button at the bottom of the form.
7. Verify that the DB was updated by executing the following SQL command and observing that the secondary_telephone field has been updated. Make sure to replace <<Copied Personal email here>> with the user's personal email address.
```
select secondary_telephone from service_members sm where personal_email = '<<Copied Personal email here>>'
```