### PR TITLE
INT B-21638 error in staging when delivering out of sit

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -49,7 +49,7 @@ require (
 	github.com/gobuffalo/validate/v3 v3.3.3
 	github.com/gocarina/gocsv v0.0.0-20221216233619-1fea7ae8d380
 	github.com/gofrs/uuid v4.4.0+incompatible
-	github.com/golang-jwt/jwt/v4 v4.5.0
+	github.com/golang-jwt/jwt/v4 v4.5.1
 	github.com/gomodule/redigo v1.9.2
 	github.com/google/go-github/v31 v31.0.0
 	github.com/gorilla/csrf v1.7.2

--- a/go.sum
+++ b/go.sum
@@ -258,8 +258,8 @@ github.com/gofrs/uuid v4.2.0+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRx
 github.com/gofrs/uuid v4.3.1+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRxnplIgP/c0N/04lM=
 github.com/gofrs/uuid v4.4.0+incompatible h1:3qXRTX8/NbyulANqlc0lchS1gqAVxRgsuW1YrTJupqA=
 github.com/gofrs/uuid v4.4.0+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRxnplIgP/c0N/04lM=
-github.com/golang-jwt/jwt/v4 v4.5.0 h1:7cYmW1XlMY7h7ii7UhUyChSgS5wUJEnm9uZVTGqOWzg=
-github.com/golang-jwt/jwt/v4 v4.5.0/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
+github.com/golang-jwt/jwt/v4 v4.5.1 h1:JdqV9zKUdtaa9gdPlywC3aeoEsR681PlKC+4F5gQgeo=
+github.com/golang-jwt/jwt/v4 v4.5.1/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/mock v1.1.1/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=

--- a/src/pages/PrimeUI/UpdateServiceItems/PrimeUIUpdateDestSITForm.jsx
+++ b/src/pages/PrimeUI/UpdateServiceItems/PrimeUIUpdateDestSITForm.jsx
@@ -14,6 +14,7 @@ import WizardNavigation from 'components/Customer/WizardNavigation/WizardNavigat
 import descriptionListStyles from 'styles/descriptionList.module.scss';
 import { primeSimulatorRoutes } from 'constants/routes';
 import { DatePickerInput } from 'components/form/fields';
+import { SERVICE_ITEM_STATUSES } from 'constants/serviceItems';
 
 const PrimeUIUpdateDestSITForm = ({ initialValues, onSubmit, serviceItem }) => {
   const { moveCodeOrID } = useParams();
@@ -70,16 +71,18 @@ const PrimeUIUpdateDestSITForm = ({ initialValues, onSubmit, serviceItem }) => {
                   <DatePickerInput name="sitRequestedDelivery" label="SIT Requested Delivery" />
                   <DatePickerInput name="sitCustomerContacted" label="SIT Customer Contacted" />
                 </div>
-                <TextField
-                  display="textarea"
-                  label="Update Reason"
-                  data-testid="updateReason"
-                  name="updateReason"
-                  className={`${formStyles.remarks}`}
-                  placeholder=""
-                  id="updateReason"
-                  maxLength={500}
-                />
+                {serviceItem.status === SERVICE_ITEM_STATUSES.REJECTED && (
+                  <TextField
+                    display="textarea"
+                    label="Update Reason"
+                    data-testid="updateReason"
+                    name="updateReason"
+                    className={`${formStyles.remarks}`}
+                    placeholder=""
+                    id="updateReason"
+                    maxLength={500}
+                  />
+                )}
               </SectionWrapper>
               <WizardNavigation
                 editMode

--- a/src/pages/PrimeUI/UpdateServiceItems/PrimeUIUpdateOriginSITForm.jsx
+++ b/src/pages/PrimeUI/UpdateServiceItems/PrimeUIUpdateOriginSITForm.jsx
@@ -14,6 +14,7 @@ import WizardNavigation from 'components/Customer/WizardNavigation/WizardNavigat
 import descriptionListStyles from 'styles/descriptionList.module.scss';
 import { primeSimulatorRoutes } from 'constants/routes';
 import { DatePickerInput } from 'components/form/fields';
+import { SERVICE_ITEM_STATUSES } from 'constants/serviceItems';
 
 const PrimeUIUpdateOriginSITForm = ({ initialValues, onSubmit, serviceItem }) => {
   const { moveCodeOrID } = useParams();
@@ -70,16 +71,18 @@ const PrimeUIUpdateOriginSITForm = ({ initialValues, onSubmit, serviceItem }) =>
                   <DatePickerInput name="sitRequestedDelivery" label="SIT Requested Delivery" />
                   <DatePickerInput name="sitCustomerContacted" label="SIT Customer Contacted" />
                 </div>
-                <TextField
-                  display="textarea"
-                  label="Update Reason"
-                  data-testid="updateReason"
-                  name="updateReason"
-                  className={`${formStyles.remarks}`}
-                  placeholder=""
-                  id="updateReason"
-                  maxLength={500}
-                />
+                {serviceItem.status === SERVICE_ITEM_STATUSES.REJECTED && (
+                  <TextField
+                    display="textarea"
+                    label="Update Reason"
+                    data-testid="updateReason"
+                    name="updateReason"
+                    className={`${formStyles.remarks}`}
+                    placeholder=""
+                    id="updateReason"
+                    maxLength={500}
+                  />
+                )}
               </SectionWrapper>
               <WizardNavigation
                 editMode

--- a/src/pages/PrimeUI/UpdateServiceItems/PrimeUIUpdateSitServiceItem.jsx
+++ b/src/pages/PrimeUI/UpdateServiceItems/PrimeUIUpdateSitServiceItem.jsx
@@ -91,17 +91,18 @@ const PrimeUIUpdateSitServiceItem = ({ setFlashMessage }) => {
       eTag,
     } = values;
 
-    const requestApprovalsRequestedStatus = serviceItem?.status === SERVICE_ITEM_STATUSES.REJECTED;
-
     const body = {
       sitDepartureDate: sitDepartureDate === 'Invalid date' ? null : formatDateForSwagger(sitDepartureDate),
       sitRequestedDelivery: sitRequestedDelivery === 'Invalid date' ? null : formatDateForSwagger(sitRequestedDelivery),
       sitCustomerContacted: sitCustomerContacted === 'Invalid date' ? null : formatDateForSwagger(sitCustomerContacted),
       reServiceCode,
       modelType: 'UpdateMTOServiceItemSIT',
-      updateReason,
-      requestApprovalsRequestedStatus,
     };
+
+    if (serviceItem?.status === SERVICE_ITEM_STATUSES.REJECTED) {
+      body.requestApprovalsRequestedStatus = true;
+      body.updateReason = updateReason;
+    }
 
     createUpdateSITServiceItemRequestMutation({ mtoServiceItemID, eTag, body });
   };

--- a/src/pages/PrimeUI/UpdateServiceItems/PrimeUpdateSitServiceItem.test.jsx
+++ b/src/pages/PrimeUI/UpdateServiceItems/PrimeUpdateSitServiceItem.test.jsx
@@ -54,6 +54,7 @@ describe('PrimeUIUpdateSitServiceItems page', () => {
             postalCode: '90210',
           },
           id: '45fe9475-d592-48f5-896a-45d4d6eb7e76',
+          status: 'REJECTED',
         },
       ],
     };
@@ -115,6 +116,7 @@ describe('PrimeUIUpdateSitServiceItems page', () => {
             postalCode: '90210',
           },
           id: '45fe9475-d592-48f5-896a-45d4d6eb7e76',
+          status: 'REJECTED',
         },
       ],
     };


### PR DESCRIPTION
## [B-21638](https://www13.v1host.com/USTRANSCOM38/assetdetail.v1?number=B-21638)

## Summary

This is a hotfix for a bug introduced in [B-20966](https://github.com/transcom/mymove/pull/13811) where an error is presented when trying to update an approved service item using the Prime Sim. Issue was due to `requestApprovalsRequestedStatus` being sent to backend as 'false' and this is not allowed for an approved service item status.

- Changed to include `requestApprovalsRequestedStatus` and `reason` in the payload only if the service item status is `REJECTED`.
- Changed to display `Reason` textbox in Prime Sim only if the service item status is `REJECTED`.

### How to test

1. Create a move with approved service items(`HHGMoveInSITEndsTomorrow` testharness also works).
2. Using prime sim, find the move and update the approved service item using 'edit' button next to it.
3. You should not see any error.

