### PR TITLE
B-21597: Add Temporary Duty (TDY) Order Type INT

### DIFF
--- a/migrations/app/migrations_manifest.txt
+++ b/migrations/app/migrations_manifest.txt
@@ -1025,4 +1025,5 @@
 20241009210749_create_view_v_locations.up.sql
 20241011201326_changes_for_actual_expense_reimbursement_field.up.sql
 20241024114748_create_gbloc_aors.up.sql
+20241029125015_add_orders_type_enum.up.sql
 20241029144404_hdt-614-adjust-accomack-county.up.sql

--- a/migrations/app/schema/20241029125015_add_orders_type_enum.up.sql
+++ b/migrations/app/schema/20241029125015_add_orders_type_enum.up.sql
@@ -1,0 +1,13 @@
+CREATE TYPE orders_type AS ENUM (
+'PERMANENT_CHANGE_OF_STATION',
+'LOCAL_MOVE',
+'RETIREMENT',
+'SEPARATION',
+'WOUNDED_WARRIOR',
+'BLUEBARK',
+'SAFETY',
+'TEMPORARY_DUTY'
+    );
+
+ALTER TABLE orders
+  ALTER COLUMN orders_type TYPE orders_type using orders_type::orders_type;

--- a/migrations/app/schema/20241029125015_add_orders_type_enum.up.sql
+++ b/migrations/app/schema/20241029125015_add_orders_type_enum.up.sql
@@ -1,3 +1,5 @@
+-- Add enum values for order.orders_type
+
 CREATE TYPE orders_type AS ENUM (
 'PERMANENT_CHANGE_OF_STATION',
 'LOCAL_MOVE',
@@ -6,8 +8,11 @@ CREATE TYPE orders_type AS ENUM (
 'WOUNDED_WARRIOR',
 'BLUEBARK',
 'SAFETY',
-'TEMPORARY_DUTY'
-    );
+'TEMPORARY_DUTY');
+
+COMMENT ON TYPE orders_type IS 'The type of orders.';
+COMMENT ON COLUMN orders.orders_type IS 'MilMove supports 8 orders types: Permanent change of station (PCS), local move, retirement, separation, wounded warrior, bluebark, safety, and temporary duty (TDY).
+In general, the moving process starts with the job/travel orders a customer receives from their service. In the orders, information describing rank, the duration of job/training, and their assigned location will determine if their entire dependent family can come, what the customer is allowed to bring, and how those items will arrive to their new location.';
 
 ALTER TABLE orders
   ALTER COLUMN orders_type TYPE orders_type using orders_type::orders_type;

--- a/pkg/gen/ghcapi/embedded_spec.go
+++ b/pkg/gen/ghcapi/embedded_spec.go
@@ -10732,7 +10732,8 @@ func init() {
         "SEPARATION",
         "WOUNDED_WARRIOR",
         "BLUEBARK",
-        "SAFETY"
+        "SAFETY",
+        "TEMPORARY_DUTY"
       ],
       "x-display-value": {
         "BLUEBARK": "BLUEBARK",
@@ -10741,6 +10742,7 @@ func init() {
         "RETIREMENT": "Retirement",
         "SAFETY": "Safety",
         "SEPARATION": "Separation",
+        "TEMPORARY_DUTY": "Temporary Duty (TDY)",
         "WOUNDED_WARRIOR": "Wounded Warrior"
       }
     },
@@ -26825,7 +26827,8 @@ func init() {
         "SEPARATION",
         "WOUNDED_WARRIOR",
         "BLUEBARK",
-        "SAFETY"
+        "SAFETY",
+        "TEMPORARY_DUTY"
       ],
       "x-display-value": {
         "BLUEBARK": "BLUEBARK",
@@ -26834,6 +26837,7 @@ func init() {
         "RETIREMENT": "Retirement",
         "SAFETY": "Safety",
         "SEPARATION": "Separation",
+        "TEMPORARY_DUTY": "Temporary Duty (TDY)",
         "WOUNDED_WARRIOR": "Wounded Warrior"
       }
     },

--- a/pkg/gen/ghcmessages/orders_type.go
+++ b/pkg/gen/ghcmessages/orders_type.go
@@ -50,6 +50,9 @@ const (
 
 	// OrdersTypeSAFETY captures enum value "SAFETY"
 	OrdersTypeSAFETY OrdersType = "SAFETY"
+
+	// OrdersTypeTEMPORARYDUTY captures enum value "TEMPORARY_DUTY"
+	OrdersTypeTEMPORARYDUTY OrdersType = "TEMPORARY_DUTY"
 )
 
 // for schema
@@ -57,7 +60,7 @@ var ordersTypeEnum []interface{}
 
 func init() {
 	var res []OrdersType
-	if err := json.Unmarshal([]byte(`["PERMANENT_CHANGE_OF_STATION","LOCAL_MOVE","RETIREMENT","SEPARATION","WOUNDED_WARRIOR","BLUEBARK","SAFETY"]`), &res); err != nil {
+	if err := json.Unmarshal([]byte(`["PERMANENT_CHANGE_OF_STATION","LOCAL_MOVE","RETIREMENT","SEPARATION","WOUNDED_WARRIOR","BLUEBARK","SAFETY","TEMPORARY_DUTY"]`), &res); err != nil {
 		panic(err)
 	}
 	for _, v := range res {

--- a/pkg/gen/internalapi/embedded_spec.go
+++ b/pkg/gen/internalapi/embedded_spec.go
@@ -5982,7 +5982,8 @@ func init() {
         "SEPARATION",
         "WOUNDED_WARRIOR",
         "BLUEBARK",
-        "SAFETY"
+        "SAFETY",
+        "TEMPORARY_DUTY"
       ],
       "x-display-value": {
         "BLUEBARK": "BLUEBARK",
@@ -5991,6 +5992,7 @@ func init() {
         "RETIREMENT": "Retirement",
         "SAFETY": "Safety",
         "SEPARATION": "Separation",
+        "TEMPORARY_DUTY": "Temporary Duty (TDY)",
         "WOUNDED_WARRIOR": "Wounded Warrior"
       }
     },
@@ -14817,7 +14819,8 @@ func init() {
         "SEPARATION",
         "WOUNDED_WARRIOR",
         "BLUEBARK",
-        "SAFETY"
+        "SAFETY",
+        "TEMPORARY_DUTY"
       ],
       "x-display-value": {
         "BLUEBARK": "BLUEBARK",
@@ -14826,6 +14829,7 @@ func init() {
         "RETIREMENT": "Retirement",
         "SAFETY": "Safety",
         "SEPARATION": "Separation",
+        "TEMPORARY_DUTY": "Temporary Duty (TDY)",
         "WOUNDED_WARRIOR": "Wounded Warrior"
       }
     },

--- a/pkg/gen/internalmessages/orders_type.go
+++ b/pkg/gen/internalmessages/orders_type.go
@@ -50,6 +50,9 @@ const (
 
 	// OrdersTypeSAFETY captures enum value "SAFETY"
 	OrdersTypeSAFETY OrdersType = "SAFETY"
+
+	// OrdersTypeTEMPORARYDUTY captures enum value "TEMPORARY_DUTY"
+	OrdersTypeTEMPORARYDUTY OrdersType = "TEMPORARY_DUTY"
 )
 
 // for schema
@@ -57,7 +60,7 @@ var ordersTypeEnum []interface{}
 
 func init() {
 	var res []OrdersType
-	if err := json.Unmarshal([]byte(`["PERMANENT_CHANGE_OF_STATION","LOCAL_MOVE","RETIREMENT","SEPARATION","WOUNDED_WARRIOR","BLUEBARK","SAFETY"]`), &res); err != nil {
+	if err := json.Unmarshal([]byte(`["PERMANENT_CHANGE_OF_STATION","LOCAL_MOVE","RETIREMENT","SEPARATION","WOUNDED_WARRIOR","BLUEBARK","SAFETY","TEMPORARY_DUTY"]`), &res); err != nil {
 		panic(err)
 	}
 	for _, v := range res {

--- a/pkg/gen/primeapi/embedded_spec.go
+++ b/pkg/gen/primeapi/embedded_spec.go
@@ -2890,7 +2890,8 @@ func init() {
         "SEPARATION",
         "WOUNDED_WARRIOR",
         "BLUEBARK",
-        "SAFETY"
+        "SAFETY",
+        "TEMPORARY_DUTY"
       ],
       "x-display-value": {
         "BLUEBARK": "BLUEBARK",
@@ -2899,6 +2900,7 @@ func init() {
         "RETIREMENT": "Retirement",
         "SAFETY": "Safety",
         "SEPARATION": "Separation",
+        "TEMPORARY_DUTY": "Temporary Duty (TDY)",
         "WOUNDED_WARRIOR": "Wounded Warrior"
       }
     },
@@ -7633,7 +7635,8 @@ func init() {
         "SEPARATION",
         "WOUNDED_WARRIOR",
         "BLUEBARK",
-        "SAFETY"
+        "SAFETY",
+        "TEMPORARY_DUTY"
       ],
       "x-display-value": {
         "BLUEBARK": "BLUEBARK",
@@ -7642,6 +7645,7 @@ func init() {
         "RETIREMENT": "Retirement",
         "SAFETY": "Safety",
         "SEPARATION": "Separation",
+        "TEMPORARY_DUTY": "Temporary Duty (TDY)",
         "WOUNDED_WARRIOR": "Wounded Warrior"
       }
     },

--- a/pkg/gen/primemessages/orders_type.go
+++ b/pkg/gen/primemessages/orders_type.go
@@ -50,6 +50,9 @@ const (
 
 	// OrdersTypeSAFETY captures enum value "SAFETY"
 	OrdersTypeSAFETY OrdersType = "SAFETY"
+
+	// OrdersTypeTEMPORARYDUTY captures enum value "TEMPORARY_DUTY"
+	OrdersTypeTEMPORARYDUTY OrdersType = "TEMPORARY_DUTY"
 )
 
 // for schema
@@ -57,7 +60,7 @@ var ordersTypeEnum []interface{}
 
 func init() {
 	var res []OrdersType
-	if err := json.Unmarshal([]byte(`["PERMANENT_CHANGE_OF_STATION","LOCAL_MOVE","RETIREMENT","SEPARATION","WOUNDED_WARRIOR","BLUEBARK","SAFETY"]`), &res); err != nil {
+	if err := json.Unmarshal([]byte(`["PERMANENT_CHANGE_OF_STATION","LOCAL_MOVE","RETIREMENT","SEPARATION","WOUNDED_WARRIOR","BLUEBARK","SAFETY","TEMPORARY_DUTY"]`), &res); err != nil {
 		panic(err)
 	}
 	for _, v := range res {

--- a/pkg/gen/primev2api/embedded_spec.go
+++ b/pkg/gen/primev2api/embedded_spec.go
@@ -2041,7 +2041,8 @@ func init() {
         "SEPARATION",
         "WOUNDED_WARRIOR",
         "BLUEBARK",
-        "SAFETY"
+        "SAFETY",
+        "TEMPORARY_DUTY"
       ],
       "x-display-value": {
         "BLUEBARK": "BLUEBARK",
@@ -2050,6 +2051,7 @@ func init() {
         "RETIREMENT": "Retirement",
         "SAFETY": "Safety",
         "SEPARATION": "Separation",
+        "TEMPORARY_DUTY": "Temporary Duty (TDY)",
         "WOUNDED_WARRIOR": "Wounded Warrior"
       }
     },
@@ -5551,7 +5553,8 @@ func init() {
         "SEPARATION",
         "WOUNDED_WARRIOR",
         "BLUEBARK",
-        "SAFETY"
+        "SAFETY",
+        "TEMPORARY_DUTY"
       ],
       "x-display-value": {
         "BLUEBARK": "BLUEBARK",
@@ -5560,6 +5563,7 @@ func init() {
         "RETIREMENT": "Retirement",
         "SAFETY": "Safety",
         "SEPARATION": "Separation",
+        "TEMPORARY_DUTY": "Temporary Duty (TDY)",
         "WOUNDED_WARRIOR": "Wounded Warrior"
       }
     },

--- a/pkg/gen/primev2messages/orders_type.go
+++ b/pkg/gen/primev2messages/orders_type.go
@@ -50,6 +50,9 @@ const (
 
 	// OrdersTypeSAFETY captures enum value "SAFETY"
 	OrdersTypeSAFETY OrdersType = "SAFETY"
+
+	// OrdersTypeTEMPORARYDUTY captures enum value "TEMPORARY_DUTY"
+	OrdersTypeTEMPORARYDUTY OrdersType = "TEMPORARY_DUTY"
 )
 
 // for schema
@@ -57,7 +60,7 @@ var ordersTypeEnum []interface{}
 
 func init() {
 	var res []OrdersType
-	if err := json.Unmarshal([]byte(`["PERMANENT_CHANGE_OF_STATION","LOCAL_MOVE","RETIREMENT","SEPARATION","WOUNDED_WARRIOR","BLUEBARK","SAFETY"]`), &res); err != nil {
+	if err := json.Unmarshal([]byte(`["PERMANENT_CHANGE_OF_STATION","LOCAL_MOVE","RETIREMENT","SEPARATION","WOUNDED_WARRIOR","BLUEBARK","SAFETY","TEMPORARY_DUTY"]`), &res); err != nil {
 		panic(err)
 	}
 	for _, v := range res {

--- a/pkg/gen/primev3api/embedded_spec.go
+++ b/pkg/gen/primev3api/embedded_spec.go
@@ -2263,7 +2263,8 @@ func init() {
         "SEPARATION",
         "WOUNDED_WARRIOR",
         "BLUEBARK",
-        "SAFETY"
+        "SAFETY",
+        "TEMPORARY_DUTY"
       ],
       "x-display-value": {
         "BLUEBARK": "BLUEBARK",
@@ -2272,6 +2273,7 @@ func init() {
         "RETIREMENT": "Retirement",
         "SAFETY": "Safety",
         "SEPARATION": "Separation",
+        "TEMPORARY_DUTY": "Temporary Duty (TDY)",
         "WOUNDED_WARRIOR": "Wounded Warrior"
       }
     },
@@ -6294,7 +6296,8 @@ func init() {
         "SEPARATION",
         "WOUNDED_WARRIOR",
         "BLUEBARK",
-        "SAFETY"
+        "SAFETY",
+        "TEMPORARY_DUTY"
       ],
       "x-display-value": {
         "BLUEBARK": "BLUEBARK",
@@ -6303,6 +6306,7 @@ func init() {
         "RETIREMENT": "Retirement",
         "SAFETY": "Safety",
         "SEPARATION": "Separation",
+        "TEMPORARY_DUTY": "Temporary Duty (TDY)",
         "WOUNDED_WARRIOR": "Wounded Warrior"
       }
     },

--- a/pkg/gen/primev3messages/orders_type.go
+++ b/pkg/gen/primev3messages/orders_type.go
@@ -50,6 +50,9 @@ const (
 
 	// OrdersTypeSAFETY captures enum value "SAFETY"
 	OrdersTypeSAFETY OrdersType = "SAFETY"
+
+	// OrdersTypeTEMPORARYDUTY captures enum value "TEMPORARY_DUTY"
+	OrdersTypeTEMPORARYDUTY OrdersType = "TEMPORARY_DUTY"
 )
 
 // for schema
@@ -57,7 +60,7 @@ var ordersTypeEnum []interface{}
 
 func init() {
 	var res []OrdersType
-	if err := json.Unmarshal([]byte(`["PERMANENT_CHANGE_OF_STATION","LOCAL_MOVE","RETIREMENT","SEPARATION","WOUNDED_WARRIOR","BLUEBARK","SAFETY"]`), &res); err != nil {
+	if err := json.Unmarshal([]byte(`["PERMANENT_CHANGE_OF_STATION","LOCAL_MOVE","RETIREMENT","SEPARATION","WOUNDED_WARRIOR","BLUEBARK","SAFETY","TEMPORARY_DUTY"]`), &res); err != nil {
 		panic(err)
 	}
 	for _, v := range res {

--- a/pkg/gen/supportapi/embedded_spec.go
+++ b/pkg/gen/supportapi/embedded_spec.go
@@ -2066,7 +2066,8 @@ func init() {
         "GHC",
         "NTS",
         "WOUNDED_WARRIOR",
-        "BLUEBARK"
+        "BLUEBARK",
+        "TEMPORARY_DUTY"
       ],
       "x-display-value": {
         "BLUEBARK": "BLUEBARK",
@@ -2076,6 +2077,7 @@ func init() {
         "PERMANENT_CHANGE_OF_STATION": "Permanent Change Of Station (PCS)",
         "RETIREMENT": "Retirement",
         "SEPARATION": "Separation",
+        "TEMPORARY_DUTY": "Temporary Duty (TDY)",
         "WOUNDED_WARRIOR": "Wounded Warrior"
       }
     },
@@ -4921,7 +4923,8 @@ func init() {
         "GHC",
         "NTS",
         "WOUNDED_WARRIOR",
-        "BLUEBARK"
+        "BLUEBARK",
+        "TEMPORARY_DUTY"
       ],
       "x-display-value": {
         "BLUEBARK": "BLUEBARK",
@@ -4931,6 +4934,7 @@ func init() {
         "PERMANENT_CHANGE_OF_STATION": "Permanent Change Of Station (PCS)",
         "RETIREMENT": "Retirement",
         "SEPARATION": "Separation",
+        "TEMPORARY_DUTY": "Temporary Duty (TDY)",
         "WOUNDED_WARRIOR": "Wounded Warrior"
       }
     },

--- a/pkg/gen/supportmessages/orders_type.go
+++ b/pkg/gen/supportmessages/orders_type.go
@@ -53,6 +53,9 @@ const (
 
 	// OrdersTypeBLUEBARK captures enum value "BLUEBARK"
 	OrdersTypeBLUEBARK OrdersType = "BLUEBARK"
+
+	// OrdersTypeTEMPORARYDUTY captures enum value "TEMPORARY_DUTY"
+	OrdersTypeTEMPORARYDUTY OrdersType = "TEMPORARY_DUTY"
 )
 
 // for schema
@@ -60,7 +63,7 @@ var ordersTypeEnum []interface{}
 
 func init() {
 	var res []OrdersType
-	if err := json.Unmarshal([]byte(`["PERMANENT_CHANGE_OF_STATION","LOCAL_MOVE","RETIREMENT","SEPARATION","GHC","NTS","WOUNDED_WARRIOR","BLUEBARK"]`), &res); err != nil {
+	if err := json.Unmarshal([]byte(`["PERMANENT_CHANGE_OF_STATION","LOCAL_MOVE","RETIREMENT","SEPARATION","GHC","NTS","WOUNDED_WARRIOR","BLUEBARK","TEMPORARY_DUTY"]`), &res); err != nil {
 		panic(err)
 	}
 	for _, v := range res {

--- a/src/components/Customer/EditOrdersForm/EditOrdersForm.stories.jsx
+++ b/src/components/Customer/EditOrdersForm/EditOrdersForm.stories.jsx
@@ -2,8 +2,10 @@ import React from 'react';
 
 import EditOrdersForm from './EditOrdersForm';
 
+import { ORDERS_TYPE } from 'constants/orders';
+
 const testInitialValues = {
-  orders_type: 'PERMANENT_CHANGE_OF_STATION',
+  orders_type: ORDERS_TYPE.PERMANENT_CHANGE_OF_STATION,
   issue_date: '2020-11-08',
   report_by_date: '2020-11-26',
   has_dependents: 'no',
@@ -93,6 +95,7 @@ const testProps = {
     { key: 'LOCAL_MOVE', value: 'Local Move' },
     { key: 'RETIREMENT', value: 'Retirement' },
     { key: 'SEPARATION', value: 'Separation' },
+    { key: 'TEMPORARY_DUTY', value: 'Temporary Duty (TDY)' },
   ],
   currentDutyLocation: {},
 };

--- a/src/components/Customer/EditOrdersForm/EditOrdersForm.test.jsx
+++ b/src/components/Customer/EditOrdersForm/EditOrdersForm.test.jsx
@@ -6,6 +6,7 @@ import EditOrdersForm from './EditOrdersForm';
 
 import { documentSizeLimitMsg } from 'shared/constants';
 import { showCounselingOffices } from 'services/internalApi';
+import { ORDERS_TYPE } from 'constants/orders';
 
 jest.mock('services/internalApi', () => ({
   ...jest.requireActual('services/internalApi'),
@@ -170,13 +171,14 @@ const testProps = {
     { key: 'LOCAL_MOVE', value: 'Local Move' },
     { key: 'RETIREMENT', value: 'Retirement' },
     { key: 'SEPARATION', value: 'Separation' },
+    { key: 'TEMPORARY_DUTY', value: 'Temporary Duty (TDY)' },
   ],
   currentDutyLocation: {},
   grade: '',
 };
 
 const initialValues = {
-  orders_type: 'PERMANENT_CHANGE_OF_STATION',
+  orders_type: ORDERS_TYPE.PERMANENT_CHANGE_OF_STATION,
   issue_date: '2020-11-08',
   report_by_date: '2020-11-26',
   has_dependents: 'No',
@@ -265,6 +267,7 @@ describe('EditOrdersForm component', () => {
       ['LOCAL_MOVE', 'LOCAL_MOVE'],
       ['RETIREMENT', 'RETIREMENT'],
       ['SEPARATION', 'SEPARATION'],
+      ['TEMPORARY_DUTY', 'TEMPORARY_DUTY'],
     ])('rendering the %s option', async (selectionOption, expectedValue) => {
       render(<EditOrdersForm {...testProps} />);
 
@@ -307,7 +310,7 @@ describe('EditOrdersForm component', () => {
       expect(submitButton).not.toBeDisabled();
     });
 
-    await userEvent.selectOptions(screen.getByLabelText(/Orders type/), 'PERMANENT_CHANGE_OF_STATION');
+    await userEvent.selectOptions(screen.getByLabelText(/Orders type/), ORDERS_TYPE.PERMANENT_CHANGE_OF_STATION);
     await userEvent.type(screen.getByLabelText(/Orders date/), '08 Nov 2020');
     await userEvent.type(screen.getByLabelText(/Report by date/), '26 Nov 2020');
     await userEvent.click(screen.getByLabelText('No'));
@@ -376,7 +379,7 @@ describe('EditOrdersForm component', () => {
       />,
     );
 
-    await userEvent.selectOptions(screen.getByLabelText(/Orders type/), 'PERMANENT_CHANGE_OF_STATION');
+    await userEvent.selectOptions(screen.getByLabelText(/Orders type/), ORDERS_TYPE.PERMANENT_CHANGE_OF_STATION);
     await userEvent.type(screen.getByLabelText(/Orders date/), '08 Nov 2020');
     await userEvent.type(screen.getByLabelText(/Report by date/), '26 Nov 2020');
     await userEvent.click(screen.getByLabelText('No'));
@@ -406,7 +409,7 @@ describe('EditOrdersForm component', () => {
     await waitFor(() => {
       expect(testProps.onSubmit).toHaveBeenCalledWith(
         expect.objectContaining({
-          orders_type: 'PERMANENT_CHANGE_OF_STATION',
+          orders_type: ORDERS_TYPE.PERMANENT_CHANGE_OF_STATION,
           has_dependents: 'no',
           issue_date: '08 Nov 2020',
           report_by_date: '26 Nov 2020',
@@ -446,7 +449,7 @@ describe('EditOrdersForm component', () => {
 
   describe('with initial values', () => {
     const testInitialValues = {
-      orders_type: 'PERMANENT_CHANGE_OF_STATION',
+      orders_type: ORDERS_TYPE.PERMANENT_CHANGE_OF_STATION,
       issue_date: '2020-11-08',
       report_by_date: '2020-11-26',
       has_dependents: 'no',
@@ -535,7 +538,7 @@ describe('EditOrdersForm component', () => {
       const modifiedProps = {
         onSubmit: jest.fn().mockImplementation(() => Promise.resolve()),
         initialValues: {
-          orders_type: 'PERMANENT_CHANGE_OF_STATION',
+          orders_type: ORDERS_TYPE.PERMANENT_CHANGE_OF_STATION,
           issue_date: '2020-11-08',
           report_by_date: '2020-11-26',
           has_dependents: 'no',
@@ -582,6 +585,7 @@ describe('EditOrdersForm component', () => {
           { key: 'LOCAL_MOVE', value: 'Local Move' },
           { key: 'RETIREMENT', value: 'Retirement' },
           { key: 'SEPARATION', value: 'Separation' },
+          { key: 'TEMPORARY_DUTY', value: 'Temporary Duty (TDY)' },
         ],
         currentDutyLocation: {},
       };
@@ -596,6 +600,86 @@ describe('EditOrdersForm component', () => {
       });
 
       expect(save).toBeDisabled();
+    });
+  });
+
+  it('submits the form when temporary duty orders type is selected', async () => {
+    // Not testing the upload interaction, so give uploaded orders to the props.
+    render(
+      <EditOrdersForm
+        {...testProps}
+        initialValues={{
+          origin_duty_location: {
+            provides_services_counseling: true,
+          },
+          uploaded_orders: [
+            {
+              id: '123',
+              createdAt: '2020-11-08',
+              bytes: 1,
+              url: 'url',
+              filename: 'Test Upload',
+              contentType: 'application/pdf',
+            },
+          ],
+        }}
+      />,
+    );
+
+    await userEvent.selectOptions(screen.getByLabelText(/Orders type/), 'TEMPORARY_DUTY');
+    await userEvent.type(screen.getByLabelText(/Orders date/), '28 Oct 2024');
+    await userEvent.type(screen.getByLabelText(/Report by date/), '28 Oct 2024');
+    await userEvent.click(screen.getByLabelText('No'));
+    await userEvent.selectOptions(screen.getByLabelText(/Pay grade/), ['E_8']);
+
+    // Test Current Duty Location Search Box interaction
+    await userEvent.type(screen.getByLabelText(/Current duty location/), 'AFB', { delay: 100 });
+    const selectedOptionCurrent = await screen.findByText(/Altus/);
+    await userEvent.click(selectedOptionCurrent);
+
+    // Test New Duty Location Search Box interaction
+    await userEvent.type(screen.getByLabelText(/New duty location/), 'AFB', { delay: 100 });
+    const selectedOptionNew = await screen.findByText(/Luke/);
+    await userEvent.click(selectedOptionNew);
+
+    await waitFor(() =>
+      expect(screen.getByRole('form')).toHaveFormValues({
+        new_duty_location: 'Luke AFB',
+        origin_duty_location: 'Altus AFB',
+      }),
+    );
+
+    const submitBtn = screen.getByRole('button', { name: 'Save' });
+    expect(submitBtn).not.toBeDisabled();
+    await userEvent.click(submitBtn);
+
+    await waitFor(() => {
+      expect(testProps.onSubmit).toHaveBeenCalledWith(
+        expect.objectContaining({
+          orders_type: ORDERS_TYPE.TEMPORARY_DUTY,
+          has_dependents: 'no',
+          issue_date: '28 Oct 2024',
+          report_by_date: '28 Oct 2024',
+          new_duty_location: {
+            address: {
+              city: 'Glendale Luke AFB',
+              country: 'United States',
+              id: 'fa51dab0-4553-4732-b843-1f33407f77bc',
+              postalCode: '85309',
+              state: 'AZ',
+              streetAddress1: 'n/a',
+            },
+            address_id: '25be4d12-fe93-47f1-bbec-1db386dfa67f',
+            affiliation: 'AIR_FORCE',
+            created_at: '2021-02-11T16:48:04.117Z',
+            id: 'a8d6b33c-8370-4e92-8df2-356b8c9d0c1a',
+            name: 'Luke AFB',
+            updated_at: '2021-02-11T16:48:04.117Z',
+          },
+          grade: 'E_8',
+        }),
+        expect.anything(),
+      );
     });
   });
 

--- a/src/components/Customer/MtoShipmentForm/MtoShipmentForm.stories.jsx
+++ b/src/components/Customer/MtoShipmentForm/MtoShipmentForm.stories.jsx
@@ -7,6 +7,7 @@ import MtoShipmentForm from './MtoShipmentForm';
 import { SHIPMENT_OPTIONS } from 'shared/constants';
 import { store } from 'shared/store';
 import { MockRouterProvider } from 'testUtils';
+import { ORDERS_TYPE } from 'constants/orders';
 
 const defaultProps = {
   pageList: ['page1', 'anotherPage/:foo/:bar'],
@@ -29,7 +30,7 @@ const defaultProps = {
     destinationAddress: undefined,
   },
   orders: {
-    orders_type: 'PERMANENT_CHANGE_OF_STATION',
+    orders_type: ORDERS_TYPE.PERMANENT_CHANGE_OF_STATION,
     authorizedWeight: 5000,
     entitlement: {
       proGear: 1000,
@@ -92,7 +93,10 @@ function renderStory(props) {
 // create shipment stories (form should not prefill customer data)
 export const HHGShipment = () => renderStory({ shipmentType: SHIPMENT_OPTIONS.HHG });
 export const HHGShipmentRetiree = () =>
-  renderStory({ shipmentType: SHIPMENT_OPTIONS.HHG, orders: { orders_type: 'RETIREMENT', authorizedWeight: 5000 } });
+  renderStory({
+    shipmentType: SHIPMENT_OPTIONS.HHG,
+    orders: { orders_type: ORDERS_TYPE.RETIREMENT, authorizedWeight: 5000 },
+  });
 export const NTSReleaseShipment = () => renderStory({ shipmentType: SHIPMENT_OPTIONS.NTSR });
 export const NTSShipment = () => renderStory({ shipmentType: SHIPMENT_OPTIONS.NTS });
 export const UBShipment = () => renderStory({ shipmentType: SHIPMENT_OPTIONS.UNACCOMPANIED_BAGGAGE });
@@ -128,7 +132,7 @@ export const EditShipmentAsSeparatee = () =>
     shipmentType: SHIPMENT_OPTIONS.HHG,
     isCreatePage: false,
     mtoShipment: mockMtoShipment,
-    orders: { orders_type: 'SEPARATION', authorizedWeight: 5000 },
+    orders: { orders_type: ORDERS_TYPE.SEPARATION, authorizedWeight: 5000 },
   });
 
 export const EditHHGShipmentWithSecondaryAddresses = () => {

--- a/src/components/Customer/MtoShipmentForm/MtoShipmentForm.test.jsx
+++ b/src/components/Customer/MtoShipmentForm/MtoShipmentForm.test.jsx
@@ -61,7 +61,7 @@ const defaultProps = {
     streetAddress2: '',
   },
   orders: {
-    orders_type: 'PERMANENT_CHANGE_OF_STATION',
+    orders_type: ORDERS_TYPE.PERMANENT_CHANGE_OF_STATION,
     has_dependents: false,
     authorizedWeight: 5000,
   },
@@ -89,7 +89,7 @@ const ubProps = {
     streetAddress2: '',
   },
   orders: {
-    orders_type: 'PERMANENT_CHANGE_OF_STATION',
+    orders_type: ORDERS_TYPE.PERMANENT_CHANGE_OF_STATION,
     has_dependents: false,
   },
   shipmentType: SHIPMENT_OPTIONS.UNACCOMPANIED_BAGGAGE,
@@ -217,6 +217,11 @@ describe('MtoShipmentForm component', () => {
 
     it('renders the correct helper text for Delivery Location when orders type is LOCAL_MOVE', async () => {
       renderMtoShipmentForm({ orders: { orders_type: ORDERS_TYPE.LOCAL_MOVE } });
+      await waitFor(() => expect(screen.getByText(/We can use the zip of your new duty location./).toBeInTheDocument));
+    });
+
+    it('renders the correct helper text for Delivery Location when orders type is TEMPORARY_DUTY', async () => {
+      renderMtoShipmentForm({ orders: { orders_type: ORDERS_TYPE.TEMPORARY_DUTY } });
       await waitFor(() => expect(screen.getByText(/We can use the zip of your new duty location./).toBeInTheDocument));
     });
 
@@ -1133,6 +1138,11 @@ describe('MtoShipmentForm component', () => {
 
     it('renders the correct helper text for Delivery Location when orders type is LOCAL_MOVE', async () => {
       renderUBShipmentForm({ orders: { orders_type: ORDERS_TYPE.LOCAL_MOVE } });
+      await waitFor(() => expect(screen.getByText(/We can use the zip of your new duty location./).toBeInTheDocument));
+    });
+
+    it('renders the correct helper text for Delivery Location when orders type is TEMPORARY_DUTY', async () => {
+      renderUBShipmentForm({ orders: { orders_type: ORDERS_TYPE.TEMPORARY_DUTY } });
       await waitFor(() => expect(screen.getByText(/We can use the zip of your new duty location./).toBeInTheDocument));
     });
 

--- a/src/components/Customer/OrdersInfoForm/OrdersInfoForm.stories.jsx
+++ b/src/components/Customer/OrdersInfoForm/OrdersInfoForm.stories.jsx
@@ -2,8 +2,10 @@ import React from 'react';
 
 import OrdersInfoForm from './OrdersInfoForm';
 
+import { ORDERS_TYPE } from 'constants/orders';
+
 const testInitialValues = {
-  orders_type: 'PERMANENT_CHANGE_OF_STATION',
+  orders_type: ORDERS_TYPE.PERMANENT_CHANGE_OF_STATION,
   issue_date: '2020-11-08',
   report_by_date: '2020-11-26',
   has_dependents: 'no',

--- a/src/components/Customer/OrdersInfoForm/OrdersInfoForm.test.jsx
+++ b/src/components/Customer/OrdersInfoForm/OrdersInfoForm.test.jsx
@@ -5,6 +5,7 @@ import userEvent from '@testing-library/user-event';
 import OrdersInfoForm from './OrdersInfoForm';
 
 import { showCounselingOffices } from 'services/internalApi';
+import { ORDERS_TYPE } from 'constants/orders';
 
 jest.mock('services/internalApi', () => ({
   ...jest.requireActual('services/internalApi'),
@@ -164,6 +165,7 @@ const testProps = {
     { key: 'LOCAL_MOVE', value: 'Local Move' },
     { key: 'RETIREMENT', value: 'Retirement' },
     { key: 'SEPARATION', value: 'Separation' },
+    { key: 'TEMPORARY_DUTY', value: 'Temporary Duty (TDY)' },
   ],
 };
 
@@ -193,23 +195,26 @@ describe('OrdersInfoForm component', () => {
     const ordersTypeDropdown = getByLabelText(/Orders type/);
     expect(ordersTypeDropdown).toBeInstanceOf(HTMLSelectElement);
 
-    await userEvent.selectOptions(ordersTypeDropdown, 'PERMANENT_CHANGE_OF_STATION');
-    expect(ordersTypeDropdown).toHaveValue('PERMANENT_CHANGE_OF_STATION');
+    await userEvent.selectOptions(ordersTypeDropdown, ORDERS_TYPE.PERMANENT_CHANGE_OF_STATION);
+    expect(ordersTypeDropdown).toHaveValue(ORDERS_TYPE.PERMANENT_CHANGE_OF_STATION);
 
-    await userEvent.selectOptions(ordersTypeDropdown, 'LOCAL_MOVE');
-    expect(ordersTypeDropdown).toHaveValue('LOCAL_MOVE');
+    await userEvent.selectOptions(ordersTypeDropdown, ORDERS_TYPE.LOCAL_MOVE);
+    expect(ordersTypeDropdown).toHaveValue(ORDERS_TYPE.LOCAL_MOVE);
 
-    await userEvent.selectOptions(ordersTypeDropdown, 'RETIREMENT');
-    expect(ordersTypeDropdown).toHaveValue('RETIREMENT');
+    await userEvent.selectOptions(ordersTypeDropdown, ORDERS_TYPE.RETIREMENT);
+    expect(ordersTypeDropdown).toHaveValue(ORDERS_TYPE.RETIREMENT);
 
-    await userEvent.selectOptions(ordersTypeDropdown, 'SEPARATION');
-    expect(ordersTypeDropdown).toHaveValue('SEPARATION');
+    await userEvent.selectOptions(ordersTypeDropdown, ORDERS_TYPE.SEPARATION);
+    expect(ordersTypeDropdown).toHaveValue(ORDERS_TYPE.SEPARATION);
+
+    await userEvent.selectOptions(ordersTypeDropdown, ORDERS_TYPE.TEMPORARY_DUTY);
+    expect(ordersTypeDropdown).toHaveValue(ORDERS_TYPE.TEMPORARY_DUTY);
   });
 
   it('allows new and current duty location to be the same', async () => {
     render(<OrdersInfoForm {...testProps} />);
 
-    await userEvent.selectOptions(screen.getByLabelText(/Orders type/), 'PERMANENT_CHANGE_OF_STATION');
+    await userEvent.selectOptions(screen.getByLabelText(/Orders type/), ORDERS_TYPE.PERMANENT_CHANGE_OF_STATION);
     await userEvent.type(screen.getByLabelText(/Orders date/), '08 Nov 2020');
     await userEvent.type(screen.getByLabelText(/Report by date/), '26 Nov 2020');
     await userEvent.click(screen.getByLabelText('No'));
@@ -272,12 +277,13 @@ describe('OrdersInfoForm component', () => {
         { key: 'LOCAL_MOVE', value: 'Local Move' },
         { key: 'RETIREMENT', value: 'Retirement' },
         { key: 'SEPARATION', value: 'Separation' },
+        { key: 'TEMPORARY_DUTY', value: 'Temporary Duty (TDY)' },
       ],
     };
 
     render(<OrdersInfoForm {...testPropsWithCounselingOffice} />);
 
-    await userEvent.selectOptions(screen.getByLabelText(/Orders type/), 'PERMANENT_CHANGE_OF_STATION');
+    await userEvent.selectOptions(screen.getByLabelText(/Orders type/), ORDERS_TYPE.PERMANENT_CHANGE_OF_STATION);
     await userEvent.type(screen.getByLabelText(/Orders date/), '08 Nov 2020');
     await userEvent.type(screen.getByLabelText(/Report by date/), '26 Nov 2020');
     await userEvent.click(screen.getByLabelText('No'));
@@ -306,7 +312,7 @@ describe('OrdersInfoForm component', () => {
     await waitFor(() => {
       expect(testPropsWithCounselingOffice.onSubmit).toHaveBeenCalledWith(
         expect.objectContaining({
-          orders_type: 'PERMANENT_CHANGE_OF_STATION',
+          orders_type: ORDERS_TYPE.PERMANENT_CHANGE_OF_STATION,
           counseling_office_id: '3be2381f-f9ed-4902-bbdc-69c69e43eb86',
           has_dependents: 'no',
           issue_date: '08 Nov 2020',
@@ -352,7 +358,7 @@ describe('OrdersInfoForm component', () => {
   it('submits the form when its valid', async () => {
     render(<OrdersInfoForm {...testProps} />);
 
-    await userEvent.selectOptions(screen.getByLabelText(/Orders type/), 'PERMANENT_CHANGE_OF_STATION');
+    await userEvent.selectOptions(screen.getByLabelText(/Orders type/), ORDERS_TYPE.PERMANENT_CHANGE_OF_STATION);
     await userEvent.type(screen.getByLabelText(/Orders date/), '08 Nov 2020');
     await userEvent.type(screen.getByLabelText(/Report by date/), '26 Nov 2020');
     await userEvent.click(screen.getByLabelText('No'));
@@ -381,7 +387,7 @@ describe('OrdersInfoForm component', () => {
     await waitFor(() => {
       expect(testProps.onSubmit).toHaveBeenCalledWith(
         expect.objectContaining({
-          orders_type: 'PERMANENT_CHANGE_OF_STATION',
+          orders_type: ORDERS_TYPE.PERMANENT_CHANGE_OF_STATION,
           has_dependents: 'no',
           issue_date: '08 Nov 2020',
           report_by_date: '26 Nov 2020',
@@ -423,6 +429,73 @@ describe('OrdersInfoForm component', () => {
     });
   });
 
+  it('submits the form when temporary duty orders type is selected', async () => {
+    render(<OrdersInfoForm {...testProps} />);
+
+    await userEvent.selectOptions(screen.getByLabelText(/Orders type/), ORDERS_TYPE.TEMPORARY_DUTY);
+    await userEvent.type(screen.getByLabelText(/Orders date/), '28 Oct 2024');
+    await userEvent.type(screen.getByLabelText(/Report by date/), '28 Oct 2024');
+    await userEvent.click(screen.getByLabelText('No'));
+    await userEvent.selectOptions(screen.getByLabelText(/Pay grade/), ['E_7']);
+
+    // Test Current Duty Location Search Box interaction
+    await userEvent.type(screen.getByLabelText(/Current duty location/), 'AFB', { delay: 100 });
+    const selectedOptionCurrent = await screen.findByText(/Altus/);
+    await userEvent.click(selectedOptionCurrent);
+
+    // Test New Duty Location Search Box interaction
+    await userEvent.type(screen.getByLabelText(/New duty location/), 'AFB', { delay: 100 });
+    const selectedOptionNew = await screen.findByText(/Luke/);
+    await userEvent.click(selectedOptionNew);
+
+    const submitBtn = screen.getByRole('button', { name: 'Next' });
+    await userEvent.click(submitBtn);
+
+    await waitFor(() => {
+      expect(testProps.onSubmit).toHaveBeenCalledWith(
+        expect.objectContaining({
+          orders_type: ORDERS_TYPE.TEMPORARY_DUTY,
+          has_dependents: 'no',
+          issue_date: '28 Oct 2024',
+          report_by_date: '28 Oct 2024',
+          new_duty_location: {
+            address: {
+              city: 'Glendale Luke AFB',
+              country: 'United States',
+              id: 'fa51dab0-4553-4732-b843-1f33407f77bc',
+              postalCode: '85309',
+              state: 'AZ',
+              streetAddress1: 'n/a',
+            },
+            address_id: '25be4d12-fe93-47f1-bbec-1db386dfa67f',
+            affiliation: 'AIR_FORCE',
+            created_at: '2021-02-11T16:48:04.117Z',
+            id: 'a8d6b33c-8370-4e92-8df2-356b8c9d0c1a',
+            name: 'Luke AFB',
+            updated_at: '2021-02-11T16:48:04.117Z',
+          },
+          grade: 'E_7',
+          origin_duty_location: {
+            address: {
+              city: '',
+              id: '00000000-0000-0000-0000-000000000000',
+              postalCode: '',
+              state: '',
+              streetAddress1: '',
+            },
+            address_id: '46c4640b-c35e-4293-a2f1-36c7b629f903',
+            affiliation: 'AIR_FORCE',
+            created_at: '2021-02-11T16:48:04.117Z',
+            id: '93f0755f-6f35-478b-9a75-35a69211da1c',
+            name: 'Altus AFB',
+            updated_at: '2021-02-11T16:48:04.117Z',
+          },
+        }),
+        expect.anything(),
+      );
+    });
+  });
+
   it('implements the onBack handler when the Back button is clicked', async () => {
     const { getByRole } = render(<OrdersInfoForm {...testProps} />);
     const backBtn = getByRole('button', { name: 'Back' });
@@ -436,7 +509,7 @@ describe('OrdersInfoForm component', () => {
 
   describe('with initial values', () => {
     const testInitialValues = {
-      orders_type: 'PERMANENT_CHANGE_OF_STATION',
+      orders_type: ORDERS_TYPE.PERMANENT_CHANGE_OF_STATION,
       issue_date: '2020-11-08',
       report_by_date: '2020-11-26',
       has_dependents: 'no',

--- a/src/components/Customer/Review/Review.stories.jsx
+++ b/src/components/Customer/Review/Review.stories.jsx
@@ -5,6 +5,7 @@ import { Summary } from 'components/Customer/Review/Summary/Summary';
 import { MOVE_STATUSES, SHIPMENT_OPTIONS } from 'shared/constants';
 import { MockProviders } from 'testUtils';
 import { shipmentStatuses } from 'constants/shipments';
+import { ORDERS_TYPE } from 'constants/orders';
 
 export default {
   title: 'Customer Components / Review Shipment',
@@ -65,7 +66,7 @@ const serviceMemberMoves = {
           name: 'Flagstaff, AZ 86004',
           updated_at: '2024-02-27T20:40:42.164Z',
         },
-        orders_type: 'PERMANENT_CHANGE_OF_STATION',
+        orders_type: ORDERS_TYPE.PERMANENT_CHANGE_OF_STATION,
         originDutyLocationGbloc: 'HAFC',
         origin_duty_location: {
           address: {
@@ -142,7 +143,7 @@ const defaultProps = {
     },
   },
   currentOrders: {
-    orders_type: 'PERMANENT_CHANGE_OF_STATION',
+    orders_type: ORDERS_TYPE.PERMANENT_CHANGE_OF_STATION,
     has_dependents: false,
     issue_date: '2020-08-11',
     grade: 'E_1',

--- a/src/components/Customer/Review/Summary/Summary.test.jsx
+++ b/src/components/Customer/Review/Summary/Summary.test.jsx
@@ -8,6 +8,7 @@ import { renderWithRouterProp } from 'testUtils';
 import { isBooleanFlagEnabled } from 'utils/featureFlags';
 import { customerRoutes } from 'constants/routes';
 import { selectCurrentMoveFromAllMoves } from 'store/entities/selectors';
+import { ORDERS_TYPE } from 'constants/orders';
 
 jest.mock('services/internalApi', () => ({
   ...jest.requireActual('services/internalApi'),
@@ -89,7 +90,7 @@ const testMove = {
       name: 'Flagstaff, AZ 86003',
       updated_at: '2024-02-27T18:22:12.471Z',
     },
-    orders_type: 'PERMANENT_CHANGE_OF_STATION',
+    orders_type: ORDERS_TYPE.PERMANENT_CHANGE_OF_STATION,
     originDutyLocationGbloc: 'BGAC',
     origin_duty_location: {
       address: {
@@ -223,7 +224,7 @@ const testProps = {
             transportation_office_id: '7f5b64b8-979c-4cbd-890b-bffd6fdf56d9',
             updated_at: '2024-02-27T18:22:12.471Z',
           },
-          orders_type: 'PERMANENT_CHANGE_OF_STATION',
+          orders_type: ORDERS_TYPE.PERMANENT_CHANGE_OF_STATION,
           originDutyLocationGbloc: 'HAFC',
           origin_duty_location: {
             address: {
@@ -351,7 +352,7 @@ const testProps = {
             name: 'Flagstaff, AZ 86003',
             updated_at: '2024-02-27T18:22:12.471Z',
           },
-          orders_type: 'PERMANENT_CHANGE_OF_STATION',
+          orders_type: ORDERS_TYPE.PERMANENT_CHANGE_OF_STATION,
           originDutyLocationGbloc: 'BGAC',
           origin_duty_location: {
             address: {
@@ -463,7 +464,7 @@ const testProps = {
             transportation_office_id: '7f5b64b8-979c-4cbd-890b-bffd6fdf56d9',
             updated_at: '2024-02-27T18:22:12.471Z',
           },
-          orders_type: 'PERMANENT_CHANGE_OF_STATION',
+          orders_type: ORDERS_TYPE.PERMANENT_CHANGE_OF_STATION,
           originDutyLocationGbloc: 'HAFC',
           origin_duty_location: {
             address: {
@@ -528,7 +529,7 @@ const testProps = {
     ],
   },
   currentOrders: {
-    orders_type: 'PERMANENT_CHANGE_OF_STATION',
+    orders_type: ORDERS_TYPE.PERMANENT_CHANGE_OF_STATION,
     has_dependents: false,
     issue_date: '2020-08-11',
     grade: 'E_1',

--- a/src/components/Office/DefinitionLists/OrdersList.stories.jsx
+++ b/src/components/Office/DefinitionLists/OrdersList.stories.jsx
@@ -3,6 +3,8 @@ import { object, text } from '@storybook/addon-knobs';
 
 import OrdersList from './OrdersList';
 
+import { ORDERS_TYPE } from 'constants/orders';
+
 export default {
   title: 'Office Components/OrdersList',
   component: OrdersList,
@@ -18,7 +20,7 @@ export const Basic = () => (
         reportByDate: text('ordersInfo.reportByDate', '2020-04-01'),
         departmentIndicator: text('ordersInfo.departmentIndicator', 'NAVY_AND_MARINES'),
         ordersNumber: text('ordersInfo.ordersNumber', '999999999'),
-        ordersType: text('ordersInfo.ordersType', 'PERMANENT_CHANGE_OF_STATION'),
+        ordersType: text('ordersInfo.ordersType', ORDERS_TYPE.PERMANENT_CHANGE_OF_STATION),
         ordersTypeDetail: text('ordersInfo.ordersTypeDetail', 'HHG_PERMITTED'),
         tacMDC: text('ordersInfo.tacMDC', '9999'),
         sacSDN: text('ordersInfo.sacSDN', '999 999999 999'),

--- a/src/components/Office/OrdersDetailForm/OrdersDetailForm.stories.jsx
+++ b/src/components/Office/OrdersDetailForm/OrdersDetailForm.stories.jsx
@@ -4,7 +4,12 @@ import { Formik } from 'formik';
 
 import OrdersDetailForm from 'components/Office/OrdersDetailForm/OrdersDetailForm';
 import { dropdownInputOptions } from 'utils/formatters';
-import { ORDERS_TYPE_OPTIONS, ORDERS_TYPE_DETAILS_OPTIONS, ORDERS_PAY_GRADE_OPTIONS } from 'constants/orders';
+import {
+  ORDERS_TYPE_OPTIONS,
+  ORDERS_TYPE_DETAILS_OPTIONS,
+  ORDERS_PAY_GRADE_OPTIONS,
+  ORDERS_TYPE,
+} from 'constants/orders';
 import { DEPARTMENT_INDICATOR_OPTIONS } from 'constants/departmentIndicators';
 
 const originDutyLocation = {
@@ -111,7 +116,7 @@ export const InitialValues = () => {
           reportByDate: '2020-04-01',
           departmentIndicator: 'NAVY_AND_MARINES',
           ordersNumber: '999999999',
-          ordersType: 'PERMANENT_CHANGE_OF_STATION',
+          ordersType: ORDERS_TYPE.PERMANENT_CHANGE_OF_STATION,
           ordersTypeDetail: 'HHG_PERMITTED',
           tac: 'Tac',
           sac: 'Sac',
@@ -164,7 +169,7 @@ export const FieldsHidden = (args) => {
           reportByDate: '2020-04-01',
           departmentIndicator: 'NAVY_AND_MARINES',
           ordersNumber: '999999999',
-          ordersType: 'PERMANENT_CHANGE_OF_STATION',
+          ordersType: ORDERS_TYPE.PERMANENT_CHANGE_OF_STATION,
           ordersTypeDetail: 'HHG_PERMITTED',
           tac: 'Tac',
           sac: 'Sac',

--- a/src/components/Office/ServiceItemsTable/resubmittedServiceItemUnitTestData.js
+++ b/src/components/Office/ServiceItemsTable/resubmittedServiceItemUnitTestData.js
@@ -2,6 +2,7 @@
 import MOVE_STATUSES from 'constants/moves';
 import { shipmentStatuses } from 'constants/shipments';
 import { SERVICE_ITEM_STATUSES } from 'constants/serviceItems';
+import { ORDERS_TYPE } from 'constants/orders';
 
 const move = {
   id: '1',
@@ -16,7 +17,7 @@ const move = {
 };
 
 const order = {
-  orders_type: 'PERMANENT_CHANGE_OF_STATION',
+  orders_type: ORDERS_TYPE.PERMANENT_CHANGE_OF_STATION,
   has_dependents: false,
   issue_date: '2020-08-11',
   grade: 'E_1',

--- a/src/constants/MoveHistory/EventTemplates/CreateOrder/createOrder.test.jsx
+++ b/src/constants/MoveHistory/EventTemplates/CreateOrder/createOrder.test.jsx
@@ -2,6 +2,7 @@ import { render, screen } from '@testing-library/react';
 
 import getTemplate from 'constants/MoveHistory/TemplateManager';
 import e from 'constants/MoveHistory/EventTemplates/CreateOrder/createOrder';
+import { ORDERS_TYPE } from 'constants/orders';
 
 describe('When given a create order event for the orders table from the office side', () => {
   const item = {
@@ -13,7 +14,7 @@ describe('When given a create order event for the orders table from the office s
       status: 'DRAFT',
       report_by_date: '2022-10-18',
       issue_date: '2022-10-11',
-      orders_type: 'PERMANENT_CHANGE_OF_STATION',
+      orders_type: ORDERS_TYPE.PERMANENT_CHANGE_OF_STATION,
       origin_duty_location_name: 'Los Angeles AFB',
       new_duty_location_name: 'Fairchild AFB',
       has_dependents: true,

--- a/src/constants/MoveHistory/EventTemplates/CreateOrders/createOrders.test.jsx
+++ b/src/constants/MoveHistory/EventTemplates/CreateOrders/createOrders.test.jsx
@@ -2,6 +2,7 @@ import { render, screen } from '@testing-library/react';
 
 import getTemplate from 'constants/MoveHistory/TemplateManager';
 import e from 'constants/MoveHistory/EventTemplates/CreateOrders/createOrders';
+import { ORDERS_TYPE } from 'constants/orders';
 
 describe('When given a created orders event for the orders table', () => {
   const item = {
@@ -13,7 +14,7 @@ describe('When given a created orders event for the orders table', () => {
       status: 'DRAFT',
       report_by_date: '2022-10-18',
       issue_date: '2022-10-11',
-      orders_type: 'PERMANENT_CHANGE_OF_STATION',
+      orders_type: ORDERS_TYPE.PERMANENT_CHANGE_OF_STATION,
       origin_duty_location_name: 'Los Angeles AFB',
       new_duty_location_name: 'Fairchild AFB',
       has_dependents: true,

--- a/src/constants/MoveHistory/EventTemplates/UpdateOrders/updateOrder.test.jsx
+++ b/src/constants/MoveHistory/EventTemplates/UpdateOrders/updateOrder.test.jsx
@@ -2,6 +2,7 @@ import { render, screen } from '@testing-library/react';
 
 import getTemplate from 'constants/MoveHistory/TemplateManager';
 import e from 'constants/MoveHistory/EventTemplates/UpdateOrders/updateOrder';
+import { ORDERS_TYPE } from 'constants/orders';
 
 describe('when given an Order update history record', () => {
   const historyRecord = {
@@ -14,7 +15,7 @@ describe('when given an Order update history record', () => {
         status: 'SUBMITTED',
         report_by_date: '2022-10-12',
         issue_date: '2022-10-11',
-        orders_type: 'PERMANENT_CHANGE_OF_STATION',
+        orders_type: ORDERS_TYPE.PERMANENT_CHANGE_OF_STATION,
         origin_duty_location_id: 'ID2',
         new_duty_location_id: 'ID2',
         has_dependents: true,
@@ -36,7 +37,7 @@ describe('when given an Order update history record', () => {
         report_by_date: '2022-10-12',
       },
       oldValues: {
-        orders_type: 'SEPARATION',
+        orders_type: ORDERS_TYPE.SEPARATION,
       },
     },
     RETIREMENT: {
@@ -46,7 +47,7 @@ describe('when given an Order update history record', () => {
       eventNameDisplay: 'Updated orders',
       changedValues: {
         report_by_date: '2022-10-12',
-        orders_type: 'RETIREMENT',
+        orders_type: ORDERS_TYPE.RETIREMENT,
       },
     },
   };

--- a/src/constants/orders.js
+++ b/src/constants/orders.js
@@ -3,6 +3,7 @@ export const ORDERS_TYPE = {
   LOCAL_MOVE: 'LOCAL_MOVE',
   RETIREMENT: 'RETIREMENT',
   SEPARATION: 'SEPARATION',
+  TEMPORARY_DUTY: 'TEMPORARY_DUTY',
 };
 
 export const SPECIAL_ORDERS_TYPES = {
@@ -22,6 +23,7 @@ export const ORDERS_TYPE_OPTIONS = {
   SEPARATION: 'Separation',
   WOUNDED_WARRIOR: 'Wounded Warrior',
   BLUEBARK: 'BLUEBARK',
+  TEMPORARY_DUTY: 'Temporary Duty (TDY)',
 };
 
 export const ORDERS_TYPE_DETAILS = {

--- a/src/pages/MyMove/AddOrders.test.jsx
+++ b/src/pages/MyMove/AddOrders.test.jsx
@@ -10,6 +10,7 @@ import { renderWithProviders } from 'testUtils';
 import { customerRoutes, generalRoutes } from 'constants/routes';
 import { selectCanAddOrders, selectServiceMemberFromLoggedInUser } from 'store/entities/selectors';
 import { setCanAddOrders, setMoveId } from 'store/general/actions';
+import { ORDERS_TYPE } from 'constants/orders';
 
 jest.mock('services/internalApi', () => ({
   ...jest.requireActual('services/internalApi'),
@@ -250,7 +251,7 @@ describe('Add Orders page', () => {
   it('next button creates the orders and updates state', async () => {
     const testOrdersValues = {
       id: 'testOrdersId',
-      orders_type: 'PERMANENT_CHANGE_OF_STATION',
+      orders_type: ORDERS_TYPE.PERMANENT_CHANGE_OF_STATION,
       issue_date: '2020-11-08',
       report_by_date: '2020-11-26',
       has_dependents: false,
@@ -290,7 +291,7 @@ describe('Add Orders page', () => {
     expect(nextBtn).toBeInTheDocument();
 
     await act(async () => {
-      await userEvent.selectOptions(screen.getByLabelText(/Orders type/), 'PERMANENT_CHANGE_OF_STATION');
+      await userEvent.selectOptions(screen.getByLabelText(/Orders type/), ORDERS_TYPE.PERMANENT_CHANGE_OF_STATION);
       await userEvent.type(screen.getByLabelText(/Orders date/), '08 Nov 2020');
       await userEvent.type(screen.getByLabelText(/Report by date/), '26 Nov 2020');
       await userEvent.click(screen.getByLabelText('No'));

--- a/src/pages/MyMove/AmendOrders/AmendOrders.test.jsx
+++ b/src/pages/MyMove/AmendOrders/AmendOrders.test.jsx
@@ -8,6 +8,7 @@ import { getOrders, submitAmendedOrders } from 'services/internalApi';
 import { customerRoutes } from 'constants/routes';
 import { renderWithProviders } from 'testUtils';
 import { selectOrdersForLoggedInUser } from 'store/entities/selectors';
+import { ORDERS_TYPE } from 'constants/orders';
 
 const mockNavigate = jest.fn();
 jest.mock('react-router-dom', () => ({
@@ -31,7 +32,7 @@ jest.mock('services/internalApi', () => ({
 
 const testPropsWithUploads = {
   id: 'testOrderId',
-  orders_type: 'PERMANENT_CHANGE_OF_STATION',
+  orders_type: ORDERS_TYPE.PERMANENT_CHANGE_OF_STATION,
   issue_date: '2020-11-08',
   report_by_date: '2020-11-26',
   has_dependents: false,
@@ -73,7 +74,7 @@ const testPropsWithUploads = {
 
 const testPropsNoUploads = {
   id: 'testOrderId2',
-  orders_type: 'PERMANENT_CHANGE_OF_STATION',
+  orders_type: ORDERS_TYPE.PERMANENT_CHANGE_OF_STATION,
   issue_date: '2020-11-08',
   report_by_date: '2020-11-26',
   has_dependents: false,

--- a/src/pages/MyMove/CreateOrEditMtoShipment.test.jsx
+++ b/src/pages/MyMove/CreateOrEditMtoShipment.test.jsx
@@ -8,6 +8,7 @@ import { customerRoutes } from 'constants/routes';
 import { SHIPMENT_OPTIONS } from 'shared/constants';
 import { renderWithRouterProp } from 'testUtils';
 import { selectCurrentMoveFromAllMoves, selectCurrentShipmentFromMove } from 'store/entities/selectors';
+import { ORDERS_TYPE } from 'constants/orders';
 
 const mockParams = { moveId: 'move123', mtoShipmentId: 'shipment123' };
 const mockPath = customerRoutes.SHIPMENT_EDIT_PATH;
@@ -178,7 +179,7 @@ const testMove = {
       name: 'Flagstaff, AZ 86003',
       updated_at: '2024-02-27T18:22:12.471Z',
     },
-    orders_type: 'PERMANENT_CHANGE_OF_STATION',
+    orders_type: ORDERS_TYPE.PERMANENT_CHANGE_OF_STATION,
     originDutyLocationGbloc: 'BGAC',
     origin_duty_location: {
       address: {

--- a/src/pages/MyMove/EditOrders.test.jsx
+++ b/src/pages/MyMove/EditOrders.test.jsx
@@ -12,6 +12,7 @@ import {
   selectOrdersForLoggedInUser,
   selectServiceMemberFromLoggedInUser,
 } from 'store/entities/selectors';
+import { ORDERS_TYPE } from 'constants/orders';
 
 const mockNavigate = jest.fn();
 jest.mock('react-router-dom', () => ({
@@ -116,7 +117,7 @@ describe('EditOrders Page', () => {
           transportation_office_id: 'd00e3ee8-baba-4991-8f3b-86c2e370d1be',
           updated_at: '2024-02-22T21:34:21.449Z',
         },
-        orders_type: 'PERMANENT_CHANGE_OF_STATION',
+        orders_type: ORDERS_TYPE.PERMANENT_CHANGE_OF_STATION,
         originDutyLocationGbloc: 'BGAC',
         origin_duty_location: {
           address: {
@@ -219,7 +220,7 @@ describe('EditOrders Page', () => {
               transportation_office_id: 'd00e3ee8-baba-4991-8f3b-86c2e370d1be',
               updated_at: '2024-02-22T21:34:21.449Z',
             },
-            orders_type: 'PERMANENT_CHANGE_OF_STATION',
+            orders_type: ORDERS_TYPE.PERMANENT_CHANGE_OF_STATION,
             originDutyLocationGbloc: 'BGAC',
             origin_duty_location: {
               address: {

--- a/src/pages/MyMove/Home/MoveHome.test.jsx
+++ b/src/pages/MyMove/Home/MoveHome.test.jsx
@@ -9,6 +9,7 @@ import MoveHome from './MoveHome';
 import { customerRoutes } from 'constants/routes';
 import { MockProviders } from 'testUtils';
 import { downloadPPMAOAPacket } from 'services/internalApi';
+import { ORDERS_TYPE } from 'constants/orders';
 
 jest.mock('containers/FlashMessage/FlashMessage', () => {
   const MockFlash = () => <div>Flash message</div>;
@@ -138,7 +139,7 @@ const defaultPropsOrdersWithUploads = {
             transportation_office_id: '0357f830-2f32-41f3-9ca2-268dd70df5cb',
             updated_at: '2024-02-15T14:42:58.875Z',
           },
-          orders_type: 'PERMANENT_CHANGE_OF_STATION',
+          orders_type: ORDERS_TYPE.PERMANENT_CHANGE_OF_STATION,
           originDutyLocationGbloc: 'HAFC',
           origin_duty_location: {
             address: {
@@ -353,7 +354,7 @@ const defaultPropsOrdersWithUnsubmittedShipments = {
             transportation_office_id: '0357f830-2f32-41f3-9ca2-268dd70df5cb',
             updated_at: '2024-02-15T14:42:58.875Z',
           },
-          orders_type: 'PERMANENT_CHANGE_OF_STATION',
+          orders_type: ORDERS_TYPE.PERMANENT_CHANGE_OF_STATION,
           originDutyLocationGbloc: 'HAFC',
           origin_duty_location: {
             address: {
@@ -568,7 +569,7 @@ const defaultPropsOrdersWithSubmittedShipments = {
             transportation_office_id: '0357f830-2f32-41f3-9ca2-268dd70df5cb',
             updated_at: '2024-02-15T14:42:58.875Z',
           },
-          orders_type: 'PERMANENT_CHANGE_OF_STATION',
+          orders_type: ORDERS_TYPE.PERMANENT_CHANGE_OF_STATION,
           originDutyLocationGbloc: 'HAFC',
           origin_duty_location: {
             address: {
@@ -753,7 +754,7 @@ const defaultPropsAmendedOrdersWithAdvanceRequested = {
             transportation_office_id: '7f5b64b8-979c-4cbd-890b-bffd6fdf56d9',
             updated_at: '2024-02-15T14:42:58.875Z',
           },
-          orders_type: 'PERMANENT_CHANGE_OF_STATION',
+          orders_type: ORDERS_TYPE.PERMANENT_CHANGE_OF_STATION,
           originDutyLocationGbloc: 'HAFC',
           origin_duty_location: {
             address: {
@@ -959,7 +960,7 @@ const defaultPropsWithAdvanceAndPPMApproved = {
             updated_at: '2024-02-15T14:42:58.875Z',
           },
           orders_number: '12345678901234',
-          orders_type: 'PERMANENT_CHANGE_OF_STATION',
+          orders_type: ORDERS_TYPE.PERMANENT_CHANGE_OF_STATION,
           orders_type_detail: 'PCS_TDY',
           originDutyLocationGbloc: 'HAFC',
           origin_duty_location: {
@@ -1459,7 +1460,7 @@ describe('Home component', () => {
               updated_at: '2024-02-15T14:42:58.875Z',
             },
             orders_number: '12345678901234',
-            orders_type: 'PERMANENT_CHANGE_OF_STATION',
+            orders_type: ORDERS_TYPE.PERMANENT_CHANGE_OF_STATION,
             orders_type_detail: 'PCS_TDY',
             originDutyLocationGbloc: 'HAFC',
             origin_duty_location: {

--- a/src/pages/MyMove/Multi-Moves/MultiMovesLandingPage.test.jsx
+++ b/src/pages/MyMove/Multi-Moves/MultiMovesLandingPage.test.jsx
@@ -8,6 +8,7 @@ import MultiMovesLandingPage from './MultiMovesLandingPage';
 
 import { MockProviders } from 'testUtils';
 import { selectServiceMemberFromLoggedInUser } from 'store/entities/selectors';
+import { ORDERS_TYPE } from 'constants/orders';
 
 // Mock external dependencies
 jest.mock('containers/FlashMessage/FlashMessage', () => {
@@ -120,7 +121,7 @@ const defaultProps = {
           service_member_id: '6686d242-e7af-4a06-afd7-7be423bfca2d',
           issue_date: '2024-01-31T00:00:00Z',
           report_by_date: '2024-02-09T00:00:00Z',
-          orders_type: 'PERMANENT_CHANGE_OF_STATION',
+          orders_type: ORDERS_TYPE.PERMANENT_CHANGE_OF_STATION,
           orders_type_detail: null,
           has_dependents: false,
           spouse_has_pro_gear: false,
@@ -356,7 +357,7 @@ const defaultPropsMultipleMove = {
           service_member_id: '6686d242-e7af-4a06-afd7-7be423bfca2d',
           issue_date: '2024-01-31T00:00:00Z',
           report_by_date: '2024-02-09T00:00:00Z',
-          orders_type: 'PERMANENT_CHANGE_OF_STATION',
+          orders_type: ORDERS_TYPE.PERMANENT_CHANGE_OF_STATION,
           orders_type_detail: null,
           has_dependents: false,
           spouse_has_pro_gear: false,
@@ -493,7 +494,7 @@ const defaultPropsMultipleMove = {
           service_member_id: '6686d242-e7af-4a06-afd7-7be423bfca2d',
           issue_date: '2024-01-31T00:00:00Z',
           report_by_date: '2024-02-09T00:00:00Z',
-          orders_type: 'PERMANENT_CHANGE_OF_STATION',
+          orders_type: ORDERS_TYPE.PERMANENT_CHANGE_OF_STATION,
           orders_type_detail: null,
           has_dependents: false,
           spouse_has_pro_gear: false,
@@ -628,7 +629,7 @@ const defaultPropsMultipleMove = {
           service_member_id: '6686d242-e7af-4a06-afd7-7be423bfca2d',
           issue_date: '2024-01-31T00:00:00Z',
           report_by_date: '2024-02-09T00:00:00Z',
-          orders_type: 'PERMANENT_CHANGE_OF_STATION',
+          orders_type: ORDERS_TYPE.PERMANENT_CHANGE_OF_STATION,
           orders_type_detail: null,
           has_dependents: false,
           spouse_has_pro_gear: false,

--- a/src/pages/MyMove/Multi-Moves/MultiMovesMoveInfoList/MultiMovesInfoList.test.jsx
+++ b/src/pages/MyMove/Multi-Moves/MultiMovesMoveInfoList/MultiMovesInfoList.test.jsx
@@ -4,12 +4,14 @@ import '@testing-library/jest-dom/extend-expect';
 
 import MultiMovesMoveInfoList from './MultiMovesMoveInfoList';
 
+import { ORDERS_TYPE } from 'constants/orders';
+
 describe('MultiMovesMoveInfoList', () => {
   const mockMoveSeparation = {
     status: 'DRAFT',
     orders: {
       issue_date: '2022-01-01',
-      orders_type: 'SEPARATION',
+      orders_type: ORDERS_TYPE.SEPARATION,
       report_by_date: '2022-02-01',
       origin_duty_location: {
         name: 'Fort Bragg North Station',
@@ -42,7 +44,7 @@ describe('MultiMovesMoveInfoList', () => {
     status: 'DRAFT',
     orders: {
       issue_date: '2022-01-01',
-      orders_type: 'RETIREMENT',
+      orders_type: ORDERS_TYPE.RETIREMENT,
       report_by_date: '2022-02-01',
       origin_duty_location: {
         name: 'Fort Bragg North Station',
@@ -75,7 +77,7 @@ describe('MultiMovesMoveInfoList', () => {
     status: 'DRAFT',
     orders: {
       issue_date: '2022-01-01',
-      orders_type: 'PERMANENT_CHANGE_OF_DUTY_STATION',
+      orders_type: ORDERS_TYPE.PERMANENT_CHANGE_OF_STATION,
       report_by_date: '2022-02-01',
       origin_duty_location: {
         name: 'Fort Bragg North Station',

--- a/src/pages/MyMove/Orders.test.jsx
+++ b/src/pages/MyMove/Orders.test.jsx
@@ -12,6 +12,7 @@ import {
   selectOrdersForLoggedInUser,
   selectServiceMemberFromLoggedInUser,
 } from 'store/entities/selectors';
+import { ORDERS_TYPE } from 'constants/orders';
 
 jest.mock('services/internalApi', () => ({
   ...jest.requireActual('services/internalApi'),
@@ -174,7 +175,7 @@ afterEach(() => {
 
 const testPropsWithUploads = {
   id: 'testOrderId',
-  orders_type: 'PERMANENT_CHANGE_OF_STATION',
+  orders_type: ORDERS_TYPE.PERMANENT_CHANGE_OF_STATION,
   issue_date: '2020-11-08',
   report_by_date: '2020-11-26',
   has_dependents: false,
@@ -233,7 +234,7 @@ const testPropsWithUploads = {
 
 const testPropsNoUploads = {
   id: 'testOrderId2',
-  orders_type: 'PERMANENT_CHANGE_OF_STATION',
+  orders_type: ORDERS_TYPE.PERMANENT_CHANGE_OF_STATION,
   issue_date: '2020-11-08',
   report_by_date: '2020-11-26',
   has_dependents: false,
@@ -342,7 +343,7 @@ describe('Orders page', () => {
               transportation_office_id: 'd00e3ee8-baba-4991-8f3b-86c2e370d1be',
               updated_at: '2024-02-22T21:34:21.449Z',
             },
-            orders_type: 'PERMANENT_CHANGE_OF_STATION',
+            orders_type: ORDERS_TYPE.PERMANENT_CHANGE_OF_STATION,
             originDutyLocationGbloc: 'BGAC',
             origin_duty_location: {
               address: {
@@ -456,7 +457,7 @@ describe('Orders page', () => {
     selectAllMoves.mockImplementation(() => testProps.serviceMemberMoves);
     const testOrdersValues = {
       id: 'testOrdersId',
-      orders_type: 'PERMANENT_CHANGE_OF_STATION',
+      orders_type: ORDERS_TYPE.PERMANENT_CHANGE_OF_STATION,
       issue_date: '2020-11-08',
       report_by_date: '2020-11-26',
       has_dependents: false,

--- a/src/pages/MyMove/Review/Review.test.jsx
+++ b/src/pages/MyMove/Review/Review.test.jsx
@@ -7,6 +7,7 @@ import { renderWithProviders } from 'testUtils';
 import { selectAllMoves, selectServiceMemberFromLoggedInUser } from 'store/entities/selectors';
 import { customerRoutes } from 'constants/routes';
 import { getAllMoves } from 'services/internalApi';
+import { ORDERS_TYPE } from 'constants/orders';
 
 // Mock the summary part of the review page since we're just testing the
 // navigation portion.
@@ -85,7 +86,7 @@ describe('Review page', () => {
             transportation_office_id: '7f5b64b8-979c-4cbd-890b-bffd6fdf56d9',
             updated_at: '2024-02-27T18:22:12.471Z',
           },
-          orders_type: 'PERMANENT_CHANGE_OF_STATION',
+          orders_type: ORDERS_TYPE.PERMANENT_CHANGE_OF_STATION,
           originDutyLocationGbloc: 'HAFC',
           origin_duty_location: {
             address: {
@@ -213,7 +214,7 @@ describe('Review page', () => {
             name: 'Flagstaff, AZ 86003',
             updated_at: '2024-02-27T18:22:12.471Z',
           },
-          orders_type: 'PERMANENT_CHANGE_OF_STATION',
+          orders_type: ORDERS_TYPE.PERMANENT_CHANGE_OF_STATION,
           originDutyLocationGbloc: 'BGAC',
           origin_duty_location: {
             address: {
@@ -325,7 +326,7 @@ describe('Review page', () => {
             transportation_office_id: '7f5b64b8-979c-4cbd-890b-bffd6fdf56d9',
             updated_at: '2024-02-27T18:22:12.471Z',
           },
-          orders_type: 'PERMANENT_CHANGE_OF_STATION',
+          orders_type: ORDERS_TYPE.PERMANENT_CHANGE_OF_STATION,
           originDutyLocationGbloc: 'HAFC',
           origin_duty_location: {
             address: {

--- a/src/pages/MyMove/UploadOrders.test.jsx
+++ b/src/pages/MyMove/UploadOrders.test.jsx
@@ -9,6 +9,7 @@ import { deleteUpload, getAllMoves, getOrders, createUploadForDocument } from 's
 import { renderWithProviders } from 'testUtils';
 import { customerRoutes } from 'constants/routes';
 import { selectOrdersForLoggedInUser, selectServiceMemberFromLoggedInUser } from 'store/entities/selectors';
+import { ORDERS_TYPE } from 'constants/orders';
 
 jest.mock('store/entities/selectors', () => ({
   ...jest.requireActual('store/entities/selectors'),
@@ -32,7 +33,7 @@ jest.mock('services/internalApi', () => ({
 
 const testOrdersValues = {
   id: 'testOrdersId',
-  orders_type: 'PERMANENT_CHANGE_OF_STATION',
+  orders_type: ORDERS_TYPE.PERMANENT_CHANGE_OF_STATION,
   issue_date: '2020-11-08',
   report_by_date: '2020-11-26',
   has_dependents: false,
@@ -59,7 +60,7 @@ const testOrdersValues = {
 
 const testPropsWithUploads = {
   id: 'testOrdersId',
-  orders_type: 'PERMANENT_CHANGE_OF_STATION',
+  orders_type: ORDERS_TYPE.PERMANENT_CHANGE_OF_STATION,
   issue_date: '2020-11-08',
   report_by_date: '2020-11-26',
   has_dependents: false,
@@ -101,7 +102,7 @@ const testPropsWithUploads = {
 
 const testPropsNoUploads = {
   id: 'testOrdersId2',
-  orders_type: 'PERMANENT_CHANGE_OF_STATION',
+  orders_type: ORDERS_TYPE.PERMANENT_CHANGE_OF_STATION,
   issue_date: '2020-11-08',
   report_by_date: '2020-11-26',
   has_dependents: false,
@@ -134,7 +135,7 @@ const testPropsNoUploads = {
 const testOrders = [
   {
     id: 'testOrdersId2',
-    orders_type: 'PERMANENT_CHANGE_OF_STATION',
+    orders_type: ORDERS_TYPE.PERMANENT_CHANGE_OF_STATION,
     issue_date: '2020-11-08',
     report_by_date: '2020-11-26',
     has_dependents: false,
@@ -164,7 +165,7 @@ const testOrders = [
   },
   {
     id: 'testOrdersId',
-    orders_type: 'PERMANENT_CHANGE_OF_STATION',
+    orders_type: ORDERS_TYPE.PERMANENT_CHANGE_OF_STATION,
     issue_date: '2020-11-08',
     report_by_date: '2020-11-26',
     has_dependents: false,
@@ -285,7 +286,7 @@ const serviceMemberMoves = {
           transportation_office_id: 'd00e3ee8-baba-4991-8f3b-86c2e370d1be',
           updated_at: '2024-02-22T21:34:21.449Z',
         },
-        orders_type: 'PERMANENT_CHANGE_OF_STATION',
+        orders_type: ORDERS_TYPE.PERMANENT_CHANGE_OF_STATION,
         originDutyLocationGbloc: 'BGAC',
         origin_duty_location: {
           address: {

--- a/src/pages/Office/MoveHistory/LabeledDetails.test.jsx
+++ b/src/pages/Office/MoveHistory/LabeledDetails.test.jsx
@@ -4,6 +4,7 @@ import { render, screen } from '@testing-library/react';
 import LabeledDetails, { retrieveTextToDisplay } from './LabeledDetails';
 
 import { SHIPMENT_OPTIONS } from 'shared/constants';
+import { ORDERS_TYPE } from 'constants/orders';
 
 describe('LabeledDetails', () => {
   describe('for each changed value', () => {
@@ -22,7 +23,7 @@ describe('LabeledDetails', () => {
       pro_gear_weight_spouse: '50',
       required_medical_equipment_weight: '300',
       organizational_clothing_and_individual_equipment: 'false',
-      orders_type: 'PERMANENT_CHANGE_OF_STATION',
+      orders_type: ORDERS_TYPE.PERMANENT_CHANGE_OF_STATION,
       orders_type_detail: 'HHG_PERMITTED',
       origin_duty_location_name: 'Origin duty location name',
       new_duty_location_name: 'New duty location name',

--- a/src/pages/Office/MovePaymentRequests/MovePaymentRequests.test.jsx
+++ b/src/pages/Office/MovePaymentRequests/MovePaymentRequests.test.jsx
@@ -11,6 +11,7 @@ import { useMovePaymentRequestsQueries } from 'hooks/queries';
 import { shipmentStatuses } from 'constants/shipments';
 import SERVICE_ITEM_STATUSES from 'constants/serviceItems';
 import { permissionTypes } from 'constants/permissions';
+import { ORDERS_TYPE } from 'constants/orders';
 
 jest.mock('hooks/queries', () => ({
   useMovePaymentRequestsQueries: jest.fn(),
@@ -44,7 +45,7 @@ const move = {
 };
 
 const order = {
-  orders_type: 'PERMANENT_CHANGE_OF_STATION',
+  orders_type: ORDERS_TYPE.PERMANENT_CHANGE_OF_STATION,
   has_dependents: false,
   issue_date: '2020-08-11',
   grade: 'E_1',

--- a/src/pages/Office/MoveTaskOrder/moveTaskOrderUnitTestData.js
+++ b/src/pages/Office/MoveTaskOrder/moveTaskOrderUnitTestData.js
@@ -5,6 +5,7 @@ import { SERVICE_ITEM_STATUSES } from 'constants/serviceItems';
 import { SIT_EXTENSION_STATUS } from 'constants/sitExtensions';
 import { SERVICE_ITEM_STATUS, SHIPMENT_OPTIONS } from 'shared/constants';
 import { SITStatusOrigin } from 'components/Office/ShipmentSITDisplay/ShipmentSITDisplayTestParams';
+import { ORDERS_TYPE } from 'constants/orders';
 
 export const unapprovedMTOQuery = {
   orders: {
@@ -2704,7 +2705,7 @@ const move = {
 };
 
 const order = {
-  orders_type: 'PERMANENT_CHANGE_OF_STATION',
+  orders_type: ORDERS_TYPE.PERMANENT_CHANGE_OF_STATION,
   has_dependents: false,
   issue_date: '2020-08-11',
   grade: 'GRADE',

--- a/src/sagas/entities.test.js
+++ b/src/sagas/entities.test.js
@@ -22,6 +22,7 @@ import {
 } from 'store/entities/actions';
 import { normalizeResponse } from 'services/swaggerRequest';
 import { addEntities } from 'shared/Entities/actions';
+import { ORDERS_TYPE } from 'constants/orders';
 
 describe('watchUpdateEntities', () => {
   const generator = watchUpdateEntities();
@@ -209,7 +210,7 @@ describe('updateOrders', () => {
         name: 'Luke AFB',
         updated_at: '2020-12-07T17:02:33.987Z',
       },
-      orders_type: 'PERMANENT_CHANGE_OF_STATION',
+      orders_type: ORDERS_TYPE.PERMANENT_CHANGE_OF_STATION,
       report_by_date: '2020-12-28',
       service_member_id: '15a17300-e1c6-4b3a-8e5d-9c47782a3961',
       spouse_has_pro_gear: false,

--- a/src/utils/orders.test.js
+++ b/src/utils/orders.test.js
@@ -5,6 +5,7 @@ describe('matchesOrdersType', () => {
   const PCSOrders = { orders_type: ORDERS_TYPE.PERMANENT_CHANGE_OF_STATION };
   const retirementOrders = { orders_type: ORDERS_TYPE.RETIREMENT };
   const separationOrders = { orders_type: ORDERS_TYPE.SEPARATION };
+  const temporaryDutyOrders = { orders_type: ORDERS_TYPE.TEMPORARY_DUTY };
   it.each([
     [PCSOrders, [ORDERS_TYPE.PERMANENT_CHANGE_OF_STATION]],
     [PCSOrders, [ORDERS_TYPE.RETIREMENT, ORDERS_TYPE.PERMANENT_CHANGE_OF_STATION]],
@@ -12,6 +13,7 @@ describe('matchesOrdersType', () => {
     [retirementOrders, [ORDERS_TYPE.PERMANENT_CHANGE_OF_STATION, ORDERS_TYPE.RETIREMENT]],
     [separationOrders, [ORDERS_TYPE.SEPARATION]],
     [separationOrders, [ORDERS_TYPE.RETIREMENT, ORDERS_TYPE.SEPARATION]],
+    [temporaryDutyOrders, [ORDERS_TYPE.TEMPORARY_DUTY]],
   ])('returns true when orders matches at least one of the provided types', (orders, ordersTypes) => {
     expect(matchesOrdersType(orders, ...ordersTypes)).toEqual(true);
   });
@@ -20,6 +22,7 @@ describe('matchesOrdersType', () => {
     [PCSOrders, ORDERS_TYPE.RETIREMENT],
     [retirementOrders, ORDERS_TYPE.SEPARATION],
     [separationOrders, ORDERS_TYPE.PERMANENT_CHANGE_OF_STATION],
+    [temporaryDutyOrders, ORDERS_TYPE.TEMPORARY_DUTY],
   ])('returns false when the orders type does not match', (orders, ordersType) => {
     expect(matchesOrdersType(matchesOrdersType(orders, ordersType))).toEqual(false);
   });

--- a/swagger-def/definitions/OrdersType.yaml
+++ b/swagger-def/definitions/OrdersType.yaml
@@ -8,6 +8,7 @@ enum:
   - WOUNDED_WARRIOR
   - BLUEBARK
   - SAFETY
+  - TEMPORARY_DUTY
 x-display-value:
   PERMANENT_CHANGE_OF_STATION: Permanent Change Of Station
   LOCAL_MOVE: Local Move
@@ -16,3 +17,4 @@ x-display-value:
   WOUNDED_WARRIOR: Wounded Warrior
   BLUEBARK: BLUEBARK
   SAFETY: Safety
+  TEMPORARY_DUTY: Temporary Duty (TDY)

--- a/swagger-def/support.yaml
+++ b/swagger-def/support.yaml
@@ -1622,6 +1622,7 @@ definitions:
       - NTS
       - WOUNDED_WARRIOR
       - BLUEBARK
+      - TEMPORARY_DUTY
     x-display-value:
       PERMANENT_CHANGE_OF_STATION: Permanent Change Of Station (PCS)
       LOCAL_MOVE: Local Move
@@ -1631,6 +1632,7 @@ definitions:
       NTS: NTS
       WOUNDED_WARRIOR: Wounded Warrior
       BLUEBARK: BLUEBARK
+      TEMPORARY_DUTY: Temporary Duty (TDY)
   OrdersTypeDetail:
     type: string
     title: Orders type detail

--- a/swagger/ghc.yaml
+++ b/swagger/ghc.yaml
@@ -8115,6 +8115,7 @@ definitions:
       - WOUNDED_WARRIOR
       - BLUEBARK
       - SAFETY
+      - TEMPORARY_DUTY
     x-display-value:
       PERMANENT_CHANGE_OF_STATION: Permanent Change Of Station
       LOCAL_MOVE: Local Move
@@ -8123,6 +8124,7 @@ definitions:
       WOUNDED_WARRIOR: Wounded Warrior
       BLUEBARK: BLUEBARK
       SAFETY: Safety
+      TEMPORARY_DUTY: Temporary Duty (TDY)
   Upload:
     description: An uploaded file.
     type: object

--- a/swagger/internal.yaml
+++ b/swagger/internal.yaml
@@ -2527,6 +2527,7 @@ definitions:
       - WOUNDED_WARRIOR
       - BLUEBARK
       - SAFETY
+      - TEMPORARY_DUTY
     x-display-value:
       PERMANENT_CHANGE_OF_STATION: Permanent Change Of Station
       LOCAL_MOVE: Local Move
@@ -2535,6 +2536,7 @@ definitions:
       WOUNDED_WARRIOR: Wounded Warrior
       BLUEBARK: BLUEBARK
       SAFETY: Safety
+      TEMPORARY_DUTY: Temporary Duty (TDY)
   Address:
     description: A postal address
     type: object

--- a/swagger/prime.yaml
+++ b/swagger/prime.yaml
@@ -2951,6 +2951,7 @@ definitions:
       - WOUNDED_WARRIOR
       - BLUEBARK
       - SAFETY
+      - TEMPORARY_DUTY
     x-display-value:
       PERMANENT_CHANGE_OF_STATION: Permanent Change Of Station
       LOCAL_MOVE: Local Move
@@ -2959,6 +2960,7 @@ definitions:
       WOUNDED_WARRIOR: Wounded Warrior
       BLUEBARK: BLUEBARK
       SAFETY: Safety
+      TEMPORARY_DUTY: Temporary Duty (TDY)
   Order:
     type: object
     required:

--- a/swagger/prime_v2.yaml
+++ b/swagger/prime_v2.yaml
@@ -1632,6 +1632,7 @@ definitions:
       - WOUNDED_WARRIOR
       - BLUEBARK
       - SAFETY
+      - TEMPORARY_DUTY
     x-display-value:
       PERMANENT_CHANGE_OF_STATION: Permanent Change Of Station
       LOCAL_MOVE: Local Move
@@ -1640,6 +1641,7 @@ definitions:
       WOUNDED_WARRIOR: Wounded Warrior
       BLUEBARK: BLUEBARK
       SAFETY: Safety
+      TEMPORARY_DUTY: Temporary Duty (TDY)
   Order:
     type: object
     required:

--- a/swagger/prime_v3.yaml
+++ b/swagger/prime_v3.yaml
@@ -1716,6 +1716,7 @@ definitions:
       - WOUNDED_WARRIOR
       - BLUEBARK
       - SAFETY
+      - TEMPORARY_DUTY
     x-display-value:
       PERMANENT_CHANGE_OF_STATION: Permanent Change Of Station
       LOCAL_MOVE: Local Move
@@ -1724,6 +1725,7 @@ definitions:
       WOUNDED_WARRIOR: Wounded Warrior
       BLUEBARK: BLUEBARK
       SAFETY: Safety
+      TEMPORARY_DUTY: Temporary Duty (TDY)
   Order:
     type: object
     required:

--- a/swagger/support.yaml
+++ b/swagger/support.yaml
@@ -1747,6 +1747,7 @@ definitions:
       - NTS
       - WOUNDED_WARRIOR
       - BLUEBARK
+      - TEMPORARY_DUTY
     x-display-value:
       PERMANENT_CHANGE_OF_STATION: Permanent Change Of Station (PCS)
       LOCAL_MOVE: Local Move
@@ -1756,6 +1757,7 @@ definitions:
       NTS: NTS
       WOUNDED_WARRIOR: Wounded Warrior
       BLUEBARK: BLUEBARK
+      TEMPORARY_DUTY: Temporary Duty (TDY)
   OrdersTypeDetail:
     type: string
     title: Orders type detail


### PR DESCRIPTION
## [B-21597](https://www13.v1host.com/USTRANSCOM38/assetdetail.v1?number=B-21597)

## Summary

The orders type of TDY vs PCS will influence differences in UB (unaccompanied baggage) shipment weight allowances. So, we needed to add the Temporary Duty (TDY) type to the orders type options.

Work in this PR:
- Made the orders_type an enum
- Added TEMPORARY_DUTY as an orders_type enum value
- Updated tests to use constants instead of hard-coded values for orders type, where it made sense to do so

To Test:
1. Create a new customer and get to the point of adding orders
2. Confirm that Temporary Duty (TDY) is an option to select for orders
3. Select TDY as your orders type
4. Continue through adding a few shipments and submit the move
5. Confirm the orders were created with orders_type of TEMPORARY_DUTY
6. Run through the SC and TOO process and keep an eye out for any oddities

<img width="713" alt="image" src="https://github.com/user-attachments/assets/186fe84f-20ba-449c-a470-9071b01e7f04">

<img width="403" alt="image" src="https://github.com/user-attachments/assets/010b7b35-04f4-438b-85cd-6137322737c3">

<img width="511" alt="image" src="https://github.com/user-attachments/assets/0351c646-8965-4fa1-80ad-d7a384a409b0">

<img width="371" alt="image" src="https://github.com/user-attachments/assets/e6fb2ce5-cc34-49e1-8f52-703ed3f8e7a4">

<img width="416" alt="image" src="https://github.com/user-attachments/assets/264e7f6e-60ee-40f7-a3b9-668a3bba6960">

508: 
<img width="1231" alt="image" src="https://github.com/user-attachments/assets/f32e926e-f7d1-4601-8456-9295fa6edad6">

