### PR TITLE
B 21467-INT PPM Verbiage Update to Customer Submit Confirmation Screen

### DIFF
--- a/src/pages/MyMove/Home/HomeHelpers.jsx
+++ b/src/pages/MyMove/Home/HomeHelpers.jsx
@@ -142,8 +142,8 @@ export const HelperPPMCloseoutSubmitted = () => (
       to your Finance office to finalize your acutal incentive amount and request payment.
     </p>
     <p>
-      If any documentation is unclear or inaccurate, the counselor will send it back for you to edit. When you are done
-      editing, you will submit it again and a counselor will review your changes.
+      If any documentation is unclear or inaccurate, the counselor will reach out to you to request clarification or
+      documentation updates.
     </p>
   </Helper>
 );

--- a/src/pages/MyMove/Home/index.test.jsx
+++ b/src/pages/MyMove/Home/index.test.jsx
@@ -1026,4 +1026,55 @@ describe('Home component', () => {
       );
     });
   });
+  describe('if the user has a ppm closeout', () => {
+    const props = {
+      ...defaultProps,
+      move: { ...defaultProps.move, status: MOVE_STATUSES.APPROVED, submitted_at: new Date().toISOString() },
+      orders,
+      uploadedOrderDocuments,
+    };
+    it('is submitted and currently in review', () => {
+      const propsForCloseoutCompleteShipment = {
+        ...props,
+        mtoShipments: [
+          createPPMShipmentWithFinalIncentive({
+            ppmShipment: {
+              status: ppmShipmentStatuses.NEEDS_CLOSEOUT,
+              pickupAddress: {
+                streetAddress1: '1 Test Street',
+                streetAddress2: '2 Test Street',
+                streetAddress3: '3 Test Street',
+                city: 'Pickup Test City',
+                state: 'NY',
+                postalCode: '10001',
+              },
+              destinationAddress: {
+                streetAddress1: '1 Test Street',
+                streetAddress2: '2 Test Street',
+                streetAddress3: '3 Test Street',
+                city: 'Destination Test City',
+                state: 'NY',
+                postalCode: '11111',
+              },
+            },
+          }),
+        ],
+      };
+      render(
+        <MockProviders>
+          <Home {...propsForCloseoutCompleteShipment} />
+        </MockProviders>,
+      );
+      expect(
+        screen.getByText(
+          'If your documentation is clear and valid, you’ll be able to download a payment packet. You can submit that packet to your Finance office to finalize your acutal incentive amount and request payment.',
+        ),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText(
+          'If any documentation is unclear or inaccurate, the counselor will reach out to you to request clarification or documentation updates.',
+        ),
+      ).toBeInTheDocument();
+    });
+  });
 });


### PR DESCRIPTION
## [B-21467 PPM Verbiage Update to Customer Submit Confirmation Screen](https://www13.v1host.com/USTRANSCOM38/assetdetail.v1?number=B-21467)


### How to test

1. log into milmove local as a user that needs a ppm closeout but hasn't been processed by SC yet (ex: needscloseout@ppm.closeout)
2. open the move
3. there should be a message near the top stating 

> If any documentation is unclear or inaccurate, the counselor will reach out to you to request clarification or documentation updates.
>
instead of:

> If any documentation is unclear or inaccurate, the counselor will send it back for you to edit. When you are done editing, you will submit it again and a counselor will review your changes.

![image](https://github.com/user-attachments/assets/7b6dfe8a-5160-48c1-b9a3-46fcb3cbda1d)

