### PR TITLE
fix flaky formatting

### DIFF
--- a/playwright/tests/office/servicescounseling/servicesCounselingNTS.spec.js
+++ b/playwright/tests/office/servicescounseling/servicesCounselingNTS.spec.js
@@ -113,11 +113,11 @@ test.describe('Services counselor user', () => {
     // Fill out the HHG and NTS accounting codes
     await page.getByTestId('hhgTacInput').fill(tac.tac);
     const today = new Date();
-    const formattedDate = new Intl.DateTimeFormat('en-GB', {
-      day: '2-digit',
-      month: 'short',
-      year: 'numeric',
-    }).format(today);
+    const day = new Intl.DateTimeFormat('en', { day: '2-digit' }).format(today);
+    const month = new Intl.DateTimeFormat('en', { month: 'short' }).format(today);
+    const year = new Intl.DateTimeFormat('en', { year: 'numeric' }).format(today);
+    const formattedDate = `${day} ${month} ${year}`;
+
     await page.locator('input[name="issueDate"]').fill(formattedDate);
 
     await page.getByTestId('hhgSacInput').fill('4K988AS098F');

--- a/playwright/tests/office/txo/tooFlowsNTS.spec.js
+++ b/playwright/tests/office/txo/tooFlowsNTS.spec.js
@@ -193,11 +193,11 @@ test.describe('TOO user', () => {
       // Fill out the HHG and NTS accounting codes
       await page.getByTestId('hhgTacInput').fill(tac.tac);
       const today = new Date();
-      const formattedDate = new Intl.DateTimeFormat('en-GB', {
-        day: '2-digit',
-        month: 'short',
-        year: 'numeric',
-      }).format(today);
+      const day = new Intl.DateTimeFormat('en', { day: '2-digit' }).format(today);
+      const month = new Intl.DateTimeFormat('en', { month: 'short' }).format(today);
+      const year = new Intl.DateTimeFormat('en', { year: 'numeric' }).format(today);
+      const formattedDate = `${day} ${month} ${year}`;
+
       await page.locator('input[name="issueDate"]').fill(formattedDate);
 
       await page.getByTestId('hhgSacInput').fill('4K988AS098F');


### PR DESCRIPTION
[Integration PR](https://github.com/transcom/mymove/pull/13613)

> [!NOTE]
> This PR to main will not include SIT changes as those are current integrationTesting specific. A separate PR will bring those in

Fixes flaky formatting causing the following test to fail
https://app.circleci.com/pipelines/github/transcom/mymove/74644/workflows/333fc39d-183e-447d-b592-802ddb69953b/jobs/1315694/tests#failed-test-0

This is due to DateTimeFormat not sharing the same format as MomentJS which we use in our src code. MomentJS is not used within Playwright at this time due to additional setup required to get it compatible with the TypeScript check enforced through our e2e tests.

Previously, this would pass in August but the formatting fails for September.