### PR TITLE
B 21353 price escalations main

### DIFF
--- a/pkg/models/re_contract_year.go
+++ b/pkg/models/re_contract_year.go
@@ -70,7 +70,7 @@ func (r *ReContractYear) Validate(_ *pop.Connection) (*validate.Errors, error) {
 	), nil
 }
 
-func GetExpectedEscalationPriceContractsCount(contractYearName string, hasOptionYear3 bool) ExpectedEscalationPriceContractsCount {
+func GetExpectedEscalationPriceContractsCount(contractYearName string) ExpectedEscalationPriceContractsCount {
 	switch contractYearName {
 	case BasePeriodYear1:
 		return ExpectedEscalationPriceContractsCount{
@@ -107,44 +107,26 @@ func GetExpectedEscalationPriceContractsCount(contractYearName string, hasOption
 			ExpectedAmountOfOptionPeriodYearsForCalculation: 2,
 			ExpectedAmountOfAwardTermsForCalculation:        0,
 		}
-	case OptionPeriod3:
+	case AwardTerm1:
 		return ExpectedEscalationPriceContractsCount{
 			ExpectedAmountOfContractYearsForCalculation:     6,
 			ExpectedAmountOfBasePeriodYearsForCalculation:   3,
-			ExpectedAmountOfOptionPeriodYearsForCalculation: 3,
-			ExpectedAmountOfAwardTermsForCalculation:        0,
-		}
-	case AwardTerm1:
-		if hasOptionYear3 {
-			return ExpectedEscalationPriceContractsCount{
-				ExpectedAmountOfContractYearsForCalculation:     7,
-				ExpectedAmountOfBasePeriodYearsForCalculation:   3,
-				ExpectedAmountOfOptionPeriodYearsForCalculation: 3,
-				ExpectedAmountOfAwardTermsForCalculation:        1,
-			}
-		} else {
-			return ExpectedEscalationPriceContractsCount{
-				ExpectedAmountOfContractYearsForCalculation:     6,
-				ExpectedAmountOfBasePeriodYearsForCalculation:   3,
-				ExpectedAmountOfOptionPeriodYearsForCalculation: 2,
-				ExpectedAmountOfAwardTermsForCalculation:        1,
-			}
+			ExpectedAmountOfOptionPeriodYearsForCalculation: 2,
+			ExpectedAmountOfAwardTermsForCalculation:        1,
 		}
 	case AwardTerm2:
-		if hasOptionYear3 {
-			return ExpectedEscalationPriceContractsCount{
-				ExpectedAmountOfContractYearsForCalculation:     8,
-				ExpectedAmountOfBasePeriodYearsForCalculation:   3,
-				ExpectedAmountOfOptionPeriodYearsForCalculation: 3,
-				ExpectedAmountOfAwardTermsForCalculation:        2,
-			}
-		} else {
-			return ExpectedEscalationPriceContractsCount{
-				ExpectedAmountOfContractYearsForCalculation:     7,
-				ExpectedAmountOfBasePeriodYearsForCalculation:   3,
-				ExpectedAmountOfOptionPeriodYearsForCalculation: 2,
-				ExpectedAmountOfAwardTermsForCalculation:        2,
-			}
+		return ExpectedEscalationPriceContractsCount{
+			ExpectedAmountOfContractYearsForCalculation:     7,
+			ExpectedAmountOfBasePeriodYearsForCalculation:   3,
+			ExpectedAmountOfOptionPeriodYearsForCalculation: 2,
+			ExpectedAmountOfAwardTermsForCalculation:        2,
+		}
+	case OptionPeriod3:
+		return ExpectedEscalationPriceContractsCount{
+			ExpectedAmountOfContractYearsForCalculation:     8,
+			ExpectedAmountOfBasePeriodYearsForCalculation:   3,
+			ExpectedAmountOfOptionPeriodYearsForCalculation: 3,
+			ExpectedAmountOfAwardTermsForCalculation:        2,
 		}
 	default:
 		return ExpectedEscalationPriceContractsCount{

--- a/pkg/models/re_contract_year.go
+++ b/pkg/models/re_contract_year.go
@@ -1,14 +1,12 @@
 package models
 
 import (
-	"fmt"
 	"time"
 
 	"github.com/gobuffalo/pop/v6"
 	"github.com/gobuffalo/validate/v3"
 	"github.com/gobuffalo/validate/v3/validators"
 	"github.com/gofrs/uuid"
-	"github.com/transcom/mymove/pkg/apperror"
 )
 
 const (
@@ -72,7 +70,7 @@ func (r *ReContractYear) Validate(_ *pop.Connection) (*validate.Errors, error) {
 	), nil
 }
 
-func GetExpectedEscalationPriceContractsCount(contractYearName string, hasOptionYear3 bool) (ExpectedEscalationPriceContractsCount, error) {
+func GetExpectedEscalationPriceContractsCount(contractYearName string, hasOptionYear3 bool) ExpectedEscalationPriceContractsCount {
 	switch contractYearName {
 	case BasePeriodYear1:
 		return ExpectedEscalationPriceContractsCount{
@@ -80,42 +78,42 @@ func GetExpectedEscalationPriceContractsCount(contractYearName string, hasOption
 			ExpectedAmountOfBasePeriodYearsForCalculation:   1,
 			ExpectedAmountOfOptionPeriodYearsForCalculation: 0,
 			ExpectedAmountOfAwardTermsForCalculation:        0,
-		}, nil
+		}
 	case BasePeriodYear2:
 		return ExpectedEscalationPriceContractsCount{
 			ExpectedAmountOfContractYearsForCalculation:     2,
 			ExpectedAmountOfBasePeriodYearsForCalculation:   2,
 			ExpectedAmountOfOptionPeriodYearsForCalculation: 0,
 			ExpectedAmountOfAwardTermsForCalculation:        0,
-		}, nil
+		}
 	case BasePeriodYear3:
 		return ExpectedEscalationPriceContractsCount{
 			ExpectedAmountOfContractYearsForCalculation:     3,
 			ExpectedAmountOfBasePeriodYearsForCalculation:   3,
 			ExpectedAmountOfOptionPeriodYearsForCalculation: 0,
 			ExpectedAmountOfAwardTermsForCalculation:        0,
-		}, nil
+		}
 	case OptionPeriod1:
 		return ExpectedEscalationPriceContractsCount{
 			ExpectedAmountOfContractYearsForCalculation:     4,
 			ExpectedAmountOfBasePeriodYearsForCalculation:   3,
 			ExpectedAmountOfOptionPeriodYearsForCalculation: 1,
 			ExpectedAmountOfAwardTermsForCalculation:        0,
-		}, nil
+		}
 	case OptionPeriod2:
 		return ExpectedEscalationPriceContractsCount{
 			ExpectedAmountOfContractYearsForCalculation:     5,
 			ExpectedAmountOfBasePeriodYearsForCalculation:   3,
 			ExpectedAmountOfOptionPeriodYearsForCalculation: 2,
 			ExpectedAmountOfAwardTermsForCalculation:        0,
-		}, nil
+		}
 	case OptionPeriod3:
 		return ExpectedEscalationPriceContractsCount{
 			ExpectedAmountOfContractYearsForCalculation:     6,
 			ExpectedAmountOfBasePeriodYearsForCalculation:   3,
 			ExpectedAmountOfOptionPeriodYearsForCalculation: 3,
 			ExpectedAmountOfAwardTermsForCalculation:        0,
-		}, nil
+		}
 	case AwardTerm1:
 		if hasOptionYear3 {
 			return ExpectedEscalationPriceContractsCount{
@@ -123,14 +121,14 @@ func GetExpectedEscalationPriceContractsCount(contractYearName string, hasOption
 				ExpectedAmountOfBasePeriodYearsForCalculation:   3,
 				ExpectedAmountOfOptionPeriodYearsForCalculation: 3,
 				ExpectedAmountOfAwardTermsForCalculation:        1,
-			}, nil
+			}
 		} else {
 			return ExpectedEscalationPriceContractsCount{
 				ExpectedAmountOfContractYearsForCalculation:     6,
 				ExpectedAmountOfBasePeriodYearsForCalculation:   3,
 				ExpectedAmountOfOptionPeriodYearsForCalculation: 2,
 				ExpectedAmountOfAwardTermsForCalculation:        1,
-			}, nil
+			}
 		}
 	case AwardTerm2:
 		if hasOptionYear3 {
@@ -139,17 +137,21 @@ func GetExpectedEscalationPriceContractsCount(contractYearName string, hasOption
 				ExpectedAmountOfBasePeriodYearsForCalculation:   3,
 				ExpectedAmountOfOptionPeriodYearsForCalculation: 3,
 				ExpectedAmountOfAwardTermsForCalculation:        2,
-			}, nil
+			}
 		} else {
 			return ExpectedEscalationPriceContractsCount{
 				ExpectedAmountOfContractYearsForCalculation:     7,
 				ExpectedAmountOfBasePeriodYearsForCalculation:   3,
 				ExpectedAmountOfOptionPeriodYearsForCalculation: 2,
 				ExpectedAmountOfAwardTermsForCalculation:        2,
-			}, nil
+			}
 		}
 	default:
-		err := apperror.NewInternalServerError(fmt.Sprintf("Unexpected contract year name %s.", contractYearName))
-		return ExpectedEscalationPriceContractsCount{}, err
+		return ExpectedEscalationPriceContractsCount{
+			ExpectedAmountOfContractYearsForCalculation:     0,
+			ExpectedAmountOfBasePeriodYearsForCalculation:   0,
+			ExpectedAmountOfOptionPeriodYearsForCalculation: 0,
+			ExpectedAmountOfAwardTermsForCalculation:        0,
+		}
 	}
 }

--- a/pkg/models/re_contract_year.go
+++ b/pkg/models/re_contract_year.go
@@ -1,6 +1,7 @@
 package models
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/gobuffalo/pop/v6"
@@ -70,7 +71,7 @@ func (r *ReContractYear) Validate(_ *pop.Connection) (*validate.Errors, error) {
 	), nil
 }
 
-func GetExpectedEscalationPriceContractsCount(contractYearName string) ExpectedEscalationPriceContractsCount {
+func GetExpectedEscalationPriceContractsCount(contractYearName string) (ExpectedEscalationPriceContractsCount, error) {
 	switch contractYearName {
 	case BasePeriodYear1:
 		return ExpectedEscalationPriceContractsCount{
@@ -78,56 +79,58 @@ func GetExpectedEscalationPriceContractsCount(contractYearName string) ExpectedE
 			ExpectedAmountOfBasePeriodYearsForCalculation:   1,
 			ExpectedAmountOfOptionPeriodYearsForCalculation: 0,
 			ExpectedAmountOfAwardTermsForCalculation:        0,
-		}
+		}, nil
 	case BasePeriodYear2:
 		return ExpectedEscalationPriceContractsCount{
 			ExpectedAmountOfContractYearsForCalculation:     2,
 			ExpectedAmountOfBasePeriodYearsForCalculation:   2,
 			ExpectedAmountOfOptionPeriodYearsForCalculation: 0,
 			ExpectedAmountOfAwardTermsForCalculation:        0,
-		}
+		}, nil
 	case BasePeriodYear3:
 		return ExpectedEscalationPriceContractsCount{
 			ExpectedAmountOfContractYearsForCalculation:     3,
 			ExpectedAmountOfBasePeriodYearsForCalculation:   3,
 			ExpectedAmountOfOptionPeriodYearsForCalculation: 0,
 			ExpectedAmountOfAwardTermsForCalculation:        0,
-		}
+		}, nil
 	case OptionPeriod1:
 		return ExpectedEscalationPriceContractsCount{
 			ExpectedAmountOfContractYearsForCalculation:     4,
 			ExpectedAmountOfBasePeriodYearsForCalculation:   3,
 			ExpectedAmountOfOptionPeriodYearsForCalculation: 1,
 			ExpectedAmountOfAwardTermsForCalculation:        0,
-		}
+		}, nil
 	case OptionPeriod2:
 		return ExpectedEscalationPriceContractsCount{
 			ExpectedAmountOfContractYearsForCalculation:     5,
 			ExpectedAmountOfBasePeriodYearsForCalculation:   3,
 			ExpectedAmountOfOptionPeriodYearsForCalculation: 2,
 			ExpectedAmountOfAwardTermsForCalculation:        0,
-		}
+		}, nil
 	case AwardTerm1:
 		return ExpectedEscalationPriceContractsCount{
 			ExpectedAmountOfContractYearsForCalculation:     6,
 			ExpectedAmountOfBasePeriodYearsForCalculation:   3,
 			ExpectedAmountOfOptionPeriodYearsForCalculation: 2,
 			ExpectedAmountOfAwardTermsForCalculation:        1,
-		}
+		}, nil
 	case AwardTerm2:
 		return ExpectedEscalationPriceContractsCount{
 			ExpectedAmountOfContractYearsForCalculation:     7,
 			ExpectedAmountOfBasePeriodYearsForCalculation:   3,
 			ExpectedAmountOfOptionPeriodYearsForCalculation: 2,
 			ExpectedAmountOfAwardTermsForCalculation:        2,
-		}
+		}, nil
 	case OptionPeriod3:
 		return ExpectedEscalationPriceContractsCount{
 			ExpectedAmountOfContractYearsForCalculation:     8,
 			ExpectedAmountOfBasePeriodYearsForCalculation:   3,
 			ExpectedAmountOfOptionPeriodYearsForCalculation: 3,
 			ExpectedAmountOfAwardTermsForCalculation:        2,
-		}
+		}, nil
 	}
-	return ExpectedEscalationPriceContractsCount{}
+
+	err := fmt.Errorf("unexpected contract year %s", contractYearName)
+	return ExpectedEscalationPriceContractsCount{}, err
 }

--- a/pkg/models/re_contract_year.go
+++ b/pkg/models/re_contract_year.go
@@ -1,12 +1,14 @@
 package models
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/gobuffalo/pop/v6"
 	"github.com/gobuffalo/validate/v3"
 	"github.com/gobuffalo/validate/v3/validators"
 	"github.com/gofrs/uuid"
+	"github.com/transcom/mymove/pkg/apperror"
 )
 
 const (
@@ -70,7 +72,7 @@ func (r *ReContractYear) Validate(_ *pop.Connection) (*validate.Errors, error) {
 	), nil
 }
 
-func GetExpectedEscalationPriceContractsCount(contractYearName string, hasOptionYear3 bool) ExpectedEscalationPriceContractsCount {
+func GetExpectedEscalationPriceContractsCount(contractYearName string, hasOptionYear3 bool) (ExpectedEscalationPriceContractsCount, error) {
 	switch contractYearName {
 	case BasePeriodYear1:
 		return ExpectedEscalationPriceContractsCount{
@@ -78,42 +80,42 @@ func GetExpectedEscalationPriceContractsCount(contractYearName string, hasOption
 			ExpectedAmountOfBasePeriodYearsForCalculation:   1,
 			ExpectedAmountOfOptionPeriodYearsForCalculation: 0,
 			ExpectedAmountOfAwardTermsForCalculation:        0,
-		}
+		}, nil
 	case BasePeriodYear2:
 		return ExpectedEscalationPriceContractsCount{
 			ExpectedAmountOfContractYearsForCalculation:     2,
 			ExpectedAmountOfBasePeriodYearsForCalculation:   2,
 			ExpectedAmountOfOptionPeriodYearsForCalculation: 0,
 			ExpectedAmountOfAwardTermsForCalculation:        0,
-		}
+		}, nil
 	case BasePeriodYear3:
 		return ExpectedEscalationPriceContractsCount{
 			ExpectedAmountOfContractYearsForCalculation:     3,
 			ExpectedAmountOfBasePeriodYearsForCalculation:   3,
 			ExpectedAmountOfOptionPeriodYearsForCalculation: 0,
 			ExpectedAmountOfAwardTermsForCalculation:        0,
-		}
+		}, nil
 	case OptionPeriod1:
 		return ExpectedEscalationPriceContractsCount{
 			ExpectedAmountOfContractYearsForCalculation:     4,
 			ExpectedAmountOfBasePeriodYearsForCalculation:   3,
 			ExpectedAmountOfOptionPeriodYearsForCalculation: 1,
 			ExpectedAmountOfAwardTermsForCalculation:        0,
-		}
+		}, nil
 	case OptionPeriod2:
 		return ExpectedEscalationPriceContractsCount{
 			ExpectedAmountOfContractYearsForCalculation:     5,
 			ExpectedAmountOfBasePeriodYearsForCalculation:   3,
 			ExpectedAmountOfOptionPeriodYearsForCalculation: 2,
 			ExpectedAmountOfAwardTermsForCalculation:        0,
-		}
+		}, nil
 	case OptionPeriod3:
 		return ExpectedEscalationPriceContractsCount{
 			ExpectedAmountOfContractYearsForCalculation:     6,
 			ExpectedAmountOfBasePeriodYearsForCalculation:   3,
 			ExpectedAmountOfOptionPeriodYearsForCalculation: 3,
 			ExpectedAmountOfAwardTermsForCalculation:        0,
-		}
+		}, nil
 	case AwardTerm1:
 		if hasOptionYear3 {
 			return ExpectedEscalationPriceContractsCount{
@@ -121,14 +123,14 @@ func GetExpectedEscalationPriceContractsCount(contractYearName string, hasOption
 				ExpectedAmountOfBasePeriodYearsForCalculation:   3,
 				ExpectedAmountOfOptionPeriodYearsForCalculation: 3,
 				ExpectedAmountOfAwardTermsForCalculation:        1,
-			}
+			}, nil
 		} else {
 			return ExpectedEscalationPriceContractsCount{
 				ExpectedAmountOfContractYearsForCalculation:     6,
 				ExpectedAmountOfBasePeriodYearsForCalculation:   3,
 				ExpectedAmountOfOptionPeriodYearsForCalculation: 2,
 				ExpectedAmountOfAwardTermsForCalculation:        1,
-			}
+			}, nil
 		}
 	case AwardTerm2:
 		if hasOptionYear3 {
@@ -137,21 +139,17 @@ func GetExpectedEscalationPriceContractsCount(contractYearName string, hasOption
 				ExpectedAmountOfBasePeriodYearsForCalculation:   3,
 				ExpectedAmountOfOptionPeriodYearsForCalculation: 3,
 				ExpectedAmountOfAwardTermsForCalculation:        2,
-			}
+			}, nil
 		} else {
 			return ExpectedEscalationPriceContractsCount{
 				ExpectedAmountOfContractYearsForCalculation:     7,
 				ExpectedAmountOfBasePeriodYearsForCalculation:   3,
 				ExpectedAmountOfOptionPeriodYearsForCalculation: 2,
 				ExpectedAmountOfAwardTermsForCalculation:        2,
-			}
+			}, nil
 		}
 	default:
-		return ExpectedEscalationPriceContractsCount{
-			ExpectedAmountOfContractYearsForCalculation:     0,
-			ExpectedAmountOfBasePeriodYearsForCalculation:   0,
-			ExpectedAmountOfOptionPeriodYearsForCalculation: 0,
-			ExpectedAmountOfAwardTermsForCalculation:        0,
-		}
+		err := apperror.NewInternalServerError(fmt.Sprintf("Unexpected contract year name %s.", contractYearName))
+		return ExpectedEscalationPriceContractsCount{}, err
 	}
 }

--- a/pkg/models/re_contract_year.go
+++ b/pkg/models/re_contract_year.go
@@ -1,13 +1,36 @@
 package models
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/gobuffalo/pop/v6"
 	"github.com/gobuffalo/validate/v3"
 	"github.com/gobuffalo/validate/v3/validators"
 	"github.com/gofrs/uuid"
+	"github.com/transcom/mymove/pkg/apperror"
 )
+
+const (
+	BasePeriodYear1 string = "Base Period Year 1"
+	BasePeriodYear2 string = "Base Period Year 2"
+	BasePeriodYear3 string = "Base Period Year 3"
+	OptionPeriod1   string = "Option Period 1"
+	OptionPeriod2   string = "Option Period 2"
+	OptionPeriod3   string = "Option Period 3"
+	AwardTerm1      string = "Award Term 1"
+	AwardTerm2      string = "Award Term 2"
+	AwardTerm       string = "Award Term"
+	OptionPeriod    string = "Option Period"
+	BasePeriodYear  string = "Base Period Year"
+)
+
+type ExpectedEscalationPriceContractsCount struct {
+	ExpectedAmountOfContractYearsForCalculation     int
+	ExpectedAmountOfBasePeriodYearsForCalculation   int
+	ExpectedAmountOfOptionPeriodYearsForCalculation int
+	ExpectedAmountOfAwardTermsForCalculation        int
+}
 
 // ReContractYear represents a single "year" of a contract
 type ReContractYear struct {
@@ -45,4 +68,86 @@ func (r *ReContractYear) Validate(_ *pop.Connection) (*validate.Errors, error) {
 		&Float64IsPresent{Field: r.EscalationCompounded, Name: "EscalationCompounded"},
 		&Float64IsGreaterThan{Field: r.EscalationCompounded, Name: "EscalationCompounded", Compared: 0},
 	), nil
+}
+
+func GetExpectedEscalationPriceContractsCount(contractYearName string, hasOptionYear3 bool) (ExpectedEscalationPriceContractsCount, error) {
+	switch contractYearName {
+	case BasePeriodYear1:
+		return ExpectedEscalationPriceContractsCount{
+			ExpectedAmountOfContractYearsForCalculation:     1,
+			ExpectedAmountOfBasePeriodYearsForCalculation:   1,
+			ExpectedAmountOfOptionPeriodYearsForCalculation: 0,
+			ExpectedAmountOfAwardTermsForCalculation:        0,
+		}, nil
+	case BasePeriodYear2:
+		return ExpectedEscalationPriceContractsCount{
+			ExpectedAmountOfContractYearsForCalculation:     2,
+			ExpectedAmountOfBasePeriodYearsForCalculation:   2,
+			ExpectedAmountOfOptionPeriodYearsForCalculation: 0,
+			ExpectedAmountOfAwardTermsForCalculation:        0,
+		}, nil
+	case BasePeriodYear3:
+		return ExpectedEscalationPriceContractsCount{
+			ExpectedAmountOfContractYearsForCalculation:     3,
+			ExpectedAmountOfBasePeriodYearsForCalculation:   3,
+			ExpectedAmountOfOptionPeriodYearsForCalculation: 0,
+			ExpectedAmountOfAwardTermsForCalculation:        0,
+		}, nil
+	case OptionPeriod1:
+		return ExpectedEscalationPriceContractsCount{
+			ExpectedAmountOfContractYearsForCalculation:     4,
+			ExpectedAmountOfBasePeriodYearsForCalculation:   3,
+			ExpectedAmountOfOptionPeriodYearsForCalculation: 1,
+			ExpectedAmountOfAwardTermsForCalculation:        0,
+		}, nil
+	case OptionPeriod2:
+		return ExpectedEscalationPriceContractsCount{
+			ExpectedAmountOfContractYearsForCalculation:     5,
+			ExpectedAmountOfBasePeriodYearsForCalculation:   3,
+			ExpectedAmountOfOptionPeriodYearsForCalculation: 2,
+			ExpectedAmountOfAwardTermsForCalculation:        0,
+		}, nil
+	case OptionPeriod3:
+		return ExpectedEscalationPriceContractsCount{
+			ExpectedAmountOfContractYearsForCalculation:     6,
+			ExpectedAmountOfBasePeriodYearsForCalculation:   3,
+			ExpectedAmountOfOptionPeriodYearsForCalculation: 3,
+			ExpectedAmountOfAwardTermsForCalculation:        0,
+		}, nil
+	case AwardTerm1:
+		if hasOptionYear3 {
+			return ExpectedEscalationPriceContractsCount{
+				ExpectedAmountOfContractYearsForCalculation:     7,
+				ExpectedAmountOfBasePeriodYearsForCalculation:   3,
+				ExpectedAmountOfOptionPeriodYearsForCalculation: 3,
+				ExpectedAmountOfAwardTermsForCalculation:        1,
+			}, nil
+		} else {
+			return ExpectedEscalationPriceContractsCount{
+				ExpectedAmountOfContractYearsForCalculation:     6,
+				ExpectedAmountOfBasePeriodYearsForCalculation:   3,
+				ExpectedAmountOfOptionPeriodYearsForCalculation: 2,
+				ExpectedAmountOfAwardTermsForCalculation:        1,
+			}, nil
+		}
+	case AwardTerm2:
+		if hasOptionYear3 {
+			return ExpectedEscalationPriceContractsCount{
+				ExpectedAmountOfContractYearsForCalculation:     8,
+				ExpectedAmountOfBasePeriodYearsForCalculation:   3,
+				ExpectedAmountOfOptionPeriodYearsForCalculation: 3,
+				ExpectedAmountOfAwardTermsForCalculation:        2,
+			}, nil
+		} else {
+			return ExpectedEscalationPriceContractsCount{
+				ExpectedAmountOfContractYearsForCalculation:     7,
+				ExpectedAmountOfBasePeriodYearsForCalculation:   3,
+				ExpectedAmountOfOptionPeriodYearsForCalculation: 2,
+				ExpectedAmountOfAwardTermsForCalculation:        2,
+			}, nil
+		}
+	default:
+		err := apperror.NewInternalServerError(fmt.Sprintf("Unexpected contract year name %s.", contractYearName))
+		return ExpectedEscalationPriceContractsCount{}, err
+	}
 }

--- a/pkg/models/re_contract_year.go
+++ b/pkg/models/re_contract_year.go
@@ -128,12 +128,6 @@ func GetExpectedEscalationPriceContractsCount(contractYearName string) ExpectedE
 			ExpectedAmountOfOptionPeriodYearsForCalculation: 3,
 			ExpectedAmountOfAwardTermsForCalculation:        2,
 		}
-	default:
-		return ExpectedEscalationPriceContractsCount{
-			ExpectedAmountOfContractYearsForCalculation:     0,
-			ExpectedAmountOfBasePeriodYearsForCalculation:   0,
-			ExpectedAmountOfOptionPeriodYearsForCalculation: 0,
-			ExpectedAmountOfAwardTermsForCalculation:        0,
-		}
 	}
+	return ExpectedEscalationPriceContractsCount{}
 }

--- a/pkg/models/re_contract_year.go
+++ b/pkg/models/re_contract_year.go
@@ -32,6 +32,8 @@ type ExpectedEscalationPriceContractsCount struct {
 	ExpectedAmountOfAwardTermsForCalculation        int
 }
 
+var ContractYears = []string{AwardTerm1, AwardTerm2, OptionPeriod1, OptionPeriod2, OptionPeriod3, BasePeriodYear2, BasePeriodYear3}
+
 // ReContractYear represents a single "year" of a contract
 type ReContractYear struct {
 	ID                   uuid.UUID `json:"id" db:"id"`

--- a/pkg/services/ghcrateengine/domestic_origin_pricer_test.go
+++ b/pkg/services/ghcrateengine/domestic_origin_pricer_test.go
@@ -69,7 +69,7 @@ func (suite *GHCRateEngineServiceSuite) TestPriceDomesticOriginWithServiceItemPa
 		suite.Equal(expectedCost, cost)
 
 		expectedParams := services.PricingDisplayParams{
-			{Key: models.ServiceItemParamNameContractYearName, Value: "Test Contract Year"},
+			{Key: models.ServiceItemParamNameContractYearName, Value: "Base Period Year 1"},
 			{Key: models.ServiceItemParamNameEscalationCompounded, Value: "1.04070"},
 			{Key: models.ServiceItemParamNameIsPeak, Value: "true"},
 			{Key: models.ServiceItemParamNamePriceRateOrFactor, Value: "1.46"},
@@ -126,7 +126,7 @@ func (suite *GHCRateEngineServiceSuite) TestPriceDomesticOrigin() {
 		suite.Equal(expectedCost, cost)
 
 		expectedParams := services.PricingDisplayParams{
-			{Key: models.ServiceItemParamNameContractYearName, Value: "Test Contract Year"},
+			{Key: models.ServiceItemParamNameContractYearName, Value: "Base Period Year 1"},
 			{Key: models.ServiceItemParamNameEscalationCompounded, Value: "1.04070"},
 			{Key: models.ServiceItemParamNameIsPeak, Value: "true"},
 			{Key: models.ServiceItemParamNamePriceRateOrFactor, Value: "1.46"},
@@ -153,7 +153,7 @@ func (suite *GHCRateEngineServiceSuite) TestPriceDomesticOrigin() {
 		suite.Equal(expectedCost, cost)
 
 		expectedParams := services.PricingDisplayParams{
-			{Key: models.ServiceItemParamNameContractYearName, Value: "Test Contract Year"},
+			{Key: models.ServiceItemParamNameContractYearName, Value: "Base Period Year 1"},
 			{Key: models.ServiceItemParamNameEscalationCompounded, Value: "1.04070"},
 			{Key: models.ServiceItemParamNameIsPeak, Value: "false"},
 			{Key: models.ServiceItemParamNamePriceRateOrFactor, Value: "1.27"},
@@ -286,7 +286,7 @@ func (suite *GHCRateEngineServiceSuite) TestPriceDomesticOrigin() {
 		suite.Equal(basePriceCents/5, fifthPriceCents)
 
 		expectedParams := services.PricingDisplayParams{
-			{Key: models.ServiceItemParamNameContractYearName, Value: "Test Contract Year"},
+			{Key: models.ServiceItemParamNameContractYearName, Value: "Base Period Year 1"},
 			{Key: models.ServiceItemParamNameEscalationCompounded, Value: "1.04070"},
 			{Key: models.ServiceItemParamNameIsPeak, Value: "true"},
 			{Key: models.ServiceItemParamNamePriceRateOrFactor, Value: "1.46"},

--- a/pkg/services/ghcrateengine/pricer_helpers.go
+++ b/pkg/services/ghcrateengine/pricer_helpers.go
@@ -524,7 +524,10 @@ func compoundEscalationFactors(appCtx appcontext.AppContext, contractID uuid.UUI
 	}
 
 	// Get expectations for price escalations calculations
-	expectations := models.GetExpectedEscalationPriceContractsCount(contractYear.Name)
+	expectations, err := models.GetExpectedEscalationPriceContractsCount(contractYear.Name)
+	if err != nil {
+		return escalatedPrice, err
+	}
 
 	// Adding contracts that are expected to be in the calculations based on the contract year to a map
 	contractYearsForCalculation := make(map[string]models.ReContractYear)

--- a/pkg/services/ghcrateengine/pricer_helpers.go
+++ b/pkg/services/ghcrateengine/pricer_helpers.go
@@ -3,6 +3,7 @@ package ghcrateengine
 import (
 	"fmt"
 	"math"
+	"slices"
 	"strconv"
 	"time"
 
@@ -495,13 +496,13 @@ func escalatePriceForContractYear(appCtx appcontext.AppContext, contractID uuid.
 
 	escalatedPrice = roundToPrecision(escalatedPrice, precision)
 
-	if contractYear.Name == models.BasePeriodYear1 {
-		escalatedPrice = escalatedPrice * contractYear.EscalationCompounded
-	} else {
+	if slices.Contains(models.ContractYears, contractYear.Name) {
 		escalatedPrice, err = compoundEscalationFactors(appCtx, contractID, contractYear, escalatedPrice)
 		if err != nil {
 			return 0, contractYear, err
 		}
+	} else {
+		escalatedPrice = escalatedPrice * contractYear.EscalationCompounded
 	}
 
 	escalatedPrice = roundToPrecision(escalatedPrice, precision)

--- a/pkg/services/ghcrateengine/pricer_helpers.go
+++ b/pkg/services/ghcrateengine/pricer_helpers.go
@@ -499,7 +499,9 @@ func escalatePriceForContractYear(appCtx appcontext.AppContext, contractID uuid.
 		escalatedPrice = escalatedPrice * contractYear.EscalationCompounded
 	} else {
 		escalatedPrice, err = compoundEscalationFactors(appCtx, contractID, contractYear, escalatedPrice)
-		return 0, contractYear, err
+		if err != nil {
+			return 0, contractYear, err
+		}
 	}
 
 	escalatedPrice = roundToPrecision(escalatedPrice, precision)

--- a/pkg/services/ghcrateengine/pricer_helpers.go
+++ b/pkg/services/ghcrateengine/pricer_helpers.go
@@ -580,7 +580,7 @@ func addContractsForEscalationCalculation(contractsMap map[string]models.ReContr
 			if _, exist := contractsMapDB[name]; exist {
 				contractsMap[contractsMapDB[name].Name] = contractsMapDB[name]
 			} else {
-				err := fmt.Errorf("Expected contract " + name + " not found")
+				err := fmt.Errorf("expected contract %s not found", name)
 				return contractsMap, err
 			}
 		}

--- a/pkg/services/ghcrateengine/pricer_helpers.go
+++ b/pkg/services/ghcrateengine/pricer_helpers.go
@@ -580,7 +580,7 @@ func addContractsForEscalationCalculation(contractsMap map[string]models.ReContr
 			if _, exist := contractsMapDB[name]; exist {
 				contractsMap[contractsMapDB[name].Name] = contractsMapDB[name]
 			} else {
-				err := apperror.NewInternalServerError(fmt.Sprintf("Expected %s contract not found", name))
+				err := fmt.Errorf("Expected contract " + name + " not found")
 				return contractsMap, err
 			}
 		}

--- a/pkg/services/ghcrateengine/pricer_helpers.go
+++ b/pkg/services/ghcrateengine/pricer_helpers.go
@@ -538,18 +538,21 @@ func compoundEscalationFactors(appCtx appcontext.AppContext, contractID uuid.UUI
 	if expectations.ExpectedAmountOfAwardTermsForCalculation > 0 {
 		contractYearsForCalculation, err = addContractsForEscalationCalculation(contractYearsForCalculation, contractsYearsFromDBMap, expectations.ExpectedAmountOfAwardTermsForCalculation, models.AwardTerm)
 		if err != nil {
+			err := apperror.NewInternalServerError(fmt.Sprintf("Error collecting expected Award Term contracts for escalated price calculations", err))
 			return escalatedPrice, err
 		}
 	}
 	if expectations.ExpectedAmountOfOptionPeriodYearsForCalculation > 0 {
 		contractYearsForCalculation, err = addContractsForEscalationCalculation(contractYearsForCalculation, contractsYearsFromDBMap, expectations.ExpectedAmountOfOptionPeriodYearsForCalculation, models.OptionPeriod)
 		if err != nil {
+			err := apperror.NewInternalServerError(fmt.Sprintf("Error collecting expected Option Period contracts for escalated price calculations", err))
 			return escalatedPrice, err
 		}
 	}
 	if expectations.ExpectedAmountOfBasePeriodYearsForCalculation > 0 {
 		contractYearsForCalculation, err = addContractsForEscalationCalculation(contractYearsForCalculation, contractsYearsFromDBMap, expectations.ExpectedAmountOfBasePeriodYearsForCalculation, models.BasePeriodYear)
 		if err != nil {
+			err := apperror.NewInternalServerError(fmt.Sprintf("Error collecting expected Base Period Year contracts for escalated price calculations", err))
 			return escalatedPrice, err
 		}
 	}

--- a/pkg/services/ghcrateengine/pricer_helpers.go
+++ b/pkg/services/ghcrateengine/pricer_helpers.go
@@ -518,17 +518,13 @@ func compoundEscalationFactors(appCtx appcontext.AppContext, contractID uuid.UUI
 
 	// A contract may have Option Year 3 but it is not guaranteed. Need to know if it does or not
 	contractsYearsFromDBMap := make(map[string]models.ReContractYear)
-	hasOptionYear3 := false
 	for _, contract := range contractYearsFromDB {
-		if contract.Name == models.OptionPeriod3 {
-			hasOptionYear3 = true
-		}
 		// Add re_contract_years record to map
 		contractsYearsFromDBMap[contract.Name] = contract
 	}
 
 	// Get expectations for price escalations calculations
-	expectations := models.GetExpectedEscalationPriceContractsCount(contractYear.Name, hasOptionYear3)
+	expectations := models.GetExpectedEscalationPriceContractsCount(contractYear.Name)
 
 	// Adding contracts that are expected to be in the calculations based on the contract year to a map
 	contractYearsForCalculation := make(map[string]models.ReContractYear)

--- a/pkg/services/ghcrateengine/pricer_helpers.go
+++ b/pkg/services/ghcrateengine/pricer_helpers.go
@@ -535,21 +535,18 @@ func compoundEscalationFactors(appCtx appcontext.AppContext, contractID uuid.UUI
 	if expectations.ExpectedAmountOfAwardTermsForCalculation > 0 {
 		contractYearsForCalculation, err = addContractsForEscalationCalculation(contractYearsForCalculation, contractsYearsFromDBMap, expectations.ExpectedAmountOfAwardTermsForCalculation, models.AwardTerm)
 		if err != nil {
-			err := apperror.NewInternalServerError(fmt.Sprintf("Error collecting expected Award Term contracts for escalated price calculations", err))
 			return escalatedPrice, err
 		}
 	}
 	if expectations.ExpectedAmountOfOptionPeriodYearsForCalculation > 0 {
 		contractYearsForCalculation, err = addContractsForEscalationCalculation(contractYearsForCalculation, contractsYearsFromDBMap, expectations.ExpectedAmountOfOptionPeriodYearsForCalculation, models.OptionPeriod)
 		if err != nil {
-			err := apperror.NewInternalServerError(fmt.Sprintf("Error collecting expected Option Period contracts for escalated price calculations", err))
 			return escalatedPrice, err
 		}
 	}
 	if expectations.ExpectedAmountOfBasePeriodYearsForCalculation > 0 {
 		contractYearsForCalculation, err = addContractsForEscalationCalculation(contractYearsForCalculation, contractsYearsFromDBMap, expectations.ExpectedAmountOfBasePeriodYearsForCalculation, models.BasePeriodYear)
 		if err != nil {
-			err := apperror.NewInternalServerError(fmt.Sprintf("Error collecting expected Base Period Year contracts for escalated price calculations", err))
 			return escalatedPrice, err
 		}
 	}

--- a/pkg/services/ghcrateengine/pricer_helpers.go
+++ b/pkg/services/ghcrateengine/pricer_helpers.go
@@ -538,21 +538,18 @@ func compoundEscalationFactors(appCtx appcontext.AppContext, contractID uuid.UUI
 	if expectations.ExpectedAmountOfAwardTermsForCalculation > 0 {
 		contractYearsForCalculation, err = addContractsForEscalationCalculation(contractYearsForCalculation, contractsYearsFromDBMap, expectations.ExpectedAmountOfAwardTermsForCalculation, models.AwardTerm)
 		if err != nil {
-			err := apperror.NewInternalServerError(fmt.Sprintf("Error collecting expected Award Term contracts for escalated price calculations", err))
 			return escalatedPrice, err
 		}
 	}
 	if expectations.ExpectedAmountOfOptionPeriodYearsForCalculation > 0 {
 		contractYearsForCalculation, err = addContractsForEscalationCalculation(contractYearsForCalculation, contractsYearsFromDBMap, expectations.ExpectedAmountOfOptionPeriodYearsForCalculation, models.OptionPeriod)
 		if err != nil {
-			err := apperror.NewInternalServerError(fmt.Sprintf("Error collecting expected Option Period contracts for escalated price calculations", err))
 			return escalatedPrice, err
 		}
 	}
 	if expectations.ExpectedAmountOfBasePeriodYearsForCalculation > 0 {
 		contractYearsForCalculation, err = addContractsForEscalationCalculation(contractYearsForCalculation, contractsYearsFromDBMap, expectations.ExpectedAmountOfBasePeriodYearsForCalculation, models.BasePeriodYear)
 		if err != nil {
-			err := apperror.NewInternalServerError(fmt.Sprintf("Error collecting expected Base Period Year contracts for escalated price calculations", err))
 			return escalatedPrice, err
 		}
 	}

--- a/pkg/services/ghcrateengine/pricer_helpers_test.go
+++ b/pkg/services/ghcrateengine/pricer_helpers_test.go
@@ -713,7 +713,7 @@ func (suite *GHCRateEngineServiceSuite) Test_escalatePriceForContractYear() {
 	})
 }
 
-func (suite *GHCRateEngineServiceSuite) Test_new() {
+func (suite *GHCRateEngineServiceSuite) Test_escalatedPriceForContractYearCompounded() {
 
 	setUpContracts := func() map[string]models.ReContractYear {
 		escalationCompounded := 1.04071

--- a/pkg/services/ghcrateengine/pricer_helpers_test.go
+++ b/pkg/services/ghcrateengine/pricer_helpers_test.go
@@ -900,7 +900,7 @@ func (suite *GHCRateEngineServiceSuite) Test_escalatedPriceForContractYearCompou
 		escalatedPrice, contractYear, err := escalatePriceForContractYear(suite.AppContextForTest(), contract.ContractID, contract.StartDate.AddDate(0, 0, 1), isLinehaul, basePrice)
 
 		suite.Error(err)
-		suite.Equal("Expected contract Option Period 1 not found", err.Error())
+		suite.Equal("expected contract Option Period 1 not found", err.Error())
 		suite.Equal(contract.ID, contractYear.ID)
 		suite.NotNil(escalatedPrice)
 	})

--- a/pkg/services/ghcrateengine/pricer_helpers_test.go
+++ b/pkg/services/ghcrateengine/pricer_helpers_test.go
@@ -712,3 +712,196 @@ func (suite *GHCRateEngineServiceSuite) Test_escalatePriceForContractYear() {
 		suite.Contains(err.Error(), "could not lookup contract year")
 	})
 }
+
+func (suite *GHCRateEngineServiceSuite) Test_new() {
+
+	setUpContracts := func() map[string]models.ReContractYear {
+		escalationCompounded := 1.04071
+		basePeriodYear1 := testdatagen.MakeReContractYear(suite.DB(),
+			testdatagen.Assertions{
+				ReContractYear: models.ReContractYear{
+					EscalationCompounded: escalationCompounded,
+					Name:                 models.BasePeriodYear1,
+				},
+			})
+		basePeriodYear2 := testdatagen.MakeReContractYear(suite.DB(),
+			testdatagen.Assertions{
+				ReContractYear: models.ReContractYear{
+					EscalationCompounded: escalationCompounded,
+					Name:                 models.BasePeriodYear2,
+					StartDate:            basePeriodYear1.StartDate.AddDate(1, 0, 0),
+					EndDate:              basePeriodYear1.EndDate.AddDate(1, 0, 0),
+				},
+			})
+		basePeriodYear3 := testdatagen.MakeReContractYear(suite.DB(),
+			testdatagen.Assertions{
+				ReContractYear: models.ReContractYear{
+					EscalationCompounded: escalationCompounded,
+					Name:                 models.BasePeriodYear3,
+					StartDate:            basePeriodYear2.StartDate.AddDate(1, 0, 0),
+					EndDate:              basePeriodYear2.EndDate.AddDate(1, 0, 0),
+				},
+			})
+		optionPeriod1 := testdatagen.MakeReContractYear(suite.DB(),
+			testdatagen.Assertions{
+				ReContractYear: models.ReContractYear{
+					EscalationCompounded: escalationCompounded,
+					Name:                 models.OptionPeriod1,
+					StartDate:            basePeriodYear3.StartDate.AddDate(1, 0, 0),
+					EndDate:              basePeriodYear3.EndDate.AddDate(1, 0, 0),
+				},
+			})
+		optionPeriod2 := testdatagen.MakeReContractYear(suite.DB(),
+			testdatagen.Assertions{
+				ReContractYear: models.ReContractYear{
+					EscalationCompounded: escalationCompounded,
+					Name:                 models.OptionPeriod2,
+					StartDate:            optionPeriod1.StartDate.AddDate(1, 0, 0),
+					EndDate:              optionPeriod1.EndDate.AddDate(1, 0, 0),
+				},
+			})
+		awardTerm1 := testdatagen.MakeReContractYear(suite.DB(),
+			testdatagen.Assertions{
+				ReContractYear: models.ReContractYear{
+					EscalationCompounded: escalationCompounded,
+					Name:                 models.AwardTerm1,
+					StartDate:            optionPeriod2.StartDate.AddDate(1, 0, 0),
+					EndDate:              optionPeriod2.EndDate.AddDate(1, 0, 0),
+				},
+			})
+		awardTerm2 := testdatagen.MakeReContractYear(suite.DB(),
+			testdatagen.Assertions{
+				ReContractYear: models.ReContractYear{
+					EscalationCompounded: escalationCompounded,
+					Name:                 models.AwardTerm2,
+					StartDate:            awardTerm1.StartDate.AddDate(1, 0, 0),
+					EndDate:              awardTerm1.EndDate.AddDate(1, 0, 0),
+				},
+			})
+
+		optionPeriod3 := testdatagen.MakeReContractYear(suite.DB(),
+			testdatagen.Assertions{
+				ReContractYear: models.ReContractYear{
+					EscalationCompounded: escalationCompounded,
+					Name:                 models.OptionPeriod3,
+					StartDate:            awardTerm2.StartDate.AddDate(1, 0, 0),
+					EndDate:              awardTerm2.EndDate.AddDate(1, 0, 0),
+				},
+			})
+
+		contractsYearsMap := make(map[string]models.ReContractYear)
+		contractsYearsMap[optionPeriod3.Name] = optionPeriod3
+		contractsYearsMap[awardTerm2.Name] = awardTerm2
+		contractsYearsMap[awardTerm1.Name] = awardTerm1
+		contractsYearsMap[optionPeriod2.Name] = optionPeriod2
+		contractsYearsMap[optionPeriod1.Name] = optionPeriod1
+		contractsYearsMap[basePeriodYear3.Name] = basePeriodYear3
+		contractsYearsMap[basePeriodYear2.Name] = basePeriodYear2
+		contractsYearsMap[basePeriodYear1.Name] = basePeriodYear1
+		return contractsYearsMap
+	}
+
+	setUpContractsWithMissingContracts := func() map[string]models.ReContractYear {
+		escalationCompounded := 1.04071
+		basePeriodYear1 := testdatagen.MakeReContractYear(suite.DB(),
+			testdatagen.Assertions{
+				ReContractYear: models.ReContractYear{
+					EscalationCompounded: escalationCompounded,
+					Name:                 models.BasePeriodYear1,
+				},
+			})
+		basePeriodYear2 := testdatagen.MakeReContractYear(suite.DB(),
+			testdatagen.Assertions{
+				ReContractYear: models.ReContractYear{
+					EscalationCompounded: escalationCompounded,
+					Name:                 models.BasePeriodYear2,
+					StartDate:            basePeriodYear1.StartDate.AddDate(1, 0, 0),
+					EndDate:              basePeriodYear1.EndDate.AddDate(1, 0, 0),
+				},
+			})
+		basePeriodYear3 := testdatagen.MakeReContractYear(suite.DB(),
+			testdatagen.Assertions{
+				ReContractYear: models.ReContractYear{
+					EscalationCompounded: escalationCompounded,
+					Name:                 models.BasePeriodYear3,
+					StartDate:            basePeriodYear2.StartDate.AddDate(1, 0, 0),
+					EndDate:              basePeriodYear2.EndDate.AddDate(1, 0, 0),
+				},
+			})
+		optionPeriod2 := testdatagen.MakeReContractYear(suite.DB(),
+			testdatagen.Assertions{
+				ReContractYear: models.ReContractYear{
+					EscalationCompounded: escalationCompounded,
+					Name:                 models.OptionPeriod2,
+					StartDate:            basePeriodYear2.StartDate.AddDate(2, 0, 0),
+					EndDate:              basePeriodYear2.EndDate.AddDate(2, 0, 0),
+				},
+			})
+		awardTerm1 := testdatagen.MakeReContractYear(suite.DB(),
+			testdatagen.Assertions{
+				ReContractYear: models.ReContractYear{
+					EscalationCompounded: escalationCompounded,
+					Name:                 models.AwardTerm1,
+					StartDate:            optionPeriod2.StartDate.AddDate(1, 0, 0),
+					EndDate:              optionPeriod2.EndDate.AddDate(1, 0, 0),
+				},
+			})
+		awardTerm2 := testdatagen.MakeReContractYear(suite.DB(),
+			testdatagen.Assertions{
+				ReContractYear: models.ReContractYear{
+					EscalationCompounded: escalationCompounded,
+					Name:                 models.AwardTerm2,
+					StartDate:            awardTerm1.StartDate.AddDate(1, 0, 0),
+					EndDate:              awardTerm1.EndDate.AddDate(1, 0, 0),
+				},
+			})
+
+		optionPeriod3 := testdatagen.MakeReContractYear(suite.DB(),
+			testdatagen.Assertions{
+				ReContractYear: models.ReContractYear{
+					EscalationCompounded: escalationCompounded,
+					Name:                 models.OptionPeriod3,
+					StartDate:            awardTerm2.StartDate.AddDate(1, 0, 0),
+					EndDate:              awardTerm2.EndDate.AddDate(1, 0, 0),
+				},
+			})
+
+		contractsYearsMap := make(map[string]models.ReContractYear)
+		contractsYearsMap[optionPeriod3.Name] = optionPeriod3
+		contractsYearsMap[awardTerm2.Name] = awardTerm2
+		contractsYearsMap[awardTerm1.Name] = awardTerm1
+		contractsYearsMap[optionPeriod2.Name] = optionPeriod2
+		contractsYearsMap[basePeriodYear3.Name] = basePeriodYear3
+		contractsYearsMap[basePeriodYear2.Name] = basePeriodYear2
+		contractsYearsMap[basePeriodYear1.Name] = basePeriodYear1
+		return contractsYearsMap
+	}
+
+	suite.Run("should correctly calculate escalated price based on the escalation factors of each contract year", func() {
+		contracts := setUpContracts()
+
+		isLinehaul := false
+		basePrice := 5117.0
+
+		contract := contracts[models.OptionPeriod3]
+
+		escalatedPrice, contractYear, err := escalatePriceForContractYear(suite.AppContextForTest(), contract.ContractID, contract.StartDate.AddDate(0, 0, 1), isLinehaul, basePrice)
+
+		suite.Nil(err)
+		suite.Equal(contract.ID, contractYear.ID)
+		suite.Equal(5981.0, escalatedPrice)
+	})
+	suite.Run("should error if an expected contract needed for the escalation price calculation is not found", func() {
+		contracts := setUpContractsWithMissingContracts()
+		isLinehaul := false
+		basePrice := 5117.0
+
+		contract := contracts[models.OptionPeriod3]
+		escalatedPrice, contractYear, err := escalatePriceForContractYear(suite.AppContextForTest(), contract.ContractID, contract.StartDate.AddDate(0, 0, 1), isLinehaul, basePrice)
+
+		suite.Error(err)
+		suite.Equal("Expected contract Option Period 1 not found", err.Error())
+		suite.Equal(contract.ID, contractYear.ID)
+		suite.NotNil(escalatedPrice)
+	})
+}

--- a/pkg/services/ghcrateengine/pricer_query_helpers.go
+++ b/pkg/services/ghcrateengine/pricer_query_helpers.go
@@ -93,6 +93,16 @@ func fetchContractYear(appCtx appcontext.AppContext, contractID uuid.UUID, date 
 	return contractYear, nil
 }
 
+func fetchContractsByContractId(appCtx appcontext.AppContext, contractID uuid.UUID) (models.ReContractYears, error) {
+	var contracts models.ReContractYears
+	err := appCtx.DB().Where("contract_id = $1", contractID).All(&contracts)
+	if err != nil {
+		return models.ReContractYears{}, err
+	}
+
+	return contracts, nil
+}
+
 func fetchShipmentTypePrice(appCtx appcontext.AppContext, contractCode string, serviceCode models.ReServiceCode, market models.Market) (models.ReShipmentTypePrice, error) {
 	var shipmentTypePrice models.ReShipmentTypePrice
 	err := appCtx.DB().Q().

--- a/pkg/services/ghcrateengine/pricer_query_helpers_test.go
+++ b/pkg/services/ghcrateengine/pricer_query_helpers_test.go
@@ -52,7 +52,7 @@ func (suite *GHCRateEngineServiceSuite) Test_fetchDomServiceAreaPrice() {
 	testCents := unit.Cents(353)
 
 	suite.Run("golden path", func() {
-		suite.setupDomesticServiceAreaPrice(models.ReServiceCodeDOFSIT, testServiceArea, testIsPeakPeriod, testCents, "Test Contract Year", 1.125)
+		suite.setupDomesticServiceAreaPrice(models.ReServiceCodeDOFSIT, testServiceArea, testIsPeakPeriod, testCents, "Base Period Year 1", 1.125)
 
 		domServiceAreaPrice, err := fetchDomServiceAreaPrice(suite.AppContextForTest(), testdatagen.DefaultContractCode, models.ReServiceCodeDOFSIT, testServiceArea, testIsPeakPeriod)
 		suite.NoError(err)
@@ -60,7 +60,7 @@ func (suite *GHCRateEngineServiceSuite) Test_fetchDomServiceAreaPrice() {
 	})
 
 	suite.Run("no records found", func() {
-		suite.setupDomesticServiceAreaPrice(models.ReServiceCodeDOFSIT, testServiceArea, testIsPeakPeriod, testCents, "Test Contract Year", 1.125)
+		suite.setupDomesticServiceAreaPrice(models.ReServiceCodeDOFSIT, testServiceArea, testIsPeakPeriod, testCents, "Base Period Year 1", 1.125)
 
 		// Look for service code DDFSIT that we haven't added
 		_, err := fetchDomServiceAreaPrice(suite.AppContextForTest(), testdatagen.DefaultContractCode, models.ReServiceCodeDDFSIT, testServiceArea, testIsPeakPeriod)

--- a/pkg/testdatagen/make_re_contract_year.go
+++ b/pkg/testdatagen/make_re_contract_year.go
@@ -20,7 +20,7 @@ func MakeReContractYear(db *pop.Connection, assertions Assertions) models.ReCont
 
 	reContractYear := models.ReContractYear{
 		ContractID:           reContract.ID,
-		Name:                 "Test Contract Year",
+		Name:                 "Base Period Year 1",
 		StartDate:            time.Date(TestYear, time.January, 1, 0, 0, 0, 0, time.UTC),
 		EndDate:              time.Date(TestYear, time.December, 31, 0, 0, 0, 0, time.UTC),
 		Escalation:           1.0197,


### PR DESCRIPTION
## [B-21353](https://www13.v1host.com/USTRANSCOM38/story.mvc/Summary?oidToken=Story%3A1014422)
## [INT PR](https://github.com/transcom/mymove/pull/14077)


## Summary

This story introduces adjustments to how the escalated price is calculated based on the contract year. There can be up to 8 total contract years for a contract. Here are the contract years in order:

1. Base Period Year 1
2. Base Period Year 2
3. Base Period Year 3
4. Option Period 1
5. Option Period 2
6. Award Term 1
7. Award Term 2
8. Option Period 3

Calculations needed to be adjusted to compound the escalation factors of each contract year. For example:
```
(A) Given a price for base period year 1
1. p = Round[p]
2. p = p * BasePeriodYear1EscalationFactor
3. p = Round[p]
4. p = p * quantity

(B) Given a price for base period year 2
1. p = Round[p]
2. p = p * BasePeriodYear1EscalationFactor
3. p = p * BasePeriodYear2EscalationFactor
4. p = Round[p]
5. p = p * quantity

(C) Given a price for base period year 3
1. p = Round[p]
2. p = p * BasePeriodYear1EscalationFactor
3. p = p * BasePeriodYear2EscalationFactor
4. p = p * BasePeriodYear3EscalationFactor
5. p = Round[p]
6. p = p * quantity

(E) Given a price for Option Period 1
1. p = Round[p]
2. p = p * BasePeriodYear1EscalationFactor
3. p = p * BasePeriodYear2EscalationFactor
4. p = p * BasePeriodYear3EscalationFactor
5. p = p * OptionPeriodYear1EscalationFactor
6. p = Round[p]
7. p = p * quantity

(F) Given a price for Option Period 2
1. p = Round[p]
2. p = p * BasePeriodYear1EscalationFactor
3. p = p * BasePeriodYear2EscalationFactor
4. p = p * BasePeriodYear3EscalationFactor
5. p = p * OptionPeriodYear1EscalationFactor
6. p = p * OptionPeriodYear2EscalationFactor
7. p = Round[p]
8. p = p * quantity

(G) Given a price for Award Term 1
1. p = Round[p]
2. p = p * BasePeriodYear1EscalationFactor
3. p = p * BasePeriodYear2EscalationFactor
4. p = p * BasePeriodYear3EscalationFactor
5. p = p * OptionPeriodYear1EscalationFactor
6. p = p * OptionPeriodYear2EscalationFactor
7. p = p * AwardTerm1EscalationFactor
8. p = Round[p]
9. p = p * quantity

(H) Given a price for Award Term 2
1. p = Round[p]
2. p = p * BasePeriodYear1EscalationFactor
3. p = p * BasePeriodYear2EscalationFactor
4. p = p * BasePeriodYear3EscalationFactor
5. p = p * OptionPeriodYear1EscalationFactor
6. p = p * OptionPeriodYear2EscalationFactor
7. p = p * AwardTerm1EscalationFactor
8. p = p * AwardTerm2EscalationFactor
9. p = Round[p]
10. p = p * quantity

(H) Given a price for Option Period 3
1. p = Round[p]
2. p = p * BasePeriodYear1EscalationFactor
3. p = p * BasePeriodYear2EscalationFactor
4. p = p * BasePeriodYear3EscalationFactor
5. p = p * OptionPeriodYear1EscalationFactor
6. p = p * OptionPeriodYear2EscalationFactor
7. p = p * AwardTerm1EscalationFactor
8. p = p * AwardTerm2EscalationFactor
9. p = p * OptionPeriodYear3EscalationFactor
10. p = Round[p]
11. p = p * quantity
```
  

Is there anything you would like reviewers to give additional scrutiny?

[this article](tbd) explains more about the approach used.

## Verification Steps for the Author

These are to be checked by the author.

- [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
- [ ] Have the Agility acceptance criteria been met for this change?

## Verification Steps for Reviewers

These are to be checked by a reviewer.

- [ ] Has the branch been pulled in and checked out?
- [ ] Have the BL acceptance criteria been met for this change?
- [ ] Was the CircleCI build successful?
- [ ] Has the code been reviewed from a standards and best practices point of view?

### Setup to Run the Code

- [Instructions for starting storybook](https://transcom.github.io/mymove-docs/docs/frontend/setup/storybook)
- [Instructions for starting the MilMove application](https://transcom.github.io/mymove-docs/docs/getting-started/application-setup/)
- [Instructions for running tests](https://transcom.github.io/mymove-docs/docs/getting-started/development/testing)

### How to test

You can control what contract year is used by setting the shipments requested pickup date pn shipment creation and setting it in between a start and end date for a specific contract year.

Database table re_contract_years:
![image](https://github.com/user-attachments/assets/8863a972-f550-4d04-b8d8-a6995402268e)

You can change the shipments Requested Pickup Date in the mto_shipments table, through the UI as a TOO by clicking "Edit Shipment" or as a Prime by clicking "Update Shipment"


1. Access MilMove as a customer
2. Create a shipment and use an HHG Shipment and set the Requested Pickup Date between  the start and end date of the re_contract_years that you want to test
3. After creating the shipment approve the shipment as a SC
4. Approve the shipment as a TOO
5. As a Prime add a destination sit service item to the shipment
6. As the TOO approve the service items for the shipment
7. As the prime create a payment request for a some service items within the shipment
8. Go to the move as a TIO and you can view the service items and their prices on the payment request
![image](https://github.com/user-attachments/assets/cba8db42-96ac-4a53-aae0-51c558398f11)
 #13130 

My Scenario:
Requested Pickup Address =  08/08/2025, which puts the contract year at Award Term 2
![image](https://github.com/user-attachments/assets/51d8e264-48c4-4c9a-9b15-6a39ec99445d)

Base price  in Cents = p = 650
Contract Year = Award Term 2
Final Weight = quantity = 3000

This case should follow steps (H)

1. 650 = Round[650]
2. 650 = 650 * (BasePeriodYear1EscalationFactor = 1)
3. 662.61 = 650 * (BasePeriodYear2EscalationFactor = 1.0.194)
4. 675.7959390000001 = 662.61 * (BasePeriodYear3EscalationFactor = 1.0199)
5. 690.0552333129 = 675.7959390000001 * (OptionPeriodYear1EscalationFactor = 1.0211)
6. 704.8224153057961 = 690.0552333129 * (OptionPeriodYear2EscalationFactor = 1.0214)
7. 718.7074168873203 = 704.8224153057961 * (AwardTerm1EscalationFactor = 1.0197)
8. 733.5127896751991 = 718.7074168873203 * (AwardTerm2EscalationFactor = 1.0206)
9. 734 = Round[733.5127896751991]
10. 22020 = 734 * ((3000/100) = 3000.ToCWTFFloat64())
22020 cents = $220.20
![image](https://github.com/user-attachments/assets/b8b45e01-041e-40dd-8f03-c5b83bcd1334)



### Frontend

- [ ] There are no aXe warnings for UI.
- [ ] This works in [Supported Browsers and their phone views](https://transcom.github.io/mymove-docs/docs/adrs/Browser-Support/#minimum-browser-requirements) (Chrome, Firefox, Edge).
- [ ] There are no new console errors in the browser devtools.
- [ ] There are no new console errors in the test output.
- [ ] If this PR adds a new component to Storybook, it ensures the component is fully responsive, OR if it is intentionally not, a wrapping div using the `officeApp` class or custom `min-width` styling is used to hide any states the would not be visible to the user.
- [ ] This change meets the standards for [Section 508 compliance](https://www.ssa.gov/accessibility/andi/help/install.html).

### Backend

- [ ] Code follows the guidelines for [Logging](https://transcom.github.io/mymove-docs/docs/getting-started/development/logging).
- [ ] The requirements listed in [Querying the Database Safely](https://transcom.github.io/mymove-docs/docs/backend/guides/golang-guide#querying-the-database-safely) have been satisfied.

### Database

#### Any new migrations/schema changes:

- [ ] Follows our guidelines for [Zero-Downtime Deploys](https://transcom.github.io/mymove-docs/docs/backend/setup/database-migrations#zero-downtime-migrations).
- [ ] Have been communicated to #g-database.
- [ ] Secure migrations have been tested following the instructions in our [docs](https://transcom.github.io/mymove-docs/docs/backend/setup/database-migrations#secure-migrations).

## Screenshots
