### PR TITLE
B-21636-INT added check before TAC query

### DIFF
--- a/pkg/services/pptas_report/pptas_report_list_fetcher.go
+++ b/pkg/services/pptas_report/pptas_report_list_fetcher.go
@@ -513,31 +513,33 @@ func buildServiceItemCrate(serviceItem models.MTOServiceItem) pptasmessages.Crat
 
 // inputs all TAC related fields and builds full line of accounting string
 func inputReportTAC(report *models.PPTASReport, pptasShipment *pptasmessages.PPTASShipment, orders models.Order, appCtx appcontext.AppContext, tacFetcher services.TransportationAccountingCodeFetcher, loa services.LineOfAccountingFetcher) error {
-	tac, err := tacFetcher.FetchOrderTransportationAccountingCodes(models.DepartmentIndicator(*orders.DepartmentIndicator), orders.IssueDate, *orders.TAC, appCtx)
-	if err != nil {
-		return err
-	} else if len(tac) < 1 {
-		return nil
-	}
+	if orders.DepartmentIndicator != nil && orders.TAC != nil && !orders.IssueDate.IsZero() {
+		tac, err := tacFetcher.FetchOrderTransportationAccountingCodes(models.DepartmentIndicator(*orders.DepartmentIndicator), orders.IssueDate, *orders.TAC, appCtx)
+		if err != nil {
+			return err
+		} else if len(tac) < 1 {
+			return nil
+		}
 
-	if tac[0].LineOfAccounting != nil {
-		longLoa := loa.BuildFullLineOfAccountingString(*tac[0].LineOfAccounting)
+		if tac[0].LineOfAccounting != nil {
+			longLoa := loa.BuildFullLineOfAccountingString(*tac[0].LineOfAccounting)
 
-		pptasShipment.Loa = &longLoa
-		pptasShipment.FiscalYear = tac[0].TacFyTxt
-		pptasShipment.Appro = tac[0].LineOfAccounting.LoaBafID
-		pptasShipment.Subhead = tac[0].LineOfAccounting.LoaTrsySfxTx
-		pptasShipment.ObjClass = tac[0].LineOfAccounting.LoaObjClsID
-		pptasShipment.Bcn = tac[0].LineOfAccounting.LoaAlltSnID
-		pptasShipment.SubAllotCD = tac[0].LineOfAccounting.LoaSbaltmtRcpntID
-		pptasShipment.Aaa = tac[0].LineOfAccounting.LoaTrnsnID
-		pptasShipment.TypeCD = tac[0].LineOfAccounting.LoaJbOrdNm
-		pptasShipment.Paa = tac[0].LineOfAccounting.LoaInstlAcntgActID
-		pptasShipment.CostCD = tac[0].LineOfAccounting.LoaPgmElmntID
-		pptasShipment.Ddcd = tac[0].LineOfAccounting.LoaDptID
+			pptasShipment.Loa = &longLoa
+			pptasShipment.FiscalYear = tac[0].TacFyTxt
+			pptasShipment.Appro = tac[0].LineOfAccounting.LoaBafID
+			pptasShipment.Subhead = tac[0].LineOfAccounting.LoaTrsySfxTx
+			pptasShipment.ObjClass = tac[0].LineOfAccounting.LoaObjClsID
+			pptasShipment.Bcn = tac[0].LineOfAccounting.LoaAlltSnID
+			pptasShipment.SubAllotCD = tac[0].LineOfAccounting.LoaSbaltmtRcpntID
+			pptasShipment.Aaa = tac[0].LineOfAccounting.LoaTrnsnID
+			pptasShipment.TypeCD = tac[0].LineOfAccounting.LoaJbOrdNm
+			pptasShipment.Paa = tac[0].LineOfAccounting.LoaInstlAcntgActID
+			pptasShipment.CostCD = tac[0].LineOfAccounting.LoaPgmElmntID
+			pptasShipment.Ddcd = tac[0].LineOfAccounting.LoaDptID
 
-		if report.OrderNumber == nil {
-			report.OrderNumber = tac[0].LineOfAccounting.LoaDocID
+			if report.OrderNumber == nil {
+				report.OrderNumber = tac[0].LineOfAccounting.LoaDocID
+			}
 		}
 	}
 


### PR DESCRIPTION
## [Agility ticket](https://www13.v1host.com/USTRANSCOM38/story.mvc/Summary?oidToken=Story%3A1028653&RoomContext=TeamRoom%3A848240&concept=TeamRoom)

## Summary

Added check for department indicator, TAC, and orders issue date before querying for TAC/LOA data. (These fields should never be nil/empty though)

### How to test

1. Import PPTAS api into Postman
2. Create a Navy move with an HHG and complete the entire move/payment process
3. http://primelocal:3000/pptas/v1/moves?since=2021-07-23T18:30:47.116Z
4. In DBeaver open the client_certs table
    look for the entry with `devlocal` in the subject column and update that row to `allow_pptas`
    the subject column will look something like this `/C=US/ST=DC/L=Washington/O=Truss/OU=AppClientTLS/CN=devlocal`
5. Check the report has the required details from the sheet linked below

> [!IMPORTANT]  
> Make sure you're using a valid TAC. You must also update the dates in the TAC and LOA tables to include this year.
> All dates should be within `lines_of_accounting.loa_bgn_dt` and `lines_of_accounting.loa_end_dt`
> All dates should be within `transportation_accounting_codes.trnsprtn_acnt_bgn_dt` and `transportation_accounting_codes.trnsprtn_acnt_end_dt`

You can use the queries below to update the dates for `E12A` tac line. Make sure you update the orders in the move to use the right tac

`UPDATE transportation_accounting_codes SET trnsprtn_acnt_end_dt = date('2026-01-01') WHERE tac = 'E12A'`
`update lines_of_accounting set loa_end_dt = date('2026-01-01') where id = '06254fc3-b763-484c-b555-42855d1ad5cd'`

[PPTAS working spreadsheet (27 June 2024) Jays Comments Dan Notes.xlsx](https://github.com/user-attachments/files/16183536/PPTAS.working.spreadsheet.27.June.2024.Jays.Comments.Dan.Notes.xlsx)