### PR TITLE
B-21374 I-13575 fix ternary

### DIFF
--- a/src/components/Customer/Review/OrdersTable/OrdersTable.jsx
+++ b/src/components/Customer/Review/OrdersTable/OrdersTable.jsx
@@ -83,7 +83,7 @@ const OrdersTable = ({
             <td>{hasDependents ? 'Yes' : 'No'}</td>
           </tr>
           {/* Group conditionally rendered OCONUS fields */}
-          {(accompaniedTour || dependentsUnderTwelve || dependentsTwelveAndOver) && (
+          {(accompaniedTour || dependentsUnderTwelve > 0 || dependentsTwelveAndOver > 0) && (
             <>
               <tr>
                 <th scope="row">Accompanied tour</th>


### PR DESCRIPTION
## [B-21374](https://www13.v1host.com/USTRANSCOM38/story.mvc/Summary?oidToken=Story%3A1014669)
## [I-13575](https://www13.v1host.com/USTRANSCOM38/assetdetail.v1?number=I-13575)
## Summary

Resolves ternary condition returning `0` on the HTML page by converting `0` as falsy to be `FALSE` when falsy.

### How to test

1. Turn on the UB flag
2. Create a new customer
3. Create a new order for PCS, HHG shipment, NO UB, NO DEPENDENTS
4. Once you reach move review the Orders section should not have this 0


## Screenshots

FROM
![Pasted Graphic](https://github.com/user-attachments/assets/3c5e0ffb-4515-4329-8f64-ada6cdd01275)

TO
![image](https://github.com/user-attachments/assets/ca65c62e-b5b4-4a9c-bb83-b6c685c20599)

