### PR TITLE
Nts loa and SIT flaky fix int

### DIFF
--- a/playwright/tests/office/servicescounseling/servicesCounselingNTS.spec.js
+++ b/playwright/tests/office/servicescounseling/servicesCounselingNTS.spec.js
@@ -113,11 +113,11 @@ test.describe('Services counselor user', () => {
     // Fill out the HHG and NTS accounting codes
     await page.getByTestId('hhgTacInput').fill(tac.tac);
     const today = new Date();
-    const formattedDate = new Intl.DateTimeFormat('en-GB', {
-      day: '2-digit',
-      month: 'short',
-      year: 'numeric',
-    }).format(today);
+    const day = new Intl.DateTimeFormat('en', { day: '2-digit' }).format(today);
+    const month = new Intl.DateTimeFormat('en', { month: 'short' }).format(today);
+    const year = new Intl.DateTimeFormat('en', { year: 'numeric' }).format(today);
+    const formattedDate = `${day} ${month} ${year}`;
+
     await page.locator('input[name="issueDate"]').fill(formattedDate);
 
     await page.getByTestId('hhgSacInput').fill('4K988AS098F');

--- a/playwright/tests/office/txo/sitUpdates.spec.js
+++ b/playwright/tests/office/txo/sitUpdates.spec.js
@@ -36,8 +36,7 @@ test.describe('TOO user', () => {
       const timeDiff = oneMonthAgo.getTime() - twoMonthsAgo.getTime();
       // get the days, converting milliseconds to days
       const daysDiff = timeDiff / (1000 * 60 * 60 * 24);
-      // be inclusive of the last day
-      const totalDaysBetweenOneMonthInclusive = daysDiff + 1;
+      const totalDaysBetweenOneMonthInclusive = daysDiff;
       // get sums
       const totalDaysUsed = totalDaysBetweenOneMonthInclusive * 2; // Origin and Dest sit each used 1 month
       const remainingDays = 90 - totalDaysUsed;
@@ -61,7 +60,7 @@ test.describe('TOO user', () => {
 
       // get authorized end date as 90 days from the origin start date (two months ago)
       const ninetyDaysFromStartDateInclusive = new Date(twoMonthsAgo);
-      ninetyDaysFromStartDateInclusive.setDate(ninetyDaysFromStartDateInclusive.getDate() + 89); // Use 89 because the last day is counted as a whole day
+      ninetyDaysFromStartDateInclusive.setDate(ninetyDaysFromStartDateInclusive.getDate() + 90);
       // format
       const day = new Intl.DateTimeFormat('en', { day: '2-digit' }).format(ninetyDaysFromStartDateInclusive);
       const month = new Intl.DateTimeFormat('en', { month: 'short' }).format(ninetyDaysFromStartDateInclusive);
@@ -110,8 +109,8 @@ test.describe('TOO user', () => {
       const destinationDaysDiff = destinationTimeDiff / (1000 * 60 * 60 * 24);
       const originDaysDiff = originTimeDiff / (1000 * 60 * 60 * 24);
       // be inclusive of the last day
-      const totalDaysBetweenDestinationInclusive = destinationDaysDiff + 1;
-      const totalDaysBetweenOriginInclusive = originDaysDiff + 1;
+      const totalDaysBetweenDestinationInclusive = destinationDaysDiff;
+      const totalDaysBetweenOriginInclusive = originDaysDiff;
       // get sums
       const totalDaysUsed = totalDaysBetweenDestinationInclusive + totalDaysBetweenOriginInclusive;
       const remainingDays = 90 - totalDaysUsed;

--- a/playwright/tests/office/txo/sitUpdates.spec.js
+++ b/playwright/tests/office/txo/sitUpdates.spec.js
@@ -7,6 +7,20 @@ test.describe('TOO user', () => {
   /** @type {TooFlowPage} */
   let tooFlowPage;
 
+  // Helper func to calculate days between 2 given dates
+  // This is to support months of 30 and 31 dayss
+  const calculateDaysDiff = (startDate, endDate) => {
+    let days = 0;
+    const currentDate = new Date(startDate);
+
+    while (currentDate < endDate) {
+      days += 1;
+      currentDate.setDate(currentDate.getDate() + 1);
+    }
+
+    return days;
+  };
+
   test.describe('previewing shipment with current SIT with past SIT', () => {
     test.beforeEach(async ({ officePage }) => {
       // build move in SIT with 90 days authorized and without pending extension requests
@@ -32,14 +46,11 @@ test.describe('TOO user', () => {
       // get 2 months ago
       const twoMonthsAgo = new Date(today);
       twoMonthsAgo.setMonth(today.getMonth() - 2);
-      // get the time diff
-      const timeDiff = oneMonthAgo.getTime() - twoMonthsAgo.getTime();
-      // get the days, converting milliseconds to days
-      const daysDiff = timeDiff / (1000 * 60 * 60 * 24);
-      // be inclusive of the last day
-      const totalDaysBetweenOneMonthInclusive = daysDiff + 1;
+      // get days between
+      const daysBetweenTwoMonthsAgoAndOneMonthAgo = calculateDaysDiff(twoMonthsAgo, oneMonthAgo);
+      const daysBetweenOneMonthAgoAndToday = calculateDaysDiff(oneMonthAgo, today);
       // get sums
-      const totalDaysUsed = totalDaysBetweenOneMonthInclusive * 2; // Origin and Dest sit each used 1 month
+      const totalDaysUsed = daysBetweenTwoMonthsAgoAndOneMonthAgo + daysBetweenOneMonthAgoAndToday;
       const remainingDays = 90 - totalDaysUsed;
       // assert that days used is the following sum
       // - past origin SIT (entry 2 months ago, departure 1 month ago)
@@ -53,19 +64,23 @@ test.describe('TOO user', () => {
       ).toBeVisible();
       // assert that total days in destination sit is 1 month, inclusive of last day
       await expect(
-        page
-          .getByTestId('sitStartAndEndTable')
-          .getByText(`${totalDaysBetweenOneMonthInclusive}`, { exact: true })
-          .first(),
+        page.getByTestId('sitStartAndEndTable').getByText(`${daysBetweenOneMonthAgoAndToday}`, { exact: true }).first(),
       ).toBeVisible();
 
-      // get authorized end date as 90 days from the origin start date (two months ago)
-      const ninetyDaysFromStartDateInclusive = new Date(twoMonthsAgo);
-      ninetyDaysFromStartDateInclusive.setDate(ninetyDaysFromStartDateInclusive.getDate() + 89); // Use 89 because the last day is counted as a whole day
+      // Get the SIT start date from the UI
+      const sitStartDateText = await page.getByTestId('sitStartAndEndTable').locator('td').nth(0).innerText();
+      const sitStartDate = new Date(sitStartDateText);
+
+      // Calculate the authorized end date by adding 90 days to the start date and then subtracting total days used
+      const authorizedEndDate = new Date(sitStartDate);
+      // Use 89 because the last day is counted as a whole day
+      // Subtract by "daysBetweenTwoMonthsAgoAndOneMonthAgo" (past SIT days) instead of total days used
+      // This is because the authorized end date is based on the remaining days at the start of the current SIT
+      authorizedEndDate.setDate(authorizedEndDate.getDate() + 89 - daysBetweenTwoMonthsAgoAndOneMonthAgo);
       // format
-      const day = new Intl.DateTimeFormat('en', { day: '2-digit' }).format(ninetyDaysFromStartDateInclusive);
-      const month = new Intl.DateTimeFormat('en', { month: 'short' }).format(ninetyDaysFromStartDateInclusive);
-      const year = new Intl.DateTimeFormat('en', { year: 'numeric' }).format(ninetyDaysFromStartDateInclusive);
+      const day = new Intl.DateTimeFormat('en', { day: '2-digit' }).format(authorizedEndDate);
+      const month = new Intl.DateTimeFormat('en', { month: 'short' }).format(authorizedEndDate);
+      const year = new Intl.DateTimeFormat('en', { year: 'numeric' }).format(authorizedEndDate);
       const expectedAuthorizedEndDate = `${day} ${month} ${year}`;
       // assert
       await expect(
@@ -103,17 +118,11 @@ test.describe('TOO user', () => {
       originDepartureDate.setMonth(today.getMonth() - 3);
       const originEntryDate = new Date(today);
       originEntryDate.setMonth(today.getMonth() - 4);
-      // get the time diff
-      const destinationTimeDiff = destinationDepartureDate.getTime() - destinationEntryDate.getTime();
-      const originTimeDiff = originDepartureDate.getTime() - originEntryDate.getTime();
-      // get the days, converting milliseconds to days
-      const destinationDaysDiff = destinationTimeDiff / (1000 * 60 * 60 * 24);
-      const originDaysDiff = originTimeDiff / (1000 * 60 * 60 * 24);
-      // be inclusive of the last day
-      const totalDaysBetweenDestinationInclusive = destinationDaysDiff + 1;
-      const totalDaysBetweenOriginInclusive = originDaysDiff + 1;
+      // days between
+      const totalDaysBetweenDestination = calculateDaysDiff(destinationEntryDate, destinationDepartureDate);
+      const totalDaysBetweenOrigin = calculateDaysDiff(originEntryDate, originDepartureDate);
       // get sums
-      const totalDaysUsed = totalDaysBetweenDestinationInclusive + totalDaysBetweenOriginInclusive;
+      const totalDaysUsed = totalDaysBetweenDestination + totalDaysBetweenOrigin;
       const remainingDays = 90 - totalDaysUsed;
       // assert sums
       await expect(
@@ -127,13 +136,13 @@ test.describe('TOO user', () => {
       await expect(
         page
           .getByTestId('previouslyUsedSitTable')
-          .getByText(`${totalDaysBetweenDestinationInclusive} days at destination`, { exact: false })
+          .getByText(`${totalDaysBetweenDestination} days at destination`, { exact: false })
           .first(),
       ).toBeVisible();
       await expect(
         page
           .getByTestId('previouslyUsedSitTable')
-          .getByText(`${totalDaysBetweenOriginInclusive} days at origin`, { exact: false })
+          .getByText(`${totalDaysBetweenOrigin} days at origin`, { exact: false })
           .first(),
       ).toBeVisible();
     });

--- a/playwright/tests/office/txo/sitUpdates.spec.js
+++ b/playwright/tests/office/txo/sitUpdates.spec.js
@@ -36,7 +36,8 @@ test.describe('TOO user', () => {
       const timeDiff = oneMonthAgo.getTime() - twoMonthsAgo.getTime();
       // get the days, converting milliseconds to days
       const daysDiff = timeDiff / (1000 * 60 * 60 * 24);
-      const totalDaysBetweenOneMonthInclusive = daysDiff;
+      // be inclusive of the last day
+      const totalDaysBetweenOneMonthInclusive = daysDiff + 1;
       // get sums
       const totalDaysUsed = totalDaysBetweenOneMonthInclusive * 2; // Origin and Dest sit each used 1 month
       const remainingDays = 90 - totalDaysUsed;
@@ -60,7 +61,7 @@ test.describe('TOO user', () => {
 
       // get authorized end date as 90 days from the origin start date (two months ago)
       const ninetyDaysFromStartDateInclusive = new Date(twoMonthsAgo);
-      ninetyDaysFromStartDateInclusive.setDate(ninetyDaysFromStartDateInclusive.getDate() + 90);
+      ninetyDaysFromStartDateInclusive.setDate(ninetyDaysFromStartDateInclusive.getDate() + 89); // Use 89 because the last day is counted as a whole day
       // format
       const day = new Intl.DateTimeFormat('en', { day: '2-digit' }).format(ninetyDaysFromStartDateInclusive);
       const month = new Intl.DateTimeFormat('en', { month: 'short' }).format(ninetyDaysFromStartDateInclusive);
@@ -109,8 +110,8 @@ test.describe('TOO user', () => {
       const destinationDaysDiff = destinationTimeDiff / (1000 * 60 * 60 * 24);
       const originDaysDiff = originTimeDiff / (1000 * 60 * 60 * 24);
       // be inclusive of the last day
-      const totalDaysBetweenDestinationInclusive = destinationDaysDiff;
-      const totalDaysBetweenOriginInclusive = originDaysDiff;
+      const totalDaysBetweenDestinationInclusive = destinationDaysDiff + 1;
+      const totalDaysBetweenOriginInclusive = originDaysDiff + 1;
       // get sums
       const totalDaysUsed = totalDaysBetweenDestinationInclusive + totalDaysBetweenOriginInclusive;
       const remainingDays = 90 - totalDaysUsed;

--- a/playwright/tests/office/txo/tooFlowsNTS.spec.js
+++ b/playwright/tests/office/txo/tooFlowsNTS.spec.js
@@ -193,11 +193,11 @@ test.describe('TOO user', () => {
       // Fill out the HHG and NTS accounting codes
       await page.getByTestId('hhgTacInput').fill(tac.tac);
       const today = new Date();
-      const formattedDate = new Intl.DateTimeFormat('en-GB', {
-        day: '2-digit',
-        month: 'short',
-        year: 'numeric',
-      }).format(today);
+      const day = new Intl.DateTimeFormat('en', { day: '2-digit' }).format(today);
+      const month = new Intl.DateTimeFormat('en', { month: 'short' }).format(today);
+      const year = new Intl.DateTimeFormat('en', { year: 'numeric' }).format(today);
+      const formattedDate = `${day} ${month} ${year}`;
+
       await page.locator('input[name="issueDate"]').fill(formattedDate);
 
       await page.getByTestId('hhgSacInput').fill('4K988AS098F');


### PR DESCRIPTION
# Lines of Accounting E2E
Fixes flaky formatting causing the following test to fail
https://app.circleci.com/pipelines/github/transcom/mymove/74644/workflows/333fc39d-183e-447d-b592-802ddb69953b/jobs/1315694/tests#failed-test-0

This is due to DateTimeFormat not sharing the same format as MomentJS which we use in our src code. MomentJS is not used within Playwright at this time due to additional setup required to get it compatible with the TypeScript check enforced through our e2e tests.

Previously, this would pass in August but the formatting fails for September.

# SIT E2E

Fixed flaky SIT tests https://app.circleci.com/pipelines/github/transcom/mymove/74655/workflows/3b2861e7-f276-4be6-b40d-6911b9caf8d5/jobs/1315834

Due to month calculation diffs

Dashboard view
![Screenshot 2024-09-03 at 10 46 44 AM](https://github.com/user-attachments/assets/cc1b27a3-b612-43d3-b9ab-7411a5377e52)

The day after today thru authorized end date (Today is already counted in the current SIT)
![image](https://github.com/user-attachments/assets/437e84c1-3488-4273-a155-e51927f38f99)

Aug 4 - Today
![image](https://github.com/user-attachments/assets/94cfb778-14cf-4887-9ce8-c05eee78c860)

July 5 - Aug 4
![image](https://github.com/user-attachments/assets/95f52ad8-2b55-46c5-8b6c-d3e5bb7222bd)
