### PR TITLE
B-21686: Allow Prime Sim User to update estimated weight and actual weight independently

### DIFF
--- a/src/pages/PrimeUI/Shipment/PrimeUIShipmentUpdate.test.jsx
+++ b/src/pages/PrimeUI/Shipment/PrimeUIShipmentUpdate.test.jsx
@@ -293,6 +293,192 @@ const approvedMoveTaskOrder = {
   },
 };
 
+const approvedMoveTaskOrderWithOneHHG = {
+  moveTaskOrder: {
+    availableToPrimeAt: '2021-10-18T18:24:41.235Z',
+    createdAt: '2021-10-18T18:24:41.362Z',
+    diversion: false,
+    eTag: 'MjAyMS0xMC0xOFQxODoyNDo0MS4zNjIxNjRa',
+    excessWeightAcknowledgedAt: null,
+    excessWeightQualifiedAt: null,
+    excessWeightUploadId: null,
+    id: '9c7b255c-2981-4bf8-839f-61c7458e2b4d',
+    moveCode: 'AR5K8V',
+    mtoShipments: [
+      {
+        actualPickupDate: '2020-03-16',
+        agents: [
+          {
+            agentType: 'RELEASING_AGENT',
+            createdAt: '2021-10-18T18:24:41.521Z',
+            eTag: 'MjAyMS0xMC0xOFQxODoyNDo0MS41MjE4NzNa',
+            email: 'test@test.email.com',
+            firstName: 'Test',
+            id: 'f2619e1b-7729-4b97-845d-6ae1ebe299f2',
+            lastName: 'Agent',
+            mtoShipmentID: 'ce01a5b7-9b44-4513-8a8d-edb60f2a4aee',
+            phone: '202-555-9301',
+            updatedAt: '2021-10-18T18:24:41.521Z',
+          },
+        ],
+        approvedDate: '2021-10-18',
+        createdAt: '2021-10-18T18:24:41.377Z',
+        customerRemarks: 'Please treat gently',
+        destinationAddress: {
+          city: 'Fairfield',
+          country: 'US',
+          eTag: 'MjAyMS0xMC0xOFQxODoyNDo0MS4zNzI3NDJa',
+          id: 'bfe61147-5fd7-426e-b473-54ccf77bde35',
+          postalCode: '94535',
+          state: 'CA',
+          streetAddress1: '987 Any Avenue',
+          streetAddress2: 'P.O. Box 9876',
+          streetAddress3: 'c/o Some Person',
+        },
+        eTag: 'MjAyMS0xMC0xOFQxODoyNDo0MS4zNzc5Nzha',
+        firstAvailableDeliveryDate: null,
+        id: 'ce01a5b8-9b44-4511-8a8d-edb60f2a4aee',
+        moveTaskOrderID: '9c7b255c-2981-4bf8-839f-61c7458e2b4d',
+        pickupAddress: {
+          city: 'Beverly Hills',
+          country: 'US',
+          eTag: 'MjAyMS0xMC0xOFQxODoyNDo0MS4zNjc3Mjda',
+          id: 'cf159eca-162c-4131-84a0-795e684416a6',
+          postalCode: '90210',
+          state: 'CA',
+          streetAddress1: '123 Any Street',
+          streetAddress2: 'P.O. Box 12345',
+          streetAddress3: 'c/o Some Person',
+        },
+        primeActualWeight: null,
+        primeEstimatedWeight: null,
+        actualProGearWeight: 1500,
+        actualSpouseProGearWeight: 250,
+        primeEstimatedWeightRecordedDate: null,
+        requestedPickupDate: '2020-03-15',
+        requiredDeliveryDate: null,
+        scheduledPickupDate: '2020-03-16',
+        secondaryDeliveryAddress: {
+          city: null,
+          postalCode: null,
+          state: null,
+          streetAddress1: null,
+        },
+        secondaryPickupAddress: {
+          city: null,
+          postalCode: null,
+          state: null,
+          streetAddress1: null,
+        },
+        shipmentType: 'HHG',
+        status: 'APPROVED',
+        updatedAt: '2021-10-18T18:24:41.377Z',
+        mtoServiceItems: null,
+      },
+    ],
+    order: {
+      customer: {
+        branch: 'AIR_FORCE',
+        dodID: '5917531070',
+        eTag: 'MjAyMS0xMC0xOFQxODoyNDo0MS4xNDIxNTZa',
+        email: 'leo_spaceman_sm@example.com',
+        firstName: 'Leo',
+        id: 'e2de409b-edb9-42af-b50f-564458e08ada',
+        lastName: 'Spacemen',
+        phone: '555-555-5555',
+        userID: 'ae204f8a-6222-45a1-9b79-e2d52441b4f2',
+      },
+      customerID: 'e2de409b-edb9-42af-b50f-564458e08ada',
+      destinationDutyLocation: {
+        address: {
+          city: 'Augusta',
+          country: 'United States',
+          eTag: 'MjAyMS0xMC0xOFQxODoyMzoxMi4zMTQzNDZa',
+          id: '5ac95be8-0230-47ea-90b4-b0f6f60de364',
+          postalCode: '30813',
+          state: 'GA',
+          streetAddress1: 'Fort Gordon',
+        },
+        addressID: '5ac95be8-0230-47ea-90b4-b0f6f60de364',
+        id: '2d5ada83-e09a-47f8-8de6-83ec51694a86',
+        name: 'Fort Gordon',
+      },
+      eTag: 'MjAyMS0xMC0xOFQxODoyNDo0MS4yMzAxMVo=',
+      entitlement: {
+        authorizedWeight: 8000,
+        dependentsAuthorized: true,
+        eTag: 'MjAyMS0xMC0xOFQxODoyNDo0MS4xNzc0MjZa',
+        id: '46ee60c2-9b17-44c7-9202-15a84327fc2f',
+        nonTemporaryStorage: true,
+        organizationalClothingAndIndividualEquipment: true,
+        privatelyOwnedVehicle: true,
+        proGearWeight: 2000,
+        proGearWeightSpouse: 500,
+        requiredMedicalEquipmentWeight: 1000,
+        storageInTransit: 2,
+        totalDependents: 1,
+        totalWeight: 5000,
+      },
+      id: '8cda4825-283c-4910-89f4-1741e2fd9cb7',
+      linesOfAccounting: 'F8E1',
+      orderNumber: 'ORDER3',
+      originDutyLocation: {
+        address: {
+          city: 'Des Moines',
+          country: 'US',
+          eTag: 'MjAyMS0xMC0xOFQxODoyNDo0MS4yMDgyNjha',
+          id: 'dbbee525-9c88-40c1-a549-6330b35972d2',
+          postalCode: '50309',
+          state: 'IA',
+          streetAddress1: '987 Other Avenue',
+          streetAddress2: 'P.O. Box 1234',
+          streetAddress3: 'c/o Another Person',
+        },
+        addressID: 'dbbee525-9c88-40c1-a549-6330b35972d2',
+        id: '0ecd8fb1-0551-44c8-a15e-83c5f4e3ae0f',
+        name: 'XOXhgDSIRS',
+      },
+      reportByDate: '2018-08-01',
+    },
+    orderID: '8cda4825-283c-4910-89f4-1741e2fd9cb7',
+    paymentRequests: [
+      {
+        eTag: 'MjAyMS0xMC0xOFQxODoyNDo0MS41Nzc2OTha',
+        id: '532ec513-8297-44b3-91a8-5167650b2869',
+        isFinal: false,
+        moveTaskOrderID: '9c7b255c-2981-4bf8-839f-61c7458e2b4d',
+        paymentRequestNumber: '3301-9920-1',
+        paymentServiceItems: [
+          {
+            eTag: 'MjAyMS0xMC0xOFQxODoyNDo0MS42Mzc5MzJa',
+            id: '8fdf0b3a-c102-4084-84fe-22903f20470b',
+            mtoServiceItemID: '8829fb28-69c1-45d7-98bc-c724478d5106',
+            paymentRequestID: '532ec513-8297-44b3-91a8-5167650b2869',
+            referenceID: '3301-9920-8fdf0b3a',
+            status: 'REQUESTED',
+          },
+        ],
+        status: 'PENDING',
+      },
+    ],
+    ppmType: 'PARTIAL',
+    referenceId: '3301-9920',
+    updatedAt: '2021-10-18T18:24:41.362Z',
+    mtoServiceItems: [
+      {
+        reServiceCode: 'STEST',
+        eTag: 'MjAyMS0xMC0xOFQxODoyNDo0MS41MzE0NjRa',
+        id: '8829fb28-69c1-45d7-98bc-c724478d5106',
+        modelType: 'MTOServiceItemBasic',
+        moveTaskOrderID: '9c7b255c-2981-4bf8-839f-61c7458e2b4d',
+        mtoShipmentID: 'ce01a5b7-9b44-4513-8a8d-edb60f2a4aee',
+        reServiceName: 'Test Service',
+        status: 'APPROVED',
+      },
+    ],
+  },
+};
+
 const moveDetailsURL = generatePath(primeSimulatorRoutes.VIEW_MOVE_PATH, { moveCodeOrID: moveId });
 
 const mockedComponent = (
@@ -303,6 +489,12 @@ const mockedComponent = (
 
 const readyReturnValue = {
   ...approvedMoveTaskOrder,
+  isLoading: false,
+  isError: false,
+  isSuccess: true,
+};
+const readyReturnValueWithOneHHG = {
+  ...approvedMoveTaskOrderWithOneHHG,
   isLoading: false,
   isError: false,
   isSuccess: true,
@@ -442,6 +634,56 @@ describe('successful submission of form', () => {
     await userEvent.type(actualSpouseProGearWeightInput, '500');
 
     const saveButton = await screen.getByRole('button', { name: 'Save' });
+
+    await waitFor(() => {
+      expect(saveButton).toBeEnabled();
+    });
+    await userEvent.click(saveButton);
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith(moveDetailsURL);
+    });
+  });
+
+  it('successful submission of form when updating a shipments actual weight but not estimated weight', async () => {
+    usePrimeSimulatorGetMove.mockReturnValue(readyReturnValueWithOneHHG);
+    updatePrimeMTOShipmentV3.mockReturnValue({});
+
+    render(mockedComponent);
+
+    const actualPickupDateInput = await screen.findByLabelText('Actual pickup');
+    await userEvent.clear(actualPickupDateInput);
+    await userEvent.type(actualPickupDateInput, '20 Oct 2021');
+
+    const actualWeightInput = screen.getByLabelText(/Actual weight/);
+    await userEvent.type(actualWeightInput, '500');
+
+    const saveButton = screen.getByRole('button', { name: 'Save' });
+
+    await waitFor(() => {
+      expect(saveButton).toBeEnabled();
+    });
+    await userEvent.click(saveButton);
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith(moveDetailsURL);
+    });
+  });
+
+  it('successful submission of form when updating a shipments estimated weight but not actual weight', async () => {
+    usePrimeSimulatorGetMove.mockReturnValue(readyReturnValueWithOneHHG);
+    updatePrimeMTOShipmentV3.mockReturnValue({});
+
+    render(mockedComponent);
+
+    const actualPickupDateInput = await screen.findByLabelText('Actual pickup');
+    await userEvent.clear(actualPickupDateInput);
+    await userEvent.type(actualPickupDateInput, '20 Oct 2021');
+
+    const actualWeightInput = screen.getByLabelText(/Estimated weight/);
+    await userEvent.type(actualWeightInput, '500');
+
+    const saveButton = screen.getByRole('button', { name: 'Save' });
 
     await waitFor(() => {
       expect(saveButton).toBeEnabled();

--- a/src/pages/PrimeUI/Shipment/PrimeUIShipmentUpdate.test.jsx
+++ b/src/pages/PrimeUI/Shipment/PrimeUIShipmentUpdate.test.jsx
@@ -680,8 +680,8 @@ describe('successful submission of form', () => {
     await userEvent.clear(actualPickupDateInput);
     await userEvent.type(actualPickupDateInput, '20 Oct 2021');
 
-    const actualWeightInput = screen.getByLabelText(/Estimated weight/);
-    await userEvent.type(actualWeightInput, '500');
+    const estimatedWeightInput = screen.getByLabelText(/Estimated weight/);
+    await userEvent.type(estimatedWeightInput, '500');
 
     const saveButton = screen.getByRole('button', { name: 'Save' });
 

--- a/src/pages/PrimeUI/Shipment/PrimeUIShipmentUpdateForm.jsx
+++ b/src/pages/PrimeUI/Shipment/PrimeUIShipmentUpdateForm.jsx
@@ -64,7 +64,6 @@ const PrimeUIShipmentUpdateForm = ({
       {editableWeightEstimateField && (
         <MaskedTextField
           data-testid="estimatedWeightInput"
-          defaultValue="0"
           name="estimatedWeight"
           label="Estimated weight (lbs)"
           id="estimatedWeightInput"
@@ -86,7 +85,6 @@ const PrimeUIShipmentUpdateForm = ({
       {editableWeightActualField && (
         <MaskedTextField
           data-testid="actualWeightInput"
-          defaultValue="0"
           name="actualWeight"
           label="Actual weight (lbs)"
           id="actualWeightInput"


### PR DESCRIPTION
## [Agility ticket](https://www13.v1host.com/USTRANSCOM38/assetdetail.v1?number=B-21686)
## [Int PR](https://github.com/transcom/mymove/pull/14381)


## Summary
Issue was that the Prime Sim User could not update Estimated Weight and Actual Weight Independently. This was happening because there is a default 0 in both text fields so if it is not removed then it would get submitted as 0, which would violate the validation rule of a value of 1 or greater. Prime API already supports updating both fields independently. The issue was the prime sim was submitting the payload with default value of 0.

Is there anything you would like reviewers to give additional scrutiny?

[this article](tbd) explains more about the approach used.

## Verification Steps for the Author

These are to be checked by the author.

- [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
- [ ] Have the Agility acceptance criteria been met for this change?

## Verification Steps for Reviewers

These are to be checked by a reviewer.

- [ ] Has the branch been pulled in and checked out?
- [ ] Have the BL acceptance criteria been met for this change?
- [ ] Was the CircleCI build successful?
- [ ] Has the code been reviewed from a standards and best practices point of view?

### Setup to Run the Code

- [Instructions for starting storybook](https://transcom.github.io/mymove-docs/docs/frontend/setup/storybook)
- [Instructions for starting the MilMove application](https://transcom.github.io/mymove-docs/docs/getting-started/application-setup/)
- [Instructions for running tests](https://transcom.github.io/mymove-docs/docs/getting-started/development/testing)

### How to test

1. Access the Prime Sim
2. Start with a shipment that has no estimated weight nor an actual weight
3. Try updating actual weight with a value greater than 0. Save the changes. Should be successful.
4. To speed up testing so you do not have to create a new shipment null out the actual weight , then update the estimated weight on the shipment as the prime.
5. Try adding a 0 in the field and you will get the validation error.

### Frontend

- [ ] There are no aXe warnings for UI.
- [ ] This works in [Supported Browsers and their phone views](https://transcom.github.io/mymove-docs/docs/adrs/Browser-Support/#minimum-browser-requirements) (Chrome, Firefox, Edge).
- [ ] There are no new console errors in the browser devtools.
- [ ] There are no new console errors in the test output.
- [ ] If this PR adds a new component to Storybook, it ensures the component is fully responsive, OR if it is intentionally not, a wrapping div using the `officeApp` class or custom `min-width` styling is used to hide any states the would not be visible to the user.
- [ ] This change meets the standards for [Section 508 compliance](https://www.ssa.gov/accessibility/andi/help/install.html).

### Backend

- [ ] Code follows the guidelines for [Logging](https://transcom.github.io/mymove-docs/docs/getting-started/development/logging).
- [ ] The requirements listed in [Querying the Database Safely](https://transcom.github.io/mymove-docs/docs/backend/guides/golang-guide#querying-the-database-safely) have been satisfied.

### Database

#### Any new migrations/schema changes:

- [ ] Follows our guidelines for [Zero-Downtime Deploys](https://transcom.github.io/mymove-docs/docs/backend/setup/database-migrations#zero-downtime-migrations).
- [ ] Have been communicated to #g-database.
- [ ] Secure migrations have been tested following the instructions in our [docs](https://transcom.github.io/mymove-docs/docs/backend/setup/database-migrations#secure-migrations).

## Screenshots
