### PR TITLE
Int b 20983 filter columns to be more user friendly duty location

### DIFF
--- a/pkg/services/order/order_fetcher.go
+++ b/pkg/services/order/order_fetcher.go
@@ -548,7 +548,7 @@ func locatorFilter(locator *string) QueryOption {
 func originDutyLocationFilter(originDutyLocation []string) QueryOption {
 	return func(query *pop.Query) {
 		if len(originDutyLocation) > 0 {
-			query.Where("origin_dl.name IN (?)", originDutyLocation)
+			query.Where("origin_dl.name ILIKE ?", "%"+strings.Join(originDutyLocation," ")+"%")
 		}
 	}
 }

--- a/pkg/services/order/order_fetcher_test.go
+++ b/pkg/services/order/order_fetcher_test.go
@@ -2,6 +2,7 @@ package order
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/gofrs/uuid"
@@ -2020,4 +2021,35 @@ func (suite *OrderServiceSuite) TestListAllOrderLocations() {
 		suite.FatalNoError(err)
 		suite.Equal(0, len(moves))
 	})
+}
+
+func (suite *OrderServiceSuite) TestOriginDutyLocationFilter() {
+	var session auth.Session
+	var expectedMove  models.Move
+	var officeUser models.OfficeUser
+	orderFetcher := NewOrderFetcher()
+	suite.PreloadData(func() {
+		setupTestData := func() (models.OfficeUser, models.Move, auth.Session) {
+			officeUser := factory.BuildOfficeUserWithRoles(suite.DB(), nil, []roles.RoleType{roles.RoleTypeTOO})
+			session := auth.Session{
+				ApplicationName: auth.OfficeApp,
+				Roles:           officeUser.User.Roles,
+				OfficeUserID:    officeUser.ID,
+				IDToken:         "fake_token",
+				AccessToken:     "fakeAccessToken",
+			}
+			move := factory.BuildMoveWithShipment(suite.DB(), nil, nil)
+			return officeUser, move, session
+		}
+		officeUser, expectedMove, session = setupTestData()
+	})
+
+    suite.Run("Returns orders matching the originDutyLocation filter", func() {
+		locationName := expectedMove.Orders.OriginDutyLocation.Name
+		params := &services.ListOrderParams{OriginDutyLocation: strings.Split(locationName, " ")}
+        expectedMoves, _, err := orderFetcher.ListOrders(suite.AppContextWithSessionForTest(&session), officeUser.ID, roles.RoleTypeTOO, params)
+        suite.NoError(err)
+		suite.Equal(1, len(expectedMoves))
+        suite.Contains(locationName, string(expectedMoves[0].Orders.OriginDutyLocation.Name))
+    })
 }

--- a/pkg/services/payment_request/payment_request_list_fetcher.go
+++ b/pkg/services/payment_request/payment_request_list_fetcher.go
@@ -316,8 +316,7 @@ func lastNameFilter(lastName *string) QueryOption {
 func dutyLocationFilter(dutyLocation *string) QueryOption {
 	return func(query *pop.Query) {
 		if dutyLocation != nil {
-			locationSearch := fmt.Sprintf("%s%%", *dutyLocation)
-			query.Where("duty_locations.name ILIKE ?", locationSearch)
+			query.Where("duty_locations.name ILIKE ?", "%"+*dutyLocation+"%")
 		}
 	}
 }


### PR DESCRIPTION
## [Agility ticket]([B-20983-Latent: Filter columns to be more user friendly - Duty Location](https://www13.v1host.com/USTRANSCOM38/story.mvc/Summary?oidToken=Story%3A1002274&RoomContext=TeamRoom%3A1007470&concept=TeamRoom))

## Summary
SC/TOO & TIO queues do not allow users to search by any match filter for Origin duty location column, Users had to enter the full/exact location in order to find the a match. These changes are to use "ILIKE" & wildcards for querying the results that match the partial string the user would enter. 

Is there anything you would like reviewers to give additional scrutiny?

[this article](tbd) explains more about the approach used.

## Verification Steps for the Author

These are to be checked by the author.

- [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
- [ ] Have the Agility acceptance criteria been met for this change?

## Verification Steps for Reviewers

These are to be checked by a reviewer.

- [ ] Has the branch been pulled in and checked out?
- [ ] Have the BL acceptance criteria been met for this change?
- [ ] Was the CircleCI build successful?
- [ ] Has the code been reviewed from a standards and best practices point of view?

### Setup to Run the Code

- [Instructions for starting storybook](https://transcom.github.io/mymove-docs/docs/frontend/setup/storybook)
- [Instructions for starting the MilMove application](https://transcom.github.io/mymove-docs/docs/getting-started/application-setup/)
- [Instructions for running tests](https://transcom.github.io/mymove-docs/docs/getting-started/development/testing)

### How to test

1. Access the MilMov application
2. Login as a SC/TOO/TIO .
3.Navigate the queue pages: SC has Counseling Queue and PPM Closeout Queue. TOO has Task Order Queue . TIO has Payment requests. 
4. Enter a search criteria in the "Origin Duty Location" field (note: try with any part of the address, i.e. City, State, Zip)
5. Search results should display matching any of the search criteria provided in the field.

### Frontend

- [ ] There are no aXe warnings for UI.
- [ ] This works in [Supported Browsers and their phone views](https://transcom.github.io/mymove-docs/docs/adrs/Browser-Support/#minimum-browser-requirements) (Chrome, Firefox, Edge).
- [ ] There are no new console errors in the browser devtools.
- [ ] There are no new console errors in the test output.
- [ ] If this PR adds a new component to Storybook, it ensures the component is fully responsive, OR if it is intentionally not, a wrapping div using the `officeApp` class or custom `min-width` styling is used to hide any states the would not be visible to the user.
- [ ] This change meets the standards for [Section 508 compliance](https://www.ssa.gov/accessibility/andi/help/install.html).

### Backend

- [ ] Code follows the guidelines for [Logging](https://transcom.github.io/mymove-docs/docs/getting-started/development/logging).
- [ ] The requirements listed in [Querying the Database Safely](https://transcom.github.io/mymove-docs/docs/backend/guides/golang-guide#querying-the-database-safely) have been satisfied.

### Database

#### Any new migrations/schema changes:

- [ ] Follows our guidelines for [Zero-Downtime Deploys](https://transcom.github.io/mymove-docs/docs/backend/setup/database-migrations#zero-downtime-migrations).
- [ ] Have been communicated to #g-database.
- [ ] Secure migrations have been tested following the instructions in our [docs](https://transcom.github.io/mymove-docs/docs/backend/setup/database-migrations#secure-migrations).

## Screenshots

https://github.com/user-attachments/assets/cd0ae790-fc8d-4b2b-8195-39ad82b7ed57

https://github.com/user-attachments/assets/3714b3b4-2b46-4651-ac99-2ef182d11827
