### PR TITLE
MAIN B-21029 rejected office users can resubmit

### DIFF
--- a/pkg/factory/office_user_factory.go
+++ b/pkg/factory/office_user_factory.go
@@ -215,7 +215,7 @@ func GetTraitActiveOfficeUser() []Customization {
 
 // GetTraitApprovedOfficeUser sets the OfficeUser in an APPROVED status
 func GetTraitApprovedOfficeUser() []Customization {
-	approvedStatus := "APPROVED"
+	approvedStatus := models.OfficeUserStatusAPPROVED
 	return []Customization{
 		{
 			Model: models.OfficeUser{
@@ -227,7 +227,7 @@ func GetTraitApprovedOfficeUser() []Customization {
 
 // GetTraitRequestedOfficeUser sets the OfficeUser in an REQUESTED status
 func GetTraitRequestedOfficeUser() []Customization {
-	requestedStatus := "REQUESTED"
+	requestedStatus := models.OfficeUserStatusREQUESTED
 	return []Customization{
 		{
 			Model: models.OfficeUser{

--- a/pkg/handlers/adminapi/office_users.go
+++ b/pkg/handlers/adminapi/office_users.go
@@ -56,7 +56,7 @@ func payloadForOfficeUserModel(o models.OfficeUser) *adminmessages.OfficeUser {
 		Email:                  handlers.FmtString(o.Email),
 		TransportationOfficeID: handlers.FmtUUID(o.TransportationOfficeID),
 		Active:                 handlers.FmtBool(o.Active),
-		Status:                 handlers.FmtStringPtr(o.Status),
+		Status:                 (*string)(o.Status),
 		CreatedAt:              *handlers.FmtDateTime(o.CreatedAt),
 		UpdatedAt:              *handlers.FmtDateTime(o.UpdatedAt),
 	}
@@ -214,7 +214,7 @@ func (h CreateOfficeUserHandler) Handle(params officeuserop.CreateOfficeUserPara
 			}
 
 			// if the user is being manually created, then we know they will already be approved
-			officeUserStatus := "APPROVED"
+			officeUserStatus := models.OfficeUserStatusAPPROVED
 
 			officeUser := models.OfficeUser{
 				LastName:               payload.LastName,

--- a/pkg/handlers/adminapi/requested_office_users.go
+++ b/pkg/handlers/adminapi/requested_office_users.go
@@ -53,7 +53,7 @@ func payloadForRequestedOfficeUserModel(o models.OfficeUser) *adminmessages.Offi
 		Email:                  handlers.FmtString(o.Email),
 		TransportationOfficeID: handlers.FmtUUID(o.TransportationOfficeID),
 		Active:                 handlers.FmtBool(o.Active),
-		Status:                 handlers.FmtStringPtr(o.Status),
+		Status:                 (*string)(o.Status),
 		Edipi:                  handlers.FmtStringPtr(o.EDIPI),
 		OtherUniqueID:          handlers.FmtStringPtr(o.OtherUniqueID),
 		RejectionReason:        handlers.FmtStringPtr(o.RejectionReason),

--- a/pkg/handlers/ghcapi/office_users.go
+++ b/pkg/handlers/ghcapi/office_users.go
@@ -69,7 +69,7 @@ func payloadForOfficeUserModel(o models.OfficeUser) *ghcmessages.OfficeUser {
 		OtherUniqueID:          handlers.FmtStringPtr(o.OtherUniqueID),
 		TransportationOfficeID: handlers.FmtUUID(o.TransportationOfficeID),
 		Active:                 handlers.FmtBool(o.Active),
-		Status:                 handlers.FmtStringPtr(o.Status),
+		Status:                 (*string)(o.Status),
 		CreatedAt:              *handlers.FmtDateTime(o.CreatedAt),
 		UpdatedAt:              *handlers.FmtDateTime(o.UpdatedAt),
 	}
@@ -122,17 +122,19 @@ func (h RequestOfficeUserHandler) Handle(params officeuserop.CreateRequestedOffi
 				return officeuserop.NewCreateRequestedOfficeUserUnprocessableEntity().WithPayload(payload), err
 			}
 
+			status := models.OfficeUserStatusREQUESTED
 			// By default set status to "REQUESTED", as is the purpose of this endpoint
 			officeUser := models.OfficeUser{
 				LastName:               payload.LastName,
 				FirstName:              payload.FirstName,
+				MiddleInitials:         payload.MiddleInitials,
 				Telephone:              payload.Telephone,
 				Email:                  payload.Email,
 				EDIPI:                  payload.Edipi,
 				OtherUniqueID:          payload.OtherUniqueID,
 				TransportationOfficeID: transportationOfficeID,
 				Active:                 false,
-				Status:                 models.StringPointer("REQUESTED"),
+				Status:                 &status,
 			}
 
 			transportationIDFilter := []services.QueryFilter{

--- a/pkg/handlers/ghcapi/office_users_test.go
+++ b/pkg/handlers/ghcapi/office_users_test.go
@@ -58,6 +58,7 @@ func (suite *HandlerSuite) TestRequestOfficeUserHandler() {
 			},
 		}
 
+		status := models.OfficeUserStatusREQUESTED
 		// Mock successful creation in the database
 		mockCreator.On(
 			"CreateOfficeUser",
@@ -73,7 +74,7 @@ func (suite *HandlerSuite) TestRequestOfficeUserHandler() {
 			Email:                  "johndoe@example.com",
 			EDIPI:                  models.StringPointer("1234567890"),
 			TransportationOfficeID: transportationOffice.ID,
-			Status:                 models.StringPointer("REQUESTED"),
+			Status:                 &status,
 			CreatedAt:              time.Now(),
 			UpdatedAt:              time.Now(),
 		}, nil, nil).Once()

--- a/pkg/models/office_user.go
+++ b/pkg/models/office_user.go
@@ -16,7 +16,7 @@ type OfficeUserStatus string
 const (
 	// OfficeUserStatusAPPROVED captures enum value "APPROVED"
 	OfficeUserStatusAPPROVED OfficeUserStatus = "APPROVED"
-	// OfficeUserStatusSUBMITTED captures enum value "REJECTED"
+	// OfficeUserStatusREJECTED captures enum value "REJECTED"
 	OfficeUserStatusREJECTED OfficeUserStatus = "REJECTED"
 	// OfficeUserStatusREQUESTED captures enum value "REQUESTED"
 	OfficeUserStatusREQUESTED OfficeUserStatus = "REQUESTED"

--- a/pkg/models/office_user.go
+++ b/pkg/models/office_user.go
@@ -10,6 +10,18 @@ import (
 	"github.com/gofrs/uuid"
 )
 
+// OfficeUserStatus represents the status of an office user
+type OfficeUserStatus string
+
+const (
+	// OfficeUserStatusAPPROVED captures enum value "APPROVED"
+	OfficeUserStatusAPPROVED OfficeUserStatus = "APPROVED"
+	// OfficeUserStatusSUBMITTED captures enum value "REJECTED"
+	OfficeUserStatusREJECTED OfficeUserStatus = "REJECTED"
+	// OfficeUserStatusREQUESTED captures enum value "REQUESTED"
+	OfficeUserStatusREQUESTED OfficeUserStatus = "REQUESTED"
+)
+
 // OfficeUser is someone who works in one of the TransportationOffices
 type OfficeUser struct {
 	ID                     uuid.UUID            `json:"id" db:"id"`
@@ -25,7 +37,7 @@ type OfficeUser struct {
 	CreatedAt              time.Time            `json:"created_at" db:"created_at"`
 	UpdatedAt              time.Time            `json:"updated_at" db:"updated_at"`
 	Active                 bool                 `json:"active" db:"active"`
-	Status                 *string              `json:"status" db:"status"`
+	Status                 *OfficeUserStatus    `json:"status" db:"status"`
 	EDIPI                  *string              `json:"edipi" db:"edipi"`
 	OtherUniqueID          *string              `json:"other_unique_id" db:"other_unique_id"`
 	RejectionReason        *string              `json:"rejection_reason" db:"rejection_reason"`

--- a/pkg/services/office_user/office_user_creator_test.go
+++ b/pkg/services/office_user/office_user_creator_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/transcom/mymove/pkg/auth"
 	"github.com/transcom/mymove/pkg/factory"
 	"github.com/transcom/mymove/pkg/models"
+	"github.com/transcom/mymove/pkg/models/roles"
 	"github.com/transcom/mymove/pkg/notifications"
 	"github.com/transcom/mymove/pkg/notifications/mocks"
 	"github.com/transcom/mymove/pkg/services"
@@ -144,6 +145,91 @@ func (suite *OfficeUserServiceSuite) TestCreateOfficeUser() {
 		suite.NotNil(officeUser.User)
 		suite.Equal(officeUser.User.ID, *officeUser.UserID)
 		mockSender.(*mocks.NotificationSender).AssertNumberOfCalls(suite.T(), "SendNotification", 0)
+	})
+
+	suite.Run("Updates previously rejected office user instead of create", func() {
+		rejectedStatus := models.OfficeUserStatusREJECTED
+		requestedStatus := models.OfficeUserStatusREQUESTED
+
+		transportationOffice := factory.BuildTransportationOffice(suite.DB(), []factory.Customization{
+			{
+				Model: models.TransportationOffice{
+					ID: uuid.Must(uuid.NewV4()),
+				},
+			}}, nil)
+
+		user := factory.BuildUser(suite.DB(), []factory.Customization{
+			{
+				Model: models.User{
+					ID:        uuid.Must(uuid.NewV4()),
+					OktaEmail: "billy+existing@leo.org",
+				},
+			},
+		}, nil)
+		officeUser := factory.BuildOfficeUserWithRoles(suite.DB(), []factory.Customization{
+			{
+				Model: models.OfficeUser{
+					ID:        uuid.Must(uuid.NewV4()),
+					FirstName: "Billy",
+					LastName:  "Bob",
+					Status:    &rejectedStatus,
+					Email:     "billy+existing@leo.org",
+				},
+			},
+			{
+				Model:    user,
+				LinkOnly: true,
+			},
+		}, []roles.RoleType{roles.RoleTypeTOO})
+
+		appCtx := appcontext.NewAppContext(suite.AppContextForTest().DB(), suite.AppContextForTest().Logger(), &auth.Session{})
+		queryBuilder := query.NewQueryBuilder()
+
+		officeUserInfo := models.OfficeUser{
+			LastName:               "Spaceman",
+			FirstName:              "Billy",
+			Email:                  officeUser.Email,
+			TransportationOfficeID: transportationOffice.ID,
+			Telephone:              "312-111-1111",
+			TransportationOffice:   transportationOffice,
+		}
+
+		fakeFetchOne := func(appCtx appcontext.AppContext, model interface{}) error {
+			switch model.(type) {
+			case *models.TransportationOffice:
+				reflect.ValueOf(model).Elem().FieldByName("ID").Set(reflect.ValueOf(transportationOffice.ID))
+			case *models.User:
+				reflect.ValueOf(model).Elem().FieldByName("ID").Set(reflect.ValueOf(officeUser.User.ID))
+				reflect.ValueOf(model).Elem().FieldByName("OktaID").Set(reflect.ValueOf(officeUser.User.OktaID))
+				reflect.ValueOf(model).Elem().FieldByName("OktaEmail").Set(reflect.ValueOf(officeUser.User.OktaEmail))
+			case *models.OfficeUser:
+				reflect.ValueOf(model).Elem().FieldByName("ID").Set(reflect.ValueOf(officeUser.ID))
+				reflect.ValueOf(model).Elem().FieldByName("Email").Set(reflect.ValueOf(officeUser.Email))
+				reflect.ValueOf(model).Elem().FieldByName("FirstName").Set(reflect.ValueOf(officeUser.FirstName))
+				reflect.ValueOf(model).Elem().FieldByName("LastName").Set(reflect.ValueOf(officeUser.LastName))
+				reflect.ValueOf(model).Elem().FieldByName("TransportationOfficeID").Set(reflect.ValueOf(officeUser.TransportationOfficeID))
+				reflect.ValueOf(model).Elem().FieldByName("Telephone").Set(reflect.ValueOf(officeUser.Telephone))
+				reflect.ValueOf(model).Elem().FieldByName("Status").Set(reflect.ValueOf(officeUser.Status))
+			}
+			return nil
+		}
+
+		filter := []services.QueryFilter{query.NewQueryFilter("id", "=", transportationOffice.ID)}
+
+		builder := &testOfficeUserQueryBuilder{
+			fakeFetchOne:  fakeFetchOne,
+			fakeCreateOne: queryBuilder.CreateOne,
+		}
+		mockSender := setUpMockNotificationSender()
+
+		creator := NewOfficeUserCreator(builder, mockSender)
+		updatedOfficeUser, verrs, err := creator.CreateOfficeUser(appCtx, &officeUserInfo, filter)
+		suite.NoError(err)
+		suite.Nil(verrs)
+		suite.NotNil(updatedOfficeUser)
+		suite.Equal(updatedOfficeUser.ID, officeUser.ID)
+		suite.Equal(updatedOfficeUser.Status, &requestedStatus)
+		suite.Nil(updatedOfficeUser.RejectionReason)
 	})
 
 	// Bad transportation office ID

--- a/pkg/services/requested_office_users/requested_office_user_list_fetcher_test.go
+++ b/pkg/services/requested_office_users/requested_office_user_list_fetcher_test.go
@@ -47,7 +47,7 @@ func (suite *RequestedOfficeUsersServiceSuite) TestFetchRequestedOfficeUserList(
 		suite.NoError(err)
 		fakeFetchMany := func(_ appcontext.AppContext, model interface{}) error {
 			value := reflect.ValueOf(model).Elem()
-			requestedStatus := "REQUESTED"
+			requestedStatus := models.OfficeUserStatusREQUESTED
 			value.Set(reflect.Append(value, reflect.ValueOf(models.OfficeUser{ID: id, Status: &requestedStatus})))
 			return nil
 		}

--- a/pkg/services/requested_office_users/requested_office_user_updater.go
+++ b/pkg/services/requested_office_users/requested_office_user_updater.go
@@ -68,8 +68,8 @@ func (o *requestedOfficeUserUpdater) UpdateRequestedOfficeUser(appCtx appcontext
 	}
 
 	if payload.Status != "" {
-		officeUser.Status = &payload.Status
-		if *officeUser.Status == string(models.OrderStatusAPPROVED) {
+		officeUser.Status = (*models.OfficeUserStatus)(&payload.Status)
+		if *officeUser.Status == models.OfficeUserStatusAPPROVED {
 			officeUser.Active = true
 		}
 	}

--- a/pkg/testdatagen/testharness/make_office_user.go
+++ b/pkg/testdatagen/testharness/make_office_user.go
@@ -37,7 +37,7 @@ func MakeOfficeUserWithTOOAndTIO(appCtx appcontext.AppContext) models.User {
 			},
 		},
 	}, nil)
-	approvedStatus := "APPROVED"
+	approvedStatus := models.OfficeUserStatusAPPROVED
 	factory.BuildOfficeUserWithRoles(appCtx.DB(), []factory.Customization{
 		{
 			Model: models.OfficeUser{

--- a/src/components/Office/RequestAccountForm/RequestAccountForm.module.scss
+++ b/src/components/Office/RequestAccountForm/RequestAccountForm.module.scss
@@ -39,3 +39,7 @@
     flex-grow: 1;
   }
 }
+
+.formSection {
+  width: 40vw;
+}

--- a/src/pages/Office/RequestAccount/RequestAccount.jsx
+++ b/src/pages/Office/RequestAccount/RequestAccount.jsx
@@ -4,6 +4,8 @@ import { func } from 'prop-types';
 import { useNavigate } from 'react-router-dom';
 import { Grid, GridContainer, Alert } from '@trussworks/react-uswds';
 
+import styles from './RequestAccount.module.scss';
+
 import { setFlashMessage as setFlashMessageAction } from 'store/flash/actions';
 import RequestAccountForm from 'components/Office/RequestAccountForm/RequestAccountForm';
 import { createOfficeAccountRequest } from 'services/ghcApi';
@@ -135,11 +137,15 @@ export const RequestAccount = ({ setFlashMessage }) => {
 
       {serverError && (
         <Grid row>
-          <Grid col desktop={{ col: 8, offset: 2 }}>
-            <Alert data-testid="alert2" type="error" headingLevel="h4" heading="An error occurred">
-              {serverError}
-            </Alert>
-          </Grid>
+          <Alert
+            data-testid="alert2"
+            type="error"
+            headingLevel="h4"
+            heading="An error occurred"
+            className={styles.error}
+          >
+            {serverError}
+          </Alert>
         </Grid>
       )}
 

--- a/src/pages/Office/RequestAccount/RequestAccount.module.scss
+++ b/src/pages/Office/RequestAccount/RequestAccount.module.scss
@@ -1,0 +1,7 @@
+.formContainer {
+    width: 40vw;
+}
+
+.error {
+    width: 100%;
+}


### PR DESCRIPTION
[INT PR](https://github.com/transcom/mymove/pull/13640)

## [Agility ticket](https://www13.v1host.com/USTRANSCOM38/assetdetail.v1?number=B-21029)

## Summary

Requested office users were not able to re-request after being rejected. We did not implement any functionality to allow that, so HERE WE ARE SUCKAS.

This PR does the following:
- adds `OfficeUserStatus` enum and updated relevant code, not sure why I didn't add that in the first place
- updates the `office_user_creator` service object to first check if the office user exists and they have a previous status of `REJECTED` - if so, it fires off a function to update values and change the status to `REQUESTED`
- added and updated relevant tests
- updated requested office user form to have a set width to get rid of rendering issues (when it's real skinny & ugly) & fix error banner to span the width of the form

### How to test

1. Access office app
2. Request an account
3. Access admin app
4. Reject that user
6. Access office app
7. Request an account with same email but different data
8. Submit - should be successful
9. Access admin app
10. You should now see that requested user with updated data

## Screenshots
Video walkthrough of admin rejection -> office user resubmission
https://github.com/user-attachments/assets/79b96d68-0686-4a50-a5f8-88e2ca2895ec



Fixed error width
![Screenshot 2024-09-05 at 11 02 29 AM](https://github.com/user-attachments/assets/06c03e55-deeb-4b5f-9cb9-d26b98c0880c)
