### PR TITLE
INT-B-21514

### DIFF
--- a/pkg/services/pptas_report/pptas_report_list_fetcher.go
+++ b/pkg/services/pptas_report/pptas_report_list_fetcher.go
@@ -232,12 +232,20 @@ func populateShipmentFields(
 
 func populatePaymentRequestFields(pptasShipment *pptasmessages.PPTASShipment, appCtx appcontext.AppContext, shipment models.MTOShipment) error {
 	var paymentRequests []models.PaymentRequest
+	approvedStatuses := []string{
+		models.PaymentRequestStatusReviewed.String(),
+		models.PaymentRequestStatusSentToGex.String(),
+		models.PaymentRequestStatusPaid.String(),
+		models.PaymentRequestStatusEDIError.String(),
+		models.PaymentRequestStatusTppsReceived.String(),
+	}
+
 	prQErr := appCtx.DB().EagerPreload(
 		"PaymentServiceItems.MTOServiceItem.ReService").
 		InnerJoin("payment_service_items", "payment_requests.id = payment_service_items.payment_request_id").
 		InnerJoin("mto_service_items", "mto_service_items.id = payment_service_items.mto_service_item_id").
 		Where("mto_service_items.mto_shipment_id = ?", shipment.ID).
-		Where("payment_requests.status = ?", models.PaymentRequestStatusReviewed).
+		Where("payment_requests.status in (?)", approvedStatuses).
 		GroupBy("payment_requests.id").
 		All(&paymentRequests)
 	if prQErr != nil {
@@ -280,6 +288,7 @@ func populatePaymentRequestFields(pptasShipment *pptasmessages.PPTASShipment, ap
 
 			switch serviceItem.MTOServiceItem.ReService.Name {
 			case "Domestic linehaul":
+				linehaulTotal += totalPrice
 			case "Domestic shorthaul":
 				linehaulTotal += totalPrice
 			case "Move management":


### PR DESCRIPTION
## [Agility ticket](https://www13.v1host.com/USTRANSCOM38/story.mvc/Summary?oidToken=Story%3A1018960)

## Summary

Updated the payment request statuses that the report fetcher grabs and fixed issue with linehaul total wasn't populating

### How to test

1. Import PPTAS api into Postman
2. Create a Navy move with an HHG and complete the entire move/payment process
3. http://primelocal:3000/pptas/v1/moves?since=2021-07-23T18:30:47.116Z
4. In DBeaver open the client_certs table
    look for the entry with `devlocal` in the subject column and update that row to `allow_pptas`
    the subject column will look something like this `/C=US/ST=DC/L=Washington/O=Truss/OU=AppClientTLS/CN=devlocal`
5. Check the report has payment request data with statuses other than reviewed.

> [!IMPORTANT]  
> Make sure you're using a valid TAC. You must also update the dates in the TAC and LOA tables to include this year.
> All dates should be within `lines_of_accounting.loa_bgn_dt` and `lines_of_accounting.loa_end_dt`
> All dates should be within `transportation_accounting_codes.trnsprtn_acnt_bgn_dt` and `transportation_accounting_codes.trnsprtn_acnt_end_dt`

You can use the queries below to update the dates for `E12A` tac line. Make sure you update the orders in the move to use the right tac

`UPDATE transportation_accounting_codes SET trnsprtn_acnt_end_dt = date('2026-01-01') WHERE tac = 'E12A'`
`update lines_of_accounting set loa_end_dt = date('2026-01-01') where id = '06254fc3-b763-484c-b555-42855d1ad5cd'`

