### PR TITLE
Migrate client proxies for http-proxy-middleware 2.0.6 to 3.0.3

### DIFF
--- a/src/setupProxy.js
+++ b/src/setupProxy.js
@@ -1,19 +1,19 @@
 const { createProxyMiddleware } = require('http-proxy-middleware');
 
 module.exports = (app) => {
-  app.use(createProxyMiddleware('/api', { target: 'http://milmovelocal:8080/' }));
-  app.use(createProxyMiddleware('/internal', { target: 'http://milmovelocal:8080/' }));
-  app.use(createProxyMiddleware('/admin', { target: 'http://milmovelocal:8080/' }));
-  app.use(createProxyMiddleware('/ghc', { target: 'http://milmovelocal:8080/' }));
-  app.use(createProxyMiddleware('/prime', { target: 'http://milmovelocal:8080/' }));
-  app.use(createProxyMiddleware('/pptas', { target: 'http://milmovelocal:8080/' }));
-  app.use(createProxyMiddleware('/support', { target: 'http://milmovelocal:8080/' }));
-  app.use(createProxyMiddleware('/testharness', { target: 'http://milmovelocal:8080/' }));
-  app.use(createProxyMiddleware('/storage', { target: 'http://milmovelocal:8080/' }));
-  app.use(createProxyMiddleware('/devlocal-auth', { target: 'http://milmovelocal:8080/' }));
-  app.use(createProxyMiddleware('/auth/**', { target: 'http://milmovelocal:8080/' }));
-  app.use(createProxyMiddleware('/logout', { target: 'http://milmovelocal:8080/' }));
-  app.use(createProxyMiddleware('/downloads', { target: 'http://milmovelocal:8080/' }));
-  app.use(createProxyMiddleware('/debug/**', { target: 'http://milmovelocal:8080/' }));
-  app.use(createProxyMiddleware('/client/**', { target: 'http://milmovelocal:8080/' }));
+  app.use('/api', createProxyMiddleware({ target: 'http://milmovelocal:8080/api' }));
+  app.use('/internal', createProxyMiddleware({ target: 'http://milmovelocal:8080/internal' }));
+  app.use('/admin', createProxyMiddleware({ target: 'http://milmovelocal:8080/admin' }));
+  app.use('/ghc', createProxyMiddleware({ target: 'http://milmovelocal:8080/ghc' }));
+  app.use('/prime', createProxyMiddleware({ target: 'http://milmovelocal:8080/prime' }));
+  app.use('/pptas', createProxyMiddleware({ target: 'http://milmovelocal:8080/pptas' }));
+  app.use('/support', createProxyMiddleware({ target: 'http://milmovelocal:8080/support' }));
+  app.use('/testharness', createProxyMiddleware({ target: 'http://milmovelocal:8080/testharness' }));
+  app.use('/storage', createProxyMiddleware({ target: 'http://milmovelocal:8080/storage' }));
+  app.use('/devlocal-auth', createProxyMiddleware({ target: 'http://milmovelocal:8080/devlocal-auth' }));
+  app.use('/auth/**', createProxyMiddleware({ target: 'http://milmovelocal:8080/auth/**' }));
+  app.use('/logout', createProxyMiddleware({ target: 'http://milmovelocal:8080/logout' }));
+  app.use('/downloads', createProxyMiddleware({ target: 'http://milmovelocal:8080/downloads' }));
+  app.use('/debug/**', createProxyMiddleware({ target: 'http://milmovelocal:8080/debug/**' }));
+  app.use('/client/**', createProxyMiddleware({ target: 'http://milmovelocal:8080/client/**' }));
 };


### PR DESCRIPTION
## Summary

[Bump http-proxy-middleware from 2.0.6 to 3.0.3](https://github.com/transcom/mymove/pull/14015) came with some breaking changes, this fixes them.

[V3 Migration Guide](https://github.com/chimurai/http-proxy-middleware/blob/master/MIGRATION.md)

"push it straight to main- and let it get to integration naturally like other lib updates" - Dre

## Verification Steps for the Author

These are to be checked by the author.

- [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
- [ ] Have the Agility acceptance criteria been met for this change?

## Verification Steps for Reviewers

These are to be checked by a reviewer.

- [ ] Has the branch been pulled in and checked out?
- [ ] Have the BL acceptance criteria been met for this change?
- [ ] Was the CircleCI build successful?
- [ ] Has the code been reviewed from a standards and best practices point of view?

### Setup to Run the Code

- [Instructions for starting storybook](https://transcom.github.io/mymove-docs/docs/frontend/setup/storybook)
- [Instructions for starting the MilMove application](https://transcom.github.io/mymove-docs/docs/getting-started/application-setup/)
- [Instructions for running tests](https://transcom.github.io/mymove-docs/docs/getting-started/development/testing)

### How to test

1. Does the client start locally and work like normal?

### Frontend

- [ ] There are no aXe warnings for UI.
- [ ] This works in [Supported Browsers and their phone views](https://transcom.github.io/mymove-docs/docs/adrs/Browser-Support/#minimum-browser-requirements) (Chrome, Firefox, Edge).
- [ ] There are no new console errors in the browser devtools.
- [ ] There are no new console errors in the test output.
- [ ] If this PR adds a new component to Storybook, it ensures the component is fully responsive, OR if it is intentionally not, a wrapping div using the `officeApp` class or custom `min-width` styling is used to hide any states the would not be visible to the user.
- [ ] This change meets the standards for [Section 508 compliance](https://www.ssa.gov/accessibility/andi/help/install.html).

### Backend

- [ ] Code follows the guidelines for [Logging](https://transcom.github.io/mymove-docs/docs/getting-started/development/logging).
- [ ] The requirements listed in [Querying the Database Safely](https://transcom.github.io/mymove-docs/docs/backend/guides/golang-guide#querying-the-database-safely) have been satisfied.

### Database

#### Any new migrations/schema changes:

- [ ] Follows our guidelines for [Zero-Downtime Deploys](https://transcom.github.io/mymove-docs/docs/backend/setup/database-migrations#zero-downtime-migrations).
- [ ] Have been communicated to #g-database.
- [ ] Secure migrations have been tested following the instructions in our [docs](https://transcom.github.io/mymove-docs/docs/backend/setup/database-migrations#secure-migrations).

## Screenshots
