### PR TITLE
B-19463-INT after rebase

### DIFF
--- a/pkg/handlers/ghcapi/internal/payloads/model_to_payload.go
+++ b/pkg/handlers/ghcapi/internal/payloads/model_to_payload.go
@@ -2115,6 +2115,7 @@ func QueueMoves(moves []models.Move) *ghcmessages.QueueMoves {
 			LockExpiresAt:           handlers.FmtDateTimePtr(move.LockExpiresAt),
 			PpmStatus:               ghcmessages.PPMStatus(ppmStatus),
 			CounselingOffice:        &transportationOffice,
+			AssignedTo:              AssignedOfficeUser(move.SCAssignedUser),
 		}
 	}
 	return &queueMoves

--- a/pkg/services/order/order_fetcher.go
+++ b/pkg/services/order/order_fetcher.go
@@ -157,6 +157,7 @@ func (f orderFetcher) ListOrders(appCtx appcontext.AppContext, officeUserID uuid
 			"MTOShipments.PPMShipment",
 			"CloseoutOffice",
 			"LockedByOfficeUser",
+			"SCAssignedUser",
 			"CounselingOffice",
 		).InnerJoin("orders", "orders.id = moves.orders_id").
 			InnerJoin("service_members", "orders.service_member_id = service_members.id").

--- a/src/components/Table/TableQueue.jsx
+++ b/src/components/Table/TableQueue.jsx
@@ -23,6 +23,7 @@ import {
   getTableQueueSortParamSessionStorageValue,
   getSelectionOptionLabel,
 } from 'components/Table/utils';
+import { formatAvailableOfficeUsers } from 'utils/queues';
 
 const defaultPageSize = 20;
 const defaultPage = 1;
@@ -49,6 +50,8 @@ const TableQueue = ({
   csvExportQueueFetcherKey,
   sessionStorageKey,
   isHeadquartersUser,
+  isSupervisor,
+  currentUserId,
 }) => {
   const [isPageReload, setIsPageReload] = useState(true);
   useEffect(() => {
@@ -96,6 +99,7 @@ const TableQueue = ({
     queueResult: {
       totalCount = 0,
       data = [],
+      availableOfficeUsers = [],
       page = getTableQueuePageSessionStorageValue(sessionStorageKey) || defaultPage,
       perPage = getTableQueuePageSizeSessionStorageValue(sessionStorageKey) || defaultPageSize,
     },
@@ -119,6 +123,14 @@ const TableQueue = ({
     [],
   );
   const tableData = useMemo(() => data, [data]);
+  const formattedAvailableOfficeUsers = formatAvailableOfficeUsers(availableOfficeUsers, isSupervisor, currentUserId);
+  // attach the available office users to the moves/row
+  const tableDataWithAvailableUsers = tableData?.map((ele) => {
+    const newEle = { ...ele };
+    newEle.availableOfficeUsers = formattedAvailableOfficeUsers;
+    return newEle;
+  });
+
   const tableColumns = useMemo(() => columns, [columns]);
   const {
     getTableProps,
@@ -138,7 +150,7 @@ const TableQueue = ({
   } = useTable(
     {
       columns: tableColumns,
-      data: tableData,
+      data: tableDataWithAvailableUsers,
       initialState: {
         hiddenColumns: defaultHiddenColumns,
         pageSize: perPage,

--- a/src/hooks/queries.js
+++ b/src/hooks/queries.js
@@ -612,9 +612,9 @@ export const useServicesCounselingQueueQueries = ({
   );
 
   const { isLoading, isError, isSuccess } = servicesCounselingQueueQuery;
-  const { queueMoves, ...dataProps } = data;
+  const { queueMoves, availableOfficeUsers, ...dataProps } = data;
   return {
-    queueResult: { data: queueMoves, ...dataProps },
+    queueResult: { data: queueMoves, availableOfficeUsers, ...dataProps },
     isLoading,
     isError,
     isSuccess,

--- a/src/pages/Office/ServicesCounselingQueue/ServicesCounselingQueue.jsx
+++ b/src/pages/Office/ServicesCounselingQueue/ServicesCounselingQueue.jsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useEffect, useState } from 'react';
 import { generatePath, useNavigate, Navigate, useParams, NavLink } from 'react-router-dom';
-import { Button } from '@trussworks/react-uswds';
+import { Button, Dropdown } from '@trussworks/react-uswds';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
 import styles from './ServicesCounselingQueue.module.scss';
@@ -48,147 +48,171 @@ import ConnectedFlashMessage from 'containers/FlashMessage/FlashMessage';
 import { isNullUndefinedOrWhitespace } from 'shared/utils';
 import CustomerSearchForm from 'components/CustomerSearchForm/CustomerSearchForm';
 import MultiSelectTypeAheadCheckBoxFilter from 'components/Table/Filters/MutliSelectTypeAheadCheckboxFilter';
+import { formatAvailableOfficeUsersForRow } from 'utils/queues';
 
-export const counselingColumns = (moveLockFlag, originLocationList, supervisor) => [
-  createHeader(
-    ' ',
-    (row) => {
-      const now = new Date();
-      // this will render a lock icon if the move is locked & if the lockExpiresAt value is after right now
-      if (row.lockedByOfficeUserID && row.lockExpiresAt && now < new Date(row.lockExpiresAt) && moveLockFlag) {
+export const counselingColumns = (moveLockFlag, originLocationList, supervisor, isQueueManagementEnabled) => {
+  const cols = [
+    createHeader(
+      ' ',
+      (row) => {
+        const now = new Date();
+        // this will render a lock icon if the move is locked & if the lockExpiresAt value is after right now
+        if (row.lockedByOfficeUserID && row.lockExpiresAt && now < new Date(row.lockExpiresAt) && moveLockFlag) {
+          return (
+            <div data-testid="lock-icon">
+              <FontAwesomeIcon icon="lock" />
+            </div>
+          );
+        }
+        return null;
+      },
+      { id: 'lock' },
+    ),
+    createHeader('ID', 'id', { id: 'id' }),
+    createHeader(
+      'Customer name',
+      (row) => {
         return (
-          <div data-testid="lock-icon">
-            <FontAwesomeIcon icon="lock" />
+          <div>
+            {CHECK_SPECIAL_ORDERS_TYPES(row.orderType) ? (
+              <span className={styles.specialMoves}>{SPECIAL_ORDERS_TYPES[`${row.orderType}`]}</span>
+            ) : null}
+            {`${row.customer.last_name}, ${row.customer.first_name}`}
           </div>
         );
-      }
-      return null;
-    },
-    { id: 'lock' },
-  ),
-  createHeader('ID', 'id', { id: 'id' }),
-  createHeader(
-    'Customer name',
-    (row) => {
-      return (
-        <div>
-          {CHECK_SPECIAL_ORDERS_TYPES(row.orderType) ? (
-            <span className={styles.specialMoves}>{SPECIAL_ORDERS_TYPES[`${row.orderType}`]}</span>
-          ) : null}
-          {`${row.customer.last_name}, ${row.customer.first_name}`}
-        </div>
-      );
-    },
-    {
-      id: 'lastName',
+      },
+      {
+        id: 'lastName',
+        isFilterable: true,
+        exportValue: (row) => {
+          return `${row.customer.last_name}, ${row.customer.first_name}`;
+        },
+      },
+    ),
+    createHeader('DoD ID', 'customer.dodID', {
+      id: 'dodID',
       isFilterable: true,
       exportValue: (row) => {
-        return `${row.customer.last_name}, ${row.customer.first_name}`;
+        return row.customer.dodID;
       },
-    },
-  ),
-  createHeader('DoD ID', 'customer.dodID', {
-    id: 'dodID',
-    isFilterable: true,
-    exportValue: (row) => {
-      return row.customer.dodID;
-    },
-  }),
-  createHeader('EMPLID', 'customer.emplid', {
-    id: 'emplid',
-    isFilterable: true,
-  }),
-  createHeader('Move code', 'locator', {
-    id: 'locator',
-    isFilterable: true,
-  }),
-  createHeader(
-    'Status',
-    (row) => {
-      return row.status !== MOVE_STATUSES.SERVICE_COUNSELING_COMPLETED
-        ? SERVICE_COUNSELING_MOVE_STATUS_LABELS[`${row.status}`]
-        : null;
-    },
-    {
-      id: 'status',
-      disableSortBy: true,
-    },
-  ),
-  createHeader(
-    'Requested move date',
-    (row) => {
-      return formatDateFromIso(row.requestedMoveDate, DATE_FORMAT_STRING);
-    },
-    {
-      id: 'requestedMoveDate',
+    }),
+    createHeader('EMPLID', 'customer.emplid', {
+      id: 'emplid',
       isFilterable: true,
-      // eslint-disable-next-line react/jsx-props-no-spreading
-      Filter: (props) => <DateSelectFilter {...props} />,
-    },
-  ),
-  createHeader(
-    'Date submitted',
-    (row) => {
-      return formatDateFromIso(row.submittedAt, DATE_FORMAT_STRING);
-    },
-    {
-      id: 'submittedAt',
+    }),
+    createHeader('Move code', 'locator', {
+      id: 'locator',
       isFilterable: true,
-      // eslint-disable-next-line react/jsx-props-no-spreading
-      Filter: (props) => <DateSelectFilter dateTime {...props} />,
-    },
-  ),
-  createHeader(
-    'Branch',
-    (row) => {
-      return serviceMemberAgencyLabel(row.customer.agency);
-    },
-    {
-      id: 'branch',
-      isFilterable: true,
-      Filter: (props) => (
+    }),
+    createHeader(
+      'Status',
+      (row) => {
+        return row.status !== MOVE_STATUSES.SERVICE_COUNSELING_COMPLETED
+          ? SERVICE_COUNSELING_MOVE_STATUS_LABELS[`${row.status}`]
+          : null;
+      },
+      {
+        id: 'status',
+        disableSortBy: true,
+      },
+    ),
+    createHeader(
+      'Requested move date',
+      (row) => {
+        return formatDateFromIso(row.requestedMoveDate, DATE_FORMAT_STRING);
+      },
+      {
+        id: 'requestedMoveDate',
+        isFilterable: true,
         // eslint-disable-next-line react/jsx-props-no-spreading
-        <SelectFilter options={BRANCH_OPTIONS} {...props} />
-      ),
-    },
-  ),
-  createHeader('Origin GBLOC', 'originGBLOC', {
-    disableSortBy: true,
-  }), // If the user is in the USMC GBLOC they will have many different GBLOCs and will want to sort and filter
-  supervisor
-    ? createHeader(
-        'Origin duty location',
-        (row) => {
-          return `${row.originDutyLocation.name}`;
-        },
-        {
+        Filter: (props) => <DateSelectFilter {...props} />,
+      },
+    ),
+    createHeader(
+      'Date submitted',
+      (row) => {
+        return formatDateFromIso(row.submittedAt, DATE_FORMAT_STRING);
+      },
+      {
+        id: 'submittedAt',
+        isFilterable: true,
+        // eslint-disable-next-line react/jsx-props-no-spreading
+        Filter: (props) => <DateSelectFilter dateTime {...props} />,
+      },
+    ),
+    createHeader(
+      'Branch',
+      (row) => {
+        return serviceMemberAgencyLabel(row.customer.agency);
+      },
+      {
+        id: 'branch',
+        isFilterable: true,
+        Filter: (props) => (
+          // eslint-disable-next-line react/jsx-props-no-spreading
+          <SelectFilter options={BRANCH_OPTIONS} {...props} />
+        ),
+      },
+    ),
+    createHeader('Origin GBLOC', 'originGBLOC', {
+      disableSortBy: true,
+    }), // If the user is in the USMC GBLOC they will have many different GBLOCs and will want to sort and filter
+    supervisor
+      ? createHeader(
+          'Origin duty location',
+          (row) => {
+            return `${row.originDutyLocation.name}`;
+          },
+          {
+            id: 'originDutyLocation',
+            isFilterable: true,
+            exportValue: (row) => {
+              return row.originDutyLocation?.name;
+            },
+            Filter: (props) => (
+              <MultiSelectTypeAheadCheckBoxFilter
+                options={originLocationList}
+                placeholder="Start typing a duty location..."
+                // eslint-disable-next-line react/jsx-props-no-spreading
+                {...props}
+              />
+            ),
+          },
+        )
+      : createHeader('Origin duty location', 'originDutyLocation.name', {
           id: 'originDutyLocation',
           isFilterable: true,
           exportValue: (row) => {
             return row.originDutyLocation?.name;
           },
-          Filter: (props) => (
-            <MultiSelectTypeAheadCheckBoxFilter
-              options={originLocationList}
-              placeholder="Start typing a duty location..."
-              // eslint-disable-next-line react/jsx-props-no-spreading
-              {...props}
-            />
-          ),
+        }),
+    createHeader('Counseling office', 'counselingOffice', {
+      id: 'counselingOffice',
+      isFilterable: true,
+    }),
+  ];
+  if (isQueueManagementEnabled)
+    cols.push(
+      createHeader(
+        'Assigned',
+        (row) => {
+          const { formattedAvailableOfficeUsers, assignedToUser } = formatAvailableOfficeUsersForRow(row);
+          return (
+            <div data-label="assignedSelect" className={styles.assignedToCol}>
+              <Dropdown defaultValue={assignedToUser?.value} title="Assigned dropdown">
+                {formattedAvailableOfficeUsers}
+              </Dropdown>
+            </div>
+          );
         },
-      )
-    : createHeader('Origin duty location', 'originDutyLocation.name', {
-        id: 'originDutyLocation',
-        isFilterable: true,
-        exportValue: (row) => {
-          return row.originDutyLocation?.name;
+        {
+          id: 'assignedTo',
         },
-      }),
-  createHeader('Counseling office', 'counselingOffice', {
-    id: 'counselingOffice',
-    isFilterable: true,
-  }),
-];
+      ),
+    );
+
+  return cols;
+};
 export const closeoutColumns = (moveLockFlag, ppmCloseoutGBLOC, ppmCloseoutOriginLocationList, supervisor) => [
   createHeader(
     ' ',
@@ -340,7 +364,7 @@ export const closeoutColumns = (moveLockFlag, ppmCloseoutGBLOC, ppmCloseoutOrigi
   }),
 ];
 
-const ServicesCounselingQueue = ({ userPrivileges }) => {
+const ServicesCounselingQueue = ({ userPrivileges, currentUserId }) => {
   const { queueType } = useParams();
   const { data, isLoading, isError } = useUserQueries();
 
@@ -348,6 +372,7 @@ const ServicesCounselingQueue = ({ userPrivileges }) => {
 
   const [isCounselorMoveCreateFFEnabled, setisCounselorMoveCreateFFEnabled] = useState(false);
   const [moveLockFlag, setMoveLockFlag] = useState(false);
+  const [isQueueManagementEnabled, setIsQueueManagementEnabled] = useState(false);
   const [setErrorState] = useState({ hasError: false, error: undefined, info: undefined });
   const [originLocationList, setOriginLocationList] = useState([]);
   const [ppmCloseoutOriginLocationList, setPpmCloseoutOriginLocationList] = useState([]);
@@ -378,6 +403,8 @@ const ServicesCounselingQueue = ({ userPrivileges }) => {
         setisCounselorMoveCreateFFEnabled(isEnabled);
         const lockedMoveFlag = await isBooleanFlagEnabled('move_lock');
         setMoveLockFlag(lockedMoveFlag);
+        const assignedColFlag = await isBooleanFlagEnabled('queue_management');
+        setIsQueueManagementEnabled(assignedColFlag);
       } catch (error) {
         const { message } = error;
         milmoveLogger.error({ message, info: null });
@@ -400,8 +427,11 @@ const ServicesCounselingQueue = ({ userPrivileges }) => {
     // if the user clicked the profile icon to edit, we want to route them elsewhere
     // since we don't have innerText, we are using the data-label property
     const editProfileDiv = e.target.closest('div[data-label="editProfile"]');
+    const assignedSelect = e.target.closest('div[data-label="assignedSelect"]');
     if (editProfileDiv) {
       navigate(generatePath(servicesCounselingRoutes.BASE_CUSTOMER_INFO_EDIT_PATH, { moveCode: values.locator }));
+    } else if (assignedSelect) {
+      // do nothing
     } else {
       navigate(generatePath(servicesCounselingRoutes.BASE_MOVE_VIEW_PATH, { moveCode: values.locator }));
     }
@@ -577,7 +607,7 @@ const ServicesCounselingQueue = ({ userPrivileges }) => {
           defaultSortedColumns={[{ id: 'submittedAt', desc: false }]}
           disableMultiSort
           disableSortBy={false}
-          columns={counselingColumns(moveLockFlag, originLocationList, supervisor)}
+          columns={counselingColumns(moveLockFlag, originLocationList, supervisor, isQueueManagementEnabled)}
           title="Moves"
           handleClick={handleClick}
           useQueries={useServicesCounselingQueueQueries}
@@ -587,6 +617,8 @@ const ServicesCounselingQueue = ({ userPrivileges }) => {
           csvExportQueueFetcherKey="queueMoves"
           sessionStorageKey={queueType}
           key={queueType}
+          isSupervisor={!!supervisor}
+          currentUserId={currentUserId}
         />
       </div>
     );

--- a/src/pages/Office/ServicesCounselingQueue/ServicesCounselingQueue.module.scss
+++ b/src/pages/Office/ServicesCounselingQueue/ServicesCounselingQueue.module.scss
@@ -35,3 +35,7 @@
   width: 7vw;
   background-color: $link;
 }
+
+.assignedToCol {
+  width: 10vw;
+}

--- a/src/pages/Office/ServicesCounselingQueue/ServicesCounselingQueue.test.jsx
+++ b/src/pages/Office/ServicesCounselingQueue/ServicesCounselingQueue.test.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { mount } from 'enzyme';
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import { OFFICE_TABLE_QUEUE_SESSION_STORAGE_ID } from '../../../components/Table/utils';
@@ -13,11 +13,17 @@ import { MOVE_STATUSES } from 'shared/constants';
 import SERVICE_MEMBER_AGENCIES from 'content/serviceMemberAgencies';
 import { servicesCounselingRoutes } from 'constants/routes';
 import MoveSearchForm from 'components/MoveSearchForm/MoveSearchForm';
+import { isBooleanFlagEnabled } from 'utils/featureFlags';
 
 jest.mock('hooks/queries', () => ({
   useUserQueries: jest.fn(),
   useServicesCounselingQueueQueries: jest.fn(),
   useServicesCounselingQueuePPMQueries: jest.fn(),
+}));
+
+jest.mock('utils/featureFlags', () => ({
+  ...jest.requireActual('utils/featureFlags'),
+  isBooleanFlagEnabled: jest.fn().mockImplementation(() => Promise.resolve(false)),
 }));
 
 const localStorageMock = (() => {
@@ -396,7 +402,8 @@ describe('ServicesCounselingQueue', () => {
       ['counselor', servicesCounselingRoutes.QUEUE_CLOSEOUT_PATH, 'closeout', serviceCounselorUser],
       ['closeout', servicesCounselingRoutes.QUEUE_COUNSELING_PATH, 'counseling', serviceCounselorUserForCloseout],
       ['closeout', servicesCounselingRoutes.QUEUE_CLOSEOUT_PATH, 'closeout', serviceCounselorUserForCloseout],
-    ])('a %s user accessing path "%s"', (userDescription, queueType, showsCounselingTab, user) => {
+    ])('a %s user accessing path "%s"', async (userDescription, queueType, showsCounselingTab, user) => {
+      isBooleanFlagEnabled.mockImplementation(() => Promise.resolve(true));
       useUserQueries.mockReturnValue(user);
       useServicesCounselingQueueQueries.mockReturnValue(serviceCounselingCompletedMoves);
       useServicesCounselingQueuePPMQueries.mockReturnValue(emptyServiceCounselingMoves);
@@ -406,36 +413,39 @@ describe('ServicesCounselingQueue', () => {
         </MockProviders>,
       );
 
-      if (showsCounselingTab === 'counseling') {
-        // Make sure "Counseling" is the active tab.
-        const counselingActive = screen.getByText('Counseling Queue', { selector: '.usa-current .tab-title' });
-        expect(counselingActive).toBeInTheDocument();
+      await waitFor(() => {
+        if (showsCounselingTab === 'counseling') {
+          // Make sure "Counseling" is the active tab.
+          const counselingActive = screen.getByText('Counseling Queue', { selector: '.usa-current .tab-title' });
+          expect(counselingActive).toBeInTheDocument();
 
-        // Check for the "Counseling" columns.
-        expect(screen.getByText(/Status/)).toBeInTheDocument();
-        expect(screen.getByText(/Requested move date/)).toBeInTheDocument();
-        expect(screen.getByText(/Date submitted/)).toBeInTheDocument();
-        expect(screen.getByText(/Origin GBLOC/)).toBeInTheDocument();
-      } else if (showsCounselingTab === 'closeout') {
-        // Make sure "PPM Closeout" is the active tab.
-        const ppmCloseoutActive = screen.getByText('PPM Closeout Queue', { selector: '.usa-current .tab-title' });
-        expect(ppmCloseoutActive).toBeInTheDocument();
+          // Check for the "Counseling" columns.
+          expect(screen.getByText(/Status/)).toBeInTheDocument();
+          expect(screen.getAllByText(/Requested move date/)[0]).toBeInTheDocument();
+          expect(screen.getAllByText(/Date submitted/)[0]).toBeInTheDocument();
+          expect(screen.getByText(/Origin GBLOC/)).toBeInTheDocument();
+          expect(screen.getByText(/Assigned/)).toBeInTheDocument();
+        } else if (showsCounselingTab === 'closeout') {
+          // Make sure "PPM Closeout" is the active tab.
+          const ppmCloseoutActive = screen.getByText('PPM Closeout Queue', { selector: '.usa-current .tab-title' });
+          expect(ppmCloseoutActive).toBeInTheDocument();
 
-        // Check for the "PPM Closeout" columns.
-        expect(screen.getByText(/Closeout initiated/)).toBeInTheDocument();
-        expect(screen.getByText(/PPM closeout location/)).toBeInTheDocument();
-        expect(screen.getByText(/Full or partial PPM/)).toBeInTheDocument();
-        expect(screen.getByText(/Destination duty location/)).toBeInTheDocument();
-        expect(screen.getByText(/Status/)).toBeInTheDocument();
-      } else {
-        // Check for the "Search" tab
-        const searchActive = screen.getByText('Search', { selector: '.usa-current .tab-title' });
-        expect(searchActive).toBeInTheDocument();
-        expect(MoveSearchForm).toBeInTheDocument();
-        userEvent.type(screen.getByLabelText('Search'), 'Joe');
-        const addCustomer = screen.getByText('Add Customer', { selector: '.usa-current .tab-title' });
-        expect(addCustomer).toBeInTheDocument();
-      }
+          // Check for the "PPM Closeout" columns.
+          expect(screen.getByText(/Closeout initiated/)).toBeInTheDocument();
+          expect(screen.getByText(/PPM closeout location/)).toBeInTheDocument();
+          expect(screen.getByText(/Full or partial PPM/)).toBeInTheDocument();
+          expect(screen.getByText(/Destination duty location/)).toBeInTheDocument();
+          expect(screen.getByText(/Status/)).toBeInTheDocument();
+        } else {
+          // Check for the "Search" tab
+          const searchActive = screen.getByText('Search', { selector: '.usa-current .tab-title' });
+          expect(searchActive).toBeInTheDocument();
+          expect(MoveSearchForm).toBeInTheDocument();
+          userEvent.type(screen.getByLabelText('Search'), 'Joe');
+          const addCustomer = screen.getByText('Add Customer', { selector: '.usa-current .tab-title' });
+          expect(addCustomer).toBeInTheDocument();
+        }
+      });
     });
   });
 });

--- a/src/pages/Office/index.jsx
+++ b/src/pages/Office/index.jsx
@@ -307,7 +307,7 @@ export class OfficeApp extends Component {
                           end
                           element={
                             <PrivateRoute requiredRoles={[roleTypes.SERVICES_COUNSELOR]}>
-                              <ServicesCounselingQueue />
+                              <ServicesCounselingQueue userPrivileges={userPrivileges} currentUserId={officeUserId} />
                             </PrivateRoute>
                           }
                         />

--- a/src/utils/queues.jsx
+++ b/src/utils/queues.jsx
@@ -1,0 +1,64 @@
+import React from 'react';
+
+import { DEFAULT_EMPTY_VALUE } from 'shared/constants';
+
+const addAssignedOfficeUser = (users, assignedTo) => {
+  const newAvailableOfficeUsers = users.slice();
+  const { lastName, firstName, id } = assignedTo;
+  newAvailableOfficeUsers.push({
+    label: `${lastName}, ${firstName}`,
+    value: id,
+  });
+  return newAvailableOfficeUsers;
+};
+
+export const formatOfficeUser = (user) => {
+  const fullName = `${user?.lastName}, ${user?.firstName}`;
+  return { label: fullName, value: user.officeUserId };
+};
+
+export const formatAvailableOfficeUsers = (users, isSupervisor, currentUserId) => {
+  if (!users.length || isSupervisor === undefined || currentUserId === undefined) return [];
+
+  // instantiate array with empty value for unassign purposes down the road
+  const newAvailableOfficeUsers = [{ label: DEFAULT_EMPTY_VALUE, value: null }];
+
+  // if they are a supervisor, push the whole list
+  if (isSupervisor) {
+    users.forEach((user) => {
+      const newUser = formatOfficeUser(user);
+      newAvailableOfficeUsers.push(newUser);
+    });
+  }
+
+  // if they're not a supervisor, just populate with currentUserId
+  if (!isSupervisor) {
+    const currentUser = users?.filter((user) => user.officeUserId === currentUserId);
+    newAvailableOfficeUsers.push(formatOfficeUser(currentUser[0]));
+  }
+
+  return newAvailableOfficeUsers;
+};
+
+export const formatAvailableOfficeUsersForRow = (row) => {
+  // dupe the row to avoid issues with passing office user array by reference
+  const updatedRow = { ...row };
+
+  // if the move is assigned to a user not present in availableOfficeUsers
+  // lets push them onto the end
+  if (row.assignedTo !== undefined && !row.availableOfficeUsers?.some((user) => user.value === row.assignedTo.id)) {
+    updatedRow.availableOfficeUsers = addAssignedOfficeUser(row.availableOfficeUsers, row.assignedTo);
+  }
+  const { assignedTo, availableOfficeUsers } = updatedRow;
+
+  // if there is an assigned user, assign to a variable so we can set a default value below
+  const assignedToUser = availableOfficeUsers.find((user) => user.value === assignedTo?.id);
+
+  const formattedAvailableOfficeUsers = availableOfficeUsers.map(({ value, label }) => (
+    <option value={value} key={`filterOption_${value}`}>
+      {label}
+    </option>
+  ));
+
+  return { formattedAvailableOfficeUsers, assignedToUser };
+};


### PR DESCRIPTION
## [Agility ticket](https://www13.v1host.com/USTRANSCOM38/assetdetail.v1?number=B-19463)
## [INT PR before rebase](https://github.com/transcom/mymove/pull/13581)
## [Main PR](https://github.com/transcom/mymove/pull/13580)

> [!IMPORTANT]
> changes differences in this PR vs original PR to INT are in ServicesCounselingQueue.jsx, look around lines 188-215. as always, your extra eyes are appreciated :) 

## Summary

This is initial queue management front end work for the Services Counselors Queue, adding an assigned column, along with a dropdown. The dropdown currently does not handle assign/un-assign functionality (that'll be dealt with in future story [20529](https://www13.v1host.com/USTRANSCOM38/assetdetail.v1?number=B-20529)

Current functionality is as follows:
-Supervisor's dropdown is populated first with a "-" to be used later for unassigning, then with all Services Counselors working at the logged in Supervisor's transportation office, and pushed onto the end, whoever it is assigned to (if it is assigned to someone outside of the office users available in the dropdown)
-Non supervisor's dropdown is populated first with a "-", then with the office user themself (for self assigning purposes), then pushed onto the end, whoever it is assigned to (if it is assigned to someone besides themself)