### PR TITLE
INT B-21038 generate fake identifiers for safety moves

### DIFF
--- a/pkg/gen/ghcapi/embedded_spec.go
+++ b/pkg/gen/ghcapi/embedded_spec.go
@@ -7357,10 +7357,10 @@ func init() {
         "current_address": {
           "$ref": "#/definitions/Address"
         },
-        "dodID": {
+        "eTag": {
           "type": "string"
         },
-        "eTag": {
+        "edipi": {
           "type": "string"
         },
         "email": {
@@ -22951,10 +22951,10 @@ func init() {
         "current_address": {
           "$ref": "#/definitions/Address"
         },
-        "dodID": {
+        "eTag": {
           "type": "string"
         },
-        "eTag": {
+        "edipi": {
           "type": "string"
         },
         "email": {

--- a/pkg/gen/ghcmessages/customer.go
+++ b/pkg/gen/ghcmessages/customer.go
@@ -34,11 +34,11 @@ type Customer struct {
 	// current address
 	CurrentAddress *Address `json:"current_address,omitempty"`
 
-	// dod ID
-	DodID string `json:"dodID,omitempty"`
-
 	// e tag
 	ETag string `json:"eTag,omitempty"`
+
+	// edipi
+	Edipi string `json:"edipi,omitempty"`
 
 	// email
 	// Pattern: ^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$

--- a/pkg/handlers/ghcapi/customer_test.go
+++ b/pkg/handlers/ghcapi/customer_test.go
@@ -53,7 +53,7 @@ func (suite *HandlerSuite) TestGetCustomerHandlerIntegration() {
 	suite.NoError(getCustomerPayload.Validate(strfmt.Default))
 
 	suite.Equal(strfmt.UUID(customer.ID.String()), getCustomerPayload.ID)
-	suite.Equal(*customer.Edipi, getCustomerPayload.DodID)
+	suite.Equal(*customer.Edipi, getCustomerPayload.Edipi)
 	suite.Equal(strfmt.UUID(customer.UserID.String()), getCustomerPayload.UserID)
 	suite.Equal(customer.Affiliation.String(), getCustomerPayload.Agency)
 	suite.Equal(customer.PersonalEmail, getCustomerPayload.Email)

--- a/pkg/handlers/ghcapi/internal/payloads/model_to_payload.go
+++ b/pkg/handlers/ghcapi/internal/payloads/model_to_payload.go
@@ -505,7 +505,7 @@ func Customer(customer *models.ServiceMember) *ghcmessages.Customer {
 	payload := ghcmessages.Customer{
 		Agency:             swag.StringValue((*string)(customer.Affiliation)),
 		CurrentAddress:     Address(customer.ResidentialAddress),
-		DodID:              swag.StringValue(customer.Edipi),
+		Edipi:              swag.StringValue(customer.Edipi),
 		Email:              customer.PersonalEmail,
 		FirstName:          swag.StringValue(customer.FirstName),
 		ID:                 strfmt.UUID(customer.ID.String()),

--- a/pkg/handlers/ghcapi/orders.go
+++ b/pkg/handlers/ghcapi/orders.go
@@ -323,22 +323,10 @@ func (h CreateOrderHandler) Handle(params orderop.CreateOrderParams) middleware.
 			}
 
 			if newOrder.OrdersType == "SAFETY" {
-				// if creating a Safety move, clear out the DoDID and OktaID for the customer
+				// if creating a Safety move, clear out the OktaID for the customer since they won't log into MilMove
 				err = models.UpdateUserOktaID(appCtx.DB(), &newOrder.ServiceMember.User, "")
 				if err != nil {
 					appCtx.Logger().Error("Authorization error updating user", zap.Error(err))
-					return orderop.NewUpdateOrderInternalServerError(), err
-				}
-
-				err = models.UpdateServiceMemberDoDID(appCtx.DB(), &newOrder.ServiceMember, nil)
-				if err != nil {
-					appCtx.Logger().Error("Authorization error updating service member", zap.Error(err))
-					return orderop.NewUpdateOrderInternalServerError(), err
-				}
-
-				err = models.UpdateServiceMemberEMPLID(appCtx.DB(), &newOrder.ServiceMember, nil)
-				if err != nil {
-					appCtx.Logger().Error("Authorization error updating service member", zap.Error(err))
 					return orderop.NewUpdateOrderInternalServerError(), err
 				}
 			}

--- a/pkg/handlers/ghcapi/queues_test.go
+++ b/pkg/handlers/ghcapi/queues_test.go
@@ -833,7 +833,7 @@ func (suite *HandlerSuite) TestGetMoveQueuesHandlerCustomerInfoFilters() {
 		result := payload.QueueMoves[0]
 
 		suite.Len(payload.QueueMoves, 1)
-		suite.Equal("11111", result.Customer.DodID)
+		suite.Equal("11111", result.Customer.Edipi)
 	})
 
 	suite.Run("returns results matching Move ID search term", func() {
@@ -1525,7 +1525,7 @@ func (suite *HandlerSuite) TestGetServicesCounselingQueueHandler() {
 
 		suite.Len(payload.QueueMoves, 2)
 		suite.Equal(order.ServiceMember.ID.String(), result1.Customer.ID.String())
-		suite.Equal(*order.ServiceMember.Edipi, result1.Customer.DodID)
+		suite.Equal(*order.ServiceMember.Edipi, result1.Customer.Edipi)
 		suite.Equal(subtestData.needsCounselingMove.Locator, result1.Locator)
 		suite.EqualValues(subtestData.needsCounselingMove.Status, result1.Status)
 		suite.Equal(subtestData.needsCounselingEarliestShipment.RequestedPickupDate.Format(time.RFC3339Nano), (time.Time)(*result1.RequestedMoveDate).Format(time.RFC3339Nano))

--- a/src/components/CustomerHeader/CustomerHeader.test.jsx
+++ b/src/components/CustomerHeader/CustomerHeader.test.jsx
@@ -5,7 +5,7 @@ import { mount } from 'enzyme';
 import CustomerHeader from './index';
 
 const props = {
-  customer: { last_name: 'Kerry', first_name: 'Smith', dodID: '999999999', emplid: '7777777', agency: 'COAST_GUARD' },
+  customer: { last_name: 'Kerry', first_name: 'Smith', edipi: '999999999', emplid: '7777777', agency: 'COAST_GUARD' },
   order: {
     agency: 'COAST_GUARD',
     grade: 'E_6',
@@ -25,7 +25,7 @@ const props = {
 };
 
 const propsRetiree = {
-  customer: { last_name: 'Kerry', first_name: 'Smith', dodID: '999999999' },
+  customer: { last_name: 'Kerry', first_name: 'Smith', edipi: '999999999' },
   order: {
     agency: 'NAVY',
     grade: 'E_6',
@@ -45,7 +45,7 @@ const propsRetiree = {
 };
 
 const propsUSMC = {
-  customer: { last_name: 'Kerry', first_name: 'Smith', dodID: '999999999' },
+  customer: { last_name: 'Kerry', first_name: 'Smith', edipi: '999999999' },
   order: {
     agency: 'MARINES',
     grade: 'E_6',
@@ -77,7 +77,7 @@ describe('CustomerHeader component', () => {
     expect(wrapper.find('[data-testid="nameBlock"]').text()).toContain('Kerry, Smith');
     expect(wrapper.find('[data-testid="nameBlock"]').text()).toContain('FKLCTR');
     expect(wrapper.find('[data-testid="deptPayGrade"]').text()).toContain('Coast Guard E-6');
-    expect(wrapper.find('[data-testid="dodId"]').text()).toContain('DoD ID 999999999');
+    expect(wrapper.find('[data-testid="edipi"]').text()).toContain('DoD ID 999999999');
     expect(wrapper.find('[data-testid="emplid"]').text()).toContain('EMPLID 7777777');
     expect(wrapper.find('[data-testid="infoBlock"]').text()).toContain('JBSA Lackland');
     expect(wrapper.find('[data-testid="infoBlock"]').text()).toContain('JB Lewis-McChord');

--- a/src/components/CustomerHeader/index.jsx
+++ b/src/components/CustomerHeader/index.jsx
@@ -56,8 +56,8 @@ const CustomerHeader = ({ customer, order, moveCode, move, userRole }) => {
               {ORDERS_BRANCH_OPTIONS[`${order.agency}`]} {ORDERS_PAY_GRADE_OPTIONS[`${order.grade}`]}
             </span>
             <span className={styles.verticalBar}>|</span>
-            <span data-testid="dodId" className={styles.details}>
-              DoD ID {customer.dodID}
+            <span data-testid="edipi" className={styles.details}>
+              DoD ID {customer.edipi}
             </span>
             {isCoastGuard && (
               <>

--- a/src/components/Office/DefinitionLists/CustomerInfoList.jsx
+++ b/src/components/Office/DefinitionLists/CustomerInfoList.jsx
@@ -19,7 +19,7 @@ const CustomerInfoList = ({ customerInfo }) => {
         </div>
         <div className={descriptionListStyles.row}>
           <dt>DoD ID</dt>
-          <dd data-testid="dodId">{customerInfo.dodId}</dd>
+          <dd data-testid="edipi">{customerInfo.edipi}</dd>
         </div>
         {customerInfo.agency === departmentIndicators.COAST_GUARD && (
           <div className={descriptionListStyles.row}>
@@ -81,7 +81,7 @@ const CustomerInfoList = ({ customerInfo }) => {
 CustomerInfoList.propTypes = {
   customerInfo: PropTypes.shape({
     name: PropTypes.string,
-    dodId: PropTypes.string,
+    edipi: PropTypes.string,
     phone: PropTypes.string,
     email: PropTypes.string,
     currentAddress: AddressShape,

--- a/src/components/Office/DefinitionLists/CustomerInfoList.test.jsx
+++ b/src/components/Office/DefinitionLists/CustomerInfoList.test.jsx
@@ -6,7 +6,7 @@ import CustomerInfoList from './CustomerInfoList';
 const info = {
   name: 'Smith, Kerry',
   agency: 'COAST_GUARD',
-  dodId: '9999999999',
+  edipi: '9999999999',
   emplid: '7777777',
   phone: '999-999-9999',
   altPhone: '888-888-8888',

--- a/src/pages/Office/CustomerOnboarding/CreateCustomerForm.jsx
+++ b/src/pages/Office/CustomerOnboarding/CreateCustomerForm.jsx
@@ -27,11 +27,14 @@ import { setFlashMessage as setFlashMessageAction } from 'store/flash/actions';
 import { elevatedPrivilegeTypes } from 'constants/userPrivileges';
 import { isBooleanFlagEnabled } from 'utils/featureFlags';
 import departmentIndicators from 'constants/departmentIndicators';
+import { generateUniqueDodid, generateUniqueEmplid } from 'utils/customer';
+import Hint from 'components/Hint';
 
 export const CreateCustomerForm = ({ userPrivileges, setFlashMessage }) => {
   const [serverError, setServerError] = useState(null);
   const [showEmplid, setShowEmplid] = useState(false);
   const [isSafetyMove, setIsSafetyMove] = useState(false);
+  const [showSafetyMoveHint, setShowSafetyMoveHint] = useState(false);
   const navigate = useNavigate();
 
   const branchOptions = dropdownInputOptions(SERVICE_MEMBER_AGENCY_LABELS);
@@ -41,6 +44,9 @@ export const CreateCustomerForm = ({ userPrivileges, setFlashMessage }) => {
   const backupContactName = 'backup_contact';
 
   const [isSafetyMoveFF, setSafetyMoveFF] = useState(false);
+
+  const uniqueDodid = generateUniqueDodid();
+  const uniqueEmplid = generateUniqueEmplid();
 
   useEffect(() => {
     isBooleanFlagEnabled('safety_move')?.then((enabled) => {
@@ -55,6 +61,7 @@ export const CreateCustomerForm = ({ userPrivileges, setFlashMessage }) => {
   const initialValues = {
     affiliation: '',
     edipi: '',
+    emplid: '',
     first_name: '',
     middle_name: '',
     last_name: '',
@@ -193,11 +200,10 @@ export const CreateCustomerForm = ({ userPrivileges, setFlashMessage }) => {
                 const { value } = e.target;
                 if (value === 'true') {
                   setIsSafetyMove(true);
+                  setShowSafetyMoveHint(true);
                   // clear out DoDID, emplid, and OKTA fields
                   setValues({
                     ...values,
-                    edipi: '',
-                    emplid: '',
                     create_okta_account: '',
                     cac_user: 'true',
                     is_safety_move: 'true',
@@ -211,10 +217,23 @@ export const CreateCustomerForm = ({ userPrivileges, setFlashMessage }) => {
                 }
               };
               const handleBranchChange = (e) => {
+                setShowSafetyMoveHint(false);
                 if (e.target.value === departmentIndicators.COAST_GUARD) {
                   setShowEmplid(true);
+                  setValues({
+                    ...values,
+                    affiliation: e.target.value,
+                    edipi: '',
+                    emplid: uniqueEmplid,
+                  });
                 } else {
                   setShowEmplid(false);
+                  setValues({
+                    ...values,
+                    affiliation: e.target.value,
+                    edipi: uniqueDodid,
+                    emplid: '',
+                  });
                 }
               };
               return (
@@ -266,6 +285,9 @@ export const CreateCustomerForm = ({ userPrivileges, setFlashMessage }) => {
                       maxLength="10"
                       isDisabled={isSafetyMove}
                     />
+                    {isSafetyMove && showSafetyMoveHint && (
+                      <Hint>Once a branch is selected, this will generate a random safety move identifier</Hint>
+                    )}
                     {showEmplid && (
                       <TextField
                         label="EMPLID"

--- a/src/pages/Office/CustomerOnboarding/CreateCustomerForm.test.jsx
+++ b/src/pages/Office/CustomerOnboarding/CreateCustomerForm.test.jsx
@@ -69,7 +69,7 @@ const fakePayload = {
   },
   create_okta_account: 'true',
   cac_user: 'false',
-  is_safety_move: 'false',
+  is_safety_move: false,
 };
 
 const fakeResponse = {
@@ -382,6 +382,71 @@ describe('CreateCustomerForm', () => {
     await userEvent.type(getByLabelText('Name'), safetyPayload.backup_contact.name);
     await userEvent.type(getByRole('textbox', { name: 'Email' }), safetyPayload.backup_contact.email);
     await userEvent.type(getByRole('textbox', { name: 'Phone' }), safetyPayload.backup_contact.telephone);
+
+    await waitFor(() => {
+      expect(saveBtn).toBeEnabled();
+    });
+    await userEvent.click(saveBtn);
+
+    await waitFor(() => {
+      expect(createCustomerWithOktaOption).toHaveBeenCalled();
+      expect(mockNavigate).toHaveBeenCalledWith(ordersPath, {
+        state: {
+          isSafetyMoveSelected: true,
+        },
+      });
+    });
+  }, 10000);
+
+  it('disables and populates DODID and EMPLID inputs when safety move is selected', async () => {
+    createCustomerWithOktaOption.mockImplementation(() => Promise.resolve(fakeResponse));
+    isBooleanFlagEnabled.mockImplementation(() => Promise.resolve(true));
+
+    const { getByLabelText, getByTestId, getByRole } = render(
+      <MockProviders>
+        <CreateCustomerForm {...testProps} />
+      </MockProviders>,
+    );
+
+    const user = userEvent.setup();
+
+    const safetyMove = await screen.findByTestId('is-safety-move-no');
+    expect(safetyMove).toBeChecked();
+
+    // check the safety move box
+    await userEvent.type(getByTestId('is-safety-move-yes'), safetyPayload.is_safety_move);
+
+    expect(await screen.findByTestId('safetyMoveHint')).toBeInTheDocument();
+
+    await user.selectOptions(getByLabelText('Branch of service'), ['COAST_GUARD']);
+
+    // the input boxes should now be disabled
+    expect(await screen.findByTestId('edipiInput')).toBeDisabled();
+    expect(await screen.findByTestId('emplidInput')).toBeDisabled();
+
+    // should be able to submit the form
+    await user.type(getByLabelText('First name'), safetyPayload.first_name);
+    await user.type(getByLabelText('Last name'), safetyPayload.last_name);
+
+    await user.type(getByLabelText('Best contact phone'), safetyPayload.telephone);
+    await user.type(getByLabelText('Personal email'), safetyPayload.personal_email);
+
+    await userEvent.type(getByTestId('res-add-street1'), safetyPayload.residential_address.streetAddress1);
+    await userEvent.type(getByTestId('res-add-city'), safetyPayload.residential_address.city);
+    await userEvent.selectOptions(getByTestId('res-add-state'), [safetyPayload.residential_address.state]);
+    await userEvent.type(getByTestId('res-add-zip'), safetyPayload.residential_address.postalCode);
+
+    await userEvent.type(getByTestId('backup-add-street1'), safetyPayload.backup_mailing_address.streetAddress1);
+    await userEvent.type(getByTestId('backup-add-city'), safetyPayload.backup_mailing_address.city);
+    await userEvent.selectOptions(getByTestId('backup-add-state'), [safetyPayload.backup_mailing_address.state]);
+    await userEvent.type(getByTestId('backup-add-zip'), safetyPayload.backup_mailing_address.postalCode);
+
+    await userEvent.type(getByLabelText('Name'), safetyPayload.backup_contact.name);
+    await userEvent.type(getByRole('textbox', { name: 'Email' }), safetyPayload.backup_contact.email);
+    await userEvent.type(getByRole('textbox', { name: 'Phone' }), safetyPayload.backup_contact.telephone);
+
+    const saveBtn = await screen.findByRole('button', { name: 'Save' });
+    expect(saveBtn).toBeInTheDocument();
 
     await waitFor(() => {
       expect(saveBtn).toBeEnabled();

--- a/src/pages/Office/MoveDetails/MoveDetails.jsx
+++ b/src/pages/Office/MoveDetails/MoveDetails.jsx
@@ -284,7 +284,7 @@ const MoveDetails = ({
   const customerInfo = {
     name: formattedCustomerName(customer.last_name, customer.first_name, customer.suffix, customer.middle_name),
     agency: customer.agency,
-    dodId: customer.dodID,
+    edipi: customer.edipi,
     emplid: customer.emplid,
     phone: customer.phone,
     altPhone: customer.secondaryTelephone,

--- a/src/utils/customer.js
+++ b/src/utils/customer.js
@@ -23,3 +23,28 @@ export const findNextServiceMemberStep = (profileState) => {
       return generalRoutes.HOME_PATH;
   }
 };
+
+export const generateUniqueDodid = () => {
+  const prefix = 'SM';
+
+  // Custom epoch start date (e.g., 2024-01-01), generates something like 1704067200000
+  const customEpoch = new Date('2024-01-01').getTime();
+  const now = Date.now();
+
+  // Calculate milliseconds since custom epoch, then convert to an 8-digit integer
+  const uniqueNumber = Math.floor((now - customEpoch) / 1000); // Dividing by 1000 to reduce to seconds
+
+  // Convert the unique number to a string, ensuring it has 8 digits
+  const uniqueStr = uniqueNumber.toString().slice(0, 8).padStart(8, '0');
+
+  return prefix + uniqueStr;
+};
+
+export const generateUniqueEmplid = () => {
+  const prefix = 'SM';
+  const customEpoch = new Date('2024-01-01').getTime();
+  const now = Date.now();
+  const uniqueNumber = Math.floor((now - customEpoch) / 1000) % 100000; // Modulo 100000 ensures it's 5 digits
+  const uniqueStr = uniqueNumber.toString().padStart(5, '0');
+  return prefix + uniqueStr;
+};

--- a/swagger-def/ghc.yaml
+++ b/swagger-def/ghc.yaml
@@ -4436,7 +4436,7 @@ definitions:
         type: string
         format: uuid
         example: c56a4180-65aa-42ec-a945-5fd21dec0538
-      dodID:
+      edipi:
         type: string
       userID:
         type: string

--- a/swagger/ghc.yaml
+++ b/swagger/ghc.yaml
@@ -4631,7 +4631,7 @@ definitions:
         type: string
         format: uuid
         example: c56a4180-65aa-42ec-a945-5fd21dec0538
-      dodID:
+      edipi:
         type: string
       userID:
         type: string


### PR DESCRIPTION
## [Agility ticket](https://www13.v1host.com/USTRANSCOM38/assetdetail.v1?number=B-21038)

## Summary

Gov wants us to generate a fake EDIPI & EMPLID for service members when a SC is creating a customer with a safety move. In order to do this, we could do a sequential count up, but since it doesn't technically matter WHAT the ID is, I am using a wombo combo of a date epoch that changes with each second. Even with 5 (EMPLID) and 8 (EDIPI) digits, having collisions that would occur at the same time will be impossible unless safety moves are created at the exact same second. Since safety moves are rare, I wanted to take the simple approach and do a frontend gen function instead of having to call the db.

This PR does the following:
- adds two generator functions to `src/utils/customer.js` that prefix with `SM` and then get the epoch of the current time, reduce it to seconds, and then shorten it to the desired length
- updated some `dodId` variables that shouldn't be there
- updated validators on `CreateCustomerForm.jsx` to allow for the `SM` prefix
- updated how the data is rendered based off of if the move is designated a safety move or not from the SC
- added in a hint
- tests

### How to test

1. You'll need to create an office user with service counseling role as well as safety moves user privileges
2. Log in as that office user
3. Go to the create customer form by accessing the "Add Customer" button when searching for a non-existing customer
4. You should see the safety move radio buttons
5. Click "Yes"
6. You'll be prompted to select a branch
7. Select Coast Guard - should now see some values pop up in each DODID and EMPLID box
8. Go back and select "No" for safety move
9. Boxes should reset and you should be prompted again to select a branch
10. Click "Yes" again to designate it as a safety move
11. Select "Army" or any other branch other than Coast Guard
12. DODID input should populate with a value and EMPLID should stay hidden
13. Complete the form with either a Coast Guard or not Coast Guard member
14. Add orders info, submit
15. Should see the values in the customer header for the move

## Screenshots
![Screenshot 2024-09-05 at 2 25 12 PM](https://github.com/user-attachments/assets/4d9435a8-80b0-42ad-902d-29a14468cbeb)

![Screenshot 2024-09-05 at 2 25 19 PM](https://github.com/user-attachments/assets/47f48b88-58a2-4d4b-962c-a6d7221baf58)

508
![Screenshot 2024-09-05 at 2 25 42 PM](https://github.com/user-attachments/assets/e24d1c65-a1cc-4a21-afb1-1d05c4f9faa9)

