### PR TITLE
Move sequence creation from sequencer_test.go to migration

### DIFF
--- a/migrations/app/migrations_manifest.txt
+++ b/migrations/app/migrations_manifest.txt
@@ -1044,4 +1044,4 @@
 20241119163933_set_inactive_NSRA15_oconus_rate_areas.up.sql
 20241120221040_change_port_location_fk_to_correct_table.up.sql
 20241122155416_total_dependents_calculation.up.sql
-20241129170027_create_test_sequence.up.sql
+20241202163059_create_test_sequence_dev_env.up.sql

--- a/migrations/app/migrations_manifest.txt
+++ b/migrations/app/migrations_manifest.txt
@@ -1044,3 +1044,4 @@
 20241119163933_set_inactive_NSRA15_oconus_rate_areas.up.sql
 20241120221040_change_port_location_fk_to_correct_table.up.sql
 20241122155416_total_dependents_calculation.up.sql
+20241129170027_create_test_sequence.up.sql

--- a/migrations/app/schema/20241129170027_create_test_sequence.up.sql
+++ b/migrations/app/schema/20241129170027_create_test_sequence.up.sql
@@ -1,0 +1,2 @@
+-- Create test_sequence in migration, moved from sequencer_test.go
+CREATE SEQUENCE IF NOT EXISTS test_sequence;

--- a/migrations/app/schema/20241129170027_create_test_sequence.up.sql
+++ b/migrations/app/schema/20241129170027_create_test_sequence.up.sql
@@ -1,2 +1,0 @@
--- Create test_sequence in migration, moved from sequencer_test.go
-CREATE SEQUENCE IF NOT EXISTS test_sequence;

--- a/migrations/app/secure/20241202163059_create_test_sequence_dev_env.up.sql
+++ b/migrations/app/secure/20241202163059_create_test_sequence_dev_env.up.sql
@@ -1,0 +1,7 @@
+-- Local test migration.
+-- This will be run on development environments.
+-- It should mirror what you intend to apply on loadtest/demo/exp/stg/prd
+-- DO NOT include any sensitive data.
+
+-- Create test_sequence in migration, moved from sequencer_test.go
+CREATE SEQUENCE IF NOT EXISTS test_sequence;

--- a/pkg/db/sequence/sequencer_test.go
+++ b/pkg/db/sequence/sequencer_test.go
@@ -13,9 +13,7 @@ type SequenceSuite struct {
 }
 
 func (suite *SequenceSuite) SetupTest() {
-	err := suite.DB().RawQuery("CREATE SEQUENCE IF NOT EXISTS test_sequence;").Exec()
-	suite.NoError(err, "Error creating test sequence")
-	err = suite.DB().RawQuery("SELECT setval($1, 1);", testSequence).Exec()
+	err := suite.DB().RawQuery("SELECT setval($1, 1);", testSequence).Exec()
 	suite.NoError(err, "Error resetting sequence")
 }
 


### PR DESCRIPTION
## Summary

The `pkg/db/sequence` step has been failing for awhile on `make server_test`. In `pkg/db/sequence/sequencer_test.go`, it would fail with `permission denied for schema public`. It started appearing roughly around the time of us upgrading from Postgres 12 to Postgres 16, and after investigating, this could have likely caused the issue, or at least contributed - "PostgreSQL 15 also revokes the CREATE permission from all users except a database owner from the public (or default) schema" per [this](https://stackoverflow.com/questions/67276391/why-am-i-getting-a-permission-denied-error-for-schema-public-on-pgadmin-4) and [this](https://stackoverflow.com/questions/75352342/permission-denied-for-schema-public-at-character-x)

I played around a _lot_ with updating the permissions as a raw query directly in `sequencer_test.go` to no avail, but then thought of just adding the sequence with a migration where we'd hopefully have the correct permissions. I believe this won't cause any issues, as line 16 of `pkg/db/sequence/sequencer_test.go` still calls setval, which will reset the sequence for test runs.

The server tests still aren't quite 100% passing, but I'm looking into that as well. Seeing a fail locally on `services/ghcimport`: 
```
package services/ghcimport is attempting to connect to database postgres
2024/11/29 19:55:45 TXNDB: package services/ghcimport will use database test_db_4 in pid 78134
2024/11/29 19:55:45 Cannot start preload savepoint `preload_data`: pq: current transaction is aborted, commands ignored until end of transaction block

```

To test:
1. Checkout this branch
2. Migrate your test_db - `make db_test_reset db_test_migrate`
3. (I still have to comment out the ld_classic in `scripts/run-server-test`)
4. Run `make server_test`
5. Verify that you get a pass for `github.com/transcom/mymove/pkg/db/sequence` in the test output