### PR TITLE
B-21581

### DIFF
--- a/pkg/handlers/ghcapi/internal/payloads/model_to_payload_test.go
+++ b/pkg/handlers/ghcapi/internal/payloads/model_to_payload_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/transcom/mymove/pkg/factory"
 	"github.com/transcom/mymove/pkg/gen/ghcmessages"
+	"github.com/transcom/mymove/pkg/gen/internalmessages"
 	"github.com/transcom/mymove/pkg/handlers"
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/models/roles"
@@ -313,6 +314,93 @@ func (suite *PayloadsSuite) TestShipmentAddressUpdate() {
 
 		suite.Nil(returnedShipmentAddressUpdate)
 	})
+}
+
+func (suite *PayloadsSuite) TestMoveWithGBLOC() {
+	defaultOrdersNumber := "ORDER3"
+	defaultTACNumber := "F8E1"
+	defaultDepartmentIndicator := "AIR_AND_SPACE_FORCE"
+	defaultGrade := "E_1"
+	defaultHasDependents := false
+	defaultSpouseHasProGear := false
+	defaultOrdersType := internalmessages.OrdersTypePERMANENTCHANGEOFSTATION
+	defaultOrdersTypeDetail := internalmessages.OrdersTypeDetail("HHG_PERMITTED")
+	defaultStatus := models.OrderStatusDRAFT
+	testYear := 2018
+	defaultIssueDate := time.Date(testYear, time.March, 15, 0, 0, 0, 0, time.UTC)
+	defaultReportByDate := time.Date(testYear, time.August, 1, 0, 0, 0, 0, time.UTC)
+	defaultGBLOC := "KKFA"
+
+	originDutyLocation := models.DutyLocation{
+		Name: "Custom Origin",
+	}
+	originDutyLocationTOName := "origin duty location transportation office"
+	firstName := "customFirst"
+	lastName := "customLast"
+	serviceMember := models.ServiceMember{
+		FirstName: &firstName,
+		LastName:  &lastName,
+	}
+	uploadedOrders := models.Document{
+		ID: uuid.Must(uuid.NewV4()),
+	}
+	dependents := 7
+	entitlement := models.Entitlement{
+		TotalDependents: &dependents,
+	}
+	amendedOrders := models.Document{
+		ID: uuid.Must(uuid.NewV4()),
+	}
+	// Create order
+	order := factory.BuildOrder(suite.DB(), []factory.Customization{
+		{
+			Model: originDutyLocation,
+			Type:  &factory.DutyLocations.OriginDutyLocation,
+		},
+		{
+			Model: models.TransportationOffice{
+				Name: originDutyLocationTOName,
+			},
+			Type: &factory.TransportationOffices.OriginDutyLocation,
+		},
+		{
+			Model: serviceMember,
+		},
+		{
+			Model: uploadedOrders,
+			Type:  &factory.Documents.UploadedOrders,
+		},
+		{
+			Model: entitlement,
+		},
+		{
+			Model: amendedOrders,
+			Type:  &factory.Documents.UploadedAmendedOrders,
+		},
+	}, nil)
+
+	suite.Equal(defaultOrdersNumber, *order.OrdersNumber)
+	suite.Equal(defaultTACNumber, *order.TAC)
+	suite.Equal(defaultDepartmentIndicator, *order.DepartmentIndicator)
+	suite.Equal(defaultGrade, string(*order.Grade))
+	suite.Equal(defaultHasDependents, order.HasDependents)
+	suite.Equal(defaultSpouseHasProGear, order.SpouseHasProGear)
+	suite.Equal(defaultOrdersType, order.OrdersType)
+	suite.Equal(defaultOrdersTypeDetail, *order.OrdersTypeDetail)
+	suite.Equal(defaultStatus, order.Status)
+	suite.Equal(defaultIssueDate, order.IssueDate)
+	suite.Equal(defaultReportByDate, order.ReportByDate)
+	suite.Equal(defaultGBLOC, *order.OriginDutyLocationGBLOC)
+
+	suite.Equal(originDutyLocation.Name, order.OriginDutyLocation.Name)
+	suite.Equal(originDutyLocationTOName, order.OriginDutyLocation.TransportationOffice.Name)
+	suite.Equal(*serviceMember.FirstName, *order.ServiceMember.FirstName)
+	suite.Equal(*serviceMember.LastName, *order.ServiceMember.LastName)
+	suite.Equal(uploadedOrders.ID, order.UploadedOrdersID)
+	suite.Equal(uploadedOrders.ID, order.UploadedOrders.ID)
+	suite.Equal(*entitlement.TotalDependents, *order.Entitlement.TotalDependents)
+	suite.Equal(amendedOrders.ID, *order.UploadedAmendedOrdersID)
+	suite.Equal(amendedOrders.ID, order.UploadedAmendedOrders.ID)
 }
 
 func (suite *PayloadsSuite) TestWeightTicketUpload() {

--- a/pkg/handlers/internalapi/orders.go
+++ b/pkg/handlers/internalapi/orders.go
@@ -382,6 +382,12 @@ func (h UpdateOrdersHandler) Handle(params ordersop.UpdateOrdersParams) middlewa
 				order.OriginDutyLocation = &originDutyLocation
 				order.OriginDutyLocationID = &originDutyLocationID
 
+				originGBLOC, originGBLOCerr := models.FetchGBLOCForPostalCode(appCtx.DB(), originDutyLocation.Address.PostalCode)
+				if originGBLOCerr != nil {
+					return handlers.ResponseForError(appCtx.Logger(), originGBLOCerr), originGBLOCerr
+				}
+				order.OriginDutyLocationGBLOC = &originGBLOC.GBLOC
+
 				if payload.MoveID != "" {
 
 					moveID, err := uuid.FromString(payload.MoveID.String())

--- a/pkg/models/order.go
+++ b/pkg/models/order.go
@@ -309,6 +309,49 @@ func (o *Order) CreateNewMove(db *pop.Connection, moveOptions MoveOptions) (*Mov
 	return createNewMove(db, *o, moveOptions)
 }
 
+/*
+ * GetOriginPostalCode returns the GBLOC for the postal code of the the origin duty location of the order.
+ */
+func (o Order) GetOriginPostalCode(db *pop.Connection) (string, error) {
+	// Since this requires looking up the order in the DB, the order must have an ID. This means, the order has to have been created first.
+	if uuid.UUID.IsNil(o.ID) {
+		return "", errors.WithMessage(ErrInvalidOrderID, "You must create the order in the DB before getting the origin GBLOC.")
+	}
+
+	err := db.Load(&o, "OriginDutyLocation.Address")
+	if err != nil {
+		if err.Error() == RecordNotFoundErrorString {
+			return "", errors.WithMessage(err, "No Origin Duty Location was found for the order ID "+o.ID.String())
+		}
+		return "", err
+	}
+
+	return o.OriginDutyLocation.Address.PostalCode, nil
+}
+
+/*
+ * GetOriginGBLOC returns the GBLOC for the postal code of the the origin duty location of the order.
+ */
+func (o Order) GetOriginGBLOC(db *pop.Connection) (string, error) {
+	// Since this requires looking up the order in the DB, the order must have an ID. This means, the order has to have been created first.
+	if uuid.UUID.IsNil(o.ID) {
+		return "", errors.WithMessage(ErrInvalidOrderID, "You must created the order in the DB before getting the destination GBLOC.")
+	}
+
+	originPostalCode, err := o.GetOriginPostalCode(db)
+	if err != nil {
+		return "", err
+	}
+
+	var originGBLOC PostalCodeToGBLOC
+	originGBLOC, err = FetchGBLOCForPostalCode(db, originPostalCode)
+	if err != nil {
+		return "", err
+	}
+
+	return originGBLOC.GBLOC, nil
+}
+
 // IsComplete checks if orders have all fields necessary to approve a move
 func (o *Order) IsComplete() bool {
 

--- a/pkg/testdatagen/scenario/shared.go
+++ b/pkg/testdatagen/scenario/shared.go
@@ -10519,6 +10519,60 @@ func CreateNeedsServicesCounseling(appCtx appcontext.AppContext, ordersType inte
 	return move
 }
 
+/*
+Create Needs Service Counseling in a non-default GBLOC - pass in orders with all required information, shipment type, destination type, locator
+*/
+func CreateNeedsServicesCounselingInOtherGBLOC(appCtx appcontext.AppContext, ordersType internalmessages.OrdersType, shipmentType models.MTOShipmentType, destinationType *models.DestinationType, locator string) models.Move {
+	db := appCtx.DB()
+	originDutyLocationAddress := factory.BuildAddress(db, []factory.Customization{
+		{
+			Model: models.Address{
+				PostalCode: "35023",
+			},
+		},
+	}, nil)
+	originDutyLocation := factory.BuildDutyLocation(db, []factory.Customization{
+		{
+			Model: models.DutyLocation{
+				Name:      "Test Location",
+				AddressID: originDutyLocationAddress.ID,
+			},
+		},
+	}, nil)
+	order := factory.BuildOrder(db, []factory.Customization{
+		{
+			Model: originDutyLocation,
+		},
+	}, nil)
+	move := factory.BuildMove(db, []factory.Customization{
+		{
+			Model:    order,
+			LinkOnly: true,
+		},
+		{
+			Model: models.Move{
+				Locator: locator,
+				Status:  models.MoveStatusNeedsServiceCounseling,
+			},
+		},
+	}, nil)
+
+	factory.BuildMTOShipment(db, []factory.Customization{
+		{
+			Model:    move,
+			LinkOnly: true,
+		},
+		{
+			Model: models.MTOShipment{
+				ShipmentType: shipmentType,
+				Status:       models.MTOShipmentStatusSubmitted,
+			},
+		},
+	}, nil)
+
+	return move
+}
+
 func CreateNeedsServicesCounselingWithAmendedOrders(appCtx appcontext.AppContext, userUploader *uploader.UserUploader, ordersType internalmessages.OrdersType, shipmentType models.MTOShipmentType, destinationType *models.DestinationType, locator string) models.Move {
 	db := appCtx.DB()
 	submittedAt := time.Now()

--- a/pkg/testdatagen/testharness/dispatch.go
+++ b/pkg/testdatagen/testharness/dispatch.go
@@ -50,6 +50,9 @@ var actionDispatcher = map[string]actionFunc{
 	"HHGMoveNeedsSC": func(appCtx appcontext.AppContext) testHarnessResponse {
 		return MakeHHGMoveNeedsSC(appCtx)
 	},
+	"HHGMoveNeedsSCOtherGBLOC": func(appCtx appcontext.AppContext) testHarnessResponse {
+		return MakeHHGMoveNeedsSCOtherGBLOC(appCtx)
+	},
 	"HHGMoveAsUSMCNeedsSC": func(appCtx appcontext.AppContext) testHarnessResponse {
 		return MakeHHGMoveNeedsServicesCounselingUSMC(appCtx)
 	},

--- a/pkg/testdatagen/testharness/make_move.go
+++ b/pkg/testdatagen/testharness/make_move.go
@@ -4013,6 +4013,22 @@ func MakeHHGMoveNeedsSC(appCtx appcontext.AppContext) models.Move {
 	return *newmove
 }
 
+// MakeHHGMoveNeedsSCOtherGBLOC creates an fully ready move needing SC approval in a non-default GBLOC
+func MakeHHGMoveNeedsSCOtherGBLOC(appCtx appcontext.AppContext) models.Move {
+	pcos := internalmessages.OrdersTypePERMANENTCHANGEOFSTATION
+	hhg := models.MTOShipmentTypeHHG
+	locator := models.GenerateLocator()
+	move := scenario.CreateNeedsServicesCounselingInOtherGBLOC(appCtx, pcos, hhg, nil, locator)
+
+	// re-fetch the move so that we ensure we have exactly what is in
+	// the db
+	newmove, err := models.FetchMove(appCtx.DB(), &auth.Session{}, move.ID)
+	if err != nil {
+		log.Panic(fmt.Errorf("failed to fetch move: %w", err))
+	}
+	return *newmove
+}
+
 // MakeBoatHaulAwayMoveNeedsSC creates an fully ready move with a boat haul-away shipment needing SC approval
 func MakeBoatHaulAwayMoveNeedsSC(appCtx appcontext.AppContext) models.Move {
 	userUploader := newUserUploader(appCtx)

--- a/playwright/tests/office/servicescounseling/servicesCounselingFlows.spec.js
+++ b/playwright/tests/office/servicescounseling/servicesCounselingFlows.spec.js
@@ -13,6 +13,33 @@ const supportingDocsEnabled = process.env.FEATURE_FLAG_MANAGE_SUPPORTING_DOCS;
 const LocationLookup = 'BEVERLY HILLS, CA 90210 (LOS ANGELES)';
 
 test.describe('Services counselor user', () => {
+  test.describe('GBLOC tests', () => {
+    test.describe('Origin Duty Location', () => {
+      let moveLocatorKKFA = '';
+      let moveLocatorCNNQ = '';
+      test.beforeEach(async ({ scPage }) => {
+        const moveKKFA = await scPage.testHarness.buildHHGMoveNeedsSC();
+        moveLocatorKKFA = moveKKFA.locator;
+        const moveCNNQ = await scPage.testHarness.buildHHGMoveNeedsSC();
+        moveLocatorCNNQ = moveCNNQ.locator;
+      });
+
+      test('when origin duty location GBLOC matches services counselor GBLOC', async ({ page }) => {
+        const locatorFilter = await page.getByTestId('locator').getByTestId('TextBoxFilter');
+        await locatorFilter.fill(moveLocatorKKFA);
+        await locatorFilter.blur();
+        await expect(page.getByTestId('locator-0')).toBeVisible();
+      });
+
+      test('when origin duty location GBLOC does not match services counselor GBLOC', async ({ page }) => {
+        const locatorFilter = await page.getByTestId('locator').getByTestId('TextBoxFilter');
+        await locatorFilter.fill(moveLocatorCNNQ);
+        await locatorFilter.blur();
+        await expect(page.getByTestId('locator-0')).not.toBeVisible();
+      });
+    });
+  });
+
   test.describe('with basic HHG move', () => {
     test.beforeEach(async ({ scPage }) => {
       const move = await scPage.testHarness.buildHHGMoveNeedsSC();
@@ -351,6 +378,8 @@ test.describe('Services counselor user', () => {
       await expect(page.getByText(LocationLookup, { exact: true })).toBeVisible();
       await page.keyboard.press('Enter');
       await page.locator('select[name="destinationType"]').selectOption({ label: 'Home of selection (HOS)' });
+      await page.getByLabel('Requested pickup date').fill('16 Mar 2022');
+
       await page.locator('[data-testid="submitForm"]').click();
       await scPage.waitForLoading();
 

--- a/playwright/tests/utils/testharness.js
+++ b/playwright/tests/utils/testharness.js
@@ -28,6 +28,9 @@ export class TestHarness {
    * @property {string} id
    * @property {string} locator
    * @property {Object} Orders
+   * @property {Object} OriginDutyLocation
+   * @property {Object} OriginDutyLocation.Address
+   * @property {string} OriginDutyLocation.Address.PostalCode
    * @property {Object} Orders.NewDutyLocation
    * @property {string} Orders.NewDutyLocation.name
    * @property {Object} Orders.ServiceMember
@@ -390,6 +393,14 @@ export class TestHarness {
    */
   async buildHHGMoveNeedsSC() {
     return this.buildDefault('HHGMoveNeedsSC');
+  }
+
+  /**
+   * Use testharness to build hhg move needing SC approval in a non-default GBLOC
+   * @returns {Promise<Move>}
+   */
+  async buildHHGMoveNeedsSCInOtherGBLOC() {
+    return this.buildDefault('HHGMoveNeedsSCOtherGBLOC');
   }
 
   /**


### PR DESCRIPTION
## [Agility Ticket B-21581](https://www13.v1host.com/USTRANSCOM38/assetdetail.v1?number=B-21581)

## [INT PR 14127](https://github.com/transcom/mymove/pull/14127)

## Testing Steps I took
Use [this doc](https://dp3.atlassian.net/wiki/download/attachments/2279735297/postal_code_to_gblocs_202311091157.csv?api=v2) to determine what zip codes to use in order to see different GBLOCs.
1. As a service member (to include CIV or other), create a move with a shipment. Pay special attention to what selection is made for your origin duty location.
2. As SC and/or TOO verify which GBLOC shows up in the Origin GBLOC column for the move when you search for it. Also verify that when you open the move as an office user, the GBLOC should also show in the top-right of the page as you are looking at the move/shipment.
3. As either the service member or as an office user, change the origin duty location to that which falls under a different GBLOC (reference the document link above which is from the helpful files section of the ByteSize M&Ms Confluence pages).
4. As SC and/or TOO verify that the GBLOC has changed.