### PR TITLE
INT I-13395 B-21431 and B-21429 fix ppm error

### DIFF
--- a/pkg/services/orchestrators/shipment/shipment_creator.go
+++ b/pkg/services/orchestrators/shipment/shipment_creator.go
@@ -92,6 +92,18 @@ func (s *shipmentCreator) CreateShipment(appCtx appcontext.AppContext, shipment 
 			if err != nil {
 				return err
 			}
+
+			// getting updated shipment since market code value was updated after PPM creation
+			var updatedShipment models.MTOShipment
+			err = txnAppCtx.DB().Find(&updatedShipment, mtoShipment.ID)
+			if err != nil {
+				return err
+			}
+			if mtoShipment.MarketCode != updatedShipment.MarketCode {
+				mtoShipment.MarketCode = updatedShipment.MarketCode
+			}
+			// since the shipment was updated, we need to ensure we have the most recent eTag
+			mtoShipment.UpdatedAt = updatedShipment.UpdatedAt
 			return nil
 		} else if isBoatShipment {
 			mtoShipment.BoatShipment.ShipmentID = mtoShipment.ID


### PR DESCRIPTION
[Previous INT PR](https://github.com/transcom/mymove/pull/13877)

## [Issue ticket](tbd)

## Summary

An issue was discovered that when creating a PPM shipment an error was returning because the `eTag` was not correct.

In a previous implementation for populating the `market_code` value in the db, the flow was this:
- Create shipment
- Create PPM shipment
- Update shipment `market_code` based off of created address values in PPM shipment (a new `eTag`)

The new `eTag` was not being updated in the object sent back to the UI, so there was a difference in that value when progressing through the PPM flow. 

This PR corrects that by:
- updating `mtoShipment` object with queried `updated_at` value
- updating `mtoShipment` object with `market_code` IF it is different than the default `d`

### How to test

1. Access MM as a customer
2. Go through and create a PPM shipment
3. You should not receive any errors