### PR TITLE
INT B-21679 I-13498

### DIFF
--- a/src/components/Customer/WizardNavigation/WizardNavigation.module.scss
+++ b/src/components/Customer/WizardNavigation/WizardNavigation.module.scss
@@ -5,9 +5,7 @@
   display: flex;
   flex-wrap: wrap;
 
-  button,
-  :global(.usa-button) {
-    margin: 0;
+  button {
     flex-grow: 0;
     flex-basis: auto;
   }

--- a/src/components/Office/ShipmentForm/ShipmentForm.module.scss
+++ b/src/components/Office/ShipmentForm/ShipmentForm.module.scss
@@ -98,6 +98,7 @@
 
   .buttonGroup {
     display: flex;
+    gap: 10px;
   }
 
   table {

--- a/src/shared/styles/_overrides.scss
+++ b/src/shared/styles/_overrides.scss
@@ -309,11 +309,13 @@
   }
 
   .usa-button {
-    margin: 0;
+    margin-top: 0;
+    margin-right:0.5rem;
   }
 }
 
 .usa-button {
+  margin-top: 0;
   margin-right:0.5rem;
 }
 

--- a/src/shared/styles/_overrides.scss
+++ b/src/shared/styles/_overrides.scss
@@ -307,6 +307,10 @@
       max-width:none;
     }
   }
+
+  .usa-button {
+    margin: 0;
+  }
 }
 
 .usa-button {


### PR DESCRIPTION
## [Agility ticket](https://www13.v1host.com/USTRANSCOM38/assetdetail.v1?number=B-21679)
## [Issue ticket](https://www13.v1host.com/USTRANSCOM38/assetdetail.v1?number=I-13498)

## Summary

We have this tricky little issue where for some reason we were having `.usa-form` and `.usa-button` mobile stylings being applied to the application. It seems to be an issue with the third party library that we use `uswds` so the fix is to override the stylings being applied within `_overrides.scss`.

## Screenshots
![Screenshot 2024-11-13 at 12 47 28 PM](https://github.com/user-attachments/assets/1adb09c1-e200-4d28-be06-d5433ce001cd)

![Screenshot 2024-11-13 at 12 47 42 PM](https://github.com/user-attachments/assets/6e8a75da-775c-4d7c-80fc-79c7dc7c29c6)

![Screenshot 2024-11-13 at 12 47 54 PM](https://github.com/user-attachments/assets/76985769-7acc-4abe-a9e7-fc0c3f64b446)

![Screenshot 2024-11-13 at 12 48 07 PM](https://github.com/user-attachments/assets/f24a12d4-8dd9-4a22-8488-433672a91bd1)

![Screenshot 2024-11-13 at 12 48 18 PM](https://github.com/user-attachments/assets/0bf5f1ee-6424-4f8a-85e9-11adcbae4473)

![Screenshot 2024-11-13 at 12 48 29 PM](https://github.com/user-attachments/assets/70528c12-fd5b-42d8-a114-39b0cb52d041)

![Screenshot 2024-11-13 at 12 48 46 PM](https://github.com/user-attachments/assets/ce0f7a27-a73b-4974-b146-7a18a917d22b)
