### PR TITLE
INT B-21679 v2

### DIFF
--- a/src/components/ButtonDropdown/ButtonDropdown.jsx
+++ b/src/components/ButtonDropdown/ButtonDropdown.jsx
@@ -7,12 +7,7 @@ import styles from './ButtonDropdown.module.scss';
 
 const ButtonDropdown = ({ children, onChange, value, ariaLabel, divClassName, testId }) => (
   <div className={classnames(styles.ButtonDropdown, divClassName)} data-testid={testId}>
-    <Dropdown
-      aria-label={ariaLabel}
-      onChange={onChange}
-      className={classnames(styles.ButtonDropdown, 'usa-button')}
-      value={value}
-    >
+    <Dropdown aria-label={ariaLabel} onChange={onChange} className={styles.ButtonDropdown} value={value}>
       {children}
     </Dropdown>
     <span className={styles.ButtonDropdownIcon} />

--- a/src/components/ButtonDropdown/ButtonDropdown.module.scss
+++ b/src/components/ButtonDropdown/ButtonDropdown.module.scss
@@ -3,7 +3,11 @@
 
 .ButtonDropdown {
   position: relative;
-  display: inline-block;
+  display: flex;
+  align-items: center;
+  font-weight: 600;
+  font-size:1.06rem;
+
   select {
     color: white;
     background-color: $primary;

--- a/src/components/Customer/WizardNavigation/WizardNavigation.module.scss
+++ b/src/components/Customer/WizardNavigation/WizardNavigation.module.scss
@@ -5,7 +5,9 @@
   display: flex;
   flex-wrap: wrap;
 
-  button {
+  button,
+  :global(.usa-button){
+    margin: 0;
     flex-grow: 0;
     flex-basis: auto;
   }

--- a/src/components/Office/CustomerSupportRemarkForm/CustomerSupportRemarkForm.module.scss
+++ b/src/components/Office/CustomerSupportRemarkForm/CustomerSupportRemarkForm.module.scss
@@ -14,4 +14,5 @@
 
 .newRemarkTextArea {
   resize: vertical;
+  margin-bottom: 2rem;
 }


### PR DESCRIPTION
## [Agility ticket](https://www13.v1host.com/USTRANSCOM38/assetdetail.v1?number=B-21679)

## Summary

Fixing wonky buttons by adding in the `.usa-button` styling again and overriding the styles because for SOME GOD FORSAKEN REASON we are still getting mobile styling applied in the create customer form.

Also made some fixes and removed the `usa-button` styling fo the add new shipment button as well as added some margin to the bottom of the customer remarks form.

Fixes have been made and you can see them logging into [EXP](https://office.exp.dp3.us/sign-in) as an office user to confirm. Careful though, it's real weird in there.

## Screenshots

![Screenshot 2024-11-14 at 11 52 26 AM](https://github.com/user-attachments/assets/ae98dde8-3ec9-4eb9-8cc3-dc43baa96d99)

![Screenshot 2024-11-14 at 12 37 50 PM](https://github.com/user-attachments/assets/73d20d69-7ddb-499e-9a0b-5474bbcbea7e)


![Screenshot 2024-11-14 at 12 36 14 PM](https://github.com/user-attachments/assets/f2990075-7f50-4df5-b546-8bfe91d4feaf)

![Screenshot 2024-11-14 at 12 38 10 PM](https://github.com/user-attachments/assets/91367351-ee0f-4dcb-ac73-705cdbca3c59)
