### PR TITLE
B-20445: Add Marine Corps BOS to Move Search and BOS filter in work queues

### DIFF
--- a/src/components/Table/SearchResultsTable.jsx
+++ b/src/components/Table/SearchResultsTable.jsx
@@ -13,12 +13,7 @@ import DateSelectFilter from 'components/Table/Filters/DateSelectFilter';
 import LoadingPlaceholder from 'shared/LoadingPlaceholder';
 import SomethingWentWrong from 'shared/SomethingWentWrong';
 import TextBoxFilter from 'components/Table/Filters/TextBoxFilter';
-import {
-  BRANCH_OPTIONS_WITH_MARINE_CORPS,
-  MOVE_STATUS_LABELS,
-  SEARCH_QUEUE_STATUS_FILTER_OPTIONS,
-  SortShape,
-} from 'constants/queues';
+import { BRANCH_OPTIONS, MOVE_STATUS_LABELS, SEARCH_QUEUE_STATUS_FILTER_OPTIONS, SortShape } from 'constants/queues';
 import { DATE_FORMAT_STRING } from 'shared/constants';
 import { formatDateFromIso, serviceMemberAgencyLabel } from 'utils/formatters';
 import MultiSelectCheckBoxFilter from 'components/Table/Filters/MultiSelectCheckBoxFilter';
@@ -107,7 +102,7 @@ const moveSearchColumns = (moveLockFlag, handleEditProfileClick) => [
       isFilterable: true,
       Filter: (props) => (
         // eslint-disable-next-line react/jsx-props-no-spreading
-        <SelectFilter options={BRANCH_OPTIONS_WITH_MARINE_CORPS} {...props} />
+        <SelectFilter options={BRANCH_OPTIONS} {...props} />
       ),
     },
   ),

--- a/src/constants/queues.js
+++ b/src/constants/queues.js
@@ -52,15 +52,6 @@ export const BRANCH_OPTIONS = [
   { value: 'AIR_FORCE', label: 'Air Force' },
   { value: 'COAST_GUARD', label: 'Coast Guard' },
   { value: 'SPACE_FORCE', label: 'Space Force' },
-];
-
-export const BRANCH_OPTIONS_WITH_MARINE_CORPS = [
-  { value: '', label: 'All' },
-  { value: 'ARMY', label: 'Army' },
-  { value: 'NAVY', label: 'Navy' },
-  { value: 'AIR_FORCE', label: 'Air Force' },
-  { value: 'COAST_GUARD', label: 'Coast Guard' },
-  { value: 'SPACE_FORCE', label: 'Space Force' },
   { value: 'MARINES', label: 'Marine Corps' },
 ];
 

--- a/src/pages/Office/MoveQueue/MoveQueue.jsx
+++ b/src/pages/Office/MoveQueue/MoveQueue.jsx
@@ -10,7 +10,7 @@ import { getMovesQueue } from 'services/ghcApi';
 import { formatDateFromIso, serviceMemberAgencyLabel } from 'utils/formatters';
 import MultiSelectCheckBoxFilter from 'components/Table/Filters/MultiSelectCheckBoxFilter';
 import SelectFilter from 'components/Table/Filters/SelectFilter';
-import { BRANCH_OPTIONS, MOVE_STATUS_OPTIONS, GBLOC, MOVE_STATUS_LABELS } from 'constants/queues';
+import { MOVE_STATUS_OPTIONS, GBLOC, MOVE_STATUS_LABELS, BRANCH_OPTIONS } from 'constants/queues';
 import TableQueue from 'components/Table/TableQueue';
 import LoadingPlaceholder from 'shared/LoadingPlaceholder';
 import SomethingWentWrong from 'shared/SomethingWentWrong';

--- a/src/pages/Office/ServicesCounselingEditShipmentDetails/ServicesCounselingEditShipmentDetails.test.jsx
+++ b/src/pages/Office/ServicesCounselingEditShipmentDetails/ServicesCounselingEditShipmentDetails.test.jsx
@@ -328,7 +328,7 @@ describe('ServicesCounselingEditShipmentDetails component', () => {
       expect(
         screen.getByText('Something went wrong, and your changes were not saved. Please try again.'),
       ).toBeVisible();
-    });
+    }, 10000);
   });
 
   it('routes to the move details page when the cancel button is clicked', async () => {

--- a/src/pages/Office/ServicesCounselingQueue/ServicesCounselingQueue.jsx
+++ b/src/pages/Office/ServicesCounselingQueue/ServicesCounselingQueue.jsx
@@ -10,7 +10,7 @@ import SelectFilter from 'components/Table/Filters/SelectFilter';
 import DateSelectFilter from 'components/Table/Filters/DateSelectFilter';
 import TableQueue from 'components/Table/TableQueue';
 import {
-  BRANCH_OPTIONS_WITH_MARINE_CORPS,
+  BRANCH_OPTIONS,
   SERVICE_COUNSELING_MOVE_STATUS_LABELS,
   SERVICE_COUNSELING_PPM_TYPE_OPTIONS,
   SERVICE_COUNSELING_PPM_TYPE_LABELS,
@@ -148,7 +148,7 @@ export const counselingColumns = (moveLockFlag, originLocationList, supervisor) 
       isFilterable: true,
       Filter: (props) => (
         // eslint-disable-next-line react/jsx-props-no-spreading
-        <SelectFilter options={BRANCH_OPTIONS_WITH_MARINE_CORPS} {...props} />
+        <SelectFilter options={BRANCH_OPTIONS} {...props} />
       ),
     },
   ),
@@ -252,7 +252,7 @@ export const closeoutColumns = (moveLockFlag, ppmCloseoutGBLOC, ppmCloseoutOrigi
       isFilterable: true,
       Filter: (props) => (
         // eslint-disable-next-line react/jsx-props-no-spreading
-        <SelectFilter options={BRANCH_OPTIONS_WITH_MARINE_CORPS} {...props} />
+        <SelectFilter options={BRANCH_OPTIONS} {...props} />
       ),
     },
   ),


### PR DESCRIPTION
## [Agility ticket B-20445](https://www13.v1host.com/USTRANSCOM38/assetdetail.v1?number=B-20445)

## Testing Steps
1. Create a new use that is Marine Corps
![Screenshot 2024-08-28 at 1 30 41 PM](https://github.com/user-attachments/assets/d2332872-31e9-4438-b32c-38b1248c8236)

Note: While creating, you may need to take note of postal codes to GBLOC conversions (https://dp3.atlassian.net/wiki/download/attachments/2279735297/postal_code_to_gblocs_202311091157.csv?api=v2)

2. Create a HHG move/shipment so that we can check the queues for office users.
3. After the move/shipment is sent to the SC for approval, sign in as an SC under the appropriate GBLOC.
4. For the initial queue, there should be a filter for branch.. select Marine Corps from that list and you should see only Marine Corps moves.
5. Select that move and approve as SC.
6. As TOO/TIO verify that you are able to see the created move when you filter by Marine Corps.
7. As TOO make sure you approve the move/shipment so that it will be available to Prime.
8. As Prime verify that you are able to see the created move when you filter by Marine Corps.

___

## ANDI screenshot
![Screenshot 2024-08-28 at 1 47 34 PM](https://github.com/user-attachments/assets/2b43ba34-95ff-45a5-a0cc-46b5e8e96b61)