### PR TITLE
B 20997 add pptas under prime simulator

### DIFF
--- a/pkg/handlers/routing/routing_init.go
+++ b/pkg/handlers/routing/routing_init.go
@@ -607,7 +607,7 @@ func mountPrimeSimulatorAPI(appCtx appcontext.AppContext, routingConfig *Config,
 				handlers.NewFileHandler(routingConfig.FileSystem,
 					routingConfig.PPTASSwaggerPath))
 			if routingConfig.ServeSwaggerUI {
-				appCtx.Logger().Info("Prime Simulator API Swagger UI serving is enabled")
+				appCtx.Logger().Info("PPTAS Simulator API Swagger UI serving is enabled")
 				r.Method("GET", "/docs",
 					handlers.NewFileHandler(routingConfig.FileSystem,
 						path.Join(routingConfig.BuildRoot, "swagger-ui", "pptas.html")))
@@ -621,7 +621,7 @@ func mountPrimeSimulatorAPI(appCtx appcontext.AppContext, routingConfig *Config,
 				rAuth.Use(addAuditUserToRequestContextMiddleware)
 				rAuth.Use(authentication.PrimeSimulatorAuthorizationMiddleware(appCtx.Logger()))
 				rAuth.Use(middleware.NoCache())
-				api := primeapi.NewPrimeAPI(routingConfig.HandlerConfig)
+				api := pptasapi.NewPPTASAPI(routingConfig.HandlerConfig)
 				tracingMiddleware := middleware.OpenAPITracing(api)
 				rAuth.Mount("/", api.Serve(tracingMiddleware))
 			})

--- a/pkg/handlers/routing/routing_init.go
+++ b/pkg/handlers/routing/routing_init.go
@@ -602,6 +602,30 @@ func mountPrimeSimulatorAPI(appCtx appcontext.AppContext, routingConfig *Config,
 				rAuth.Mount("/", api.Serve(tracingMiddleware))
 			})
 		})
+		site.Route("/pptas/v1", func(r chi.Router) {
+			r.Method("GET", "/swagger.yaml",
+				handlers.NewFileHandler(routingConfig.FileSystem,
+					routingConfig.PPTASSwaggerPath))
+			if routingConfig.ServeSwaggerUI {
+				appCtx.Logger().Info("Prime Simulator API Swagger UI serving is enabled")
+				r.Method("GET", "/docs",
+					handlers.NewFileHandler(routingConfig.FileSystem,
+						path.Join(routingConfig.BuildRoot, "swagger-ui", "pptas.html")))
+			} else {
+				r.Method("GET", "/docs", http.NotFoundHandler())
+			}
+
+			// Mux for prime simulator API that enforces auth
+			r.Route("/", func(rAuth chi.Router) {
+				rAuth.Use(userAuthMiddleware)
+				rAuth.Use(addAuditUserToRequestContextMiddleware)
+				rAuth.Use(authentication.PrimeSimulatorAuthorizationMiddleware(appCtx.Logger()))
+				rAuth.Use(middleware.NoCache())
+				api := primeapi.NewPrimeAPI(routingConfig.HandlerConfig)
+				tracingMiddleware := middleware.OpenAPITracing(api)
+				rAuth.Mount("/", api.Serve(tracingMiddleware))
+			})
+		})
 		// Support API serves to support Prime API testing outside of production environments, hence why it is
 		// mounted inside the Prime sim API without client cert middleware
 		if routingConfig.ServeSupport {


### PR DESCRIPTION
## [B-20997](https://www13.v1host.com/USTRANSCOM38/assetdetail.v1?number=B-20997)

## Summary

> [!IMPORTANT]  
> This update is not for production release. This is strictly to allow PPTAS to be testable with the Prime Simulator in the integration/staging environments.

Adds the PPTAS API to be able to be called using the Prime Simulator Routing (so that Postman may be used to call the endpoints contained).
## Verification Steps for Reviewers
1. Run MilMove locally
2. log in to prime simulator, make sure that cookies are syncing with Postman
3. Make a call to the endpoint using the "list moves" while run locally in postman using `http://officelocal:3000/pptas/v1/moves?since=2021-07-23T18:30:47.116Z`
4. Data returned does not matter, only that the error is not 404 not found. Any response aside from that would be passing.