### PR TITLE
Int b 21380 secure sql query

### DIFF
--- a/pkg/handlers/config_test.go
+++ b/pkg/handlers/config_test.go
@@ -1,0 +1,44 @@
+package handlers
+
+import (
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/go-openapi/runtime/middleware"
+	"github.com/stretchr/testify/suite"
+
+	"github.com/transcom/mymove/pkg/appcontext"
+	"github.com/transcom/mymove/pkg/auth"
+	"github.com/transcom/mymove/pkg/testingsuite"
+)
+
+type ConfigSuite struct {
+	*testingsuite.PopTestSuite
+}
+
+func TestConfigSuite(t *testing.T) {
+	ts := &ConfigSuite{
+		PopTestSuite: testingsuite.NewPopTestSuite(testingsuite.CurrentPackage(), testingsuite.WithPerTestTransaction()),
+	}
+	suite.Run(t, ts)
+	ts.PopTestSuite.TearDown()
+}
+
+func (suite *ConfigSuite) TestConfigHandler() {
+	suite.Run("AuditableAppContextFromRequestWithErrors executes the function argument it is passed", func() {
+
+		appCtx := suite.AppContextForTest()
+		sessionManagers := auth.SetupSessionManagers(nil, false, time.Duration(180*time.Second), time.Duration(180*time.Second))
+		handler := NewHandlerConfig(appCtx.DB(), nil, "", nil, nil, nil, nil, nil, false, nil, nil, false, ApplicationTestServername(), sessionManagers, nil)
+		req, err := http.NewRequest("GET", "/", nil)
+		suite.NoError(err)
+		myMethodCalled := false
+		myFunction := func(appCtx appcontext.AppContext) (middleware.Responder, error) {
+			myMethodCalled = true
+			return nil, nil
+		}
+		handler.AuditableAppContextFromRequestWithErrors(req, myFunction)
+		suite.Equal(myMethodCalled, true)
+	})
+}


### PR DESCRIPTION
## [Agility ticket]
(https://www13.v1host.com/USTRANSCOM38/story.mvc/Summary?oidToken=Story%3A1014751)

## Summary
The purpose of this story is to ensure that this query is not vulnerable to SQL Injection. Ideally I would be able to use a parameterized query here, but that does not seem to be possible with this type of Set statement. The next best option was to validate that the input does not contain anything malicious by running it through a regex matcher. I added a regex matcher that will validate that the input contains only a valid uuid. If it does not an error is returned, otherwise it uses the audit user ID as before.

Is there anything you would like reviewers to give additional scrutiny?

[this article]
(https://www.uuidtools.com/what-is-uuid) I stole the regex from here, but also added the started and end characters

## Verification Steps for the Author

These are to be checked by the author.

- [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
- [ ] Have the Agility acceptance criteria been met for this change?

## Verification Steps for Reviewers

These are to be checked by a reviewer.

- [x] Has the branch been pulled in and checked out?
- [x] Have the BL acceptance criteria been met for this change?
- [x] Was the CircleCI build successful?
- [ ] Has the code been reviewed from a standards and best practices point of view?

### Setup to Run the Code

- [Instructions for starting storybook](https://transcom.github.io/mymove-docs/docs/frontend/setup/storybook)
- [Instructions for starting the MilMove application](https://transcom.github.io/mymove-docs/docs/getting-started/application-setup/)
- [Instructions for running tests](https://transcom.github.io/mymove-docs/docs/getting-started/development/testing)

### How to test
Since this code gets hit by a ton of different handlers, you only need to do some action that causes some handler to execute.

1. Access the MilMove Application.
2. Login as a Service Counselor.
3. Click on any move.

### Frontend

- [ ] There are no aXe warnings for UI.
- [ ] This works in [Supported Browsers and their phone views](https://transcom.github.io/mymove-docs/docs/adrs/Browser-Support/#minimum-browser-requirements) (Chrome, Firefox, Edge).
- [ ] There are no new console errors in the browser devtools.
- [ ] There are no new console errors in the test output.
- [ ] If this PR adds a new component to Storybook, it ensures the component is fully responsive, OR if it is intentionally not, a wrapping div using the `officeApp` class or custom `min-width` styling is used to hide any states the would not be visible to the user.
- [ ] This change meets the standards for [Section 508 compliance](https://www.ssa.gov/accessibility/andi/help/install.html).

### Backend

- [ ] Code follows the guidelines for [Logging](https://transcom.github.io/mymove-docs/docs/getting-started/development/logging).
- [ ] The requirements listed in [Querying the Database Safely](https://transcom.github.io/mymove-docs/docs/backend/guides/golang-guide#querying-the-database-safely) have been satisfied.

### Database

#### Any new migrations/schema changes:

- [ ] Follows our guidelines for [Zero-Downtime Deploys](https://transcom.github.io/mymove-docs/docs/backend/setup/database-migrations#zero-downtime-migrations).
- [ ] Have been communicated to #g-database.
- [ ] Secure migrations have been tested following the instructions in our [docs](https://transcom.github.io/mymove-docs/docs/backend/setup/database-migrations#secure-migrations).

## Screenshots
