### PR TITLE
B 20535 special moves queue assigned

### DIFF
--- a/pkg/gen/ghcapi/embedded_spec.go
+++ b/pkg/gen/ghcapi/embedded_spec.go
@@ -6491,9 +6491,6 @@ func init() {
         "firstName": {
           "type": "string"
         },
-        "hasSafetyPrivilege": {
-          "type": "boolean"
-        },
         "lastName": {
           "type": "string"
         },
@@ -22578,9 +22575,6 @@ func init() {
       "properties": {
         "firstName": {
           "type": "string"
-        },
-        "hasSafetyPrivilege": {
-          "type": "boolean"
         },
         "lastName": {
           "type": "string"

--- a/pkg/gen/ghcmessages/available_office_user.go
+++ b/pkg/gen/ghcmessages/available_office_user.go
@@ -22,9 +22,6 @@ type AvailableOfficeUser struct {
 	// first name
 	FirstName string `json:"firstName,omitempty"`
 
-	// has safety privilege
-	HasSafetyPrivilege bool `json:"hasSafetyPrivilege,omitempty"`
-
 	// last name
 	LastName string `json:"lastName,omitempty"`
 

--- a/pkg/handlers/ghcapi/internal/payloads/model_to_payload.go
+++ b/pkg/handlers/ghcapi/internal/payloads/model_to_payload.go
@@ -2103,25 +2103,22 @@ func QueueAvailableOfficeUsers(officeUsers []models.OfficeUser) *ghcmessages.Ava
 	availableOfficeUsers := make(ghcmessages.AvailableOfficeUsers, len(officeUsers))
 	for i, officeUser := range officeUsers {
 
-		hasSafety := officeUser.User.Privileges.HasPrivilege(models.PrivilegeTypeSafety)
-
 		availableOfficeUsers[i] = &ghcmessages.AvailableOfficeUser{
-			LastName:           officeUser.LastName,
-			FirstName:          officeUser.FirstName,
-			OfficeUserID:       *handlers.FmtUUID(officeUser.ID),
-			HasSafetyPrivilege: swag.BoolValue(&hasSafety),
+			LastName:     officeUser.LastName,
+			FirstName:    officeUser.FirstName,
+			OfficeUserID: *handlers.FmtUUID(officeUser.ID),
 		}
 	}
 
 	return &availableOfficeUsers
 }
 
-func queueMoveIsAssignable(move models.Move, assignedToUser *ghcmessages.AssignedOfficeUser, isCloseoutQueue bool, role roles.RoleType, officeUser models.OfficeUser, isSupervisor bool, isHQRole bool, ppmCloseoutGblocs bool) bool {
+func queueMoveIsAssignable(move models.Move, assignedToUser *ghcmessages.AssignedOfficeUser, isCloseoutQueue bool, officeUser models.OfficeUser, ppmCloseoutGblocs bool) bool {
 	// default to false
 	isAssignable := false
 
 	// HQ role is read only
-	if isHQRole {
+	if officeUser.User.Roles.HasRole(roles.RoleTypeHQ) {
 		isAssignable = false
 		return isAssignable
 	}
@@ -2131,14 +2128,15 @@ func queueMoveIsAssignable(move models.Move, assignedToUser *ghcmessages.Assigne
 		isAssignable = true
 	}
 
+	isSupervisor := officeUser.User.Privileges.HasPrivilege(models.PrivilegeTypeSupervisor)
 	// in TOO queues, all moves are assignable for supervisor users
-	if role == roles.RoleTypeTOO && isSupervisor {
+	if officeUser.User.Roles.HasRole(roles.RoleTypeTOO) && isSupervisor {
 		isAssignable = true
 	}
 
 	// if it is assigned in the SCs queue
 	// it is only assignable if the user is a supervisor...
-	if role == roles.RoleTypeServicesCounselor && isSupervisor {
+	if officeUser.User.Roles.HasRole(roles.RoleTypeServicesCounselor) && isSupervisor {
 		// AND we are in the counseling queue AND the move's counseling office is the supervisor's transportation office
 		if !isCloseoutQueue && move.CounselingOfficeID != nil && *move.CounselingOfficeID == officeUser.TransportationOfficeID {
 			isAssignable = true
@@ -2157,8 +2155,8 @@ func queueMoveIsAssignable(move models.Move, assignedToUser *ghcmessages.Assigne
 	return isAssignable
 }
 
-func servicesCounselorAvailableOfficeUsers(move models.Move, officeUsers []models.OfficeUser, role roles.RoleType, officeUser models.OfficeUser, ppmCloseoutGblocs bool, isCloseoutQueue bool) []models.OfficeUser {
-	if role == roles.RoleTypeServicesCounselor {
+func servicesCounselorAvailableOfficeUsers(move models.Move, officeUsers []models.OfficeUser, officeUser models.OfficeUser, ppmCloseoutGblocs bool, isCloseoutQueue bool) []models.OfficeUser {
+	if officeUser.User.Roles.HasRole(roles.RoleTypeServicesCounselor) {
 		// if the office user currently assigned to the move works outside of the logged in users counseling office
 		// add them to the set
 		if move.SCAssignedUser != nil && move.SCAssignedUser.TransportationOfficeID != officeUser.TransportationOfficeID {
@@ -2186,7 +2184,7 @@ func servicesCounselorAvailableOfficeUsers(move models.Move, officeUsers []model
 }
 
 // QueueMoves payload
-func QueueMoves(moves []models.Move, officeUsers []models.OfficeUser, requestedPpmStatus *models.PPMShipmentStatus, role roles.RoleType, officeUser models.OfficeUser, isSupervisor bool, isHQRole bool) *ghcmessages.QueueMoves {
+func QueueMoves(moves []models.Move, officeUsers []models.OfficeUser, requestedPpmStatus *models.PPMShipmentStatus, officeUser models.OfficeUser, officeUsersSafety []models.OfficeUser) *ghcmessages.QueueMoves {
 	queueMoves := make(ghcmessages.QueueMoves, len(moves))
 	for i, move := range moves {
 		customer := move.Orders.ServiceMember
@@ -2257,10 +2255,10 @@ func QueueMoves(moves []models.Move, officeUsers []models.OfficeUser, requestedP
 
 		// determine if there is an assigned user
 		var assignedToUser *ghcmessages.AssignedOfficeUser
-		if role == roles.RoleTypeServicesCounselor && move.SCAssignedUser != nil {
+		if officeUser.User.Roles.HasRole(roles.RoleTypeServicesCounselor) && move.SCAssignedUser != nil {
 			assignedToUser = AssignedOfficeUser(move.SCAssignedUser)
 		}
-		if role == roles.RoleTypeTOO && move.TOOAssignedUser != nil {
+		if officeUser.User.Roles.HasRole(roles.RoleTypeTOO) && move.TOOAssignedUser != nil {
 			assignedToUser = AssignedOfficeUser(move.TOOAssignedUser)
 		}
 
@@ -2269,16 +2267,20 @@ func QueueMoves(moves []models.Move, officeUsers []models.OfficeUser, requestedP
 		// requestedPpmStatus also represents if we are viewing the closeout queue
 		isCloseoutQueue := requestedPpmStatus != nil && *requestedPpmStatus == models.PPMShipmentStatusNeedsCloseout
 		// determine if the move is assignable
-		assignable := queueMoveIsAssignable(move, assignedToUser, isCloseoutQueue, role, officeUser, isSupervisor, isHQRole, ppmCloseoutGblocs)
+		assignable := queueMoveIsAssignable(move, assignedToUser, isCloseoutQueue, officeUser, ppmCloseoutGblocs)
 
+		isSupervisor := officeUser.User.Privileges.HasPrivilege(models.PrivilegeTypeSupervisor)
 		// only need to attach available office users if move is assignable
 		var apiAvailableOfficeUsers ghcmessages.AvailableOfficeUsers
 		if assignable {
 			// non SC roles don't need the extra logic, just make availableOfficeUsers = officeUsers
 			availableOfficeUsers := officeUsers
 
-			if role == roles.RoleTypeServicesCounselor {
-				availableOfficeUsers = servicesCounselorAvailableOfficeUsers(move, availableOfficeUsers, role, officeUser, ppmCloseoutGblocs, isCloseoutQueue)
+			if isSupervisor && move.Orders.OrdersType == "SAFETY" {
+				availableOfficeUsers = officeUsersSafety
+			}
+			if officeUser.User.Roles.HasRole(roles.RoleTypeServicesCounselor) {
+				availableOfficeUsers = servicesCounselorAvailableOfficeUsers(move, availableOfficeUsers, officeUser, ppmCloseoutGblocs, isCloseoutQueue)
 			}
 
 			apiAvailableOfficeUsers = *QueueAvailableOfficeUsers(availableOfficeUsers)
@@ -2378,7 +2380,7 @@ func queuePaymentRequestStatus(paymentRequest models.PaymentRequest) string {
 }
 
 // QueuePaymentRequests payload
-func QueuePaymentRequests(paymentRequests *models.PaymentRequests, officeUsers []models.OfficeUser, officeUser models.OfficeUser, isSupervisor bool, isHQRole bool) *ghcmessages.QueuePaymentRequests {
+func QueuePaymentRequests(paymentRequests *models.PaymentRequests, officeUsers []models.OfficeUser, officeUser models.OfficeUser, officeUsersSafety []models.OfficeUser) *ghcmessages.QueuePaymentRequests {
 
 	queuePaymentRequests := make(ghcmessages.QueuePaymentRequests, len(*paymentRequests))
 
@@ -2414,11 +2416,12 @@ func QueuePaymentRequests(paymentRequests *models.PaymentRequests, officeUsers [
 			isAssignable = true
 		}
 
+		isSupervisor := officeUser.User.Privileges.HasPrivilege(models.PrivilegeTypeSupervisor)
 		if isSupervisor {
 			isAssignable = true
 		}
 
-		if isHQRole {
+		if officeUser.User.Roles.HasRole(roles.RoleTypeHQ) {
 			isAssignable = false
 		}
 
@@ -2427,6 +2430,9 @@ func QueuePaymentRequests(paymentRequests *models.PaymentRequests, officeUsers [
 		// only need to attach available office users if move is assignable
 		if queuePaymentRequests[i].Assignable {
 			availableOfficeUsers := officeUsers
+			if isSupervisor && orders.OrdersType == "SAFETY" {
+				availableOfficeUsers = officeUsersSafety
+			}
 			if !isSupervisor {
 				availableOfficeUsers = models.OfficeUsers{officeUser}
 			}

--- a/pkg/handlers/ghcapi/internal/payloads/model_to_payload.go
+++ b/pkg/handlers/ghcapi/internal/payloads/model_to_payload.go
@@ -2116,6 +2116,75 @@ func QueueAvailableOfficeUsers(officeUsers []models.OfficeUser) *ghcmessages.Ava
 	return &availableOfficeUsers
 }
 
+func queueMoveIsAssignable(move models.Move, assignedToUser *ghcmessages.AssignedOfficeUser, isCloseoutQueue bool, role roles.RoleType, officeUser models.OfficeUser, isSupervisor bool, isHQRole bool, ppmCloseoutGblocs bool) bool {
+	// default to false
+	isAssignable := false
+
+	// HQ role is read only
+	if isHQRole {
+		isAssignable = false
+		return isAssignable
+	}
+
+	// if its unassigned its assignable in all cases
+	if assignedToUser == nil {
+		isAssignable = true
+	}
+
+	// in TOO queues, all moves are assignable for supervisor users
+	if role == roles.RoleTypeTOO && isSupervisor {
+		isAssignable = true
+	}
+
+	// if it is assigned in the SCs queue
+	// it is only assignable if the user is a supervisor...
+	if role == roles.RoleTypeServicesCounselor && isSupervisor {
+		// AND we are in the counseling queue AND the move's counseling office is the supervisor's transportation office
+		if !isCloseoutQueue && move.CounselingOfficeID != nil && *move.CounselingOfficeID == officeUser.TransportationOfficeID {
+			isAssignable = true
+		}
+		// OR we are in the closeout queue AND the move's closeout office is the supervisor's transportation office
+		if isCloseoutQueue && move.CloseoutOfficeID != nil && *move.CloseoutOfficeID == officeUser.TransportationOfficeID {
+			isAssignable = true
+		}
+
+		// OR theyre a navy, marine, or coast guard supervisor
+		if ppmCloseoutGblocs {
+			isAssignable = true
+		}
+	}
+
+	return isAssignable
+}
+
+func servicesCounselorAvailableOfficeUsers(move models.Move, officeUsers []models.OfficeUser, role roles.RoleType, officeUser models.OfficeUser, ppmCloseoutGblocs bool, isCloseoutQueue bool) []models.OfficeUser {
+	if role == roles.RoleTypeServicesCounselor {
+		// if the office user currently assigned to the move works outside of the logged in users counseling office
+		// add them to the set
+		if move.SCAssignedUser != nil && move.SCAssignedUser.TransportationOfficeID != officeUser.TransportationOfficeID {
+			officeUsers = append(officeUsers, *move.SCAssignedUser)
+		}
+
+		// if there is no counseling office
+		// OR if our current user doesn't work at the move's counseling office
+		// only available user should be themself
+		if !isCloseoutQueue && (move.CounselingOfficeID == nil) || (move.CounselingOfficeID != nil && *move.CounselingOfficeID != officeUser.TransportationOfficeID) {
+			officeUsers = models.OfficeUsers{officeUser}
+		}
+
+		// if its the closeout queue and its not a Navy, Marine, or Coast Guard user
+		// and the move doesn't have a closeout office
+		// OR the move's closeout office is not the office users office
+		// only available user should be themself
+		if isCloseoutQueue && !ppmCloseoutGblocs && move.CloseoutOfficeID == nil || (move.CloseoutOfficeID != nil && *move.CloseoutOfficeID != officeUser.TransportationOfficeID) {
+			officeUsers = models.OfficeUsers{officeUser}
+
+		}
+	}
+
+	return officeUsers
+}
+
 // QueueMoves payload
 func QueueMoves(moves []models.Move, officeUsers []models.OfficeUser, requestedPpmStatus *models.PPMShipmentStatus, role roles.RoleType, officeUser models.OfficeUser, isSupervisor bool, isHQRole bool) *ghcmessages.QueueMoves {
 	queueMoves := make(ghcmessages.QueueMoves, len(moves))
@@ -2184,6 +2253,37 @@ func QueueMoves(moves []models.Move, officeUsers []models.OfficeUser, requestedP
 			}
 		}
 
+		// queue assignment logic below
+
+		// determine if there is an assigned user
+		var assignedToUser *ghcmessages.AssignedOfficeUser
+		if role == roles.RoleTypeServicesCounselor && move.SCAssignedUser != nil {
+			assignedToUser = AssignedOfficeUser(move.SCAssignedUser)
+		}
+		if role == roles.RoleTypeTOO && move.TOOAssignedUser != nil {
+			assignedToUser = AssignedOfficeUser(move.TOOAssignedUser)
+		}
+
+		// these branches have their own closeout specific offices
+		ppmCloseoutGblocs := closeoutLocation == "NAVY" || closeoutLocation == "TVCB" || closeoutLocation == "USCG"
+		// requestedPpmStatus also represents if we are viewing the closeout queue
+		isCloseoutQueue := requestedPpmStatus != nil && *requestedPpmStatus == models.PPMShipmentStatusNeedsCloseout
+		// determine if the move is assignable
+		assignable := queueMoveIsAssignable(move, assignedToUser, isCloseoutQueue, role, officeUser, isSupervisor, isHQRole, ppmCloseoutGblocs)
+
+		// only need to attach available office users if move is assignable
+		var apiAvailableOfficeUsers ghcmessages.AvailableOfficeUsers
+		if assignable {
+			// non SC roles don't need the extra logic, just make availableOfficeUsers = officeUsers
+			availableOfficeUsers := officeUsers
+
+			if role == roles.RoleTypeServicesCounselor {
+				availableOfficeUsers = servicesCounselorAvailableOfficeUsers(move, availableOfficeUsers, role, officeUser, ppmCloseoutGblocs, isCloseoutQueue)
+			}
+
+			apiAvailableOfficeUsers = *QueueAvailableOfficeUsers(availableOfficeUsers)
+		}
+
 		queueMoves[i] = &ghcmessages.QueueMove{
 			Customer:                Customer(&customer),
 			Status:                  ghcmessages.MoveStatus(move.Status),
@@ -2207,59 +2307,9 @@ func QueueMoves(moves []models.Move, officeUsers []models.OfficeUser, requestedP
 			PpmStatus:               ghcmessages.PPMStatus(ppmStatus),
 			CounselingOffice:        &transportationOffice,
 			CounselingOfficeID:      handlers.FmtUUID(transportationOfficeId),
-		}
-
-		if role == roles.RoleTypeServicesCounselor && move.SCAssignedUser != nil {
-			queueMoves[i].AssignedTo = AssignedOfficeUser(move.SCAssignedUser)
-		}
-		if role == roles.RoleTypeTOO && move.TOOAssignedUser != nil {
-			queueMoves[i].AssignedTo = AssignedOfficeUser(move.TOOAssignedUser)
-		}
-
-		// scenarios where a move is assinable:
-
-		// if it is unassigned, it is always assignable
-		isAssignable := false
-		if queueMoves[i].AssignedTo == nil {
-			isAssignable = true
-		}
-
-		// in TOO queues, all moves are assignable for supervisor users
-		if role == roles.RoleTypeTOO && isSupervisor {
-			isAssignable = true
-		}
-
-		// if it is assigned in the SCs queue
-		// it is only assignable if the user is a supervisor
-		// and if the move's counseling office is the supervisor's transportation office
-		if role == roles.RoleTypeServicesCounselor && isSupervisor && move.CounselingOfficeID != nil && *move.CounselingOfficeID == officeUser.TransportationOfficeID {
-			isAssignable = true
-		}
-
-		if isHQRole {
-			isAssignable = false
-		}
-
-		queueMoves[i].Assignable = isAssignable
-
-		// only need to attach available office users if move is assignable
-		if queueMoves[i].Assignable {
-			availableOfficeUsers := officeUsers
-			if role == roles.RoleTypeServicesCounselor {
-				// if there is no counseling office
-				// OR if our current user doesn't work at the move's counseling office
-				// only available user should be themself
-				if (move.CounselingOfficeID == nil) || (move.CounselingOfficeID != nil && *move.CounselingOfficeID != officeUser.TransportationOfficeID) {
-					availableOfficeUsers = models.OfficeUsers{officeUser}
-				}
-
-				// if the office user currently assigned to move works outside of the logged in users counseling office
-				// add them to the set
-				if move.SCAssignedUser != nil && move.SCAssignedUser.TransportationOfficeID != officeUser.TransportationOfficeID {
-					availableOfficeUsers = append(availableOfficeUsers, *move.SCAssignedUser)
-				}
-			}
-			queueMoves[i].AvailableOfficeUsers = *QueueAvailableOfficeUsers(availableOfficeUsers)
+			AssignedTo:              assignedToUser,
+			Assignable:              assignable,
+			AvailableOfficeUsers:    apiAvailableOfficeUsers,
 		}
 	}
 	return &queueMoves

--- a/pkg/handlers/ghcapi/queues.go
+++ b/pkg/handlers/ghcapi/queues.go
@@ -106,10 +106,24 @@ func (h GetMovesQueueHandler) Handle(params queues.GetMovesQueueParams) middlewa
 			if err != nil {
 				appCtx.Logger().Error("Error retreiving user privileges", zap.Error(err))
 			}
+			officeUser.User.Privileges = privileges
+			officeUser.User.Roles = appCtx.Session().Roles
 
-			isSupervisor := privileges.HasPrivilege(models.PrivilegeTypeSupervisor)
 			var officeUsers models.OfficeUsers
-			if isSupervisor {
+			var officeUsersSafety models.OfficeUsers
+			if privileges.HasPrivilege(models.PrivilegeTypeSupervisor) {
+				if privileges.HasPrivilege(models.PrivilegeTypeSafety) {
+					officeUsersSafety, err = h.OfficeUserFetcherPop.FetchSafetyMoveOfficeUsersByRoleAndOffice(
+						appCtx,
+						roles.RoleTypeTOO,
+						officeUser.TransportationOfficeID,
+					)
+					if err != nil {
+						appCtx.Logger().
+							Error("error fetching safety move office users", zap.Error(err))
+						return queues.NewGetMovesQueueInternalServerError(), err
+					}
+				}
 				officeUsers, err = h.OfficeUserFetcherPop.FetchOfficeUsersByRoleAndOffice(
 					appCtx,
 					roles.RoleTypeTOO,
@@ -145,9 +159,8 @@ func (h GetMovesQueueHandler) Handle(params queues.GetMovesQueueParams) middlewa
 					appCtx.Logger().Error(fmt.Sprintf("failed to unlock moves for office user ID: %s", officeUserID), zap.Error(err))
 				}
 			}
-			isHQrole := appCtx.Session().Roles.HasRole(roles.RoleTypeHQ)
 
-			queueMoves := payloads.QueueMoves(moves, officeUsers, nil, roles.RoleTypeTOO, officeUser, isSupervisor, isHQrole)
+			queueMoves := payloads.QueueMoves(moves, officeUsers, nil, officeUser, officeUsersSafety)
 
 			result := &ghcmessages.QueueMovesResult{
 				Page:       *ListOrderParams.Page,
@@ -288,11 +301,35 @@ func (h GetPaymentRequestsQueueHandler) Handle(
 				}
 			}
 
-			officeUsers, err := h.OfficeUserFetcherPop.FetchOfficeUsersByRoleAndOffice(
-				appCtx,
-				roles.RoleTypeTIO,
-				officeUser.TransportationOfficeID,
-			)
+			privileges, err := models.FetchPrivilegesForUser(appCtx.DB(), appCtx.Session().UserID)
+			if err != nil {
+				appCtx.Logger().Error("Error retreiving user privileges", zap.Error(err))
+			}
+			officeUser.User.Privileges = privileges
+			officeUser.User.Roles = appCtx.Session().Roles
+
+			var officeUsers models.OfficeUsers
+			var officeUsersSafety models.OfficeUsers
+
+			if privileges.HasPrivilege(models.PrivilegeTypeSupervisor) {
+				if privileges.HasPrivilege(models.PrivilegeTypeSafety) {
+					officeUsersSafety, err = h.OfficeUserFetcherPop.FetchSafetyMoveOfficeUsersByRoleAndOffice(
+						appCtx,
+						roles.RoleTypeTIO,
+						officeUser.TransportationOfficeID,
+					)
+					if err != nil {
+						appCtx.Logger().
+							Error("error fetching safety move office users", zap.Error(err))
+						return queues.NewGetMovesQueueInternalServerError(), err
+					}
+				}
+				officeUsers, err = h.OfficeUserFetcherPop.FetchOfficeUsersByRoleAndOffice(
+					appCtx,
+					roles.RoleTypeTIO,
+					officeUser.TransportationOfficeID,
+				)
+			}
 
 			if err != nil {
 				appCtx.Logger().
@@ -321,15 +358,7 @@ func (h GetPaymentRequestsQueueHandler) Handle(
 				}
 			}
 
-			privileges, err := models.FetchPrivilegesForUser(appCtx.DB(), appCtx.Session().UserID)
-			if err != nil {
-				appCtx.Logger().Error("Error retreiving user privileges", zap.Error(err))
-			}
-
-			isHQrole := appCtx.Session().Roles.HasRole(roles.RoleTypeHQ)
-
-			isSupervisor := privileges.HasPrivilege(models.PrivilegeTypeSupervisor)
-			queuePaymentRequests := payloads.QueuePaymentRequests(paymentRequests, officeUsers, officeUser, isSupervisor, isHQrole)
+			queuePaymentRequests := payloads.QueuePaymentRequests(paymentRequests, officeUsers, officeUser, officeUsersSafety)
 
 			result := &ghcmessages.QueuePaymentRequestsResult{
 				TotalCount:           int64(count),
@@ -439,11 +468,25 @@ func (h GetServicesCounselingQueueHandler) Handle(
 			if err != nil {
 				appCtx.Logger().Error("Error retreiving user privileges", zap.Error(err))
 			}
+			officeUser.User.Privileges = privileges
+			officeUser.User.Roles = appCtx.Session().Roles
 
-			isSupervisor := privileges.HasPrivilege(models.PrivilegeTypeSupervisor)
 			var officeUsers models.OfficeUsers
+			var officeUsersSafety models.OfficeUsers
 
-			if isSupervisor {
+			if privileges.HasPrivilege(models.PrivilegeTypeSupervisor) {
+				if privileges.HasPrivilege(models.PrivilegeTypeSafety) {
+					officeUsersSafety, err = h.OfficeUserFetcherPop.FetchSafetyMoveOfficeUsersByRoleAndOffice(
+						appCtx,
+						roles.RoleTypeServicesCounselor,
+						officeUser.TransportationOfficeID,
+					)
+					if err != nil {
+						appCtx.Logger().
+							Error("error fetching safety move office users", zap.Error(err))
+						return queues.NewGetMovesQueueInternalServerError(), err
+					}
+				}
 				officeUsers, err = h.OfficeUserFetcherPop.FetchOfficeUsersByRoleAndOffice(
 					appCtx,
 					roles.RoleTypeServicesCounselor,
@@ -479,9 +522,8 @@ func (h GetServicesCounselingQueueHandler) Handle(
 					appCtx.Logger().Error(fmt.Sprintf("failed to unlock moves for office user ID: %s", officeUserID), zap.Error(err))
 				}
 			}
-			isHQrole := appCtx.Session().Roles.HasRole(roles.RoleTypeHQ)
 
-			queueMoves := payloads.QueueMoves(moves, officeUsers, &requestedPpmStatus, roles.RoleTypeServicesCounselor, officeUser, isSupervisor, isHQrole)
+			queueMoves := payloads.QueueMoves(moves, officeUsers, &requestedPpmStatus, officeUser, officeUsersSafety)
 
 			result := &ghcmessages.QueueMovesResult{
 				Page:       *ListOrderParams.Page,

--- a/pkg/services/mocks/OfficeUserFetcherPop.go
+++ b/pkg/services/mocks/OfficeUserFetcherPop.go
@@ -76,6 +76,36 @@ func (_m *OfficeUserFetcherPop) FetchOfficeUsersByRoleAndOffice(appCtx appcontex
 	return r0, r1
 }
 
+// FetchSafetyMoveOfficeUsersByRoleAndOffice provides a mock function with given fields: appCtx, role, officeID
+func (_m *OfficeUserFetcherPop) FetchSafetyMoveOfficeUsersByRoleAndOffice(appCtx appcontext.AppContext, role roles.RoleType, officeID uuid.UUID) ([]models.OfficeUser, error) {
+	ret := _m.Called(appCtx, role, officeID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for FetchSafetyMoveOfficeUsersByRoleAndOffice")
+	}
+
+	var r0 []models.OfficeUser
+	var r1 error
+	if rf, ok := ret.Get(0).(func(appcontext.AppContext, roles.RoleType, uuid.UUID) ([]models.OfficeUser, error)); ok {
+		return rf(appCtx, role, officeID)
+	}
+	if rf, ok := ret.Get(0).(func(appcontext.AppContext, roles.RoleType, uuid.UUID) []models.OfficeUser); ok {
+		r0 = rf(appCtx, role, officeID)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]models.OfficeUser)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(appcontext.AppContext, roles.RoleType, uuid.UUID) error); ok {
+		r1 = rf(appCtx, role, officeID)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // NewOfficeUserFetcherPop creates a new instance of OfficeUserFetcherPop. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
 // The first argument is typically a *testing.T value.
 func NewOfficeUserFetcherPop(t interface {

--- a/pkg/services/office_user.go
+++ b/pkg/services/office_user.go
@@ -23,6 +23,7 @@ type OfficeUserFetcher interface {
 type OfficeUserFetcherPop interface {
 	FetchOfficeUserByID(appCtx appcontext.AppContext, id uuid.UUID) (models.OfficeUser, error)
 	FetchOfficeUsersByRoleAndOffice(appCtx appcontext.AppContext, role roles.RoleType, officeID uuid.UUID) ([]models.OfficeUser, error)
+	FetchSafetyMoveOfficeUsersByRoleAndOffice(appCtx appcontext.AppContext, role roles.RoleType, officeID uuid.UUID) ([]models.OfficeUser, error)
 }
 
 // OfficeUserGblocFetcher is the exported interface for fetching the GBLOC of the

--- a/pkg/services/order/order_fetcher.go
+++ b/pkg/services/order/order_fetcher.go
@@ -134,6 +134,7 @@ func (f orderFetcher) ListOrders(appCtx appcontext.AppContext, officeUserID uuid
 			"Orders.OrdersType",
 			"MTOShipments.PPMShipment",
 			"LockedByOfficeUser",
+			"SCAssignedUser",
 		).InnerJoin("orders", "orders.id = moves.orders_id").
 			InnerJoin("service_members", "orders.service_member_id = service_members.id").
 			InnerJoin("mto_shipments", "moves.id = mto_shipments.move_id").
@@ -141,6 +142,7 @@ func (f orderFetcher) ListOrders(appCtx appcontext.AppContext, officeUserID uuid
 			InnerJoin("duty_locations as origin_dl", "orders.origin_duty_location_id = origin_dl.id").
 			LeftJoin("duty_locations as dest_dl", "dest_dl.id = orders.new_duty_location_id").
 			LeftJoin("office_users", "office_users.id = moves.locked_by").
+			LeftJoin("office_users as assigned_user", "moves.sc_assigned_id  = assigned_user.id").
 			Where("show = ?", models.BoolPointer(true))
 
 		if !privileges.HasPrivilege(models.PrivilegeTypeSafety) {

--- a/src/pages/Office/HeadquartersQueues/HeadquartersQueues.jsx
+++ b/src/pages/Office/HeadquartersQueues/HeadquartersQueues.jsx
@@ -38,7 +38,7 @@ import { milmoveLogger } from 'utils/milmoveLog';
 import ConnectedFlashMessage from 'containers/FlashMessage/FlashMessage';
 import CustomerSearchForm from 'components/CustomerSearchForm/CustomerSearchForm';
 
-const HeadquartersQueue = () => {
+const HeadquartersQueue = ({ isQueueManagementFFEnabled }) => {
   const navigate = useNavigate();
   const { queueType } = useParams();
   const [search, setSearch] = useState({ moveCode: null, dodID: null, customerName: null, paymentRequestCode: null });
@@ -237,7 +237,7 @@ const HeadquartersQueue = () => {
           defaultSortedColumns={[{ id: 'status', desc: false }]}
           disableMultiSort
           disableSortBy={false}
-          columns={tooQueueColumns(moveLockFlag, showBranchFilter)}
+          columns={tooQueueColumns(moveLockFlag, isQueueManagementFFEnabled, showBranchFilter)}
           title="All moves"
           handleClick={handleClickNavigateToDetails}
           useQueries={useMovesQueueQueries}
@@ -264,7 +264,7 @@ const HeadquartersQueue = () => {
           defaultSortedColumns={[{ id: 'age', desc: true }]}
           disableMultiSort
           disableSortBy={false}
-          columns={tioQueueColumns(moveLockFlag, showBranchFilter)}
+          columns={tioQueueColumns(moveLockFlag, isQueueManagementFFEnabled, showBranchFilter)}
           title="Payment requests"
           handleClick={handleClickNavigateToPaymentRequests}
           useQueries={usePaymentRequestQueueQueries}
@@ -291,7 +291,7 @@ const HeadquartersQueue = () => {
           defaultSortedColumns={[{ id: 'closeoutInitiated', desc: false }]}
           disableMultiSort
           disableSortBy={false}
-          columns={closeoutColumns(moveLockFlag, inPPMCloseoutGBLOC)}
+          columns={closeoutColumns(moveLockFlag, inPPMCloseoutGBLOC, null, null, isQueueManagementFFEnabled)}
           title="Moves"
           handleClick={handleClickNavigateToDetails}
           useQueries={useServicesCounselingQueuePPMQueries}
@@ -319,7 +319,7 @@ const HeadquartersQueue = () => {
           defaultSortedColumns={[{ id: 'submittedAt', desc: false }]}
           disableMultiSort
           disableSortBy={false}
-          columns={counselingColumns(moveLockFlag)}
+          columns={counselingColumns(moveLockFlag, null, null, isQueueManagementFFEnabled)}
           title="Moves"
           handleClick={handleClickNavigateToDetails}
           useQueries={useServicesCounselingQueueQueries}

--- a/src/pages/Office/ServicesCounselingQueue/ServicesCounselingQueue.jsx
+++ b/src/pages/Office/ServicesCounselingQueue/ServicesCounselingQueue.jsx
@@ -197,7 +197,7 @@ export const counselingColumns = (moveLockFlag, originLocationList, supervisor, 
         'Assigned',
         (row) => {
           return !row?.assignable ? (
-            <div>{`${row.assignedTo?.lastName}, ${row.assignedTo?.firstName}`}</div>
+            <div>{row.assignedTo ? `${row.assignedTo?.lastName}, ${row.assignedTo?.firstName}` : ''}</div>
           ) : (
             <div data-label="assignedSelect" className={styles.assignedToCol}>
               <Dropdown
@@ -224,156 +224,196 @@ export const counselingColumns = (moveLockFlag, originLocationList, supervisor, 
 
   return cols;
 };
-export const closeoutColumns = (moveLockFlag, ppmCloseoutGBLOC, ppmCloseoutOriginLocationList, supervisor) => [
-  createHeader(
-    ' ',
-    (row) => {
-      const now = new Date();
-      // this will render a lock icon if the move is locked & if the lockExpiresAt value is after right now
-      if (row.lockedByOfficeUserID && row.lockExpiresAt && now < new Date(row.lockExpiresAt) && moveLockFlag) {
+export const closeoutColumns = (
+  moveLockFlag,
+  ppmCloseoutGBLOC,
+  ppmCloseoutOriginLocationList,
+  supervisor,
+  isQueueManagementEnabled,
+) => {
+  const cols = [
+    createHeader(
+      ' ',
+      (row) => {
+        const now = new Date();
+        // this will render a lock icon if the move is locked & if the lockExpiresAt value is after right now
+        if (row.lockedByOfficeUserID && row.lockExpiresAt && now < new Date(row.lockExpiresAt) && moveLockFlag) {
+          return (
+            <div id={row.id}>
+              <FontAwesomeIcon icon="lock" />
+            </div>
+          );
+        }
+        return null;
+      },
+      { id: 'lock' },
+    ),
+    createHeader('ID', 'id', { id: 'id' }),
+    createHeader(
+      'Customer name',
+      (row) => {
         return (
-          <div id={row.id}>
-            <FontAwesomeIcon icon="lock" />
+          <div>
+            {CHECK_SPECIAL_ORDERS_TYPES(row.orderType) ? (
+              <span className={styles.specialMoves}>{SPECIAL_ORDERS_TYPES[`${row.orderType}`]}</span>
+            ) : null}
+            {`${row.customer.last_name}, ${row.customer.first_name}`}
           </div>
         );
-      }
-      return null;
-    },
-    { id: 'lock' },
-  ),
-  createHeader('ID', 'id', { id: 'id' }),
-  createHeader(
-    'Customer name',
-    (row) => {
-      return (
-        <div>
-          {CHECK_SPECIAL_ORDERS_TYPES(row.orderType) ? (
-            <span className={styles.specialMoves}>{SPECIAL_ORDERS_TYPES[`${row.orderType}`]}</span>
-          ) : null}
-          {`${row.customer.last_name}, ${row.customer.first_name}`}
-        </div>
-      );
-    },
-    {
-      id: 'lastName',
+      },
+      {
+        id: 'lastName',
+        isFilterable: true,
+        exportValue: (row) => {
+          return `${row.customer.last_name}, ${row.customer.first_name}`;
+        },
+      },
+    ),
+    createHeader('DoD ID', 'customer.dodID', {
+      id: 'dodID',
       isFilterable: true,
       exportValue: (row) => {
-        return `${row.customer.last_name}, ${row.customer.first_name}`;
+        return row.customer.dodID;
       },
-    },
-  ),
-  createHeader('DoD ID', 'customer.dodID', {
-    id: 'dodID',
-    isFilterable: true,
-    exportValue: (row) => {
-      return row.customer.dodID;
-    },
-  }),
-  createHeader('EMPLID', 'customer.emplid', {
-    id: 'emplid',
-    isFilterable: true,
-  }),
-  createHeader('Move code', 'locator', {
-    id: 'locator',
-    isFilterable: true,
-  }),
-  createHeader(
-    'Branch',
-    (row) => {
-      return serviceMemberAgencyLabel(row.customer.agency);
-    },
-    {
-      id: 'branch',
+    }),
+    createHeader('EMPLID', 'customer.emplid', {
+      id: 'emplid',
       isFilterable: true,
-      Filter: (props) => (
+    }),
+    createHeader('Move code', 'locator', {
+      id: 'locator',
+      isFilterable: true,
+    }),
+    createHeader(
+      'Branch',
+      (row) => {
+        return serviceMemberAgencyLabel(row.customer.agency);
+      },
+      {
+        id: 'branch',
+        isFilterable: true,
+        Filter: (props) => (
+          // eslint-disable-next-line react/jsx-props-no-spreading
+          <SelectFilter options={BRANCH_OPTIONS} {...props} />
+        ),
+      },
+    ),
+    createHeader(
+      'Status',
+      (row) => {
+        return SERVICE_COUNSELING_PPM_STATUS_LABELS[`${row.ppmStatus}`];
+      },
+      {
+        id: 'ppmStatus',
+        isFilterable: true,
+        Filter: (props) => (
+          // eslint-disable-next-line react/jsx-props-no-spreading
+          <SelectFilter options={SERVICE_COUNSELING_PPM_STATUS_OPTIONS} {...props} />
+        ),
+      },
+    ),
+    createHeader(
+      'Closeout initiated',
+      (row) => {
+        return formatDateFromIso(row.closeoutInitiated, DATE_FORMAT_STRING);
+      },
+      {
+        id: 'closeoutInitiated',
+        isFilterable: true,
         // eslint-disable-next-line react/jsx-props-no-spreading
-        <SelectFilter options={BRANCH_OPTIONS} {...props} />
-      ),
-    },
-  ),
-  createHeader(
-    'Status',
-    (row) => {
-      return SERVICE_COUNSELING_PPM_STATUS_LABELS[`${row.ppmStatus}`];
-    },
-    {
-      id: 'ppmStatus',
-      isFilterable: true,
-      Filter: (props) => (
-        // eslint-disable-next-line react/jsx-props-no-spreading
-        <SelectFilter options={SERVICE_COUNSELING_PPM_STATUS_OPTIONS} {...props} />
-      ),
-    },
-  ),
-  createHeader(
-    'Closeout initiated',
-    (row) => {
-      return formatDateFromIso(row.closeoutInitiated, DATE_FORMAT_STRING);
-    },
-    {
-      id: 'closeoutInitiated',
-      isFilterable: true,
-      // eslint-disable-next-line react/jsx-props-no-spreading
-      Filter: (props) => <DateSelectFilter dateTime {...props} />,
-    },
-  ),
-  createHeader(
-    'Full or partial PPM',
-    (row) => {
-      return SERVICE_COUNSELING_PPM_TYPE_LABELS[`${row.ppmType}`];
-    },
-    {
-      id: 'ppmType',
-      isFilterable: true,
-      Filter: (props) => (
-        // eslint-disable-next-line react/jsx-props-no-spreading
-        <SelectFilter options={SERVICE_COUNSELING_PPM_TYPE_OPTIONS} {...props} />
-      ),
-    },
-  ),
-  supervisor
-    ? createHeader(
-        'Origin duty location',
-        (row) => {
-          return `${row.originDutyLocation.name}`;
-        },
-        {
+        Filter: (props) => <DateSelectFilter dateTime {...props} />,
+      },
+    ),
+    createHeader(
+      'Full or partial PPM',
+      (row) => {
+        return SERVICE_COUNSELING_PPM_TYPE_LABELS[`${row.ppmType}`];
+      },
+      {
+        id: 'ppmType',
+        isFilterable: true,
+        Filter: (props) => (
+          // eslint-disable-next-line react/jsx-props-no-spreading
+          <SelectFilter options={SERVICE_COUNSELING_PPM_TYPE_OPTIONS} {...props} />
+        ),
+      },
+    ),
+    supervisor
+      ? createHeader(
+          'Origin duty location',
+          (row) => {
+            return `${row.originDutyLocation.name}`;
+          },
+          {
+            id: 'originDutyLocation',
+            isFilterable: true,
+            exportValue: (row) => {
+              return row.originDutyLocation?.name;
+            },
+            Filter: (props) => (
+              <MultiSelectTypeAheadCheckBoxFilter
+                options={ppmCloseoutOriginLocationList}
+                placeholder="Start typing a duty location..."
+                // eslint-disable-next-line react/jsx-props-no-spreading
+                {...props}
+              />
+            ),
+          },
+        )
+      : createHeader('Origin duty location', 'originDutyLocation.name', {
           id: 'originDutyLocation',
           isFilterable: true,
           exportValue: (row) => {
             return row.originDutyLocation?.name;
           },
-          Filter: (props) => (
-            <MultiSelectTypeAheadCheckBoxFilter
-              options={ppmCloseoutOriginLocationList}
-              placeholder="Start typing a duty location..."
-              // eslint-disable-next-line react/jsx-props-no-spreading
-              {...props}
-            />
-          ),
+        }),
+    createHeader('Destination duty location', 'destinationDutyLocation.name', {
+      id: 'destinationDutyLocation',
+      isFilterable: true,
+      exportValue: (row) => {
+        return row.destinationDutyLocation?.name;
+      },
+    }),
+    createHeader('PPM closeout location', 'closeoutLocation', {
+      id: 'closeoutLocation',
+      // This filter only makes sense if we're not in a closeout GBLOC. Users in a closeout GBLOC will
+      // see the same value in this column for every move.
+      isFilterable: !ppmCloseoutGBLOC,
+    }),
+  ];
+  if (isQueueManagementEnabled)
+    cols.push(
+      createHeader(
+        'Assigned',
+        (row) => {
+          return !row?.assignable ? (
+            <div>{row.assignedTo ? `${row.assignedTo?.lastName}, ${row.assignedTo?.firstName}` : ''}</div>
+          ) : (
+            <div data-label="assignedSelect" className={styles.assignedToCol}>
+              <Dropdown
+                defaultValue={row.assignedTo?.officeUserId}
+                onChange={(e) => handleQueueAssignment(row.id, e.target.value, roleTypes.SERVICES_COUNSELOR)}
+                title="Assigned dropdown"
+              >
+                <option value={null}>{DEFAULT_EMPTY_VALUE}</option>
+                {row.availableOfficeUsers.map(({ lastName, firstName, officeUserId }) => (
+                  <option value={officeUserId} key={`filterOption_${officeUserId}`}>
+                    {`${lastName}, ${firstName}`}
+                  </option>
+                ))}
+              </Dropdown>
+            </div>
+          );
         },
-      )
-    : createHeader('Origin duty location', 'originDutyLocation.name', {
-        id: 'originDutyLocation',
-        isFilterable: true,
-        exportValue: (row) => {
-          return row.originDutyLocation?.name;
+        {
+          id: 'assignedTo',
+          isFilterable: true,
         },
-      }),
-  createHeader('Destination duty location', 'destinationDutyLocation.name', {
-    id: 'destinationDutyLocation',
-    isFilterable: true,
-    exportValue: (row) => {
-      return row.destinationDutyLocation?.name;
-    },
-  }),
-  createHeader('PPM closeout location', 'closeoutLocation', {
-    id: 'closeoutLocation',
-    // This filter only makes sense if we're not in a closeout GBLOC. Users in a closeout GBLOC will
-    // see the same value in this column for every move.
-    isFilterable: !ppmCloseoutGBLOC,
-  }),
-];
+      ),
+    );
+
+  return cols;
+};
 
 const ServicesCounselingQueue = ({ userPrivileges, isQueueManagementFFEnabled }) => {
   const { queueType } = useParams();
@@ -588,7 +628,13 @@ const ServicesCounselingQueue = ({ userPrivileges, isQueueManagementFFEnabled })
           defaultSortedColumns={[{ id: 'closeoutInitiated', desc: false }]}
           disableMultiSort
           disableSortBy={false}
-          columns={closeoutColumns(moveLockFlag, inPPMCloseoutGBLOC, ppmCloseoutOriginLocationList, supervisor)}
+          columns={closeoutColumns(
+            moveLockFlag,
+            inPPMCloseoutGBLOC,
+            ppmCloseoutOriginLocationList,
+            supervisor,
+            isQueueManagementFFEnabled,
+          )}
           title="Moves"
           handleClick={handleClick}
           useQueries={useServicesCounselingQueuePPMQueries}

--- a/src/pages/Office/ServicesCounselingQueue/ServicesCounselingQueue.test.jsx
+++ b/src/pages/Office/ServicesCounselingQueue/ServicesCounselingQueue.test.jsx
@@ -508,6 +508,7 @@ describe('ServicesCounselingQueue', () => {
           expect(screen.getByText(/Full or partial PPM/)).toBeInTheDocument();
           expect(screen.getByText(/Destination duty location/)).toBeInTheDocument();
           expect(screen.getByText(/Status/)).toBeInTheDocument();
+          expect(screen.getByText(/Assigned/)).toBeInTheDocument();
         } else {
           // Check for the "Search" tab
           const searchActive = screen.getByText('Search', { selector: '.usa-current .tab-title' });

--- a/src/pages/Office/index.jsx
+++ b/src/pages/Office/index.jsx
@@ -292,7 +292,7 @@ export class OfficeApp extends Component {
                         end
                         element={
                           <PrivateRoute requiredRoles={hqRoleFlag ? [roleTypes.HQ] : [undefined]}>
-                            <HeadquartersQueues />
+                            <HeadquartersQueues isQueueManagementFFEnabled={queueManagementFlag} />
                           </PrivateRoute>
                         }
                       />
@@ -366,7 +366,7 @@ export class OfficeApp extends Component {
                           end
                           element={
                             <PrivateRoute requiredRoles={hqRoleFlag ? [roleTypes.HQ] : [undefined]}>
-                              <HeadquartersQueues />
+                              <HeadquartersQueues isQueueManagementFFEnabled={queueManagementFlag} />
                             </PrivateRoute>
                           }
                         />

--- a/swagger-def/ghc.yaml
+++ b/swagger-def/ghc.yaml
@@ -6784,8 +6784,6 @@ definitions:
         type: string
       firstName:
         type: string
-      hasSafetyPrivilege:
-        type: boolean
   QueueMoves:
     type: array
     items:

--- a/swagger/ghc.yaml
+++ b/swagger/ghc.yaml
@@ -7077,8 +7077,6 @@ definitions:
         type: string
       firstName:
         type: string
-      hasSafetyPrivilege:
-        type: boolean
   QueueMoves:
     type: array
     items:


### PR DESCRIPTION
## [Agility ticket](https://www13.v1host.com/USTRANSCOM38/story.mvc/Summary?oidToken=Story%3A981461&RoomContext=TeamRoom%3A848240&concept=TeamRoom)

## Summary

This story will cover the SC, TOO, and TIO office users.  Supervisors with safety privilege should see safety moves and their assignment drop down should only include users with safety privileges.

### How to test

1. You will need several SC accounts setup, all in the same transportation office.
   a. SC supervisor with safety privilege.
   b. SC user (non-supervisor) with safety privilege.
   c. SC supervisor without safety privilege.
   d. SC user (non-supervisor) without safety privilege.
2. Setup at least one non-safety move to have the counseling office match your SC user's transportation office.
3. Setup at least one safety move to have the counseling office match your SC user's transportation office.
4. Login as the SC supervisor with safety priv and:
   a. Verify that you can see only SC safety priv office members on the safety move you made in step 3 (that is assigned to your counseling office).
   b. Verify that you see all SCs setup above on a non-safety move in your counseling office.
5. Login as the SC supervisor without safety priv and since you won't see the safety move you created, just verify that you can still see all SC members you expect in the dropdown for moves in your counseling office.
6. Now go back to step 1 and create or change your users to TOO and run through steps 2-5.
7. Finally, go back to step 1 and create or change your users to TIO and run through steps 2-5.
