### PR TITLE
INT B-21846 TOO/SC can create UB shipments

### DIFF
--- a/src/components/Office/RequestedShipments/ApprovedRequestedShipments.jsx
+++ b/src/components/Office/RequestedShipments/ApprovedRequestedShipments.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import * as PropTypes from 'prop-types';
 import { generatePath, useParams, useNavigate } from 'react-router-dom';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
@@ -86,15 +86,29 @@ const ApprovedRequestedShipments = ({
 
   const dutyLocationPostal = { postalCode: ordersInfo.newDutyLocation?.address?.postalCode };
 
-  const [enableBoat, setEnableBoat] = React.useState(false);
-  const [enableMobileHome, setEnableMobileHome] = React.useState(false);
-  React.useEffect(() => {
+  const [enableBoat, setEnableBoat] = useState(false);
+  const [enableMobileHome, setEnableMobileHome] = useState(false);
+  const [enableUB, setEnableUB] = useState(false);
+  const [isOconusMove, setIsOconusMove] = useState(false);
+
+  useEffect(() => {
     const fetchData = async () => {
       setEnableBoat(await isBooleanFlagEnabled(FEATURE_FLAG_KEYS.BOAT));
       setEnableMobileHome(await isBooleanFlagEnabled(FEATURE_FLAG_KEYS.MOBILE_HOME));
+      setEnableUB(await isBooleanFlagEnabled(FEATURE_FLAG_KEYS.UNACCOMPANIED_BAGGAGE));
     };
     fetchData();
   }, []);
+
+  const { newDutyLocation, currentDutyLocation } = ordersInfo;
+  useEffect(() => {
+    // Check if duty locations on the orders qualify as OCONUS to conditionally render the UB shipment option
+    if (currentDutyLocation?.address?.isOconus || newDutyLocation?.address?.isOconus) {
+      setIsOconusMove(true);
+    } else {
+      setIsOconusMove(false);
+    }
+  }, [currentDutyLocation, newDutyLocation, isOconusMove, enableUB]);
 
   const allowedShipmentOptions = () => {
     return (
@@ -107,6 +121,7 @@ const ApprovedRequestedShipments = ({
         <option value={SHIPMENT_OPTIONS_URL.NTSrelease}>NTS-release</option>
         {enableBoat && <option value={SHIPMENT_OPTIONS_URL.BOAT}>Boat</option>}
         {enableMobileHome && <option value={SHIPMENT_OPTIONS_URL.MOBILE_HOME}>Mobile Home</option>}
+        {enableUB && isOconusMove && <option value={SHIPMENT_OPTIONS_URL.UNACCOMPANIED_BAGGAGE}>UB</option>}
       </>
     );
   };

--- a/src/components/Office/RequestedShipments/RequestedShipments.test.jsx
+++ b/src/components/Office/RequestedShipments/RequestedShipments.test.jsx
@@ -502,6 +502,7 @@ describe('RequestedShipments', () => {
         SHIPMENT_OPTIONS_URL.NTSrelease,
         SHIPMENT_OPTIONS_URL.MOBILE_HOME,
         SHIPMENT_OPTIONS_URL.BOAT,
+        SHIPMENT_OPTIONS_URL.UNACCOMPANIED_BAGGAGE,
       ],
     ])('selects the %s option and navigates to the matching form for that shipment type', async (shipmentType) => {
       render(

--- a/src/components/Office/RequestedShipments/SubmittedRequestedShipments.jsx
+++ b/src/components/Office/RequestedShipments/SubmittedRequestedShipments.jsx
@@ -65,14 +65,27 @@ const SubmittedRequestedShipments = ({
   const [filteredShipments, setFilteredShipments] = useState([]);
   const [enableBoat, setEnableBoat] = useState(false);
   const [enableMobileHome, setEnableMobileHome] = useState(false);
+  const [enableUB, setEnableUB] = useState(false);
+  const [isOconusMove, setIsOconusMove] = useState(false);
 
   useEffect(() => {
     const fetchData = async () => {
       setEnableBoat(await isBooleanFlagEnabled(FEATURE_FLAG_KEYS.BOAT));
       setEnableMobileHome(await isBooleanFlagEnabled(FEATURE_FLAG_KEYS.MOBILE_HOME));
+      setEnableUB(await isBooleanFlagEnabled(FEATURE_FLAG_KEYS.UNACCOMPANIED_BAGGAGE));
     };
     fetchData();
   }, []);
+
+  const { newDutyLocation, currentDutyLocation } = ordersInfo;
+  useEffect(() => {
+    // Check if duty locations on the orders qualify as OCONUS to conditionally render the UB shipment option
+    if (currentDutyLocation?.address?.isOconus || newDutyLocation?.address?.isOconus) {
+      setIsOconusMove(true);
+    } else {
+      setIsOconusMove(false);
+    }
+  }, [currentDutyLocation, newDutyLocation, isOconusMove, enableUB]);
 
   const filterPrimeShipments = mtoShipments.filter((shipment) => !shipment.usesExternalVendor);
 
@@ -126,6 +139,7 @@ const SubmittedRequestedShipments = ({
         <option value={SHIPMENT_OPTIONS_URL.NTSrelease}>NTS-release</option>
         {enableBoat && <option value={SHIPMENT_OPTIONS_URL.BOAT}>Boat</option>}
         {enableMobileHome && <option value={SHIPMENT_OPTIONS_URL.MOBILE_HOME}>Mobile Home</option>}
+        {enableUB && isOconusMove && <option value={SHIPMENT_OPTIONS_URL.UNACCOMPANIED_BAGGAGE}>UB</option>}
       </>
     );
   };

--- a/src/components/Office/ShipmentForm/ShipmentForm.jsx
+++ b/src/components/Office/ShipmentForm/ShipmentForm.jsx
@@ -890,7 +890,7 @@ const ShipmentForm = (props) => {
               </SectionWrapper>
 
               <Form className={formStyles.form}>
-                {isTOO && !isHHG && !isPPM && !isBoat && !isMobileHome && <ShipmentVendor />}
+                {isTOO && !isHHG && !isPPM && !isBoat && !isMobileHome && !isUB && <ShipmentVendor />}
 
                 {isNTSR && <ShipmentWeightInput userRole={userRole} />}
 

--- a/src/components/Office/ShipmentForm/ShipmentForm.test.jsx
+++ b/src/components/Office/ShipmentForm/ShipmentForm.test.jsx
@@ -212,7 +212,7 @@ const defaultProps = {
   serviceMember: {
     weightAllotment: {
       totalWeightSelf: 5000,
-      ubAllowance: 400,
+      unaccompaniedBaggageAllowance: 400,
     },
     agency: '',
   },

--- a/src/components/ShipmentTag/ShipmentTag.module.scss
+++ b/src/components/ShipmentTag/ShipmentTag.module.scss
@@ -34,4 +34,7 @@
   &.MobileHome {
     background-color: $accent-mobile-home;
   }
+  &.UB {
+    background-color: $accent-ub;
+  }
 }

--- a/src/pages/Office/AddShipment/AddShipment.jsx
+++ b/src/pages/Office/AddShipment/AddShipment.jsx
@@ -27,6 +27,8 @@ const AddShipment = () => {
     shipmentType = SHIPMENT_OPTIONS.BOAT;
   } else if (shipmentType === SHIPMENT_OPTIONS_URL.MOBILE_HOME) {
     shipmentType = SHIPMENT_OPTIONS.MOBILE_HOME;
+  } else if (shipmentType === SHIPMENT_OPTIONS_URL.UNACCOMPANIED_BAGGAGE) {
+    shipmentType = SHIPMENT_OPTIONS.UNACCOMPANIED_BAGGAGE;
   } else {
     shipmentType = SHIPMENT_OPTIONS[shipmentType];
   }

--- a/src/pages/Office/ServicesCounselingAddShipment/ServicesCounselingAddShipment.jsx
+++ b/src/pages/Office/ServicesCounselingAddShipment/ServicesCounselingAddShipment.jsx
@@ -27,6 +27,8 @@ const ServicesCounselingAddShipment = () => {
     shipmentType = SHIPMENT_OPTIONS.BOAT;
   } else if (shipmentType === SHIPMENT_OPTIONS_URL.MOBILE_HOME) {
     shipmentType = SHIPMENT_OPTIONS.MOBILE_HOME;
+  } else if (shipmentType === SHIPMENT_OPTIONS_URL.UNACCOMPANIED_BAGGAGE) {
+    shipmentType = SHIPMENT_OPTIONS.UNACCOMPANIED_BAGGAGE;
   } else {
     shipmentType = SHIPMENT_OPTIONS[shipmentType];
   }

--- a/src/pages/Office/ServicesCounselingMoveDetails/ServicesCounselingMoveDetails.jsx
+++ b/src/pages/Office/ServicesCounselingMoveDetails/ServicesCounselingMoveDetails.jsx
@@ -76,6 +76,8 @@ const ServicesCounselingMoveDetails = ({
   const [isCancelMoveModalVisible, setIsCancelMoveModalVisible] = useState(false);
   const [enableBoat, setEnableBoat] = useState(false);
   const [enableMobileHome, setEnableMobileHome] = useState(false);
+  const [enableUB, setEnableUB] = useState(false);
+  const [isOconusMove, setIsOconusMove] = useState(false);
   const { upload, amendedUpload } = useOrdersDocumentQueries(moveCode);
   const [errorMessage, setErrorMessage] = useState(null);
   const documentsForViewer = Object.values(upload || {})
@@ -90,7 +92,7 @@ const ServicesCounselingMoveDetails = ({
 
   const validOrdersDocuments = Object.values(orderDocuments || {})?.filter((file) => !file.deletedAt);
 
-  const { customer, entitlement: allowances } = order;
+  const { customer, entitlement: allowances, originDutyLocation, destinationDutyLocation } = order;
 
   const moveWeightTotal = calculateWeightRequested(mtoShipments);
 
@@ -169,9 +171,19 @@ const ServicesCounselingMoveDetails = ({
     const fetchData = async () => {
       setEnableBoat(await isBooleanFlagEnabled(FEATURE_FLAG_KEYS.BOAT));
       setEnableMobileHome(await isBooleanFlagEnabled(FEATURE_FLAG_KEYS.MOBILE_HOME));
+      setEnableUB(await isBooleanFlagEnabled(FEATURE_FLAG_KEYS.UNACCOMPANIED_BAGGAGE));
     };
     fetchData();
   }, []);
+
+  useEffect(() => {
+    // Check if either currentDutyLocation or newDutyLocation is OCONUS to conditionally render the UB shipment option
+    if (originDutyLocation?.address?.isOconus || destinationDutyLocation?.address?.isOconus) {
+      setIsOconusMove(true);
+    } else {
+      setIsOconusMove(false);
+    }
+  }, [originDutyLocation, destinationDutyLocation, isOconusMove, enableUB]);
 
   // for now we are only showing dest type on retiree and separatee orders
   const isRetirementOrSeparation =
@@ -623,6 +635,7 @@ const ServicesCounselingMoveDetails = ({
         <option value={SHIPMENT_OPTIONS_URL.NTSrelease}>NTS-release</option>
         {enableBoat && <option value={SHIPMENT_OPTIONS_URL.BOAT}>Boat</option>}
         {enableMobileHome && <option value={SHIPMENT_OPTIONS_URL.MOBILE_HOME}>Mobile Home</option>}
+        {enableUB && isOconusMove && <option value={SHIPMENT_OPTIONS_URL.UNACCOMPANIED_BAGGAGE}>UB</option>}
       </>
     );
   };


### PR DESCRIPTION
## [Agility ticket](https://www13.v1host.com/USTRANSCOM38/assetdetail.v1?number=B-21846)

## Summary

Small oopsie - forgot to add in the UB option for the SC/TOO to add UB shipments via the dropdown. This PR addresses adding in that logic and conditionally rendering the UB option if the UB flag is on and if one or both of the duty locations are OCONUS.

Also added in styling for the UB shipment tag & tests.

### How to test

1. Access MM as office user, ensure UB flag is on
2. Create customer with a duty locations that are CONUS
3. Go to add a shipment - should not be able to add a UB shipment
4. Create a new move, but with one or both duty locations being OCONUS
5. Go to add a shipment - should now see the UB option
6. Go through the workflow as SC/TOO and ensure you can complete creation of UB shipments

## Screenshots

![Screenshot 2024-11-26 at 1 06 01 PM](https://github.com/user-attachments/assets/7213527b-44e2-4c9e-9f77-bac9b6f145eb)

![Screenshot 2024-11-26 at 1 05 13 PM](https://github.com/user-attachments/assets/7a84003d-1586-423e-887d-3abb2f60b0b5)

Changed back to CONUS addies for duty locations
![Screenshot 2024-11-26 at 1 07 34 PM](https://github.com/user-attachments/assets/1041873e-8c9b-4005-b47a-001d042ce9b9)

Changed one to be OCONUS - now TOO can select UB
![Screenshot 2024-11-26 at 1 07 52 PM](https://github.com/user-attachments/assets/7acf7b26-681c-45ce-8264-cd2d46550a9e)

