### PR TITLE
B 20441 int

### DIFF
--- a/migrations/app/migrations_manifest.txt
+++ b/migrations/app/migrations_manifest.txt
@@ -997,3 +997,4 @@
 20240820151043_add_gsr_role.up.sql
 20240821180447_populating_locked_price_cents_for_ms_and_cs.up.sql
 20240822180409_adding_locked_price_cents_service_param.up.sql
+20240905192913_adding_prices_to_unpriced_cs_ms_service_items.up.sql

--- a/migrations/app/schema/20240905192913_adding_prices_to_unpriced_cs_ms_service_items.up.sql
+++ b/migrations/app/schema/20240905192913_adding_prices_to_unpriced_cs_ms_service_items.up.sql
@@ -1,0 +1,28 @@
+-- Filling in pricing_estimates for unprices services code MS and CS service items. Service items should not be able to reach this state
+-- but some older data exists where unpriced MS and CS items exist
+SET statement_timeout = 300000;
+SET lock_timeout = 300000;
+SET idle_in_transaction_session_timeout = 300000;
+
+UPDATE mto_service_items AS ms
+SET locked_price_cents =
+        CASE
+            when price_cents > 0 then price_cents
+            when price_cents <= 0 then 0
+        END,
+    pricing_estimate =
+        CASE
+            when price_cents > 0 then price_cents
+            when price_cents <= 0 then 0
+        END
+FROM re_task_order_fees AS tf
+JOIN re_contract_years AS cy
+ON tf.contract_year_id = cy.id
+JOIN re_contracts AS c
+ON cy.contract_id = c.id
+JOIN re_services AS s
+ON tf.service_id = s.id
+WHERE ms.locked_price_cents = null
+    AND ms.pricing_estimate = null
+    AND re_service_id = s.id
+    AND s.code = 'MS' OR  s.code = 'CS'

--- a/pkg/handlers/ghcapi/mto_service_items.go
+++ b/pkg/handlers/ghcapi/mto_service_items.go
@@ -392,9 +392,9 @@ func (h ListMTOServiceItemsHandler) Handle(params mtoserviceitemop.ListMTOServic
 					var displayParams services.PricingDisplayParams
 					var err error
 					if serviceItems[index].ReService.Code == "CS" {
-						price, displayParams, err = h.counselingPricer.Price(appCtx, *serviceItems[index].LockedPriceCents)
+						price, displayParams, err = h.counselingPricer.Price(appCtx, serviceItems[index].LockedPriceCents)
 					} else if serviceItems[index].ReService.Code == "MS" {
-						price, displayParams, err = h.moveManagementPricer.Price(appCtx, *serviceItems[index].LockedPriceCents)
+						price, displayParams, err = h.moveManagementPricer.Price(appCtx, serviceItems[index].LockedPriceCents)
 					}
 
 					for _, param := range displayParams {

--- a/pkg/services/ghc_rate_engine.go
+++ b/pkg/services/ghc_rate_engine.go
@@ -33,7 +33,7 @@ type ParamsPricer interface {
 //
 //go:generate mockery --name ManagementServicesPricer
 type ManagementServicesPricer interface {
-	Price(appCtx appcontext.AppContext, lockedPriceCents unit.Cents) (unit.Cents, PricingDisplayParams, error)
+	Price(appCtx appcontext.AppContext, lockedPriceCents *unit.Cents) (unit.Cents, PricingDisplayParams, error)
 	ParamsPricer
 }
 
@@ -41,7 +41,7 @@ type ManagementServicesPricer interface {
 //
 //go:generate mockery --name CounselingServicesPricer
 type CounselingServicesPricer interface {
-	Price(appCtx appcontext.AppContext, lockedPriceCents unit.Cents) (unit.Cents, PricingDisplayParams, error)
+	Price(appCtx appcontext.AppContext, lockedPriceCents *unit.Cents) (unit.Cents, PricingDisplayParams, error)
 	ParamsPricer
 }
 

--- a/pkg/services/ghcrateengine/counseling_services_pricer.go
+++ b/pkg/services/ghcrateengine/counseling_services_pricer.go
@@ -1,6 +1,8 @@
 package ghcrateengine
 
 import (
+	"fmt"
+
 	"github.com/transcom/mymove/pkg/appcontext"
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/services"
@@ -16,16 +18,20 @@ func NewCounselingServicesPricer() services.CounselingServicesPricer {
 }
 
 // Price determines the price for a counseling service
-func (p counselingServicesPricer) Price(appCtx appcontext.AppContext, lockedPriceCents unit.Cents) (unit.Cents, services.PricingDisplayParams, error) {
+func (p counselingServicesPricer) Price(appCtx appcontext.AppContext, lockedPriceCents *unit.Cents) (unit.Cents, services.PricingDisplayParams, error) {
+
+	if lockedPriceCents == nil {
+		return 0, nil, fmt.Errorf("invalid value for locked_price_cents")
+	}
 
 	params := services.PricingDisplayParams{
 		{
 			Key:   models.ServiceItemParamNamePriceRateOrFactor,
-			Value: FormatCents(lockedPriceCents),
+			Value: FormatCents(*lockedPriceCents),
 		},
 	}
 
-	return lockedPriceCents, params, nil
+	return *lockedPriceCents, params, nil
 }
 
 // PriceUsingParams determines the price for a counseling service given PaymentServiceItemParams
@@ -36,5 +42,6 @@ func (p counselingServicesPricer) PriceUsingParams(appCtx appcontext.AppContext,
 		return unit.Cents(0), nil, err
 	}
 
-	return p.Price(appCtx, unit.Cents(lockedPriceCents))
+	lockedPrice := unit.Cents(lockedPriceCents)
+	return p.Price(appCtx, &lockedPrice)
 }

--- a/pkg/services/ghcrateengine/counseling_services_pricer_test.go
+++ b/pkg/services/ghcrateengine/counseling_services_pricer_test.go
@@ -12,6 +12,7 @@ const (
 )
 
 func (suite *GHCRateEngineServiceSuite) TestPriceCounselingServices() {
+	lockedPrice := csPriceCents
 	counselingServicesPricer := NewCounselingServicesPricer()
 
 	suite.Run("success using PaymentServiceItemParams", func() {
@@ -31,7 +32,7 @@ func (suite *GHCRateEngineServiceSuite) TestPriceCounselingServices() {
 	suite.Run("success without PaymentServiceItemParams", func() {
 		suite.setupTaskOrderFeeData(models.ReServiceCodeCS, csPriceCents)
 
-		priceCents, _, err := counselingServicesPricer.Price(suite.AppContextForTest(), csPriceCents)
+		priceCents, _, err := counselingServicesPricer.Price(suite.AppContextForTest(), &lockedPrice)
 		suite.NoError(err)
 		suite.Equal(csPriceCents, priceCents)
 	})

--- a/pkg/services/ghcrateengine/management_services_pricer.go
+++ b/pkg/services/ghcrateengine/management_services_pricer.go
@@ -1,6 +1,8 @@
 package ghcrateengine
 
 import (
+	"fmt"
+
 	"github.com/transcom/mymove/pkg/appcontext"
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/services"
@@ -16,16 +18,20 @@ func NewManagementServicesPricer() services.ManagementServicesPricer {
 }
 
 // Price determines the price for a management service
-func (p managementServicesPricer) Price(appCtx appcontext.AppContext, lockedPriceCents unit.Cents) (unit.Cents, services.PricingDisplayParams, error) {
+func (p managementServicesPricer) Price(appCtx appcontext.AppContext, lockedPriceCents *unit.Cents) (unit.Cents, services.PricingDisplayParams, error) {
+
+	if lockedPriceCents == nil {
+		return 0, nil, fmt.Errorf("invalid value for locked_price_cents")
+	}
 
 	params := services.PricingDisplayParams{
 		{
 			Key:   models.ServiceItemParamNamePriceRateOrFactor,
-			Value: FormatCents(lockedPriceCents),
+			Value: FormatCents(*lockedPriceCents),
 		},
 	}
 
-	return lockedPriceCents, params, nil
+	return *lockedPriceCents, params, nil
 }
 
 // PriceUsingParams determines the price for a management service given PaymentServiceItemParams
@@ -36,5 +42,6 @@ func (p managementServicesPricer) PriceUsingParams(appCtx appcontext.AppContext,
 		return unit.Cents(0), nil, err
 	}
 
-	return p.Price(appCtx, unit.Cents(lockedPriceCents))
+	lockedPrice := unit.Cents(lockedPriceCents)
+	return p.Price(appCtx, &lockedPrice)
 }

--- a/pkg/services/ghcrateengine/management_services_pricer_test.go
+++ b/pkg/services/ghcrateengine/management_services_pricer_test.go
@@ -12,6 +12,7 @@ const (
 )
 
 func (suite *GHCRateEngineServiceSuite) TestPriceManagementServices() {
+	lockedPrice := csPriceCents
 	suite.Run("success using PaymentServiceItemParams", func() {
 		suite.setupTaskOrderFeeData(models.ReServiceCodeMS, msPriceCents)
 		paymentServiceItem := suite.setupManagementServicesItem()
@@ -32,7 +33,7 @@ func (suite *GHCRateEngineServiceSuite) TestPriceManagementServices() {
 		suite.setupTaskOrderFeeData(models.ReServiceCodeMS, msPriceCents)
 		managementServicesPricer := NewManagementServicesPricer()
 
-		priceCents, _, err := managementServicesPricer.Price(suite.AppContextForTest(), msPriceCents)
+		priceCents, _, err := managementServicesPricer.Price(suite.AppContextForTest(), &lockedPrice)
 		suite.NoError(err)
 		suite.Equal(msPriceCents, priceCents)
 	})

--- a/pkg/services/mocks/CounselingServicesPricer.go
+++ b/pkg/services/mocks/CounselingServicesPricer.go
@@ -19,22 +19,22 @@ type CounselingServicesPricer struct {
 }
 
 // Price provides a mock function with given fields: appCtx, lockedPriceCents
-func (_m *CounselingServicesPricer) Price(appCtx appcontext.AppContext, lockedPriceCents unit.Cents) (unit.Cents, services.PricingDisplayParams, error) {
+func (_m *CounselingServicesPricer) Price(appCtx appcontext.AppContext, lockedPriceCents *unit.Cents) (unit.Cents, services.PricingDisplayParams, error) {
 	ret := _m.Called(appCtx, lockedPriceCents)
 
 	var r0 unit.Cents
 	var r1 services.PricingDisplayParams
 	var r2 error
-	if rf, ok := ret.Get(0).(func(appcontext.AppContext, unit.Cents) (unit.Cents, services.PricingDisplayParams, error)); ok {
+	if rf, ok := ret.Get(0).(func(appcontext.AppContext, *unit.Cents) (unit.Cents, services.PricingDisplayParams, error)); ok {
 		return rf(appCtx, lockedPriceCents)
 	}
-	if rf, ok := ret.Get(0).(func(appcontext.AppContext, unit.Cents) unit.Cents); ok {
+	if rf, ok := ret.Get(0).(func(appcontext.AppContext, *unit.Cents) unit.Cents); ok {
 		r0 = rf(appCtx, lockedPriceCents)
 	} else {
 		r0 = ret.Get(0).(unit.Cents)
 	}
 
-	if rf, ok := ret.Get(1).(func(appcontext.AppContext, unit.Cents) services.PricingDisplayParams); ok {
+	if rf, ok := ret.Get(1).(func(appcontext.AppContext, *unit.Cents) services.PricingDisplayParams); ok {
 		r1 = rf(appCtx, lockedPriceCents)
 	} else {
 		if ret.Get(1) != nil {
@@ -42,7 +42,7 @@ func (_m *CounselingServicesPricer) Price(appCtx appcontext.AppContext, lockedPr
 		}
 	}
 
-	if rf, ok := ret.Get(2).(func(appcontext.AppContext, unit.Cents) error); ok {
+	if rf, ok := ret.Get(2).(func(appcontext.AppContext, *unit.Cents) error); ok {
 		r2 = rf(appCtx, lockedPriceCents)
 	} else {
 		r2 = ret.Error(2)

--- a/pkg/services/mocks/ManagementServicesPricer.go
+++ b/pkg/services/mocks/ManagementServicesPricer.go
@@ -19,22 +19,22 @@ type ManagementServicesPricer struct {
 }
 
 // Price provides a mock function with given fields: appCtx, lockedPriceCents
-func (_m *ManagementServicesPricer) Price(appCtx appcontext.AppContext, lockedPriceCents unit.Cents) (unit.Cents, services.PricingDisplayParams, error) {
+func (_m *ManagementServicesPricer) Price(appCtx appcontext.AppContext, lockedPriceCents *unit.Cents) (unit.Cents, services.PricingDisplayParams, error) {
 	ret := _m.Called(appCtx, lockedPriceCents)
 
 	var r0 unit.Cents
 	var r1 services.PricingDisplayParams
 	var r2 error
-	if rf, ok := ret.Get(0).(func(appcontext.AppContext, unit.Cents) (unit.Cents, services.PricingDisplayParams, error)); ok {
+	if rf, ok := ret.Get(0).(func(appcontext.AppContext, *unit.Cents) (unit.Cents, services.PricingDisplayParams, error)); ok {
 		return rf(appCtx, lockedPriceCents)
 	}
-	if rf, ok := ret.Get(0).(func(appcontext.AppContext, unit.Cents) unit.Cents); ok {
+	if rf, ok := ret.Get(0).(func(appcontext.AppContext, *unit.Cents) unit.Cents); ok {
 		r0 = rf(appCtx, lockedPriceCents)
 	} else {
 		r0 = ret.Get(0).(unit.Cents)
 	}
 
-	if rf, ok := ret.Get(1).(func(appcontext.AppContext, unit.Cents) services.PricingDisplayParams); ok {
+	if rf, ok := ret.Get(1).(func(appcontext.AppContext, *unit.Cents) services.PricingDisplayParams); ok {
 		r1 = rf(appCtx, lockedPriceCents)
 	} else {
 		if ret.Get(1) != nil {
@@ -42,7 +42,7 @@ func (_m *ManagementServicesPricer) Price(appCtx appcontext.AppContext, lockedPr
 		}
 	}
 
-	if rf, ok := ret.Get(2).(func(appcontext.AppContext, unit.Cents) error); ok {
+	if rf, ok := ret.Get(2).(func(appcontext.AppContext, *unit.Cents) error); ok {
 		r2 = rf(appCtx, lockedPriceCents)
 	} else {
 		r2 = ret.Error(2)


### PR DESCRIPTION
## [B-20441](https://www13.v1host.com/USTRANSCOM38/story.mvc/Summary?oidToken=Story%3A979321)

## Summary

Fixes an issue where previous changes did not account for older moves that did not contain a pricing_estimate

## Verification Steps for the Author

These are to be checked by the author.

- [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
- [ ] Have the Agility acceptance criteria been met for this change?

## Verification Steps for Reviewers

These are to be checked by a reviewer.

- [ ] Has the branch been pulled in and checked out?
- [ ] Have the BL acceptance criteria been met for this change?
- [ ] Was the CircleCI build successful?
- [ ] Has the code been reviewed from a standards and best practices point of view?

### Setup to Run the Code

- [Instructions for starting storybook](https://transcom.github.io/mymove-docs/docs/frontend/setup/storybook)
- [Instructions for starting the MilMove application](https://transcom.github.io/mymove-docs/docs/getting-started/application-setup/)
- [Instructions for running tests](https://transcom.github.io/mymove-docs/docs/getting-started/development/testing)

### How to test

1. Access the Office application
2. Login as a TOO
3. Find a move that doesn't have approved shipments yet (just to ensure good data)
4. Approve the shipments and add some combination of MS and CS service items

NOTE: At this point I would recommend editing the db directly and altering the lockedPriceCents column in mto_service_items to a different value. This way you can validate that the value from this column is the one being used, and not the one from re_task_order_fees (which was used previously and will likely be an identical value in your local to lockedPriceCents, but has the ability to change in prod. Hence this task to lock the pricing down)

Can use the following queries to easily find the service item for MS/CS fee to change the locked price.

select moves.id from moves where moves.locator ='INSERT_MOVE_CODE_HERE';

### For MS use msi.re_service_id ='1130e612-94eb-49a7-973d-72f33685e551'
### For CS use msi.re_service_id ='9dc919da-9b66-407b-9f17-05c0f03fcb50'
select * from mto_service_items msi where msi.move_id = 'YOUR_ID_FROM_PREV_QUERY' and msi.re_service_id ='1130e612-94eb-49a7-973d-72f33685e551';

6. Log in to the Prime simulator
7. Find the move you made available by approving the first shipment
8. Create a payment request that includes some combination of MS and CS service items (and more if you want)
9. Verify that the value in the 'LockedPriceCents' field from the MTOServiceItem (converted to lockedPriceCents paymentServiceItemParam) is being used to populate the payment service items for MS and CS. This can be done through breakpoints in the counseling_services_pricer or management_service_pricer, or by checking in the payment_service_items db table.

### Frontend

- [ ] There are no aXe warnings for UI.
- [ ] This works in [Supported Browsers and their phone views](https://transcom.github.io/mymove-docs/docs/adrs/Browser-Support/#minimum-browser-requirements) (Chrome, Firefox, Edge).
- [ ] There are no new console errors in the browser devtools.
- [ ] There are no new console errors in the test output.
- [ ] If this PR adds a new component to Storybook, it ensures the component is fully responsive, OR if it is intentionally not, a wrapping div using the `officeApp` class or custom `min-width` styling is used to hide any states the would not be visible to the user.
- [ ] This change meets the standards for [Section 508 compliance](https://www.ssa.gov/accessibility/andi/help/install.html).

### Backend

- [ ] Code follows the guidelines for [Logging](https://transcom.github.io/mymove-docs/docs/getting-started/development/logging).
- [ ] The requirements listed in [Querying the Database Safely](https://transcom.github.io/mymove-docs/docs/backend/guides/golang-guide#querying-the-database-safely) have been satisfied.

### Database

#### Any new migrations/schema changes:

- [ ] Follows our guidelines for [Zero-Downtime Deploys](https://transcom.github.io/mymove-docs/docs/backend/setup/database-migrations#zero-downtime-migrations).
- [ ] Have been communicated to #g-database.
- [ ] Secure migrations have been tested following the instructions in our [docs](https://transcom.github.io/mymove-docs/docs/backend/setup/database-migrations#secure-migrations).

## Screenshots