### PR TITLE
B 20490 int part2

### DIFF
--- a/src/constants/MoveHistory/EventTemplates/CreateMTOShipment/createMTOShipment.jsx
+++ b/src/constants/MoveHistory/EventTemplates/CreateMTOShipment/createMTOShipment.jsx
@@ -7,23 +7,11 @@ import { getMtoShipmentLabel } from 'utils/formatMtoShipment';
 
 const formatChangedValues = (historyRecord) => {
   const { changedValues } = historyRecord;
-  const { diversion, usesExternalVendor } = historyRecord.changedValues;
-
   const newChangedValues = {
     ...changedValues,
     ...getMtoShipmentLabel(historyRecord),
   };
 
-  if (diversion) {
-    newChangedValues.diversion = 'Yes';
-  } else {
-    newChangedValues.diversion = 'No';
-  }
-  if (usesExternalVendor) {
-    newChangedValues.uses_external_vendor = 'Yes';
-  } else {
-    newChangedValues.uses_external_vendor = 'No';
-  }
   if (historyRecord.context[0].shipment_type === 'PPM') {
     newChangedValues.status = null; // Status will always be draft when shipment is created, not useful information.
   }

--- a/src/constants/MoveHistory/EventTemplates/UpdateCustomer/updateCustomer.jsx
+++ b/src/constants/MoveHistory/EventTemplates/UpdateCustomer/updateCustomer.jsx
@@ -5,27 +5,10 @@ import o from 'constants/MoveHistory/UIDisplay/Operations';
 import t from 'constants/MoveHistory/Database/Tables';
 import LabeledDetails from 'pages/Office/MoveHistory/LabeledDetails';
 
-const formatChangedValues = (historyRecord) => {
-  const { changedValues } = historyRecord;
-  const { emailIsPreferred, phoneIsPreferred } = changedValues;
-  const newChangedValues = { ...changedValues };
-  if (emailIsPreferred) {
-    newChangedValues.email_is_preferred = 'Yes';
-  } else {
-    newChangedValues.email_is_preferred = 'No';
-  }
-  if (phoneIsPreferred) {
-    newChangedValues.phone_is_preferred = 'Yes';
-  } else {
-    newChangedValues.phone_is_preferred = 'No';
-  }
-  return { ...historyRecord, changedValues: newChangedValues };
-};
-
 export default {
   action: a.UPDATE,
   eventName: o.updateCustomer,
   tableName: t.service_members,
   getEventNameDisplay: () => 'Updated profile',
-  getDetails: (historyRecord) => <LabeledDetails historyRecord={formatChangedValues(historyRecord)} />,
+  getDetails: (historyRecord) => <LabeledDetails historyRecord={historyRecord} />,
 };


### PR DESCRIPTION
## [Agility ticket](https://www13.v1host.com/USTRANSCOM38/story.mvc/Summary?oidToken=Story%3A980558&RoomContext=TeamRoom%3A848240&concept=TeamRoom)

## [Previous Int PR](https://github.com/transcom/mymove/pull/13723)

## Summary

Found a small bug I forgot to fix with some boolean fields.

### How to test

1. Either create a new milmove customer or use an existing customer and update the Phone preferred and Email preferred check boxes under Customer info.
2. Create an HHG shipment or use an existing one.
3. Check the Move History tab on the move and verify that there are not dashes (-) next to the fields of Email preferred, Phone preferred, Diversion, and Uses external vendor in the Details column.  Screen shots below show the Event and example with dashes only.

![image](https://github.com/user-attachments/assets/387373d9-bc85-4efe-8816-f0eb855f18b1)


![image](https://github.com/user-attachments/assets/70746a28-64bb-4a96-8624-e2314c581bba)

