### PR TITLE
B-20947 Fix: Apply GCC calculation Fix to Payment Packet

### DIFF
--- a/pkg/services/shipment_summary_worksheet/shipment_summary_worksheet.go
+++ b/pkg/services/shipment_summary_worksheet/shipment_summary_worksheet.go
@@ -241,7 +241,7 @@ func (s SSWPPMComputer) FormatValuesShipmentSummaryWorksheetFormPage1(data model
 
 		finalPPMWeight := FormatPPMWeightFinal(data.PPMShipmentFinalWeight)
 		page1.ShipmentWeights = finalPPMWeight
-		page1.ActualObligationGCC100 = finalPPMWeight + "; " + formattedShipment.FinalIncentive
+		page1.ActualObligationGCC100 = formattedShipment.ShipmentWeightForObligation + " - Actual lbs; "
 		page1.PreparationDate1, err = formatSSWDate(data.SignedCertifications, data.PPMShipment.ID)
 		if err != nil {
 			return page1, err


### PR DESCRIPTION
## [Agility ticket](https://www13.v1host.com/USTRANSCOM38/assetdetail.v1?number=B-20947)
## [Issue Ticket  I-13317](https://www13.v1host.com/USTRANSCOM38/Issue.mvc/Summary?oidToken=Issue%3A1011718)
## [Main PR for B-20947](https://github.com/transcom/mymove/pull/13705)

## Summary
When working B-20947 the calculation fix was applied to AOA Packets but not the Payment Packets. So the payment packets are still showing the incorrect value but the AOA packet is now showing the correct value. This was just a missed AC because payment packet was referred to as "PPM SSW". In This PR I am applying the same calculation fix for the AOA packet to the payment packet as well. Both are supposed to use the same calculations according to the ACs. Solves issue I-13317.


Is there anything you would like reviewers to give additional scrutiny?

[this article](tbd) explains more about the approach used.

## Verification Steps for the Author

These are to be checked by the author.

- [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
- [ ] Have the Agility acceptance criteria been met for this change?

## Verification Steps for Reviewers

These are to be checked by a reviewer.

- [ ] Has the branch been pulled in and checked out?
- [ ] Have the BL acceptance criteria been met for this change?
- [ ] Was the CircleCI build successful?
- [ ] Has the code been reviewed from a standards and best practices point of view?

### Setup to Run the Code

- [Instructions for starting storybook](https://transcom.github.io/mymove-docs/docs/frontend/setup/storybook)
- [Instructions for starting the MilMove application](https://transcom.github.io/mymove-docs/docs/getting-started/application-setup/)
- [Instructions for running tests](https://transcom.github.io/mymove-docs/docs/getting-started/development/testing)

### How to test

1. Access office as a service counselor
2. Select a PPM Closeout move
3. Make sure to approve all the documents as a counselor so the Payment Packet link will show 
4. while under Move Details Tab scroll down and select "Download Payment Packet (PDF)"
5. Once downloaded inspect the 100% GCC value under Actual Obligations section under the Entitlements & move summary
6. The value should be the actual weight up to the (entitlement weight or allowed weight) whichever is lessor. The value should also not include any Progear. For Example:

If:
Entitlement = 5000
TotalWeight = 7500
Actual Weight = 4000
Then 100% GCC should equal 4000lbs

If:
Entitlement = 5000
TotalWeight = 7500
Actual Weight = 6000
Then 100% GCC should equal 5000lbs


You can add weight tickets as a customer by going to a customer with a PPM Shipment and following step 6:
![image](https://github.com/user-attachments/assets/a5e6034b-6141-4595-a96c-4bba7c43cdf6)


### Frontend

- [ ] There are no aXe warnings for UI.
- [ ] This works in [Supported Browsers and their phone views](https://transcom.github.io/mymove-docs/docs/adrs/Browser-Support/#minimum-browser-requirements) (Chrome, Firefox, Edge).
- [ ] There are no new console errors in the browser devtools.
- [ ] There are no new console errors in the test output.
- [ ] If this PR adds a new component to Storybook, it ensures the component is fully responsive, OR if it is intentionally not, a wrapping div using the `officeApp` class or custom `min-width` styling is used to hide any states the would not be visible to the user.
- [ ] This change meets the standards for [Section 508 compliance](https://www.ssa.gov/accessibility/andi/help/install.html).

### Backend

- [ ] Code follows the guidelines for [Logging](https://transcom.github.io/mymove-docs/docs/getting-started/development/logging).
- [ ] The requirements listed in [Querying the Database Safely](https://transcom.github.io/mymove-docs/docs/backend/guides/golang-guide#querying-the-database-safely) have been satisfied.

### Database

#### Any new migrations/schema changes:

- [ ] Follows our guidelines for [Zero-Downtime Deploys](https://transcom.github.io/mymove-docs/docs/backend/setup/database-migrations#zero-downtime-migrations).
- [ ] Have been communicated to #g-database.
- [ ] Secure migrations have been tested following the instructions in our [docs](https://transcom.github.io/mymove-docs/docs/backend/setup/database-migrations#secure-migrations).

## Screenshots
