### PR TITLE
B-21667 UB UI Updates for Office Users - INT

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -154,7 +154,7 @@ export FEATURE_FLAG_NTS=true
 export FEATURE_FLAG_NTSR=true
 export FEATURE_FLAG_BOAT=true
 export FEATURE_FLAG_MOBILE_HOME=true
-export FEATURE_FLAG_UNACCOMPANIED_BAGGAGE=true
+export FEATURE_FLAG_UNACCOMPANIED_BAGGAGE=false
 
 # Feature flag to allow AK to be entered as a state
 export FEATURE_FLAG_ENABLE_ALASKA=false

--- a/.envrc
+++ b/.envrc
@@ -154,7 +154,7 @@ export FEATURE_FLAG_NTS=true
 export FEATURE_FLAG_NTSR=true
 export FEATURE_FLAG_BOAT=true
 export FEATURE_FLAG_MOBILE_HOME=true
-export FEATURE_FLAG_UNACCOMPANIED_BAGGAGE=false
+export FEATURE_FLAG_UNACCOMPANIED_BAGGAGE=true
 
 # Feature flag to allow AK to be entered as a state
 export FEATURE_FLAG_ENABLE_ALASKA=false

--- a/src/components/Office/DefinitionLists/AllowancesList.jsx
+++ b/src/components/Office/DefinitionLists/AllowancesList.jsx
@@ -52,36 +52,34 @@ const AllowancesList = ({ info, showVisualCues }) => {
         it will be safe to assume it is an OCONUS order. With this, if one field is present
         we show all four. Otherwise, we show none */}
         {/* Wrap in FF */}
-        {enableUB &&
-          (info?.accompaniedTour ||
-            info?.dependentsTwelveAndOver ||
-            info?.dependentsUnderTwelve ||
-            info?.ubAllowance) && (
-            <>
-              <div className={descriptionListStyles.row}>
-                <dt>Accompanied tour</dt>
-                <dd data-testid="ordersAccompaniedTour">{info.accompaniedTour ? 'Yes' : 'No'}</dd>
-              </div>
-              <div className={descriptionListStyles.row}>
-                <dt>Dependents under age 12</dt>
-                <dd data-testid="ordersDependentsUnderTwelve">
-                  {info.dependentsUnderTwelve ? info.dependentsUnderTwelve : DEFAULT_EMPTY_VALUE}
-                </dd>
-              </div>
-              <div className={descriptionListStyles.row}>
-                <dt>Dependents over age 12</dt>
-                <dd data-testid="ordersDependentsTwelveAndOver">
-                  {info.dependentsTwelveAndOver ? info.dependentsTwelveAndOver : DEFAULT_EMPTY_VALUE}
-                </dd>
-              </div>
-              <div className={descriptionListStyles.row}>
-                <dt>Unaccompanied baggage allowance</dt>
-                <dd data-testid="unaccompaniedBaggageAllowance">
-                  {info.ubAllowance ? formatWeight(info.ubAllowance) : DEFAULT_EMPTY_VALUE}
-                </dd>
-              </div>
-            </>
-          )}
+        {enableUB && (info?.accompaniedTour || info?.dependentsTwelveAndOver || info?.dependentsUnderTwelve) && (
+          <>
+            <div className={descriptionListStyles.row}>
+              <dt>Accompanied tour</dt>
+              <dd data-testid="ordersAccompaniedTour">{info.accompaniedTour ? 'Yes' : 'No'}</dd>
+            </div>
+            <div className={descriptionListStyles.row}>
+              <dt>Dependents under age 12</dt>
+              <dd data-testid="ordersDependentsUnderTwelve">
+                {info.dependentsUnderTwelve ? info.dependentsUnderTwelve : DEFAULT_EMPTY_VALUE}
+              </dd>
+            </div>
+            <div className={descriptionListStyles.row}>
+              <dt>Dependents over age 12</dt>
+              <dd data-testid="ordersDependentsTwelveAndOver">
+                {info.dependentsTwelveAndOver ? info.dependentsTwelveAndOver : DEFAULT_EMPTY_VALUE}
+              </dd>
+            </div>
+          </>
+        )}
+        {enableUB && info?.ubAllowance >= 0 && (
+          <div className={descriptionListStyles.row}>
+            <dt>Unaccompanied baggage allowance</dt>
+            <dd data-testid="unaccompaniedBaggageAllowance">
+              {info.ubAllowance ? formatWeight(info.ubAllowance) : DEFAULT_EMPTY_VALUE}
+            </dd>
+          </div>
+        )}
         {/* End OCONUS fields */}
         <div className={visualCuesStyle}>
           <dt>Pro-gear</dt>

--- a/src/components/Office/DefinitionLists/AllowancesList.jsx
+++ b/src/components/Office/DefinitionLists/AllowancesList.jsx
@@ -13,7 +13,6 @@ import { ORDERS_BRANCH_OPTIONS } from 'constants/orders';
 
 const AllowancesList = ({ info, showVisualCues }) => {
   const [enableUB, setEnableUB] = useState(false);
-
   const visualCuesStyle = classNames(descriptionListStyles.row, {
     [`${descriptionListStyles.rowWithVisualCue}`]: showVisualCues,
   });
@@ -51,28 +50,38 @@ const AllowancesList = ({ info, showVisualCues }) => {
         {/* As these fields are grouped together and only apply to OCONUS orders
         They will all be NULL for CONUS orders. If one of these fields are present,
         it will be safe to assume it is an OCONUS order. With this, if one field is present
-        we show all three. Otherwise, we show none */}
+        we show all four. Otherwise, we show none */}
         {/* Wrap in FF */}
-        {enableUB && (info?.accompaniedTour || info?.dependentsTwelveAndOver || info?.dependentsUnderTwelve) && (
-          <>
-            <div className={descriptionListStyles.row}>
-              <dt>Accompanied tour</dt>
-              <dd data-testid="ordersAccompaniedTour">{info.accompaniedTour ? 'Yes' : 'No'}</dd>
-            </div>
-            <div className={descriptionListStyles.row}>
-              <dt>Dependents under age 12</dt>
-              <dd data-testid="ordersDependentsUnderTwelve">
-                {info.dependentsUnderTwelve ? info.dependentsUnderTwelve : DEFAULT_EMPTY_VALUE}
-              </dd>
-            </div>
-            <div className={descriptionListStyles.row}>
-              <dt>Dependents over age 12</dt>
-              <dd data-testid="ordersDependentsTwelveAndOver">
-                {info.dependentsTwelveAndOver ? info.dependentsTwelveAndOver : DEFAULT_EMPTY_VALUE}
-              </dd>
-            </div>
-          </>
-        )}
+        {enableUB &&
+          (info?.accompaniedTour ||
+            info?.dependentsTwelveAndOver ||
+            info?.dependentsUnderTwelve ||
+            info?.ubAllowance) && (
+            <>
+              <div className={descriptionListStyles.row}>
+                <dt>Accompanied tour</dt>
+                <dd data-testid="ordersAccompaniedTour">{info.accompaniedTour ? 'Yes' : 'No'}</dd>
+              </div>
+              <div className={descriptionListStyles.row}>
+                <dt>Dependents under age 12</dt>
+                <dd data-testid="ordersDependentsUnderTwelve">
+                  {info.dependentsUnderTwelve ? info.dependentsUnderTwelve : DEFAULT_EMPTY_VALUE}
+                </dd>
+              </div>
+              <div className={descriptionListStyles.row}>
+                <dt>Dependents over age 12</dt>
+                <dd data-testid="ordersDependentsTwelveAndOver">
+                  {info.dependentsTwelveAndOver ? info.dependentsTwelveAndOver : DEFAULT_EMPTY_VALUE}
+                </dd>
+              </div>
+              <div className={descriptionListStyles.row}>
+                <dt>Unaccompanied baggage allowance</dt>
+                <dd data-testid="unaccompaniedBaggageAllowance">
+                  {info.ubAllowance ? formatWeight(info.ubAllowance) : DEFAULT_EMPTY_VALUE}
+                </dd>
+              </div>
+            </>
+          )}
         {/* End OCONUS fields */}
         <div className={visualCuesStyle}>
           <dt>Pro-gear</dt>
@@ -112,6 +121,7 @@ AllowancesList.propTypes = {
     dependents: PropTypes.bool,
     requiredMedicalEquipmentWeight: PropTypes.number,
     organizationalClothingAndIndividualEquipment: PropTypes.bool,
+    ubAllowance: PropTypes.number,
   }).isRequired,
   showVisualCues: PropTypes.bool,
 };

--- a/src/components/Office/DefinitionLists/AllowancesList.stories.jsx
+++ b/src/components/Office/DefinitionLists/AllowancesList.stories.jsx
@@ -24,6 +24,7 @@ const info = {
   dependents: true,
   requiredMedicalEquipmentWeight: 1000,
   organizationalClothingAndIndividualEquipment: true,
+  ubAllowance: 400,
 };
 
 export const Basic = () => <AllowancesList info={object('info', info)} />;

--- a/src/components/Office/DefinitionLists/AllowancesList.test.jsx
+++ b/src/components/Office/DefinitionLists/AllowancesList.test.jsx
@@ -18,18 +18,21 @@ const info = {
   dependents: true,
   requiredMedicalEquipmentWeight: 1000,
   organizationalClothingAndIndividualEquipment: true,
+  ubAllowance: 400,
 };
 
 const initialValuesOconusAdditions = {
   accompaniedTour: true,
   dependentsTwelveAndOver: '2',
   dependentsUnderTwelve: '4',
+  ubAllowance: 400,
 };
 
 const oconusInfo = {
   accompaniedTour: true,
   dependentsTwelveAndOver: 2,
   dependentsUnderTwelve: 4,
+  ubAllowance: 400,
 };
 
 jest.mock('formik', () => ({
@@ -39,6 +42,7 @@ jest.mock('formik', () => ({
       accompaniedTour: true,
       dependentsTwelveAndOver: '2',
       dependentsUnderTwelve: '4',
+      ubAllowance: '400',
     };
 
     switch (field.type) {
@@ -152,6 +156,7 @@ describe('AllowancesList', () => {
     expect(screen.queryByText('Accompanied tour')).not.toBeInTheDocument();
     expect(screen.queryByLabelText(/Number of dependents under the age of 12/)).not.toBeInTheDocument();
     expect(screen.queryByLabelText(/Number of dependents of the age 12 or over/)).not.toBeInTheDocument();
+    expect(screen.queryByText('Unaccompanied baggage allowance')).not.toBeInTheDocument();
   });
 
   it('does render oconus fields when present', async () => {
@@ -167,5 +172,7 @@ describe('AllowancesList', () => {
     await waitFor(() => expect(screen.getByTestId('ordersAccompaniedTour')).toBeInTheDocument());
     expect(screen.getByTestId('ordersDependentsUnderTwelve')).toBeInTheDocument();
     expect(screen.getByTestId('ordersDependentsTwelveAndOver')).toBeInTheDocument();
+    expect(screen.getByTestId('unaccompaniedBaggageAllowance')).toBeInTheDocument();
+    expect(screen.getByTestId('unaccompaniedBaggageAllowance').textContent).toEqual('400 lbs');
   });
 });

--- a/src/components/Office/ShipmentForm/ShipmentForm.jsx
+++ b/src/components/Office/ShipmentForm/ShipmentForm.jsx
@@ -270,6 +270,7 @@ const ShipmentForm = (props) => {
     shipmentType === SHIPMENT_OPTIONS.BOAT ||
     shipmentType === SHIPMENT_TYPES.BOAT_HAUL_AWAY ||
     shipmentType === SHIPMENT_TYPES.BOAT_TOW_AWAY;
+  const isUB = shipmentType === SHIPMENT_OPTIONS.UNACCOMPANIED_BAGGAGE;
 
   const showAccountingCodes = isNTS || isNTSR;
 
@@ -875,10 +876,17 @@ const ShipmentForm = (props) => {
               </div>
 
               <SectionWrapper className={styles.weightAllowance}>
-                <p>
-                  <strong>Weight allowance: </strong>
-                  {formatWeight(serviceMember.weightAllotment.totalWeightSelf)}
-                </p>
+                {isUB ? (
+                  <p data-testid="ubWeightAllowance">
+                    <strong>UB Weight allowance: </strong>
+                    {formatWeight(serviceMember.weightAllotment.ubAllowance)}
+                  </p>
+                ) : (
+                  <p data-testid="weightAllowance">
+                    <strong>Weight allowance: </strong>
+                    {formatWeight(serviceMember.weightAllotment.totalWeightSelf)}
+                  </p>
+                )}
               </SectionWrapper>
 
               <Form className={formStyles.form}>
@@ -1666,6 +1674,7 @@ ShipmentForm.propTypes = {
   serviceMember: shape({
     weightAllotment: shape({
       totalWeightSelf: number,
+      ubAllowance: number,
     }),
     agency: string.isRequired,
   }).isRequired,

--- a/src/components/Office/ShipmentForm/ShipmentForm.stories.jsx
+++ b/src/components/Office/ShipmentForm/ShipmentForm.stories.jsx
@@ -36,6 +36,7 @@ const defaultProps = {
   serviceMember: {
     weightAllotment: {
       totalWeightSelf: 5000,
+      ubAllowance: 400,
     },
   },
   isCreatePage: true,

--- a/src/components/Office/ShipmentForm/ShipmentForm.test.jsx
+++ b/src/components/Office/ShipmentForm/ShipmentForm.test.jsx
@@ -44,8 +44,6 @@ const mockMtoShipment = {
   counselorRemarks: 'mock counselor remarks',
   requestedPickupDate: '2020-03-01',
   requestedDeliveryDate: '2020-03-30',
-  // requestedPickupDate: '2021-06-07',
-  // requestedDeliveryDate: '2021-06-14',
   hasSecondaryDeliveryAddress: false,
   hasSecondaryPickupAddress: false,
   pickupAddress: {
@@ -170,6 +168,24 @@ const mockMtoShipment = {
   ],
 };
 
+const mockUBShipment = {
+  id: 'shipment123',
+  moveTaskOrderId: 'mock move id',
+  customerRemarks: 'mock customer remarks',
+  counselorRemarks: 'mock counselor remarks',
+  requestedPickupDate: '2020-03-01',
+  requestedDeliveryDate: '2020-03-30',
+  hasSecondaryDeliveryAddress: false,
+  hasSecondaryPickupAddress: false,
+  pickupAddress: {
+    streetAddress1: '812 S 129th St',
+    city: 'San Antonio',
+    state: 'TX',
+    postalCode: '78234',
+  },
+  shipmentType: SHIPMENT_OPTIONS.UNACCOMPANIED_BAGGAGE,
+};
+
 const defaultProps = {
   isCreatePage: true,
   submitHandler: jest.fn(),
@@ -196,6 +212,7 @@ const defaultProps = {
   serviceMember: {
     weightAllotment: {
       totalWeightSelf: 5000,
+      ubAllowance: 400,
     },
     agency: '',
   },
@@ -610,6 +627,40 @@ describe('ShipmentForm component', () => {
       });
       expect(screen.getByText('We can use the zip of their new duty location:')).toBeTruthy();
       expect(screen.queryByLabelText('Destination type')).toBeNull();
+    });
+  });
+
+  describe('weight allowance appears at the top of the page', () => {
+    it('renders the UB weight allowance for UB shipment form', async () => {
+      renderWithRouter(
+        <ShipmentForm
+          {...defaultProps}
+          isCreatePage={false}
+          shipmentType={SHIPMENT_OPTIONS.UNACCOMPANIED_BAGGAGE}
+          displayDestinationType={false}
+          mtoShipment={{
+            ...mockUBShipment,
+          }}
+        />,
+      );
+
+      expect(screen.getByTestId('ubWeightAllowance')).toBeInTheDocument();
+    });
+
+    it('renders the weight allowance for shipment form', async () => {
+      renderWithRouter(
+        <ShipmentForm
+          {...defaultProps}
+          isCreatePage={false}
+          shipmentType={SHIPMENT_OPTIONS.HHG}
+          displayDestinationType={false}
+          mtoShipment={{
+            ...mockMtoShipment,
+          }}
+        />,
+      );
+
+      expect(screen.getByTestId('weightAllowance')).toBeInTheDocument();
     });
   });
 

--- a/src/pages/Office/MoveDetails/MoveDetails.jsx
+++ b/src/pages/Office/MoveDetails/MoveDetails.jsx
@@ -362,6 +362,7 @@ const MoveDetails = ({
     dependentsUnderTwelve: allowances.dependentsUnderTwelve,
     dependentsTwelveAndOver: allowances.dependentsTwelveAndOver,
     accompaniedTour: allowances.accompaniedTour,
+    ubAllowance: allowances.ubAllowance,
   };
 
   const customerInfo = {

--- a/src/pages/Office/ServicesCounselingMoveDetails/ServicesCounselingMoveDetails.jsx
+++ b/src/pages/Office/ServicesCounselingMoveDetails/ServicesCounselingMoveDetails.jsx
@@ -370,6 +370,7 @@ const ServicesCounselingMoveDetails = ({
     dependentsUnderTwelve: allowances.dependentsUnderTwelve,
     dependentsTwelveAndOver: allowances.dependentsTwelveAndOver,
     accompaniedTour: allowances.accompaniedTour,
+    ubAllowance: allowances.ubAllowance,
   };
 
   const ordersInfo = {


### PR DESCRIPTION
> [!IMPORTANT]
> Upstream: [B-21375](https://github.com/transcom/mymove/pull/14137)
> Upstream: [B-21376](https://github.com/transcom/mymove/pull/14102)

## [Agility ticket](https://www13.v1host.com/USTRANSCOM38/story.mvc/Summary?oidToken=Story%3A1030447)

## AC

Given I am an a SC/TOO/TIO
When I am viewing the allowances section
Then I can see but not edit the calculated UB allowance on the page

Given I am an a SC/TOO/TIO
When I view the Edit Shipment Details section
Then I can see the UB allowance (edited) 

### How to test

# Customer
1. Turn the UB flag on in .envrc.
2. Pick a duty location and edit it's address is_oconus flag to true.
3. Pick that duty location when adding your orders so you can create a UB shipment.
4. Add a UB shipment
5. Add an HHG or non-UB shipment
6. Finish out the move as a customer
7. Check the database and make sure that there is a value for order.entitlement.ub_allowance (0 is ok)

# SC
8. Log in as an SC
9. Go to your move and view the Allowances section
10. Verify that you can see a line for "Unaccompanied baggage allowance" with the value of your order.entitlement.ub_allowance there - either a number value or a dash for 0.
11. If you had a zero value, either edit the variables to calculate a correct UB allowance (grade, branch, orders type, accompanied, dependents authorized) or just edit it directly in the database.
12. Make sure you can see both a number value with lbs and a dash for 0.
13. As an SC, click the Edit Allowances button
14. Make sure you can't see or edit the UB weight allowance field on the Edit page
15. Get the move to the point of being available to the TOO

# TOO
16. As the TOO, you should see two or more shipments, one being UB.
![image](https://github.com/user-attachments/assets/98d8c842-2f0c-4410-804a-c394b8bc480a)
17. Click on Edit shipment for the UB shipment
18. You should see a UB weight allowance value at the top of the page that matches the values in the database
![image](https://github.com/user-attachments/assets/ef2623d7-9a77-49e0-8169-28435c8cd5d7)
![image](https://github.com/user-attachments/assets/e2fdd6c5-44b6-475e-8dbe-1ec271da97c4)
19. Click on Edit shipment for the non UB shipment
20. You should NOT see the UB weight allowance, but should see the overall allowance
![image](https://github.com/user-attachments/assets/0e4d3c5b-f9ff-4b66-915c-9b7501ea9168)
21. Still as the TOO, view the Allowances section
22. Verify that you can see a line for "Unaccompanied baggage allowance" with the value of your order.entitlement.ub_allowance there - either a number value or a dash for 0.
23. If you had a zero value, either edit the variables to calculate a correct UB allowance (grade, branch, orders type, accompanied, dependents authorized) or just edit it directly in the database.
24. Make sure you can see both a number value with lbs and a dash for 0.
25. As an TOO, click the Edit Allowances button
26. Make sure you can't see or edit the UB weight allowance field on the Edit page


### Frontend

- [x] This change meets the standards for [Section 508 compliance](https://www.ssa.gov/accessibility/andi/help/install.html).

## Screenshots
![image](https://github.com/user-attachments/assets/c9e11d60-cd01-49cb-940d-0d47eeb3368a)
![image](https://github.com/user-attachments/assets/b2b4f243-067c-40b2-8ece-8aa9249db1e3)
![image](https://github.com/user-attachments/assets/48f97e3d-f5cb-4d39-9eb6-20104c7ac13f)
