### PR TITLE
INT B-21073 v3 updating service member creation update flow

### DIFF
--- a/pkg/models/service_member.go
+++ b/pkg/models/service_member.go
@@ -213,6 +213,49 @@ func SaveServiceMember(appCtx appcontext.AppContext, serviceMember *ServiceMembe
 				return err
 			}
 			serviceMember.ResidentialAddress.County = county
+
+			// until international moves are supported, we will default the country for created addresses to "US"
+			if serviceMember.ResidentialAddress.Country != nil && serviceMember.ResidentialAddress.Country.Country != "" {
+				country, err := FetchCountryByCode(appCtx.DB(), serviceMember.ResidentialAddress.Country.Country)
+				if err != nil {
+					return err
+				}
+				serviceMember.ResidentialAddress.Country = &country
+				serviceMember.ResidentialAddress.CountryId = &country.ID
+			} else {
+				country, err := FetchCountryByCode(appCtx.DB(), "US")
+				if err != nil {
+					return err
+				}
+				serviceMember.ResidentialAddress.Country = &country
+				serviceMember.ResidentialAddress.CountryId = &country.ID
+			}
+
+			if serviceMember.ResidentialAddress.Country != nil {
+				country := serviceMember.ResidentialAddress.Country
+				if country.Country != "US" || country.Country == "US" && serviceMember.ResidentialAddress.State == "AK" || country.Country == "US" && serviceMember.ResidentialAddress.State == "HI" {
+					boolTrueVal := true
+					serviceMember.ResidentialAddress.IsOconus = &boolTrueVal
+				} else {
+					boolFalseVal := false
+					serviceMember.ResidentialAddress.IsOconus = &boolFalseVal
+				}
+			} else if serviceMember.ResidentialAddress.CountryId != nil {
+				country, err := FetchCountryByID(appCtx.DB(), *serviceMember.ResidentialAddress.CountryId)
+				if err != nil {
+					return err
+				}
+				if country.Country != "US" || country.Country == "US" && serviceMember.ResidentialAddress.State == "AK" || country.Country == "US" && serviceMember.ResidentialAddress.State == "HI" {
+					boolTrueVal := true
+					serviceMember.ResidentialAddress.IsOconus = &boolTrueVal
+				} else {
+					boolFalseVal := false
+					serviceMember.ResidentialAddress.IsOconus = &boolFalseVal
+				}
+			} else {
+				boolFalseVal := false
+				serviceMember.ResidentialAddress.IsOconus = &boolFalseVal
+			}
 			if verrs, err := txnAppCtx.DB().ValidateAndSave(serviceMember.ResidentialAddress); verrs.HasAny() || err != nil {
 				responseVErrors.Append(verrs)
 				responseError = err

--- a/pkg/models/service_member_test.go
+++ b/pkg/models/service_member_test.go
@@ -328,3 +328,42 @@ func (suite *ModelSuite) TestFetchLatestOrders() {
 		suite.Equal(actualOrder.UploadedAmendedOrders.UserUploads[0].ID, nonDeletedAmendedUpload.ID)
 	})
 }
+
+func (suite *ModelSuite) TestSaveServiceMember() {
+	user1 := factory.BuildDefaultUser(suite.DB())
+
+	firstName := "Billy"
+	lastName := "Bob"
+	sm := m.ServiceMember{
+		User:      user1,
+		UserID:    user1.ID,
+		FirstName: &firstName,
+		LastName:  &lastName,
+	}
+	suite.MustSave(&sm)
+	appCtx := suite.AppContextForTest()
+
+	// updating residential address
+	resAddress := m.Address{
+		StreetAddress1: "987 Other Avenue",
+		City:           "Tulsa",
+		State:          "OK",
+		PostalCode:     "74133",
+	}
+	sm.ResidentialAddress = &resAddress
+	verrs, err := m.SaveServiceMember(appCtx, &sm)
+	suite.NoError(err)
+	suite.False(verrs.HasAny())
+
+	// updating backup address
+	backupAddress := m.Address{
+		StreetAddress1: "987 Backup Avenue",
+		City:           "Tulsa",
+		State:          "OK",
+		PostalCode:     "74133",
+	}
+	sm.BackupMailingAddress = &backupAddress
+	verrs, err = m.SaveServiceMember(appCtx, &sm)
+	suite.NoError(err)
+	suite.False(verrs.HasAny())
+}


### PR DESCRIPTION
[First PR](https://github.com/transcom/mymove/pull/13853)
[Second PR](https://github.com/transcom/mymove/pull/13890)

## [Agility ticket](https://www13.v1host.com/USTRANSCOM38/assetdetail.v1?number=B-21073)

## Summary

Discovered that the service member profile creation/update flow does not use the expected service objects and instead uses a function in the models file. Updating that function to include `country_id` when saving the service member.

### How to test

1. Access MM as a customer
2. Create your profile & your addresses
3. Check out the `addresses` table and ensure that the `country_id` is populated