### PR TITLE
Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,5 +6,4 @@
 # owners will be requested for a review.
 # Add language specific code owners if it becomes relevant
 
-* @transcom/codeowners
 /migrations/* @transcom/cacidatabaseteam


### PR DESCRIPTION
require code owner for db files

after this is merged- I will set code owner required for the integrationTesting branch- which will force a required approval from persons in the cacidatabaseTeam GitHub group