### PR TITLE
INT-B-20465 Customer selecting a counseling office.

### DIFF
--- a/pkg/gen/internalapi/embedded_spec.go
+++ b/pkg/gen/internalapi/embedded_spec.go
@@ -4155,6 +4155,12 @@ func init() {
         "new_duty_location_id"
       ],
       "properties": {
+        "counseling_office_id": {
+          "type": "string",
+          "format": "uuid",
+          "x-nullable": true,
+          "example": "cf1addea-a4f9-4173-8506-2bb82a064cb7"
+        },
         "department_indicator": {
           "$ref": "#/definitions/DeptIndicator"
         },
@@ -4375,6 +4381,10 @@ func init() {
         "name": {
           "type": "string",
           "example": "Fort Bragg North Station"
+        },
+        "provides_services_counseling": {
+          "type": "boolean",
+          "x-nullable": false
         },
         "transportation_office": {
           "$ref": "#/definitions/TransportationOffice"
@@ -12935,6 +12945,12 @@ func init() {
         "new_duty_location_id"
       ],
       "properties": {
+        "counseling_office_id": {
+          "type": "string",
+          "format": "uuid",
+          "x-nullable": true,
+          "example": "cf1addea-a4f9-4173-8506-2bb82a064cb7"
+        },
         "department_indicator": {
           "$ref": "#/definitions/DeptIndicator"
         },
@@ -13157,6 +13173,10 @@ func init() {
         "name": {
           "type": "string",
           "example": "Fort Bragg North Station"
+        },
+        "provides_services_counseling": {
+          "type": "boolean",
+          "x-nullable": false
         },
         "transportation_office": {
           "$ref": "#/definitions/TransportationOffice"

--- a/pkg/gen/internalmessages/create_update_orders.go
+++ b/pkg/gen/internalmessages/create_update_orders.go
@@ -19,6 +19,11 @@ import (
 // swagger:model CreateUpdateOrders
 type CreateUpdateOrders struct {
 
+	// counseling office id
+	// Example: cf1addea-a4f9-4173-8506-2bb82a064cb7
+	// Format: uuid
+	CounselingOfficeID *strfmt.UUID `json:"counseling_office_id,omitempty"`
+
 	// department indicator
 	DepartmentIndicator *DeptIndicator `json:"department_indicator,omitempty"`
 
@@ -90,6 +95,10 @@ type CreateUpdateOrders struct {
 func (m *CreateUpdateOrders) Validate(formats strfmt.Registry) error {
 	var res []error
 
+	if err := m.validateCounselingOfficeID(formats); err != nil {
+		res = append(res, err)
+	}
+
 	if err := m.validateDepartmentIndicator(formats); err != nil {
 		res = append(res, err)
 	}
@@ -137,6 +146,18 @@ func (m *CreateUpdateOrders) Validate(formats strfmt.Registry) error {
 	if len(res) > 0 {
 		return errors.CompositeValidationError(res...)
 	}
+	return nil
+}
+
+func (m *CreateUpdateOrders) validateCounselingOfficeID(formats strfmt.Registry) error {
+	if swag.IsZero(m.CounselingOfficeID) { // not required
+		return nil
+	}
+
+	if err := validate.FormatOf("counseling_office_id", "body", "uuid", m.CounselingOfficeID.String(), formats); err != nil {
+		return err
+	}
+
 	return nil
 }
 

--- a/pkg/gen/internalmessages/duty_location_payload.go
+++ b/pkg/gen/internalmessages/duty_location_payload.go
@@ -48,6 +48,9 @@ type DutyLocationPayload struct {
 	// Required: true
 	Name *string `json:"name"`
 
+	// provides services counseling
+	ProvidesServicesCounseling bool `json:"provides_services_counseling,omitempty"`
+
 	// transportation office
 	TransportationOffice *TransportationOffice `json:"transportation_office,omitempty"`
 

--- a/pkg/handlers/internalapi/duty_locations.go
+++ b/pkg/handlers/internalapi/duty_locations.go
@@ -21,14 +21,15 @@ func payloadForDutyLocationModel(location models.DutyLocation) *internalmessages
 		return nil
 	}
 	payload := internalmessages.DutyLocationPayload{
-		ID:                     handlers.FmtUUID(location.ID),
-		CreatedAt:              handlers.FmtDateTime(location.CreatedAt),
-		UpdatedAt:              handlers.FmtDateTime(location.UpdatedAt),
-		Name:                   models.StringPointer(location.Name),
-		Affiliation:            location.Affiliation,
-		AddressID:              handlers.FmtUUID(location.AddressID),
-		Address:                payloads.Address(&location.Address),
-		TransportationOfficeID: handlers.FmtUUIDPtr(location.TransportationOfficeID),
+		ID:                         handlers.FmtUUID(location.ID),
+		CreatedAt:                  handlers.FmtDateTime(location.CreatedAt),
+		UpdatedAt:                  handlers.FmtDateTime(location.UpdatedAt),
+		Name:                       models.StringPointer(location.Name),
+		Affiliation:                location.Affiliation,
+		AddressID:                  handlers.FmtUUID(location.AddressID),
+		Address:                    payloads.Address(&location.Address),
+		TransportationOfficeID:     handlers.FmtUUIDPtr(location.TransportationOfficeID),
+		ProvidesServicesCounseling: location.ProvidesServicesCounseling,
 	}
 	payload.TransportationOffice = payloads.TransportationOffice(location.TransportationOffice)
 

--- a/pkg/handlers/internalapi/orders.go
+++ b/pkg/handlers/internalapi/orders.go
@@ -243,6 +243,15 @@ func (h CreateOrdersHandler) Handle(params ordersop.CreateOrdersParams) middlewa
 			moveOptions := models.MoveOptions{
 				Show: models.BoolPointer(true),
 			}
+
+			if payload.CounselingOfficeID != nil {
+				counselingOffice, err := uuid.FromString(payload.CounselingOfficeID.String())
+				if err != nil {
+					return handlers.ResponseForError(appCtx.Logger(), err), err
+				}
+				moveOptions.CounselingOfficeID = &counselingOffice
+			}
+
 			newMove, verrs, err := newOrder.CreateNewMove(appCtx.DB(), moveOptions)
 			if err != nil || verrs.HasAny() {
 				return handlers.ResponseForVErrors(appCtx.Logger(), verrs, err), err

--- a/pkg/handlers/routing/routing_init.go
+++ b/pkg/handlers/routing/routing_init.go
@@ -602,30 +602,6 @@ func mountPrimeSimulatorAPI(appCtx appcontext.AppContext, routingConfig *Config,
 				rAuth.Mount("/", api.Serve(tracingMiddleware))
 			})
 		})
-		site.Route("/pptas/v1", func(r chi.Router) {
-			r.Method("GET", "/swagger.yaml",
-				handlers.NewFileHandler(routingConfig.FileSystem,
-					routingConfig.PPTASSwaggerPath))
-			if routingConfig.ServeSwaggerUI {
-				appCtx.Logger().Info("PPTAS Simulator API Swagger UI serving is enabled")
-				r.Method("GET", "/docs",
-					handlers.NewFileHandler(routingConfig.FileSystem,
-						path.Join(routingConfig.BuildRoot, "swagger-ui", "pptas.html")))
-			} else {
-				r.Method("GET", "/docs", http.NotFoundHandler())
-			}
-
-			// Mux for prime simulator API that enforces auth
-			r.Route("/", func(rAuth chi.Router) {
-				rAuth.Use(userAuthMiddleware)
-				rAuth.Use(addAuditUserToRequestContextMiddleware)
-				rAuth.Use(authentication.PrimeSimulatorAuthorizationMiddleware(appCtx.Logger()))
-				rAuth.Use(middleware.NoCache())
-				api := pptasapi.NewPPTASAPI(routingConfig.HandlerConfig)
-				tracingMiddleware := middleware.OpenAPITracing(api)
-				rAuth.Mount("/", api.Serve(tracingMiddleware))
-			})
-		})
 		// Support API serves to support Prime API testing outside of production environments, hence why it is
 		// mounted inside the Prime sim API without client cert middleware
 		if routingConfig.ServeSupport {

--- a/pkg/services/shipment_summary_worksheet/shipment_summary_worksheet.go
+++ b/pkg/services/shipment_summary_worksheet/shipment_summary_worksheet.go
@@ -72,7 +72,6 @@ func (SSWPPMComputer *SSWPPMComputer) FormatValuesShipmentSummaryWorksheet(shipm
 	if err != nil {
 		return page1, page2, services.Page3Values{}, errors.WithStack(err)
 	}
-
 	return page1, page2, page3, nil
 }
 

--- a/pkg/services/shipment_summary_worksheet/shipment_summary_worksheet_test.go
+++ b/pkg/services/shipment_summary_worksheet/shipment_summary_worksheet_test.go
@@ -315,23 +315,10 @@ func (suite *ShipmentSummaryWorksheetServiceSuite) TestFormatValuesShipmentSumma
 		SpouseHasProGear:  true,
 		Grade:             &grade,
 	}
-	expectedPickupDate := time.Date(2019, time.January, 11, 0, 0, 0, 0, time.UTC)
-	actualPickupDate := time.Date(2019, time.February, 11, 0, 0, 0, 0, time.UTC)
 	netWeight := unit.Pound(4000)
 	cents := unit.Cents(1000)
 	locator := "ABCDEF-01"
-	estIncentive := unit.Cents(1000000)
-	PPMShipment := models.PPMShipment{
-		ExpectedDepartureDate:  expectedPickupDate,
-		ActualMoveDate:         &actualPickupDate,
-		Status:                 models.PPMShipmentStatusWaitingOnCustomer,
-		EstimatedWeight:        &netWeight,
-		AdvanceAmountRequested: &cents,
-		EstimatedIncentive:     &estIncentive,
-		Shipment: models.MTOShipment{
-			ShipmentLocator: &locator,
-		},
-	}
+
 	ssd := models.ShipmentSummaryFormData{
 		ServiceMember:           serviceMember,
 		Order:                   order,
@@ -340,7 +327,6 @@ func (suite *ShipmentSummaryWorksheetServiceSuite) TestFormatValuesShipmentSumma
 		PPMRemainingEntitlement: 3000,
 		WeightAllotment:         wtgEntitlements,
 		PreparationDate:         time.Date(2019, 1, 1, 1, 1, 1, 1, time.UTC),
-		PPMShipment:             PPMShipment,
 	}
 
 	mockPPMCloseoutFetcher := &mocks.PPMCloseoutFetcher{}
@@ -580,6 +566,63 @@ func (suite *ShipmentSummaryWorksheetServiceSuite) TestFormatValuesShipmentSumma
 	suite.Equal("SAC", sswPage2.SAC)
 }
 
+func (suite *ShipmentSummaryWorksheetServiceSuite) TestFormatValuesShipmentSummaryWorksheetFormPage3() {
+	yuma := factory.FetchOrBuildCurrentDutyLocation(suite.DB())
+	fortGordon := factory.FetchOrBuildOrdersDutyLocation(suite.DB())
+	wtgEntitlements := models.SSWMaxWeightEntitlement{}
+	serviceMember := models.ServiceMember{}
+	order := models.Order{}
+	expectedPickupDate := time.Date(2019, time.January, 11, 0, 0, 0, 0, time.UTC)
+	actualPickupDate := time.Date(2019, time.February, 11, 0, 0, 0, 0, time.UTC)
+	netWeight := unit.Pound(4000)
+	cents := unit.Cents(1000)
+	locator := "ABCDEF-01"
+	move := factory.BuildMoveWithPPMShipment(suite.DB(), nil, nil)
+	PPMShipment := models.PPMShipment{
+		ID:                     move.MTOShipments[0].PPMShipment.ID,
+		ExpectedDepartureDate:  expectedPickupDate,
+		ActualMoveDate:         &actualPickupDate,
+		Status:                 models.PPMShipmentStatusWaitingOnCustomer,
+		EstimatedWeight:        &netWeight,
+		AdvanceAmountRequested: &cents,
+		Shipment: models.MTOShipment{
+			ShipmentLocator: &locator,
+		},
+	}
+	ssd := models.ShipmentSummaryFormData{
+		AllShipments:            move.MTOShipments,
+		ServiceMember:           serviceMember,
+		Order:                   order,
+		CurrentDutyLocation:     yuma,
+		NewDutyLocation:         fortGordon,
+		PPMRemainingEntitlement: 3000,
+		WeightAllotment:         wtgEntitlements,
+		PreparationDate:         time.Date(2019, 1, 1, 1, 1, 1, 1, time.UTC),
+		PPMShipment:             PPMShipment,
+	}
+	mockPPMCloseoutFetcher := &mocks.PPMCloseoutFetcher{}
+	sswPPMComputer := NewSSWPPMComputer(mockPPMCloseoutFetcher)
+	sswPage3, err := sswPPMComputer.FormatValuesShipmentSummaryWorksheetFormPage3(ssd, false)
+	suite.NoError(err)
+	suite.Equal(FormatDate(time.Now()), sswPage3.PreparationDate3)
+	suite.Equal(make(map[string]string), sswPage3.AddShipments)
+}
+
+func (suite *ShipmentSummaryWorksheetServiceSuite) TestFormatAdditionalHHG() {
+	page3Map := make(map[string]string)
+	i := 1
+	hhg := factory.BuildMTOShipment(suite.DB(), nil, nil)
+	locator := "ABCDEF"
+	hhg.ShipmentLocator = &locator
+
+	page3Map, err := formatAdditionalHHG(page3Map, i, hhg)
+	suite.NoError(err)
+	suite.Equal(*hhg.ShipmentLocator+" HHG", page3Map["AddShipmentNumberAndTypes1"])
+	suite.Equal("16-Mar-2020 Actual", page3Map["AddShipmentPickUpDates1"])
+	suite.Equal("980 Actual", page3Map["AddShipmentWeights1"])
+	suite.Equal(FormatEnum(string(hhg.Status), ""), page3Map["AddShipmentStatus1"])
+}
+
 func (suite *ShipmentSummaryWorksheetServiceSuite) TestMemberPaidRemainingPPMEntitlementFormatValuesShipmentSummaryWorksheetFormPage2() {
 	storageExpense := models.MovingExpenseReceiptTypeStorage
 	amount := unit.Cents(10000)
@@ -625,7 +668,6 @@ func (suite *ShipmentSummaryWorksheetServiceSuite) TestMemberPaidRemainingPPMEnt
 	mockPPMCloseoutFetcher := &mocks.PPMCloseoutFetcher{}
 	sswPPMComputer := NewSSWPPMComputer(mockPPMCloseoutFetcher)
 	sswPage2, _ := sswPPMComputer.FormatValuesShipmentSummaryWorksheetFormPage2(ssd, true)
-
 	suite.Equal("$4.00", sswPage2.PPMRemainingEntitlement)
 }
 
@@ -757,63 +799,6 @@ func (suite *ShipmentSummaryWorksheetServiceSuite) TestGTCCPaidRemainingPPMEntit
 	sswPPMComputer := NewSSWPPMComputer(mockPPMCloseoutFetcher)
 	sswPage2, _ := sswPPMComputer.FormatValuesShipmentSummaryWorksheetFormPage2(ssd, true)
 	suite.Equal("$105.00", sswPage2.PPMRemainingEntitlement)
-}
-func (suite *ShipmentSummaryWorksheetServiceSuite) TestFormatValuesShipmentSummaryWorksheetFormPage3() {
-	yuma := factory.FetchOrBuildCurrentDutyLocation(suite.DB())
-	fortGordon := factory.FetchOrBuildOrdersDutyLocation(suite.DB())
-	wtgEntitlements := models.SSWMaxWeightEntitlement{}
-	serviceMember := models.ServiceMember{}
-	order := models.Order{}
-	expectedPickupDate := time.Date(2019, time.January, 11, 0, 0, 0, 0, time.UTC)
-	actualPickupDate := time.Date(2019, time.February, 11, 0, 0, 0, 0, time.UTC)
-	netWeight := unit.Pound(4000)
-	cents := unit.Cents(1000)
-	locator := "ABCDEF-01"
-	move := factory.BuildMoveWithPPMShipment(suite.DB(), nil, nil)
-	PPMShipment := models.PPMShipment{
-		ID:                     move.MTOShipments[0].PPMShipment.ID,
-		ExpectedDepartureDate:  expectedPickupDate,
-		ActualMoveDate:         &actualPickupDate,
-		Status:                 models.PPMShipmentStatusWaitingOnCustomer,
-		EstimatedWeight:        &netWeight,
-		AdvanceAmountRequested: &cents,
-		Shipment: models.MTOShipment{
-			ShipmentLocator: &locator,
-		},
-	}
-
-	ssd := models.ShipmentSummaryFormData{
-		AllShipments:            move.MTOShipments,
-		ServiceMember:           serviceMember,
-		Order:                   order,
-		CurrentDutyLocation:     yuma,
-		NewDutyLocation:         fortGordon,
-		PPMRemainingEntitlement: 3000,
-		WeightAllotment:         wtgEntitlements,
-		PreparationDate:         time.Date(2019, 1, 1, 1, 1, 1, 1, time.UTC),
-		PPMShipment:             PPMShipment,
-	}
-	mockPPMCloseoutFetcher := &mocks.PPMCloseoutFetcher{}
-	sswPPMComputer := NewSSWPPMComputer(mockPPMCloseoutFetcher)
-	sswPage3, err := sswPPMComputer.FormatValuesShipmentSummaryWorksheetFormPage3(ssd, false)
-	suite.NoError(err)
-	suite.Equal(FormatDate(time.Now()), sswPage3.PreparationDate3)
-	suite.Equal(make(map[string]string), sswPage3.AddShipments)
-}
-
-func (suite *ShipmentSummaryWorksheetServiceSuite) TestFormatAdditionalHHG() {
-	page3Map := make(map[string]string)
-	i := 1
-	hhg := factory.BuildMTOShipment(suite.DB(), nil, nil)
-	locator := "ABCDEF"
-	hhg.ShipmentLocator = &locator
-
-	page3Map, err := formatAdditionalHHG(page3Map, i, hhg)
-	suite.NoError(err)
-	suite.Equal(*hhg.ShipmentLocator+" HHG", page3Map["AddShipmentNumberAndTypes1"])
-	suite.Equal("16-Mar-2020 Actual", page3Map["AddShipmentPickUpDates1"])
-	suite.Equal("980 Actual", page3Map["AddShipmentWeights1"])
-	suite.Equal(FormatEnum(string(hhg.Status), ""), page3Map["AddShipmentStatus1"])
 }
 
 func (suite *ShipmentSummaryWorksheetServiceSuite) TestGroupExpenses() {

--- a/src/components/Customer/OrdersInfoForm/OrdersInfoForm.jsx
+++ b/src/components/Customer/OrdersInfoForm/OrdersInfoForm.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { Formik, Field } from 'formik';
 import * as Yup from 'yup';
@@ -17,12 +17,12 @@ import SectionWrapper from 'components/Customer/SectionWrapper';
 import WizardNavigation from 'components/Customer/WizardNavigation/WizardNavigation';
 import Callout from 'components/Callout';
 import { formatLabelReportByDate, dropdownInputOptions } from 'utils/formatters';
+import { showCounselingOffices } from 'services/internalApi';
 
 let originMeta;
 let newDutyMeta = '';
 const OrdersInfoForm = ({ ordersTypeOptions, initialValues, onSubmit, onBack }) => {
   const payGradeOptions = dropdownInputOptions(ORDERS_PAY_GRADE_OPTIONS);
-
   const validationSchema = Yup.object().shape({
     orders_type: Yup.mixed()
       .oneOf(ordersTypeOptions.map((i) => i.key))
@@ -37,7 +37,21 @@ const OrdersInfoForm = ({ ordersTypeOptions, initialValues, onSubmit, onBack }) 
     new_duty_location: Yup.object().nullable().required('Required'),
     grade: Yup.mixed().oneOf(Object.keys(ORDERS_PAY_GRADE_OPTIONS)).required('Required'),
     origin_duty_location: Yup.object().nullable().required('Required'),
+    counseling_office_id: Yup.string(),
   });
+  const [office, setOffice] = useState('');
+  const [officeOptions, setOfficeOptions] = useState(null);
+  useEffect(() => {
+    showCounselingOffices(office.id).then((fetchedData) => {
+      if (fetchedData.body) {
+        const transformedItems = fetchedData.body.map((item) => ({
+          key: item.id,
+          value: item.name,
+        }));
+        setOfficeOptions(transformedItems);
+      }
+    });
+  }, [office]);
 
   return (
     <Formik initialValues={initialValues} validateOnMount validationSchema={validationSchema} onSubmit={onSubmit}>
@@ -111,10 +125,21 @@ const OrdersInfoForm = ({ ordersTypeOptions, initialValues, onSubmit, onBack }) 
                 hint="Required"
                 name="origin_duty_location"
                 id="origin_duty_location"
+                onOfficeChange={(e) => {
+                  setOffice(e);
+                }}
                 required
                 metaOverride={originMeta}
               />
-
+              {office.provides_services_counseling && (
+                <DropdownInput
+                  label="Counseling Office"
+                  name="counseling_office_id"
+                  id="counseling_office_id"
+                  required
+                  options={officeOptions}
+                />
+              )}
               {isRetirementOrSeparation ? (
                 <>
                   <h3 className={styles.calloutLabel}>Where are you entitled to move?</h3>

--- a/src/components/Customer/OrdersInfoForm/OrdersInfoForm.jsx
+++ b/src/components/Customer/OrdersInfoForm/OrdersInfoForm.jsx
@@ -39,19 +39,19 @@ const OrdersInfoForm = ({ ordersTypeOptions, initialValues, onSubmit, onBack }) 
     origin_duty_location: Yup.object().nullable().required('Required'),
     counseling_office_id: Yup.string(),
   });
-  const [office, setOffice] = useState('');
+  const [dutyLocation, setDutyLocation] = useState('');
   const [officeOptions, setOfficeOptions] = useState(null);
   useEffect(() => {
-    showCounselingOffices(office.id).then((fetchedData) => {
+    showCounselingOffices(dutyLocation.id).then((fetchedData) => {
       if (fetchedData.body) {
-        const transformedItems = fetchedData.body.map((item) => ({
+        const counselingOffices = fetchedData.body.map((item) => ({
           key: item.id,
           value: item.name,
         }));
-        setOfficeOptions(transformedItems);
+        setOfficeOptions(counselingOffices);
       }
     });
-  }, [office]);
+  }, [dutyLocation]);
 
   return (
     <Formik initialValues={initialValues} validateOnMount validationSchema={validationSchema} onSubmit={onSubmit}>
@@ -125,13 +125,13 @@ const OrdersInfoForm = ({ ordersTypeOptions, initialValues, onSubmit, onBack }) 
                 hint="Required"
                 name="origin_duty_location"
                 id="origin_duty_location"
-                onOfficeChange={(e) => {
-                  setOffice(e);
+                onDutyLocationChange={(e) => {
+                  setDutyLocation(e);
                 }}
                 required
                 metaOverride={originMeta}
               />
-              {office.provides_services_counseling && (
+              {dutyLocation.provides_services_counseling && (
                 <DropdownInput
                   label="Counseling Office"
                   name="counseling_office_id"

--- a/src/components/Customer/OrdersInfoForm/OrdersInfoForm.test.jsx
+++ b/src/components/Customer/OrdersInfoForm/OrdersInfoForm.test.jsx
@@ -4,6 +4,26 @@ import userEvent from '@testing-library/user-event';
 
 import OrdersInfoForm from './OrdersInfoForm';
 
+import { showCounselingOffices } from 'services/internalApi';
+
+jest.mock('services/internalApi', () => ({
+  ...jest.requireActual('services/internalApi'),
+  showCounselingOffices: jest.fn().mockImplementation(() =>
+    Promise.resolve({
+      body: [
+        {
+          id: '3e937c1f-5539-4919-954d-017989130584',
+          name: 'Albuquerque AFB',
+        },
+        {
+          id: 'fa51dab0-4553-4732-b843-1f33407f77bc',
+          name: 'Glendale Luke AFB',
+        },
+      ],
+    }),
+  ),
+}));
+
 jest.mock('components/LocationSearchBox/api', () => ({
   ShowAddress: jest.fn().mockImplementation(() =>
     Promise.resolve({
@@ -146,6 +166,34 @@ const testProps = {
     { key: 'SEPARATION', value: 'Separation' },
   ],
 };
+const couselingOfficeProps = {
+  onSubmit: jest.fn().mockImplementation(() => Promise.resolve()),
+  initialValues: {
+    orders_type: '',
+    issue_date: '',
+    report_by_date: '',
+    has_dependents: '',
+    new_duty_location: {},
+    grade: '',
+    origin_duty_location: {
+      address_id: '69da140a-eb77-4f1a-8d3c-f22ac0371c7a',
+      affiliation: 'AIR_FORCE',
+      created_at: '2024-08-26T18:52:07.847Z',
+      id: 'c9995f16-b173-410b-afa7-f148b0da7e7e',
+      name: 'Altus AFB, OK 73523',
+      provides_services_counseling: true,
+      transportation_office_id: '3be2381f-f9ed-4902-bbdc-69c69e43eb86',
+      updated_at: '2024-08-26T18:52:07.847Z',
+    },
+  },
+  onBack: jest.fn(),
+  ordersTypeOptions: [
+    { key: 'PERMANENT_CHANGE_OF_STATION', value: 'Permanent Change Of Station (PCS)' },
+    { key: 'LOCAL_MOVE', value: 'Local Move' },
+    { key: 'RETIREMENT', value: 'Retirement' },
+    { key: 'SEPARATION', value: 'Separation' },
+  ],
+};
 
 describe('OrdersInfoForm component', () => {
   it('renders the form inputs', async () => {
@@ -167,6 +215,7 @@ describe('OrdersInfoForm component', () => {
   });
 
   it('renders each option for orders type', async () => {
+    showCounselingOffices.mockImplementation(() => Promise.resolve({}));
     const { getByLabelText } = render(<OrdersInfoForm {...testProps} />);
 
     const ordersTypeDropdown = getByLabelText(/Orders type/);
@@ -314,6 +363,84 @@ describe('OrdersInfoForm component', () => {
 
     await waitFor(() => {
       expect(testProps.onBack).toHaveBeenCalled();
+    });
+  });
+
+  it('submits the form with counseling office', async () => {
+    showCounselingOffices.mockImplementation(() => Promise.resolve({}));
+    render(<OrdersInfoForm {...couselingOfficeProps} />);
+
+    await userEvent.selectOptions(screen.getByLabelText('Orders type'), 'PERMANENT_CHANGE_OF_STATION');
+    await userEvent.type(screen.getByLabelText('Orders date'), '08 Nov 2020');
+    await userEvent.type(screen.getByLabelText('Report by date'), '26 Nov 2020');
+    await userEvent.click(screen.getByLabelText('No'));
+    await userEvent.selectOptions(screen.getByLabelText('Pay grade'), ['E_5']);
+
+    // Test Current Duty Location Search Box interaction
+    await userEvent.type(screen.getByLabelText('Current duty location'), 'AFB', { delay: 100 });
+    const selectedOptionCurrent = await screen.findByText(/Altus/);
+    await userEvent.click(selectedOptionCurrent);
+
+    //  Issue - cannto find the label Couseling Office
+    await userEvent.selectOptions(screen.getByLabelText('Counseling Office'), ['PPPO Altus AFB - USAF']);
+
+    // Test New Duty Location Search Box interaction
+    await userEvent.type(screen.getByLabelText('New duty location'), 'AFB', { delay: 100 });
+    const selectedOptionNew = await screen.findByText(/Luke/);
+    await userEvent.click(selectedOptionNew);
+
+    await waitFor(() => {
+      expect(screen.getByRole('form')).toHaveFormValues({
+        new_duty_location: 'Luke AFB',
+        origin_duty_location: 'Altus AFB',
+      });
+    });
+
+    const submitBtn = screen.getByRole('button', { name: 'Next' });
+    await userEvent.click(submitBtn);
+
+    await waitFor(() => {
+      expect(testProps.onSubmit).toHaveBeenCalledWith(
+        expect.objectContaining({
+          orders_type: 'PERMANENT_CHANGE_OF_STATION',
+          has_dependents: 'no',
+          issue_date: '08 Nov 2020',
+          report_by_date: '26 Nov 2020',
+          new_duty_location: {
+            address: {
+              city: 'Glendale Luke AFB',
+              country: 'United States',
+              id: 'fa51dab0-4553-4732-b843-1f33407f77bc',
+              postalCode: '85309',
+              state: 'AZ',
+              streetAddress1: 'n/a',
+            },
+            address_id: '25be4d12-fe93-47f1-bbec-1db386dfa67f',
+            affiliation: 'AIR_FORCE',
+            created_at: '2021-02-11T16:48:04.117Z',
+            id: 'a8d6b33c-8370-4e92-8df2-356b8c9d0c1a',
+            name: 'Luke AFB',
+            updated_at: '2021-02-11T16:48:04.117Z',
+          },
+          grade: 'E_5',
+          origin_duty_location: {
+            address: {
+              city: '',
+              id: '00000000-0000-0000-0000-000000000000',
+              postalCode: '',
+              state: '',
+              streetAddress1: '',
+            },
+            address_id: '46c4640b-c35e-4293-a2f1-36c7b629f903',
+            affiliation: 'AIR_FORCE',
+            created_at: '2021-02-11T16:48:04.117Z',
+            id: '93f0755f-6f35-478b-9a75-35a69211da1c',
+            name: 'Altus AFB',
+            updated_at: '2021-02-11T16:48:04.117Z',
+          },
+        }),
+        expect.anything(),
+      );
     });
   });
 

--- a/src/components/LocationSearchBox/LocationSearchBox.jsx
+++ b/src/components/LocationSearchBox/LocationSearchBox.jsx
@@ -113,7 +113,7 @@ export const LocationSearchBoxComponent = ({
   isDisabled,
   handleZipCityOnChange,
 }) => {
-  const { value, onChange, name: inputName } = input;
+  const { value, onChange, officeState, name: inputName } = input;
 
   const [inputValue, setInputValue] = useState('');
   let disabledStyles = {};
@@ -169,11 +169,12 @@ export const LocationSearchBoxComponent = ({
         ...selectedValue,
         address,
       };
-
+      officeState(newValue);
       onChange(newValue);
       return newValue;
     }
 
+    officeState(selectedValue);
     onChange(selectedValue);
 
     if (handleZipCityOnChange !== null) {
@@ -210,6 +211,7 @@ export const LocationSearchBoxComponent = ({
 
   const noOptionsMessage = () => (inputValue.length ? 'No Options' : 'No Options');
   const hasLocation = !!value && !!value.address;
+
   return (
     <FormGroup>
       <div className="labelWrapper">
@@ -250,6 +252,7 @@ export const LocationSearchBoxComponent = ({
 
 export const LocationSearchBoxContainer = (props) => {
   const { searchLocations } = props;
+
   return <LocationSearchBoxComponent {...props} searchLocations={searchLocations} showAddress={ShowAddress} />;
 };
 

--- a/src/components/LocationSearchBox/LocationSearchBox.jsx
+++ b/src/components/LocationSearchBox/LocationSearchBox.jsx
@@ -113,7 +113,7 @@ export const LocationSearchBoxComponent = ({
   isDisabled,
   handleZipCityOnChange,
 }) => {
-  const { value, onChange, officeState, name: inputName } = input;
+  const { value, onChange, locationState, name: inputName } = input;
 
   const [inputValue, setInputValue] = useState('');
   let disabledStyles = {};
@@ -169,12 +169,12 @@ export const LocationSearchBoxComponent = ({
         ...selectedValue,
         address,
       };
-      officeState(newValue);
+      locationState(newValue);
       onChange(newValue);
       return newValue;
     }
 
-    officeState(selectedValue);
+    locationState(selectedValue);
     onChange(selectedValue);
 
     if (handleZipCityOnChange !== null) {
@@ -265,6 +265,7 @@ LocationSearchBoxContainer.propTypes = {
     name: PropTypes.string,
     onChange: PropTypes.func,
     value: DutyLocationShape,
+    locationState: PropTypes.func,
   }),
   hint: PropTypes.node,
   placeholder: PropTypes.string,
@@ -281,6 +282,7 @@ LocationSearchBoxContainer.defaultProps = {
     name: '',
     onChange: () => {},
     value: undefined,
+    locationState: () => {},
   },
   hint: '',
   placeholder: 'Start typing a duty location...',

--- a/src/components/LocationSearchBox/LocationSearchBox.test.jsx
+++ b/src/components/LocationSearchBox/LocationSearchBox.test.jsx
@@ -202,9 +202,10 @@ describe('LocationSearchBoxContainer', () => {
   describe('selecting options', () => {
     it('selects an option, calls the onChange callback prop', async () => {
       const onChange = jest.fn();
+      const locationState = jest.fn();
       render(
         <LocationSearchBox
-          input={{ name: 'test_component', onChange }}
+          input={{ name: 'test_component', onChange, locationState }}
           title="Test Component"
           name="test_component"
           searchLocations={mockLocationSearch}

--- a/src/components/Table/SearchResultsTable.jsx
+++ b/src/components/Table/SearchResultsTable.jsx
@@ -1,26 +1,26 @@
-import React, { useState, useEffect, useMemo } from 'react';
-import { useTable, useFilters, usePagination, useSortBy } from 'react-table';
-import { generatePath, useNavigate } from 'react-router';
-import PropTypes from 'prop-types';
-import { Button } from '@trussworks/react-uswds';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { Button } from '@trussworks/react-uswds';
+import PropTypes from 'prop-types';
+import React, { useEffect, useMemo, useState } from 'react';
+import { generatePath, useNavigate } from 'react-router';
+import { useFilters, usePagination, useSortBy, useTable } from 'react-table';
 
 import styles from './SearchResultsTable.module.scss';
 import { createHeader } from './utils';
 
-import Table from 'components/Table/Table';
 import DateSelectFilter from 'components/Table/Filters/DateSelectFilter';
-import LoadingPlaceholder from 'shared/LoadingPlaceholder';
-import SomethingWentWrong from 'shared/SomethingWentWrong';
-import TextBoxFilter from 'components/Table/Filters/TextBoxFilter';
-import { BRANCH_OPTIONS, MOVE_STATUS_LABELS, SEARCH_QUEUE_STATUS_FILTER_OPTIONS, SortShape } from 'constants/queues';
-import { DATE_FORMAT_STRING } from 'shared/constants';
-import { formatDateFromIso, serviceMemberAgencyLabel } from 'utils/formatters';
 import MultiSelectCheckBoxFilter from 'components/Table/Filters/MultiSelectCheckBoxFilter';
 import SelectFilter from 'components/Table/Filters/SelectFilter';
-import { servicesCounselingRoutes } from 'constants/routes';
+import TextBoxFilter from 'components/Table/Filters/TextBoxFilter';
+import Table from 'components/Table/Table';
 import { CHECK_SPECIAL_ORDERS_TYPES, SPECIAL_ORDERS_TYPES } from 'constants/orders';
+import { BRANCH_OPTIONS, MOVE_STATUS_LABELS, SEARCH_QUEUE_STATUS_FILTER_OPTIONS, SortShape } from 'constants/queues';
+import { servicesCounselingRoutes } from 'constants/routes';
+import { DATE_FORMAT_STRING } from 'shared/constants';
+import LoadingPlaceholder from 'shared/LoadingPlaceholder';
+import SomethingWentWrong from 'shared/SomethingWentWrong';
 import { isBooleanFlagEnabled } from 'utils/featureFlags';
+import { formatDateFromIso, serviceMemberAgencyLabel } from 'utils/formatters';
 
 const moveSearchColumns = (moveLockFlag, handleEditProfileClick) => [
   createHeader(' ', (row) => {

--- a/src/components/form/fields/CloseoutOfficeInput.jsx
+++ b/src/components/form/fields/CloseoutOfficeInput.jsx
@@ -19,6 +19,7 @@ export const CloseoutOfficeInput = (props) => {
         value: field.value,
         onChange: helpers.setValue,
         name,
+        locationState: () => {},
       }}
       errorMsg={errorString}
       displayAddress={displayAddress}

--- a/src/components/form/fields/DutyLocationInput.jsx
+++ b/src/components/form/fields/DutyLocationInput.jsx
@@ -7,14 +7,22 @@ import './DropdownInput.module.scss';
 
 // TODO: refactor component when we can to make it more user friendly with Formik
 export const DutyLocationInput = (props) => {
-  const { label, name, displayAddress, hint, placeholder, isDisabled, searchLocations, metaOverride, onOfficeChange } =
-    props;
+  const {
+    label,
+    name,
+    displayAddress,
+    hint,
+    placeholder,
+    isDisabled,
+    searchLocations,
+    metaOverride,
+    onDutyLocationChange,
+  } = props;
   const [field, meta, helpers] = useField(props);
-
   const { touched } = useFormikContext();
-  const handleOfficeChange = (event) => {
-    if (onOfficeChange) {
-      onOfficeChange(event);
+  const handleDutyLocationChange = (event) => {
+    if (onDutyLocationChange) {
+      onDutyLocationChange(event);
     }
   };
 
@@ -39,7 +47,7 @@ export const DutyLocationInput = (props) => {
       input={{
         value: field.value,
         onChange: handleChange,
-        officeState: handleOfficeChange,
+        locationState: handleDutyLocationChange,
         name,
       }}
       errorMsg={errorString}
@@ -63,7 +71,7 @@ DutyLocationInput.propTypes = {
   isDisabled: PropTypes.bool,
   searchLocations: PropTypes.func,
   metaOverride: PropTypes.string,
-  onOfficeChange: PropTypes.func,
+  onDutyLocationChange: PropTypes.func,
 };
 
 DutyLocationInput.defaultProps = {
@@ -73,7 +81,7 @@ DutyLocationInput.defaultProps = {
   isDisabled: false,
   searchLocations: undefined,
   metaOverride: '',
-  onOfficeChange: undefined,
+  onDutyLocationChange: undefined,
 };
 
 export default DutyLocationInput;

--- a/src/components/form/fields/DutyLocationInput.jsx
+++ b/src/components/form/fields/DutyLocationInput.jsx
@@ -7,10 +7,16 @@ import './DropdownInput.module.scss';
 
 // TODO: refactor component when we can to make it more user friendly with Formik
 export const DutyLocationInput = (props) => {
-  const { label, name, displayAddress, hint, placeholder, isDisabled, searchLocations, metaOverride } = props;
+  const { label, name, displayAddress, hint, placeholder, isDisabled, searchLocations, metaOverride, onOfficeChange } =
+    props;
   const [field, meta, helpers] = useField(props);
 
   const { touched } = useFormikContext();
+  const handleOfficeChange = (event) => {
+    if (onOfficeChange) {
+      onOfficeChange(event);
+    }
+  };
 
   let errorString = '';
   if (metaOverride && metaOverride !== '') {
@@ -33,6 +39,7 @@ export const DutyLocationInput = (props) => {
       input={{
         value: field.value,
         onChange: handleChange,
+        officeState: handleOfficeChange,
         name,
       }}
       errorMsg={errorString}
@@ -56,6 +63,7 @@ DutyLocationInput.propTypes = {
   isDisabled: PropTypes.bool,
   searchLocations: PropTypes.func,
   metaOverride: PropTypes.string,
+  onOfficeChange: PropTypes.func,
 };
 
 DutyLocationInput.defaultProps = {
@@ -65,6 +73,7 @@ DutyLocationInput.defaultProps = {
   isDisabled: false,
   searchLocations: undefined,
   metaOverride: '',
+  onOfficeChange: undefined,
 };
 
 export default DutyLocationInput;

--- a/src/pages/MyMove/AddOrders.jsx
+++ b/src/pages/MyMove/AddOrders.jsx
@@ -37,6 +37,7 @@ const AddOrders = ({ context, serviceMemberId, updateServiceMember, updateOrders
       grade: values.grade,
       origin_duty_location_id: values.origin_duty_location.id,
       spouse_has_pro_gear: false,
+      counseling_office: values.counseling_office,
     };
 
     try {

--- a/src/pages/MyMove/AddOrders.test.jsx
+++ b/src/pages/MyMove/AddOrders.test.jsx
@@ -4,7 +4,7 @@ import userEvent from '@testing-library/user-event';
 
 import AddOrders from './AddOrders';
 
-import { createOrders, getServiceMember } from 'services/internalApi';
+import { createOrders, getServiceMember, showCounselingOffices } from 'services/internalApi';
 import { renderWithProviders } from 'testUtils';
 import { customerRoutes } from 'constants/routes';
 import { selectServiceMemberFromLoggedInUser } from 'store/entities/selectors';
@@ -14,6 +14,20 @@ jest.mock('services/internalApi', () => ({
   getServiceMember: jest.fn().mockImplementation(() => Promise.resolve()),
   getResponseError: jest.fn().mockImplementation(() => Promise.resolve()),
   createOrders: jest.fn().mockImplementation(() => Promise.resolve()),
+  showCounselingOffices: jest.fn().mockImplementation(() =>
+    Promise.resolve({
+      body: [
+        {
+          id: '3e937c1f-5539-4919-954d-017989130584',
+          name: 'Albuquerque AFB',
+        },
+        {
+          id: 'fa51dab0-4553-4732-b843-1f33407f77bc',
+          name: 'Glendale Luke AFB',
+        },
+      ],
+    }),
+  ),
 }));
 
 jest.mock('store/entities/selectors', () => ({
@@ -163,6 +177,7 @@ describe('Add Orders page', () => {
   };
 
   it('renders all content of Orders component', async () => {
+    showCounselingOffices.mockImplementation(() => Promise.resolve({}));
     selectServiceMemberFromLoggedInUser.mockImplementation(() => serviceMember);
     renderWithProviders(<AddOrders {...testProps} />, {
       path: customerRoutes.ORDERS_ADD_PATH,

--- a/src/pages/MyMove/Orders.test.jsx
+++ b/src/pages/MyMove/Orders.test.jsx
@@ -450,6 +450,7 @@ describe('Orders page', () => {
   });
 
   it('next button patches the orders updates state', async () => {
+    showCounselingOffices.mockImplementation(() => Promise.resolve({}));
     selectServiceMemberFromLoggedInUser.mockImplementation(() => serviceMember);
     selectOrdersForLoggedInUser.mockImplementation(() => testProps.orders);
     selectAllMoves.mockImplementation(() => testProps.serviceMemberMoves);
@@ -499,6 +500,7 @@ describe('Orders page', () => {
   });
 
   it('shows an error if the API returns an error', async () => {
+    showCounselingOffices.mockImplementation(() => Promise.resolve({}));
     selectServiceMemberFromLoggedInUser.mockImplementation(() => serviceMember);
     selectOrdersForLoggedInUser.mockImplementation(() => testProps.orders);
     selectAllMoves.mockImplementation(() => testProps.serviceMemberMoves);

--- a/src/pages/MyMove/Orders.test.jsx
+++ b/src/pages/MyMove/Orders.test.jsx
@@ -4,7 +4,7 @@ import userEvent from '@testing-library/user-event';
 
 import Orders from './Orders';
 
-import { getOrders, patchOrders } from 'services/internalApi';
+import { getOrders, patchOrders, showCounselingOffices } from 'services/internalApi';
 import { renderWithProviders } from 'testUtils';
 import { customerRoutes } from 'constants/routes';
 import {
@@ -17,6 +17,20 @@ jest.mock('services/internalApi', () => ({
   ...jest.requireActual('services/internalApi'),
   patchOrders: jest.fn().mockImplementation(() => Promise.resolve()),
   getOrders: jest.fn().mockImplementation(() => Promise.resolve()),
+  showCounselingOffices: jest.fn().mockImplementation(() =>
+    Promise.resolve({
+      body: [
+        {
+          id: '3e937c1f-5539-4919-954d-017989130584',
+          name: 'Albuquerque AFB',
+        },
+        {
+          id: 'fa51dab0-4553-4732-b843-1f33407f77bc',
+          name: 'Glendale Luke AFB',
+        },
+      ],
+    }),
+  ),
 }));
 
 jest.mock('components/LocationSearchBox/api', () => ({
@@ -415,6 +429,7 @@ describe('Orders page', () => {
   });
 
   it('renders appropriate order data on load', async () => {
+    showCounselingOffices.mockImplementation(() => Promise.resolve({}));
     selectServiceMemberFromLoggedInUser.mockImplementation(() => serviceMember);
     selectOrdersForLoggedInUser.mockImplementation(() => testProps.orders);
     selectAllMoves.mockImplementation(() => testProps.serviceMemberMoves);

--- a/swagger-def/definitions/DutyLocationPayload.yaml
+++ b/swagger-def/definitions/DutyLocationPayload.yaml
@@ -28,6 +28,9 @@ properties:
   updated_at:
     type: string
     format: date-time
+  provides_services_counseling:
+    type: boolean
+    x-nullable: false
 required:
   - id
   - name

--- a/swagger-def/internal.yaml
+++ b/swagger-def/internal.yaml
@@ -1466,6 +1466,11 @@ definitions:
         type: string
         format: uuid
         example: c56a4180-65aa-42ec-a945-5fd21dec0538
+      counseling_office_id:
+        type: string
+        format: uuid
+        example: cf1addea-a4f9-4173-8506-2bb82a064cb7
+        x-nullable: true
       orders_number:
         type: string
         title: Orders Number

--- a/swagger/internal.yaml
+++ b/swagger/internal.yaml
@@ -1493,6 +1493,11 @@ definitions:
         type: string
         format: uuid
         example: c56a4180-65aa-42ec-a945-5fd21dec0538
+      counseling_office_id:
+        type: string
+        format: uuid
+        example: cf1addea-a4f9-4173-8506-2bb82a064cb7
+        x-nullable: true
       orders_number:
         type: string
         title: Orders Number
@@ -2758,6 +2763,9 @@ definitions:
       updated_at:
         type: string
         format: date-time
+      provides_services_counseling:
+        type: boolean
+        x-nullable: false
     required:
       - id
       - name


### PR DESCRIPTION
## [Agility ticket](https://www13.v1host.com/USTRANSCOM38/assetdetail.v1?number=B-20465)

## Summary
When a customer selects an origin duty location assigned to government counseling, then they will also be asked to select a counseling office within the same GBLOC. This field will be called "Counseling Office".



### How to test as a Customer
1.  Login as a Customer
2. Select a counseling Office while creating a new move
3. Check the Moves data table for corresponding counseling_office_id

### How to test as a Service Counselor
1.  Login as a Service Counselor
2. Verify the counseling queue's counseling Office column matches what was created in previous move


## 508 Screenshots
[508Screenshots-20465.pdf](https://github.com/user-attachments/files/16971315/508Screenshots-20465.pdf)
