### PR TITLE
B-20292 (I-13262): Kick back due to the alt telephone number reverting to original number after getting 2 forms away

### DIFF
--- a/pkg/handlers/internalapi/service_members.go
+++ b/pkg/handlers/internalapi/service_members.go
@@ -235,8 +235,9 @@ func (h PatchServiceMemberHandler) patchServiceMemberWithPayload(serviceMember *
 	if payload.Telephone != nil {
 		serviceMember.Telephone = payload.Telephone
 	}
-	// Need to be able to accept a nil value for this optional field
-	serviceMember.SecondaryTelephone = payload.SecondaryTelephone
+	if payload.SecondaryTelephone != nil {
+		serviceMember.SecondaryTelephone = payload.SecondaryTelephone
+	}
 	if payload.PersonalEmail != nil {
 		serviceMember.PersonalEmail = payload.PersonalEmail
 	}

--- a/src/pages/MyMove/Profile/ContactInfo.jsx
+++ b/src/pages/MyMove/Profile/ContactInfo.jsx
@@ -37,13 +37,13 @@ export const ContactInfo = ({ serviceMember, updateServiceMember, userEmail }) =
     const payload = {
       id: serviceMember.id,
       telephone: values?.telephone,
-      secondary_telephone: values?.secondary_telephone,
+      secondary_telephone: values?.secondary_telephone || '',
       personal_email: values?.personal_email,
       phone_is_preferred: values?.phone_is_preferred,
       email_is_preferred: values?.email_is_preferred,
     };
-    if (!payload.secondary_telephone) {
-      delete payload.secondary_telephone;
+    if (!payload.secondary_telephone || payload.secondary_telephone === '') {
+      payload.secondary_telephone = '';
     }
 
     return patchServiceMember(payload)

--- a/src/pages/Office/CustomerOnboarding/CreateCustomerForm.jsx
+++ b/src/pages/Office/CustomerOnboarding/CreateCustomerForm.jsx
@@ -41,7 +41,6 @@ export const CreateCustomerForm = ({ userPrivileges, setFlashMessage }) => {
   const backupContactName = 'backup_contact';
 
   const [isSafetyMoveFF, setSafetyMoveFF] = useState(false);
-  const [secondaryTelephoneNum, setSecondaryTelephoneNum] = useState('');
 
   useEffect(() => {
     isBooleanFlagEnabled('safety_move')?.then((enabled) => {
@@ -190,16 +189,6 @@ export const CreateCustomerForm = ({ userPrivileges, setFlashMessage }) => {
         <Grid col desktop={{ col: 8 }} className={styles.nameForm}>
           <Formik initialValues={initialValues} validateOnMount validationSchema={validationSchema} onSubmit={onSubmit}>
             {({ isValid, handleSubmit, setValues, values, handleChange }) => {
-              const handleSubmitNext = () => {
-                setValues({
-                  ...values,
-                  secondary_telephone: secondaryTelephoneNum,
-                });
-                handleSubmit();
-              };
-              const handlePhoneNumChange = (value) => {
-                setSecondaryTelephoneNum(value);
-              };
               const handleIsSafetyMove = (e) => {
                 const { value } = e.target;
                 if (value === 'true') {
@@ -316,7 +305,6 @@ export const CreateCustomerForm = ({ userPrivileges, setFlashMessage }) => {
                       type="tel"
                       minimum="12"
                       mask="000{-}000{-}0000"
-                      onChange={handlePhoneNumChange}
                     />
                     <TextField label="Personal email" id="personalEmail" name="personal_email" required />
                     <Label>Preferred contact method (optional)</Label>
@@ -491,7 +479,7 @@ export const CreateCustomerForm = ({ userPrivileges, setFlashMessage }) => {
                       editMode
                       onCancelClick={handleBack}
                       disableNext={!isValid}
-                      onNextClick={handleSubmitNext}
+                      onNextClick={handleSubmit}
                     />
                   </div>
                 </Form>


### PR DESCRIPTION
## [B-20292](https://www13.v1host.com/USTRANSCOM38/assetdetail.v1?number=B-20292)
## [I-13262](https://www13.v1host.com/USTRANSCOM38/issue.mvc/summary?oidToken=Issue%3A1004633)
## [Original INT PR](https://github.com/transcom/mymove/pull/13578)

## Testing Steps
Note: it may help to have the dev tools open on the Network section to verify that the customer object either has or does not have the secondary_telephone property on it.
1. Create a new customer account and start entering in information.
2. When you get to the section that asks for "Best contact phone", "Alt. phone", "Personal email", as well as "Preferred contact method," you should enter all the required information as well as an "Alt. phone".
3. Click the form's "Next" button to navigate to the next section.
4. Click the form's "Back" button to navigate back to the previous section that showed phone numbers and an email address field. At this point you should see all of the previously entered information.
5. Now erase the value of the "Alt. phone" field.
6. Click the form's "Next" button.
7. Fill out the details of this section of the form and click the form's "Next" button.
8. Click the form's "Back" button.
9. Now click this form's "Back" button to get back to the phone numbers section. You should see no value in the "Alt. phone" field.
10. I recommend completing the account creation forms and also verifying that the other testing steps in the [original INT PR](https://github.com/transcom/mymove/pull/13578) are still working and producing the desired result.