### PR TITLE
MAIN B-22139

### DIFF
--- a/migrations/app/migrations_manifest.txt
+++ b/migrations/app/migrations_manifest.txt
@@ -1050,3 +1050,4 @@
 20241203024453_add_ppm_max_incentive_column.up.sql
 20241204155919_update_ordering_proc.up.sql
 20241204210208_retroactive_update_of_ppm_max_and_estimated_incentives_prd.up.sql
+20241227153723_remove_empty_string_emplid_values.up.sql

--- a/migrations/app/schema/20241227153723_remove_empty_string_emplid_values.up.sql
+++ b/migrations/app/schema/20241227153723_remove_empty_string_emplid_values.up.sql
@@ -1,0 +1,4 @@
+-- removing empty string values from the emplid column
+UPDATE service_members
+SET emplid = null
+WHERE emplid = '';

--- a/pkg/handlers/ghcapi/customer.go
+++ b/pkg/handlers/ghcapi/customer.go
@@ -216,6 +216,11 @@ func (h CreateCustomerWithOktaOptionHandler) Handle(params customercodeop.Create
 				return customercodeop.NewCreateCustomerWithOktaOptionUnprocessableEntity().WithPayload(payload), badDataError
 			}
 
+			// emplid needs to be unique so if it is not provided, we need to ensure it is nil by checking for empty strings
+			if payload.Emplid != nil && *payload.Emplid == "" {
+				payload.Emplid = nil
+			}
+
 			// declaring okta values outside of if statements so we can use them later
 			var oktaSub string
 			oktaUser := &models.CreatedOktaUser{}

--- a/pkg/handlers/ghcapi/customer_test.go
+++ b/pkg/handlers/ghcapi/customer_test.go
@@ -218,6 +218,7 @@ func (suite *HandlerSuite) TestCreateCustomerWithOktaOptionHandler() {
 		suite.Equal(body.BackupContact.Email, createdCustomerPayload.BackupContact.Email)
 		// when CacUser is false, this indicates a non-CAC user so CacValidated is set to true
 		suite.Equal(true, createdCustomerPayload.CacValidated)
+		suite.Nil(body.Emplid)
 	})
 
 	suite.Run("Unable to create customer when using an existing DODID", func() {

--- a/src/pages/Office/CustomerOnboarding/CreateCustomerForm.jsx
+++ b/src/pages/Office/CustomerOnboarding/CreateCustomerForm.jsx
@@ -62,7 +62,7 @@ export const CreateCustomerForm = ({ userPrivileges, setFlashMessage, setCanAddO
   const initialValues = {
     affiliation: '',
     edipi: '',
-    emplid: '',
+    emplid: null,
     first_name: '',
     middle_name: '',
     last_name: '',
@@ -110,7 +110,7 @@ export const CreateCustomerForm = ({ userPrivileges, setFlashMessage, setCanAddO
     const body = {
       affiliation: values.affiliation,
       edipi: values.edipi,
-      emplid: values.emplid || '',
+      emplid: values.emplid,
       firstName: values.first_name,
       middleName: values.middle_name,
       lastName: values.last_name,
@@ -234,7 +234,7 @@ export const CreateCustomerForm = ({ userPrivileges, setFlashMessage, setCanAddO
                     ...values,
                     affiliation: '',
                     edipi: '',
-                    emplid: '',
+                    emplid: null,
                     is_safety_move: 'false',
                   });
                 }
@@ -255,7 +255,7 @@ export const CreateCustomerForm = ({ userPrivileges, setFlashMessage, setCanAddO
                     ...values,
                     affiliation: e.target.value,
                     edipi: '',
-                    emplid: '',
+                    emplid: null,
                   });
                 } else if (e.target.value !== departmentIndicators.COAST_GUARD && isSafetyMove) {
                   setShowEmplid(false);
@@ -263,7 +263,7 @@ export const CreateCustomerForm = ({ userPrivileges, setFlashMessage, setCanAddO
                     ...values,
                     affiliation: e.target.value,
                     edipi: uniqueDodid,
-                    emplid: '',
+                    emplid: null,
                   });
                 } else {
                   setShowEmplid(false);
@@ -271,7 +271,7 @@ export const CreateCustomerForm = ({ userPrivileges, setFlashMessage, setCanAddO
                     ...values,
                     affiliation: e.target.value,
                     edipi: '',
-                    emplid: '',
+                    emplid: null,
                   });
                 }
               };

--- a/src/pages/Office/CustomerOnboarding/CreateCustomerForm.test.jsx
+++ b/src/pages/Office/CustomerOnboarding/CreateCustomerForm.test.jsx
@@ -413,7 +413,11 @@ describe('CreateCustomerForm', () => {
     await userEvent.click(saveBtn);
 
     await waitFor(() => {
-      expect(createCustomerWithOktaOption).toHaveBeenCalled();
+      expect(createCustomerWithOktaOption).toHaveBeenCalledWith(
+        expect.objectContaining({
+          body: expect.objectContaining({ emplid: null }),
+        }),
+      );
       expect(testProps.setCanAddOrders).toHaveBeenCalledWith(true);
       expect(mockNavigate).toHaveBeenCalledWith(ordersPath, {
         state: {
@@ -486,6 +490,15 @@ describe('CreateCustomerForm', () => {
     await userEvent.type(getByTestId('emplidInput'), '1234567');
     await waitFor(() => {
       expect(saveBtn).toBeEnabled(); // EMPLID is set now, all validations true
+    });
+    await userEvent.click(saveBtn);
+
+    await waitFor(() => {
+      expect(createCustomerWithOktaOption).toHaveBeenCalledWith(
+        expect.objectContaining({
+          body: expect.objectContaining({ emplid: '1234567' }),
+        }),
+      );
     });
   }, 20000);
 
@@ -629,11 +642,11 @@ describe('CreateCustomerForm', () => {
 
     await waitFor(() => {
       expect(createCustomerWithOktaOption).toHaveBeenCalled();
-      expect(mockNavigate).toHaveBeenCalledWith(ordersPath, {
-        state: {
-          isSafetyMoveSelected: true,
-        },
-      });
+    });
+    expect(mockNavigate).toHaveBeenCalledWith(ordersPath, {
+      state: {
+        isSafetyMoveSelected: true,
+      },
     });
   }, 20000);
 });

--- a/src/pages/Office/CustomerOnboarding/CreateCustomerForm.test.jsx
+++ b/src/pages/Office/CustomerOnboarding/CreateCustomerForm.test.jsx
@@ -642,11 +642,11 @@ describe('CreateCustomerForm', () => {
 
     await waitFor(() => {
       expect(createCustomerWithOktaOption).toHaveBeenCalled();
-    });
-    expect(mockNavigate).toHaveBeenCalledWith(ordersPath, {
-      state: {
-        isSafetyMoveSelected: true,
-      },
+      expect(mockNavigate).toHaveBeenCalledWith(ordersPath, {
+        state: {
+          isSafetyMoveSelected: true,
+        },
+      });
     });
   }, 20000);
 });


### PR DESCRIPTION
[INT PR](https://github.com/transcom/mymove/pull/14477)

**NOTE**
There is a small difference in code change in `CreateCustomerForm.test.jsx` due to fixing a flaky test that exists on `integrationTesting` but does not exist on `main`

## [Agility ticket](https://www13.v1host.com/USTRANSCOM38/assetdetail.v1?number=B-22139)

## Summary

There's was a discovered defect in prod where a SC was getting an error when trying to create any customer. Prod has a unique constraint on the `emplid` column and was being saved as an empty string (`""`) instead of `null`.

Approach is to remove all `emplid` rows that have empty strings, fix the code that is saving as an empty string if no value is provided, as well as adding in a backend check.

### How to test

1. You will need to manually add the unique constraint to your local dev db, but first you'll need to sanitize by removing the empty string `emplid` column. In DBeaver, run this:
```
UPDATE service_members 
SET emplid = null 
WHERE emplid = '';

ALTER TABLE service_members
ADD CONSTRAINT service_members_emplid_unique_key UNIQUE (emplid);
```
2. Login as a SC and create any customer of any affiliation
3. Go back and create another one, ensure you don't get an error
4. Confirm you can also create Coast Guard folks without error and the dup check still happens
5. Profit
6. Ensure you drop the unique constraint if ya want to:
```
ALTER TABLE service_members DROP CONSTRAINT service_members_emplid_unique_key;
```
