### PR TITLE
Int b 21409 retiree separatee email updates move submitted

### DIFF
--- a/pkg/assets/notifications/templates/move_submitted_template.html
+++ b/pkg/assets/notifications/templates/move_submitted_template.html
@@ -2,7 +2,7 @@
 
 <p>
   This is a confirmation that you have submitted the details for your move {{if .OriginDutyLocation}}from
-  {{.OriginDutyLocation}} {{ end }}to {{.DestinationDutyLocation}}.
+  {{.OriginDutyLocation}} {{ end }}to {{.DestinationLocation}}.
 </p>
 
 <p>

--- a/pkg/assets/notifications/templates/move_submitted_template.txt
+++ b/pkg/assets/notifications/templates/move_submitted_template.txt
@@ -1,6 +1,6 @@
 *** DO NOT REPLY directly to this email ***
 
-This is a confirmation that you have submitted the details for your move {{if .OriginDutyLocation}}from {{.OriginDutyLocation}} {{ end }}to {{.DestinationDutyLocation}}.
+This is a confirmation that you have submitted the details for your move {{if .OriginDutyLocation}}from {{.OriginDutyLocation}} {{ end }}to {{.DestinationLocation}}.
 
 We have assigned you a move code: {{.Locator}}. You can use this code when talking to any representative about your move.
 

--- a/pkg/notifications/move_submitted.go
+++ b/pkg/notifications/move_submitted.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/transcom/mymove/pkg/appcontext"
 	"github.com/transcom/mymove/pkg/assets"
+	"github.com/transcom/mymove/pkg/gen/internalmessages"
 	"github.com/transcom/mymove/pkg/models"
 )
 
@@ -52,6 +53,17 @@ func (m MoveSubmitted) emails(appCtx appcontext.AppContext) ([]emailContent, err
 		return emails, err
 	}
 
+	destinationAddress := orders.NewDutyLocation.Name
+	isSeparateeRetiree := orders.OrdersType == internalmessages.OrdersTypeRETIREMENT || orders.OrdersType == internalmessages.OrdersTypeSEPARATION
+	if isSeparateeRetiree && len(move.MTOShipments) > 0 {
+		destAddr := *move.MTOShipments[0].DestinationAddress
+		optionalStreetAddress2 := ""
+		if destAddr.StreetAddress2 != nil {
+			optionalStreetAddress2 = *destAddr.StreetAddress2
+		}
+		destinationAddress = fmt.Sprintf("%s %s, %s, %s %s", destAddr.StreetAddress1, optionalStreetAddress2, destAddr.City, destAddr.State, destAddr.PostalCode)
+	}
+
 	originDutyLocation := orders.OriginDutyLocation
 	providesGovernmentCounseling := false
 	if originDutyLocation != nil {
@@ -89,7 +101,7 @@ func (m MoveSubmitted) emails(appCtx appcontext.AppContext) ([]emailContent, err
 
 	htmlBody, textBody, err := m.renderTemplates(appCtx, moveSubmittedEmailData{
 		OriginDutyLocation:                originDutyLocationName,
-		DestinationDutyLocation:           orders.NewDutyLocation.Name,
+		DestinationLocation:               destinationAddress,
 		OriginDutyLocationPhoneLine:       originDutyLocationPhoneLine,
 		Locator:                           move.Locator,
 		WeightAllowance:                   humanize.Comma(int64(weight)),
@@ -129,7 +141,7 @@ func (m MoveSubmitted) renderTemplates(appCtx appcontext.AppContext, data moveSu
 
 type moveSubmittedEmailData struct {
 	OriginDutyLocation                *string
-	DestinationDutyLocation           string
+	DestinationLocation               string
 	OriginDutyLocationPhoneLine       *string
 	Locator                           string
 	WeightAllowance                   string

--- a/pkg/notifications/move_submitted.go
+++ b/pkg/notifications/move_submitted.go
@@ -55,13 +55,17 @@ func (m MoveSubmitted) emails(appCtx appcontext.AppContext) ([]emailContent, err
 
 	destinationAddress := orders.NewDutyLocation.Name
 	isSeparateeRetiree := orders.OrdersType == internalmessages.OrdersTypeRETIREMENT || orders.OrdersType == internalmessages.OrdersTypeSEPARATION
-	if isSeparateeRetiree && len(move.MTOShipments) > 0 {
+	if isSeparateeRetiree && len(move.MTOShipments) > 0 && move.MTOShipments[0].DestinationAddress != nil {
 		destAddr := *move.MTOShipments[0].DestinationAddress
 		optionalStreetAddress2 := ""
 		if destAddr.StreetAddress2 != nil {
-			optionalStreetAddress2 = *destAddr.StreetAddress2
+			optionalStreetAddress2 = " " + *destAddr.StreetAddress2
 		}
-		destinationAddress = fmt.Sprintf("%s %s, %s, %s %s", destAddr.StreetAddress1, optionalStreetAddress2, destAddr.City, destAddr.State, destAddr.PostalCode)
+		optionalStreetAddress3 := ""
+		if destAddr.StreetAddress3 != nil {
+			optionalStreetAddress3 = " " + *destAddr.StreetAddress3
+		}
+		destinationAddress = fmt.Sprintf("%s%s%s, %s, %s %s", destAddr.StreetAddress1, optionalStreetAddress2, optionalStreetAddress3, destAddr.City, destAddr.State, destAddr.PostalCode)
 	}
 
 	originDutyLocation := orders.OriginDutyLocation

--- a/pkg/notifications/move_submitted_test.go
+++ b/pkg/notifications/move_submitted_test.go
@@ -79,6 +79,7 @@ func (suite *NotificationSuite) TestMoveSubmittedDestinationIsFirstShipmentForSe
 	suite.NotEmpty(email.textBody)
 	suite.Contains(email.textBody, move.MTOShipments[0].DestinationAddress.StreetAddress1)
 	suite.Contains(email.textBody, *move.MTOShipments[0].DestinationAddress.StreetAddress2)
+	suite.Contains(email.textBody, *move.MTOShipments[0].DestinationAddress.StreetAddress3)
 	suite.Contains(email.textBody, move.MTOShipments[0].DestinationAddress.City)
 	suite.Contains(email.textBody, move.MTOShipments[0].DestinationAddress.State)
 	suite.Contains(email.textBody, move.MTOShipments[0].DestinationAddress.PostalCode)
@@ -111,6 +112,7 @@ func (suite *NotificationSuite) TestMoveSubmittedDestinationIsFirstShipmentForRe
 	suite.NotEmpty(email.textBody)
 	suite.Contains(email.textBody, move.MTOShipments[0].DestinationAddress.StreetAddress1)
 	suite.Contains(email.textBody, *move.MTOShipments[0].DestinationAddress.StreetAddress2)
+	suite.Contains(email.textBody, *move.MTOShipments[0].DestinationAddress.StreetAddress3)
 	suite.Contains(email.textBody, move.MTOShipments[0].DestinationAddress.City)
 	suite.Contains(email.textBody, move.MTOShipments[0].DestinationAddress.State)
 	suite.Contains(email.textBody, move.MTOShipments[0].DestinationAddress.PostalCode)
@@ -142,6 +144,9 @@ func (suite *NotificationSuite) TestMoveSubmittedDestinationIsDutyStationForPcsT
 	suite.NotEmpty(email.htmlBody)
 	suite.NotEmpty(email.textBody)
 	suite.Contains(email.textBody, move.Orders.NewDutyLocation.Name)
+	suite.NotContains(email.textBody, move.MTOShipments[0].DestinationAddress.StreetAddress1)
+	suite.NotContains(email.textBody, *move.MTOShipments[0].DestinationAddress.StreetAddress2)
+	suite.NotContains(email.textBody, *move.MTOShipments[0].DestinationAddress.StreetAddress3)
 }
 
 func (suite *NotificationSuite) TestMoveSubmittedHTMLTemplateRenderWithGovCounseling() {

--- a/pkg/notifications/move_submitted_test.go
+++ b/pkg/notifications/move_submitted_test.go
@@ -3,6 +3,8 @@ package notifications
 import (
 	"github.com/transcom/mymove/pkg/auth"
 	"github.com/transcom/mymove/pkg/factory"
+	"github.com/transcom/mymove/pkg/gen/internalmessages"
+	"github.com/transcom/mymove/pkg/models"
 )
 
 func (suite *NotificationSuite) TestMoveSubmitted() {
@@ -50,6 +52,98 @@ func (suite *NotificationSuite) TestMoveSubmittedoriginDSTransportInfoIsNil() {
 	suite.Contains(email.textBody, move.Orders.OriginDutyLocation.Name)
 }
 
+func (suite *NotificationSuite) TestMoveSubmittedDestinationIsFirstShipmentForSeparatee() {
+	move := factory.BuildMoveWithShipment(suite.DB(), []factory.Customization{
+		{
+			Model: models.Order{
+				OrdersType: internalmessages.OrdersTypeSEPARATION,
+			},
+		},
+	}, nil)
+	notification := NewMoveSubmitted(move.ID)
+
+	emails, err := notification.emails(suite.AppContextWithSessionForTest(&auth.Session{
+		ServiceMemberID: move.Orders.ServiceMember.ID,
+		ApplicationName: auth.MilApp,
+	}))
+	subject := "Thank you for submitting your move details"
+
+	suite.NoError(err)
+	suite.Equal(len(emails), 1)
+
+	email := emails[0]
+	sm := move.Orders.ServiceMember
+	suite.Equal(email.recipientEmail, *sm.PersonalEmail)
+	suite.Equal(email.subject, subject)
+	suite.NotEmpty(email.htmlBody)
+	suite.NotEmpty(email.textBody)
+	suite.Contains(email.textBody, move.MTOShipments[0].DestinationAddress.StreetAddress1)
+	suite.Contains(email.textBody, *move.MTOShipments[0].DestinationAddress.StreetAddress2)
+	suite.Contains(email.textBody, move.MTOShipments[0].DestinationAddress.City)
+	suite.Contains(email.textBody, move.MTOShipments[0].DestinationAddress.State)
+	suite.Contains(email.textBody, move.MTOShipments[0].DestinationAddress.PostalCode)
+}
+
+func (suite *NotificationSuite) TestMoveSubmittedDestinationIsFirstShipmentForRetiree() {
+	move := factory.BuildMoveWithShipment(suite.DB(), []factory.Customization{
+		{
+			Model: models.Order{
+				OrdersType: internalmessages.OrdersTypeRETIREMENT,
+			},
+		},
+	}, nil)
+	notification := NewMoveSubmitted(move.ID)
+
+	emails, err := notification.emails(suite.AppContextWithSessionForTest(&auth.Session{
+		ServiceMemberID: move.Orders.ServiceMember.ID,
+		ApplicationName: auth.MilApp,
+	}))
+	subject := "Thank you for submitting your move details"
+
+	suite.NoError(err)
+	suite.Equal(len(emails), 1)
+
+	email := emails[0]
+	sm := move.Orders.ServiceMember
+	suite.Equal(email.recipientEmail, *sm.PersonalEmail)
+	suite.Equal(email.subject, subject)
+	suite.NotEmpty(email.htmlBody)
+	suite.NotEmpty(email.textBody)
+	suite.Contains(email.textBody, move.MTOShipments[0].DestinationAddress.StreetAddress1)
+	suite.Contains(email.textBody, *move.MTOShipments[0].DestinationAddress.StreetAddress2)
+	suite.Contains(email.textBody, move.MTOShipments[0].DestinationAddress.City)
+	suite.Contains(email.textBody, move.MTOShipments[0].DestinationAddress.State)
+	suite.Contains(email.textBody, move.MTOShipments[0].DestinationAddress.PostalCode)
+}
+
+func (suite *NotificationSuite) TestMoveSubmittedDestinationIsDutyStationForPcsType() {
+	move := factory.BuildMoveWithShipment(suite.DB(), []factory.Customization{
+		{
+			Model: models.Order{
+				OrdersType: internalmessages.OrdersTypePERMANENTCHANGEOFSTATION,
+			},
+		},
+	}, nil)
+	notification := NewMoveSubmitted(move.ID)
+
+	emails, err := notification.emails(suite.AppContextWithSessionForTest(&auth.Session{
+		ServiceMemberID: move.Orders.ServiceMember.ID,
+		ApplicationName: auth.MilApp,
+	}))
+	subject := "Thank you for submitting your move details"
+
+	suite.NoError(err)
+	suite.Equal(len(emails), 1)
+
+	email := emails[0]
+	sm := move.Orders.ServiceMember
+	suite.Equal(email.recipientEmail, *sm.PersonalEmail)
+	suite.Equal(email.subject, subject)
+	suite.NotEmpty(email.htmlBody)
+	suite.NotEmpty(email.textBody)
+	suite.Contains(email.textBody, move.Orders.NewDutyLocation.Name)
+}
+
 func (suite *NotificationSuite) TestMoveSubmittedHTMLTemplateRenderWithGovCounseling() {
 	approver := factory.BuildUser(nil, nil, nil)
 	move := factory.BuildMove(suite.DB(), nil, nil)
@@ -60,7 +154,7 @@ func (suite *NotificationSuite) TestMoveSubmittedHTMLTemplateRenderWithGovCounse
 
 	s := moveSubmittedEmailData{
 		OriginDutyLocation:                &originDutyLocation,
-		DestinationDutyLocation:           "destDutyLocation",
+		DestinationLocation:               "destDutyLocation",
 		OriginDutyLocationPhoneLine:       &originDutyLocationPhoneLine,
 		Locator:                           "abc123",
 		WeightAllowance:                   "7,999",
@@ -172,7 +266,7 @@ func (suite *NotificationSuite) TestMoveSubmittedHTMLTemplateRenderWithoutGovCou
 
 	s := moveSubmittedEmailData{
 		OriginDutyLocation:                &originDutyLocation,
-		DestinationDutyLocation:           "destDutyLocation",
+		DestinationLocation:               "destDutyLocation",
 		OriginDutyLocationPhoneLine:       &originDutyLocationPhoneLine,
 		Locator:                           "abc123",
 		WeightAllowance:                   "7,999",
@@ -271,7 +365,7 @@ func (suite *NotificationSuite) TestMoveSubmittedHTMLTemplateRenderNoDutyLocatio
 
 	s := moveSubmittedEmailData{
 		OriginDutyLocation:                nil,
-		DestinationDutyLocation:           "destDutyLocation",
+		DestinationLocation:               "destDutyLocation",
 		OriginDutyLocationPhoneLine:       nil,
 		Locator:                           "abc123",
 		WeightAllowance:                   "7,999",
@@ -374,7 +468,7 @@ func (suite *NotificationSuite) TestMoveSubmittedTextTemplateRender() {
 
 	s := moveSubmittedEmailData{
 		OriginDutyLocation:                &originDutyLocation,
-		DestinationDutyLocation:           "destDutyLocation",
+		DestinationLocation:               "destDutyLocation",
 		OriginDutyLocationPhoneLine:       &originDutyLocationPhoneLine,
 		Locator:                           "abc123",
 		WeightAllowance:                   "7,999",


### PR DESCRIPTION
## [B-21409](Shipment Email modification for Retiree/Separatee (1 of 4))

https://www13.v1host.com/USTRANSCOM38/assetdetail.v1?number=B-21409

## Summary

Updates the destination duty location of the "move submitted" email for order types with Separation/Retirement.
These order types will use the address of the first shipment instead.

## Verification Steps for the Author

These are to be checked by the author.

- [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
- [ ] Have the Agility acceptance criteria been met for this change?

## Verification Steps for Reviewers

These are to be checked by a reviewer.

- [ ] Has the branch been pulled in and checked out?
- [ ] Have the BL acceptance criteria been met for this change?
- [ ] Was the CircleCI build successful?
- [ ] Has the code been reviewed from a standards and best practices point of view?

### Setup to Run the Code

- [Instructions for starting storybook](https://transcom.github.io/mymove-docs/docs/frontend/setup/storybook)
- [Instructions for starting the MilMove application](https://transcom.github.io/mymove-docs/docs/getting-started/application-setup/)
- [Instructions for running tests](https://transcom.github.io/mymove-docs/docs/getting-started/development/testing)

### How to test

1. Access the app
2. Login as a Customer
3. Create a new order
4. Set order type as either "Separation" or "Retirement"
5. Fill out order information (arbitrary)
6. Add a new HHG or PPM shipment to the order (note the destination address for later testing)
7. Sign and Submit (complete) the order for approval of TOO
8. Check associated email sent to the Customer -- Separation/Retiree emails should list the address of the first shipment, NOT the "HOR, PLEAD or HOS" (new duty station)

NOTE - repeat the above for other order types (PERMANENT CHANGE OF STATION | LOCAL MOVE | WOUNDED WARRIOR), bluebark/safety do not receive notification.


If you want to test within the local dev environment, run the following to start the backend server with email support
`EMAIL_BACKEND=ses AWS_REGION=us-gov-west-1  aws-vault exec transcom-gov-dev -- make server_run`

### Frontend

- [ ] There are no aXe warnings for UI.
- [ ] This works in [Supported Browsers and their phone views](https://transcom.github.io/mymove-docs/docs/adrs/Browser-Support/#minimum-browser-requirements) (Chrome, Firefox, Edge).
- [ ] There are no new console errors in the browser devtools.
- [ ] There are no new console errors in the test output.
- [ ] If this PR adds a new component to Storybook, it ensures the component is fully responsive, OR if it is intentionally not, a wrapping div using the `officeApp` class or custom `min-width` styling is used to hide any states the would not be visible to the user.
- [ ] This change meets the standards for [Section 508 compliance](https://www.ssa.gov/accessibility/andi/help/install.html).

### Backend

- [ ] Code follows the guidelines for [Logging](https://transcom.github.io/mymove-docs/docs/getting-started/development/logging).
- [ ] The requirements listed in [Querying the Database Safely](https://transcom.github.io/mymove-docs/docs/backend/guides/golang-guide#querying-the-database-safely) have been satisfied.

### Database

#### Any new migrations/schema changes:

- [ ] Follows our guidelines for [Zero-Downtime Deploys](https://transcom.github.io/mymove-docs/docs/backend/setup/database-migrations#zero-downtime-migrations).
- [ ] Have been communicated to #g-database.
- [ ] Secure migrations have been tested following the instructions in our [docs](https://transcom.github.io/mymove-docs/docs/backend/setup/database-migrations#secure-migrations).

## Screenshots

order type selection
<img width="807" alt="image" src="https://github.com/user-attachments/assets/f24db35c-2695-46a2-a1f3-e2b131dfe60a">

HOR, PLEAD or HOS selection (new duty station)
<img width="965" alt="image" src="https://github.com/user-attachments/assets/dc938efc-6f39-4f3d-91fa-e4a81b8ae5f0">

setup shipments
<img width="851" alt="image" src="https://github.com/user-attachments/assets/e5bf0ef3-7d7c-4f7a-8183-0fedcf353f7e">

sign and submit
<img width="851" alt="image" src="https://github.com/user-attachments/assets/e4ce220c-ee58-4db5-ab45-598b8489e908">

email (local dev environment)
<img width="971" alt="image" src="https://github.com/user-attachments/assets/1f87bce8-7477-4887-a695-673042c76db9">

