### PR TITLE
B-19044 I-13359 fix

### DIFF
--- a/src/pages/Office/MoveTaskOrder/MoveTaskOrder.jsx
+++ b/src/pages/Office/MoveTaskOrder/MoveTaskOrder.jsx
@@ -67,6 +67,7 @@ import { tooRoutes } from 'constants/routes';
 import { formatDateForSwagger } from 'shared/dates';
 import EditSitEntryDateModal from 'components/Office/EditSitEntryDateModal/EditSitEntryDateModal';
 import { formatWeight } from 'utils/formatters';
+import { roleTypes } from 'constants/userRoles';
 
 const nonShipmentSectionLabels = {
   'move-weights': 'Move weights',
@@ -139,6 +140,7 @@ export const MoveTaskOrder = (props) => {
     setExcessWeightRiskCount,
     setMessage,
     setUnapprovedSITExtensionCount,
+    userRole,
     isMoveLocked,
   } = props;
 
@@ -803,7 +805,7 @@ export const MoveTaskOrder = (props) => {
 
   /* ------------------ Update Shipment approvals ------------------------- */
   useEffect(() => {
-    if (mtoShipments) {
+    if (mtoShipments && userRole !== roleTypes.SERVICES_COUNSELOR) {
       const shipmentCount = mtoShipments?.length
         ? mtoShipments.filter((shipment) => shipment.status === shipmentStatuses.SUBMITTED).length
         : 0;
@@ -814,7 +816,7 @@ export const MoveTaskOrder = (props) => {
         : 0;
       setExternalVendorShipmentCount(externalVendorShipments);
     }
-  }, [mtoShipments, setUnapprovedShipmentCount]);
+  }, [mtoShipments, setUnapprovedShipmentCount, userRole]);
 
   /* ------------------ Update Weight related alerts and estimates ------------------------- */
   useEffect(() => {

--- a/src/pages/Office/ServicesCounselingMoveInfo/ServicesCounselingMoveInfo.jsx
+++ b/src/pages/Office/ServicesCounselingMoveInfo/ServicesCounselingMoveInfo.jsx
@@ -246,6 +246,7 @@ const ServicesCounselingMoveInfo = () => {
                 setUnapprovedServiceItemCount={setUnapprovedServiceItemCount}
                 setExcessWeightRiskCount={setExcessWeightRiskCount}
                 setUnapprovedSITExtensionCount={setUnApprovedSITExtensionCount}
+                userRole={roleTypes.SERVICES_COUNSELOR}
                 isMoveLocked={isMoveLocked}
               />
             }


### PR DESCRIPTION
## [Agility ticket](https://www13.v1host.com/USTRANSCOM38/assetdetail.v1?number=B-19044)
## [Issue ticket](https://www13.v1host.com/USTRANSCOM38/Issue.mvc/Summary?oidToken=Issue%3A1018699)

## Summary

We removed the state function `setUnapprovedShipmentCount` for services counselor from the parent component. UNFORTUNATELY, the services counselor shares the `MoveTaskOrder` component, which is looking for that state change function. 

Added in a check to not look for that function if the user is a services counselor, passing in the role type from the parent component `ServicesCounselingMoveInfo.jsx`

### How to test

1. Access MM as a SC
2. Navigate all parts of the app for that user
3. Ensure there's no errors
