### PR TITLE
MMHDT 614 Integration

### DIFF
--- a/migrations/app/migrations_manifest.txt
+++ b/migrations/app/migrations_manifest.txt
@@ -1025,3 +1025,4 @@
 20241009210749_create_view_v_locations.up.sql
 20241011201326_changes_for_actual_expense_reimbursement_field.up.sql
 20241024114748_create_gbloc_aors.up.sql
+20241029144404_hdt-614-adjust-accomack-county.up.sql

--- a/migrations/app/schema/20241029144404_hdt-614-adjust-accomack-county.up.sql
+++ b/migrations/app/schema/20241029144404_hdt-614-adjust-accomack-county.up.sql
@@ -1,0 +1,8 @@
+-- Set temp timeout due to large file modification
+-- Time is 5 minutes in milliseconds
+SET statement_timeout = 300000;
+SET lock_timeout = 300000;
+SET idle_in_transaction_session_timeout = 300000;
+
+-- Adjust postal code to GBLOC per MMHDT 582
+update postal_code_to_gblocs pctg SET gbloc = 'BGNC' FROM us_post_region_cities usprc where pctg.postal_code = usprc.uspr_zip_id and usprc.usprc_county_nm = 'ACCOMACK'


### PR DESCRIPTION
[MMHDT-614](https://jira.csde.caci.com/browse/MMHDT-614)

## Summary
All ACCOMACK county GBLOCs must be set to be "BGNC". Currently they are split between two GBLOCS of "BGNC" and "BGAC"

## Steps to test

1. Run
```sql
SELECT pctg.*
FROM postal_code_to_gblocs pctg
JOIN us_post_region_cities usprc
  ON pctg.postal_code = usprc.uspr_zip_id
WHERE usprc.usprc_county_nm = 'ACCOMACK';
```
2. You will see GBLOCs of BGNC and BGAC
3. Migrate the db
4. Rerun the script, you will only see GBLOCS of BGNC