### PR TITLE
B-21524 adding space

### DIFF
--- a/pkg/assets/notifications/templates/move_counseled_template.html
+++ b/pkg/assets/notifications/templates/move_counseled_template.html
@@ -10,7 +10,7 @@ If you are doing a Personally Procured Move (PPM), you can start moving your per
   {{if .ActualExpenseReimbursement}}
   <li>Please Note: Your PPM has been designated as Actual Expense Reimbursement. This is the standard entitlement for Civilian employees. For uniformed Service Members, your PPM may have been designated as Actual Expense Reimbursement due to failure to receive authorization prior to movement or failure to obtain certified weight tickets. Actual Expense Reimbursement means reimbursement for expenses not to exceed the Government Constructed Cost (GCC).</li>
   {{end}}
-  <li>Remember to get legible certified weight tickets for both the empty and full weights for every trip you perform. If you do not upload legible certified weight tickets, your PPM incentive(or Actual Expense Reimbursement for Civilians) could be affected. Failure to obtain weight tickets will result in losing eligibility to receive your incentive.</li>
+  <li>Remember to get legible certified weight tickets for both the empty and full weights for every trip you perform. If you do not upload legible certified weight tickets, your PPM incentive (or Actual Expense Reimbursement for Civilians) could be affected. Failure to obtain weight tickets will result in losing eligibility to receive your incentive.</li>
 <p>Note: To receive allowance for Pro-Gear, you must identify allowable items and provide weight tickets separately for Pro-Gear.</p>
   <li>For authorized storage:</li>
     <ul>

--- a/pkg/assets/notifications/templates/move_counseled_template.txt
+++ b/pkg/assets/notifications/templates/move_counseled_template.txt
@@ -9,7 +9,7 @@ Next steps for a PPM:
     {{if .ActualExpenseReimbursement}}
     * Please Note: Your PPM has been designated as Actual Expense Reimbursement. This is the standard entitlement for Civilian employees. For uniformed Service Members, your PPM may have been designated as Actual Expense Reimbursement due to failure to receive authorization prior to movement or failure to obtain certified weight tickets. Actual Expense Reimbursement means reimbursement for expenses not to exceed the Government Constructed Cost (GCC).
     {{end}}
-    * Remember to get legible certified weight tickets for both the empty and full weights for every trip you perform. If you do not upload legible certified weight tickets, your PPM incentive(or Actual Expense Reimbursement for Civilians) could be affected. Failure to obtain weight tickets will result in losing eligibility to receive your incentive.
+    * Remember to get legible certified weight tickets for both the empty and full weights for every trip you perform. If you do not upload legible certified weight tickets, your PPM incentive (or Actual Expense Reimbursement for Civilians) could be affected. Failure to obtain weight tickets will result in losing eligibility to receive your incentive.
 Note: To receive allowance for Pro-Gear, you must identify allowable items and provide weight tickets separately for Pro-Gear.
     * For authorized storage:
         * You will need to get weight ticket(s) for the items you store.

--- a/pkg/notifications/move_counseled_test.go
+++ b/pkg/notifications/move_counseled_test.go
@@ -56,7 +56,7 @@ If you are doing a Personally Procured Move (PPM), you can start moving your per
 <p><strong>Next steps for a PPM:</strong>
 <ul>
   <li>Please Note: Your PPM has been designated as Actual Expense Reimbursement. This is the standard entitlement for Civilian employees. For uniformed Service Members, your PPM may have been designated as Actual Expense Reimbursement due to failure to receive authorization prior to movement or failure to obtain certified weight tickets. Actual Expense Reimbursement means reimbursement for expenses not to exceed the Government Constructed Cost (GCC).</li>
-  <li>Remember to get legible certified weight tickets for both the empty and full weights for every trip you perform. If you do not upload legible certified weight tickets, your PPM incentive(or Actual Expense Reimbursement for Civilians) could be affected. Failure to obtain weight tickets will result in losing eligibility to receive your incentive.</li>
+  <li>Remember to get legible certified weight tickets for both the empty and full weights for every trip you perform. If you do not upload legible certified weight tickets, your PPM incentive (or Actual Expense Reimbursement for Civilians) could be affected. Failure to obtain weight tickets will result in losing eligibility to receive your incentive.</li>
 <p>Note: To receive allowance for Pro-Gear, you must identify allowable items and provide weight tickets separately for Pro-Gear.</p>
   <li>For authorized storage:</li>
     <ul>
@@ -111,7 +111,7 @@ What this means to you:
 If you are doing a Personally Procured Move (PPM), you can start moving your personal property.
 
 Next steps for a PPM:
-    * Remember to get legible certified weight tickets for both the empty and full weights for every trip you perform. If you do not upload legible certified weight tickets, your PPM incentive(or Actual Expense Reimbursement for Civilians) could be affected. Failure to obtain weight tickets will result in losing eligibility to receive your incentive.
+    * Remember to get legible certified weight tickets for both the empty and full weights for every trip you perform. If you do not upload legible certified weight tickets, your PPM incentive (or Actual Expense Reimbursement for Civilians) could be affected. Failure to obtain weight tickets will result in losing eligibility to receive your incentive.
 Note: To receive allowance for Pro-Gear, you must identify allowable items and provide weight tickets separately for Pro-Gear.
     * For authorized storage:
         * You will need to get weight ticket(s) for the items you store.


### PR DESCRIPTION
## [B-21524](https://www13.v1host.com/USTRANSCOM38/story.mvc/Summary?oidToken=Story%3A1020745)

## Summary

Integration PR: https://github.com/transcom/mymove/pull/14013
This PR adds a space that was missing between "your PPM incentive (or Actual..."

## Verification Steps for Reviewers

These are to be checked by a reviewer.

- [ ] Has the branch been pulled in and checked out?
- [ ] Have the BL acceptance criteria been met for this change?
- [ ] Was the CircleCI build successful?
- [ ] Has the code been reviewed from a standards and best practices point of view?

### How to test
**Test non actual expense move**

1. Instead of runnning make server_run run this: 
`EMAIL_BACKEND=ses AWS_REGION=us-gov-west-1  aws-vault exec transcom-gov-dev -- make server_run `
and then run make client_run
2. Create a PPM move
3. Login as a Service counselor and submit the move details
4. Confirm added space here "your PPM incentive (or Actual..."

**Test actual expense move**

1. Create a PPM move
2. in the database set its "isActualExpenseReimbursement" to true
3. Login as a Service counselor and submit the move details
6. Confirm added space here "your PPM incentive (or Actual..."

### Backend

- [ ] Code follows the guidelines for [Logging](https://transcom.github.io/mymove-docs/docs/getting-started/development/logging).
- [ ] The requirements listed in [Querying the Database Safely](https://transcom.github.io/mymove-docs/docs/backend/guides/golang-guide#querying-the-database-safely) have been satisfied.

## Screenshots
**_ActualExpenseReimbursement_**
<img width="738" alt="Screenshot 2024-10-30 at 11 27 26 AM" src="https://github.com/user-attachments/assets/591d3d4c-de82-4519-a573-551acfc3e6e1">

**_Not ActualExpenseReimbursement_**
<img width="740" alt="Screenshot 2024-10-30 at 11 14 46 AM" src="https://github.com/user-attachments/assets/2ffc8a5c-bb20-4701-b4d6-c38edc27e0a9">


**_AC Email:_**
<img width="1041" alt="Screenshot 2024-10-29 at 8 46 38 AM" src="https://github.com/user-attachments/assets/f7289379-b453-41c5-b917-a08a19bc0ef8">

[Email #2 - Your counselor has approved your move details update - 2 Oct 24 (1).docx](https://github.com/user-attachments/files/17557728/Email.2.-.Your.counselor.has.approved.your.move.details.update.-.2.Oct.24.1.docx)
