### PR TITLE
B-21627-INT SC queue hotfix

### DIFF
--- a/scripts/ensure-js-test-coverage
+++ b/scripts/ensure-js-test-coverage
@@ -34,7 +34,7 @@ new_percent = total_coverage_percent(new_file)
 print(f"Baseline test coverage: {baseline_percent}")
 print(f"New test coverage: {new_percent}")
 
-if new_percent <= (baseline_percent - COVERAGE_TOLERANCE):
+if new_percent < (baseline_percent - COVERAGE_TOLERANCE):
   print("Test Coverage has decreased")
   print("Refer to the following to learn how to resolve this:")
   print(f"{HELP_URL}")

--- a/src/pages/Office/index.jsx
+++ b/src/pages/Office/index.jsx
@@ -313,7 +313,10 @@ export class OfficeApp extends Component {
                           end
                           element={
                             <PrivateRoute requiredRoles={[roleTypes.SERVICES_COUNSELOR]}>
-                              <ServicesCounselingQueue isQueueManagementFFEnabled={queueManagementFlag} />
+                              <ServicesCounselingQueue
+                                userPrivileges={userPrivileges}
+                                isQueueManagementFFEnabled={queueManagementFlag}
+                              />
                             </PrivateRoute>
                           }
                         />


### PR DESCRIPTION
## [Agility ticket](https://www13.v1host.com/USTRANSCOM38/assetdetail.v1?number=B-21627)

## Summary

A dev who shall remain UNNAMED accidentally took a line of code out, so we are no longer passing userPriv down to the SC Queue component. This fixes that unnamed devs mistake.

TEST:

1. Login as a SC Supervisor and confirm the Origin Duty Location filter is a dropdown again