### PR TITLE
B-19191: Email Template not locating all duty location names

### DIFF
--- a/pkg/notifications/move_submitted.go
+++ b/pkg/notifications/move_submitted.go
@@ -72,7 +72,8 @@ func (m MoveSubmitted) emails(appCtx appcontext.AppContext) ([]emailContent, err
 	if originDSTransportInfo != nil {
 		originDutyLocationName = &originDSTransportInfo.Name
 		originDutyLocationPhoneLine = &originDSTransportInfo.PhoneLine
-
+	} else if originDutyLocation != nil {
+		originDutyLocationName = &originDutyLocation.Name
 	}
 
 	totalEntitlement := models.GetWeightAllotment(*orders.Grade)

--- a/pkg/notifications/move_submitted_test.go
+++ b/pkg/notifications/move_submitted_test.go
@@ -26,6 +26,30 @@ func (suite *NotificationSuite) TestMoveSubmitted() {
 	suite.NotEmpty(email.textBody)
 }
 
+func (suite *NotificationSuite) TestMoveSubmittedoriginDSTransportInfoIsNil() {
+	move := factory.BuildMove(suite.DB(), nil, nil)
+	notification := NewMoveSubmitted(move.ID)
+
+	move.Orders.OriginDutyLocationID = nil
+
+	emails, err := notification.emails(suite.AppContextWithSessionForTest(&auth.Session{
+		ServiceMemberID: move.Orders.ServiceMember.ID,
+		ApplicationName: auth.MilApp,
+	}))
+	subject := "Thank you for submitting your move details"
+
+	suite.NoError(err)
+	suite.Equal(len(emails), 1)
+
+	email := emails[0]
+	sm := move.Orders.ServiceMember
+	suite.Equal(email.recipientEmail, *sm.PersonalEmail)
+	suite.Equal(email.subject, subject)
+	suite.NotEmpty(email.htmlBody)
+	suite.NotEmpty(email.textBody)
+	suite.Contains(email.textBody, move.Orders.OriginDutyLocation.Name)
+}
+
 func (suite *NotificationSuite) TestMoveSubmittedHTMLTemplateRenderWithGovCounseling() {
 	approver := factory.BuildUser(nil, nil, nil)
 	move := factory.BuildMove(suite.DB(), nil, nil)


### PR DESCRIPTION
## [INT PR](https://github.com/transcom/mymove/pull/13579)
## [Agility ticket B-19191](https://www13.v1host.com/USTRANSCOM38/assetdetail.v1?number=B-19191)
## Steps to test (copied from the INT PR)
1. Fire up the server with the following command.
```
EMAIL_BACKEND=ses AWS_REGION=us-gov-west-1  aws-vault exec transcom-gov-dev -- make server_run
```
2. Fire up the client as well.
Note: make sure you set the Customer's personal email to an address you can check
3. Create a Move/Shipment with Chelmsford, MA 01824 (or some other location that doesn't automatically register a duty location other than the City, State, Zip) for the origin location.
4. You should receive the email which is triggered when move details are submitted. The email should contain the Origin address information (as seen below).
![Screenshot 2024-08-27 at 4 28 11 PM](https://github.com/user-attachments/assets/6e608a3a-4938-47ed-ab33-d4bdbb3bdf12)
