### PR TITLE
B-21597 Updating invalid orders type INT

### DIFF
--- a/migrations/app/schema/20241029125015_add_orders_type_enum.up.sql
+++ b/migrations/app/schema/20241029125015_add_orders_type_enum.up.sql
@@ -1,5 +1,9 @@
 -- Add enum values for order.orders_type
 
+UPDATE orders
+SET orders_type = 'PERMANENT_CHANGE_OF_STATION'
+WHERE orders_type = 'VARIOUS' OR orders_type = 'NTS' OR orders_type = 'DEPENDENT_TRAVEL' OR orders_type = 'GHC';
+
 CREATE TYPE orders_type AS ENUM (
 'PERMANENT_CHANGE_OF_STATION',
 'LOCAL_MOVE',


### PR DESCRIPTION
## [Agility ticket](https://www13.v1host.com/USTRANSCOM38/assetdetail.v1?number=B-21597)
## [First INT PR](https://github.com/transcom/mymove/pull/14049)

## Summary

A follow on update to the migration to update (in the stg and prd environments) some moves that had types that are no longer valid - VARIOUS, NTS, DEPENDENT_TRAVEL, GHC. Updating those all to PERMANENT_CHANGE_OF_STATION per the PO's request.

