### PR TITLE
B 20533 INT -   HQ/TIO payment request cleanup

### DIFF
--- a/pkg/handlers/ghcapi/internal/payloads/model_to_payload.go
+++ b/pkg/handlers/ghcapi/internal/payloads/model_to_payload.go
@@ -2236,7 +2236,6 @@ func QueueMoves(moves []models.Move, officeUsers []models.OfficeUser, requestedP
 			isAssignable = true
 		}
 
-		// add isHqRolecheck here
 		if isHQRole {
 			isAssignable = false
 		}

--- a/pkg/services/ppmshipment/ppm_shipment_creator.go
+++ b/pkg/services/ppmshipment/ppm_shipment_creator.go
@@ -67,6 +67,7 @@ func (f *ppmShipmentCreator) createPPMShipment(appCtx appcontext.AppContext, ppm
 				}
 			}
 			ppmShipment.PickupAddressID = &address.ID
+			ppmShipment.PickupAddress = address
 		}
 
 		if ppmShipment.SecondaryPickupAddress != nil {

--- a/playwright/tests/office/servicescounseling/servicesCounselingFlows.spec.js
+++ b/playwright/tests/office/servicescounseling/servicesCounselingFlows.spec.js
@@ -428,7 +428,7 @@ test.describe('Services counselor user', () => {
     await page.getByRole('button', { name: 'Confirm' }).click();
     await scPage.waitForPage.moveDetails();
 
-    await expect(page.getByText('PACKET READY FOR DOWNLOAD')).toBeVisible();
+    await expect(page.getByTestId('ShipmentContainer').getByTestId('tag')).toContainText('packet ready for download');
 
     // Navigate to the "View documents" page
     await expect(page.getByRole('button', { name: /View documents/i })).toBeVisible();
@@ -454,7 +454,7 @@ test.describe('Services counselor user', () => {
     await page.getByTestId('reviewDocumentsContinueButton').click();
     await scPage.waitForPage.moveDetails();
 
-    await expect(page.getByText('PACKET READY FOR DOWNLOAD')).toBeVisible();
+    await expect(page.getByTestId('ShipmentContainer').getByTestId('tag')).toContainText('packet ready for download');
   });
 
   test.describe('Edit shipment info and incentives', () => {

--- a/scripts/ensure-go-test-coverage
+++ b/scripts/ensure-go-test-coverage
@@ -29,7 +29,6 @@ baseline_file = sys.argv[1]
 new_file = sys.argv[2]
 
 baseline_percent = 0.0
-COVERAGE_TOLERANCE = 0.1
 # we can remove this conditional once the baselines are being saved on main
 if not os.path.exists(baseline_file):
   print(f"Baseline file '{baseline_file}' does not exist, assuming 0")
@@ -41,7 +40,7 @@ new_percent = total_coverage_percent(new_file)
 print(f"Baseline test coverage: {baseline_percent}")
 print(f"New test coverage: {new_percent}")
 
-if new_percent < (baseline_percent - COVERAGE_TOLERANCE):
+if new_percent < baseline_percent:
   print("\n--- DIFF of the baseline test coverage compared to this PR ---")
   print("    Note, not all changes will be meaningful, look for test coverage %% decreases\n")
   coverage_diff(baseline_file, new_file)

--- a/scripts/ensure-js-test-coverage
+++ b/scripts/ensure-js-test-coverage
@@ -22,7 +22,6 @@ baseline_file = sys.argv[1]
 new_file = sys.argv[2]
 
 baseline_percent = 0.0
-COVERAGE_TOLERANCE = 0.1
 # we can remove this conditional once the baselines are being saved on master
 if not os.path.exists(baseline_file):
   print(f"Baseline file '{baseline_file}' does not exist, assuming 0")
@@ -34,7 +33,7 @@ new_percent = total_coverage_percent(new_file)
 print(f"Baseline test coverage: {baseline_percent}")
 print(f"New test coverage: {new_percent}")
 
-if new_percent <= (baseline_percent - COVERAGE_TOLERANCE):
+if new_percent < baseline_percent:
   print("Test Coverage has decreased")
   print("Refer to the following to learn how to resolve this:")
   print(f"{HELP_URL}")


### PR DESCRIPTION
## [Agility ticket](https://www13.v1host.com/USTRANSCOM38/assetdetail.v1?number=B-20533)

## Summary
**When assigning a payment request to a TIO, assign all payment requests from that move to that TIO**
HQ users queues should be READ ONLY in ALL CASES

>[!IMPORTANT]
>Contains 20777 Code
>## Referencing PR
>[B-20777 TIO Queue Management. ](https://github.com/transcom/mymove/pull/13907)


## Test Steps for TIO
1. Login as prime and create multiple payment requests for the same move
2. Login as TIO and assign one payment to yourself.
3. refresh the page
4. all payment requests for that move, should now be assigned to you as well.

## Test Steps for HQ.
1. login as an HQ role
2. View the payments request queue, Verify that assigned column Is read only and not assignable
3. View the Task Order Queue, verify that the assigned column is read only and not assignable 

