### PR TITLE
MAIN B-21638 error in staging when delivering out of sit

### DIFF
--- a/src/pages/PrimeUI/UpdateServiceItems/PrimeUIUpdateDestSITForm.jsx
+++ b/src/pages/PrimeUI/UpdateServiceItems/PrimeUIUpdateDestSITForm.jsx
@@ -14,6 +14,7 @@ import WizardNavigation from 'components/Customer/WizardNavigation/WizardNavigat
 import descriptionListStyles from 'styles/descriptionList.module.scss';
 import { primeSimulatorRoutes } from 'constants/routes';
 import { DatePickerInput } from 'components/form/fields';
+import { SERVICE_ITEM_STATUSES } from 'constants/serviceItems';
 
 const PrimeUIUpdateDestSITForm = ({ initialValues, onSubmit, serviceItem }) => {
   const { moveCodeOrID } = useParams();
@@ -70,16 +71,18 @@ const PrimeUIUpdateDestSITForm = ({ initialValues, onSubmit, serviceItem }) => {
                   <DatePickerInput name="sitRequestedDelivery" label="SIT Requested Delivery" />
                   <DatePickerInput name="sitCustomerContacted" label="SIT Customer Contacted" />
                 </div>
-                <TextField
-                  display="textarea"
-                  label="Update Reason"
-                  data-testid="updateReason"
-                  name="updateReason"
-                  className={`${formStyles.remarks}`}
-                  placeholder=""
-                  id="updateReason"
-                  maxLength={500}
-                />
+                {serviceItem.status === SERVICE_ITEM_STATUSES.REJECTED && (
+                  <TextField
+                    display="textarea"
+                    label="Update Reason"
+                    data-testid="updateReason"
+                    name="updateReason"
+                    className={`${formStyles.remarks}`}
+                    placeholder=""
+                    id="updateReason"
+                    maxLength={500}
+                  />
+                )}
               </SectionWrapper>
               <WizardNavigation
                 editMode

--- a/src/pages/PrimeUI/UpdateServiceItems/PrimeUIUpdateOriginSITForm.jsx
+++ b/src/pages/PrimeUI/UpdateServiceItems/PrimeUIUpdateOriginSITForm.jsx
@@ -14,6 +14,7 @@ import WizardNavigation from 'components/Customer/WizardNavigation/WizardNavigat
 import descriptionListStyles from 'styles/descriptionList.module.scss';
 import { primeSimulatorRoutes } from 'constants/routes';
 import { DatePickerInput } from 'components/form/fields';
+import { SERVICE_ITEM_STATUSES } from 'constants/serviceItems';
 
 const PrimeUIUpdateOriginSITForm = ({ initialValues, onSubmit, serviceItem }) => {
   const { moveCodeOrID } = useParams();
@@ -70,16 +71,18 @@ const PrimeUIUpdateOriginSITForm = ({ initialValues, onSubmit, serviceItem }) =>
                   <DatePickerInput name="sitRequestedDelivery" label="SIT Requested Delivery" />
                   <DatePickerInput name="sitCustomerContacted" label="SIT Customer Contacted" />
                 </div>
-                <TextField
-                  display="textarea"
-                  label="Update Reason"
-                  data-testid="updateReason"
-                  name="updateReason"
-                  className={`${formStyles.remarks}`}
-                  placeholder=""
-                  id="updateReason"
-                  maxLength={500}
-                />
+                {serviceItem.status === SERVICE_ITEM_STATUSES.REJECTED && (
+                  <TextField
+                    display="textarea"
+                    label="Update Reason"
+                    data-testid="updateReason"
+                    name="updateReason"
+                    className={`${formStyles.remarks}`}
+                    placeholder=""
+                    id="updateReason"
+                    maxLength={500}
+                  />
+                )}
               </SectionWrapper>
               <WizardNavigation
                 editMode

--- a/src/pages/PrimeUI/UpdateServiceItems/PrimeUIUpdateSitServiceItem.jsx
+++ b/src/pages/PrimeUI/UpdateServiceItems/PrimeUIUpdateSitServiceItem.jsx
@@ -97,11 +97,11 @@ const PrimeUIUpdateSitServiceItem = ({ setFlashMessage }) => {
       sitCustomerContacted: sitCustomerContacted === 'Invalid date' ? null : formatDateForSwagger(sitCustomerContacted),
       reServiceCode,
       modelType: 'UpdateMTOServiceItemSIT',
-      updateReason,
     };
 
     if (serviceItem?.status === SERVICE_ITEM_STATUSES.REJECTED) {
       body.requestApprovalsRequestedStatus = true;
+      body.updateReason = updateReason;
     }
 
     createUpdateSITServiceItemRequestMutation({ mtoServiceItemID, eTag, body });

--- a/src/pages/PrimeUI/UpdateServiceItems/PrimeUIUpdateSitServiceItem.jsx
+++ b/src/pages/PrimeUI/UpdateServiceItems/PrimeUIUpdateSitServiceItem.jsx
@@ -91,8 +91,6 @@ const PrimeUIUpdateSitServiceItem = ({ setFlashMessage }) => {
       eTag,
     } = values;
 
-    const requestApprovalsRequestedStatus = serviceItem?.status === SERVICE_ITEM_STATUSES.REJECTED;
-
     const body = {
       sitDepartureDate: sitDepartureDate === 'Invalid date' ? null : formatDateForSwagger(sitDepartureDate),
       sitRequestedDelivery: sitRequestedDelivery === 'Invalid date' ? null : formatDateForSwagger(sitRequestedDelivery),
@@ -100,8 +98,11 @@ const PrimeUIUpdateSitServiceItem = ({ setFlashMessage }) => {
       reServiceCode,
       modelType: 'UpdateMTOServiceItemSIT',
       updateReason,
-      requestApprovalsRequestedStatus,
     };
+
+    if (serviceItem?.status === SERVICE_ITEM_STATUSES.REJECTED) {
+      body.requestApprovalsRequestedStatus = true;
+    }
 
     createUpdateSITServiceItemRequestMutation({ mtoServiceItemID, eTag, body });
   };

--- a/src/pages/PrimeUI/UpdateServiceItems/PrimeUpdateSitServiceItem.test.jsx
+++ b/src/pages/PrimeUI/UpdateServiceItems/PrimeUpdateSitServiceItem.test.jsx
@@ -54,6 +54,7 @@ describe('PrimeUIUpdateSitServiceItems page', () => {
             postalCode: '90210',
           },
           id: '45fe9475-d592-48f5-896a-45d4d6eb7e76',
+          status: 'REJECTED',
         },
       ],
     };
@@ -115,6 +116,7 @@ describe('PrimeUIUpdateSitServiceItems page', () => {
             postalCode: '90210',
           },
           id: '45fe9475-d592-48f5-896a-45d4d6eb7e76',
+          status: 'REJECTED',
         },
       ],
     };


### PR DESCRIPTION
## [B-21638](https://www13.v1host.com/USTRANSCOM38/assetdetail.v1?number=B-21638)

INT PR: https://github.com/transcom/mymove/pull/14116

## Summary

This is a hotfix for a bug introduced in [B-20966](https://github.com/transcom/mymove/pull/13811) where an error is presented when trying to update an approved service item using the Prime Sim. Issue was due to `requestApprovalsRequestedStatus` being sent to backend as 'false' and this is not allowed for an approved service item status.

- Changed to include `requestApprovalsRequestedStatus` and `reason` in the payload only if the service item status is `REJECTED`.
- Changed to display `Reason` textbox in Prime Sim only if the service item status is `REJECTED`.

### How to test

1. Create a move with approved service items(`HHGMoveInSITEndsTomorrow` testharness also works).
2. Using prime sim, find the move and update the approved service item using 'edit' button next to it.
3. You should not see any error.

