### PR TITLE
B 22186 int - errors when deleting then uploading documents

### DIFF
--- a/pkg/handlers/ghcapi/documents.go
+++ b/pkg/handlers/ghcapi/documents.go
@@ -53,7 +53,7 @@ func (h GetDocumentHandler) Handle(params documentop.GetDocumentParams) middlewa
 				return handlers.ResponseForError(appCtx.Logger(), err), err
 			}
 
-			document, err := models.FetchDocument(appCtx.DB(), appCtx.Session(), documentID, true)
+			document, err := models.FetchDocument(appCtx.DB(), appCtx.Session(), documentID)
 			if err != nil {
 				return handlers.ResponseForError(appCtx.Logger(), err), err
 			}

--- a/pkg/handlers/ghcapi/uploads.go
+++ b/pkg/handlers/ghcapi/uploads.go
@@ -50,7 +50,7 @@ func (h CreateUploadHandler) Handle(params uploadop.CreateUploadParams) middlewa
 				}
 
 				// Fetch document to ensure user has access to it
-				document, docErr := models.FetchDocument(appCtx.DB(), appCtx.Session(), documentID, true)
+				document, docErr := models.FetchDocument(appCtx.DB(), appCtx.Session(), documentID)
 				if docErr != nil {
 					return handlers.ResponseForError(appCtx.Logger(), docErr), rollbackErr
 				}

--- a/pkg/handlers/internalapi/documents.go
+++ b/pkg/handlers/internalapi/documents.go
@@ -73,7 +73,7 @@ func (h ShowDocumentHandler) Handle(params documentop.ShowDocumentParams) middle
 				return handlers.ResponseForError(appCtx.Logger(), err), err
 			}
 
-			document, err := models.FetchDocument(appCtx.DB(), appCtx.Session(), documentID, false)
+			document, err := models.FetchDocument(appCtx.DB(), appCtx.Session(), documentID)
 			if err != nil {
 				return handlers.ResponseForError(appCtx.Logger(), err), err
 			}

--- a/pkg/handlers/internalapi/uploads.go
+++ b/pkg/handlers/internalapi/uploads.go
@@ -70,7 +70,7 @@ func (h CreateUploadHandler) Handle(params uploadop.CreateUploadParams) middlewa
 				}
 
 				// Fetch document to ensure user has access to it
-				document, docErr := models.FetchDocument(appCtx.DB(), appCtx.Session(), documentID, true)
+				document, docErr := models.FetchDocument(appCtx.DB(), appCtx.Session(), documentID)
 				if docErr != nil {
 					return handlers.ResponseForError(appCtx.Logger(), docErr), rollbackErr
 				}
@@ -267,7 +267,7 @@ func (h CreatePPMUploadHandler) Handle(params ppmop.CreatePPMUploadParams) middl
 			documentID := uuid.FromStringOrNil(params.DocumentID.String())
 
 			// Fetch document to ensure user has access to it
-			document, docErr := models.FetchDocument(appCtx.DB(), appCtx.Session(), documentID, true)
+			document, docErr := models.FetchDocument(appCtx.DB(), appCtx.Session(), documentID)
 			if docErr != nil {
 				docNotFoundErr := fmt.Errorf("documentId %q was not found for this user", documentID)
 				return ppmop.NewCreatePPMUploadNotFound().WithPayload(payloads.ClientError(handlers.NotFoundMessage, docNotFoundErr.Error(), h.GetTraceIDFromRequest(params.HTTPRequest))), docNotFoundErr

--- a/pkg/services/paperwork/prime_download_user_upload_to_pdf_converter.go
+++ b/pkg/services/paperwork/prime_download_user_upload_to_pdf_converter.go
@@ -117,7 +117,7 @@ func (g *moveUserUploadToPDFDownloader) GenerateDownloadMoveUserUploadPDF(appCtx
 
 // Build orderUploadDocType for document
 func (g *moveUserUploadToPDFDownloader) buildPdfBatchInfo(appCtx appcontext.AppContext, uploadDocType services.MoveOrderUploadType, documentID uuid.UUID) (*pdfBatchInfo, error) {
-	document, err := models.FetchDocumentWithNoRestrictions(appCtx.DB(), appCtx.Session(), documentID, false)
+	document, err := models.FetchDocumentWithNoRestrictions(appCtx.DB(), appCtx.Session(), documentID)
 	if err != nil {
 		return nil, errors.Wrap(err, fmt.Sprintf("error fetching document domain by id: %s", documentID))
 	}


### PR DESCRIPTION
## [B-22186](https://www13.v1host.com/USTRANSCOM38/story.mvc/Summary?oidToken=Story%3A1051053)

## Summary

There have been errors occurring in production when documents are deleted and then new documents uploaded. Sometimes this would occur immediately after deleting an uploaded document and then uploading it again, other times this would occur when attempting to download the AOA or Payment Packets. The method used to fetch the documents included a bool for including deleted documents or not and a lot of these calls were passing in true. Conversations with the PO we decided to remove this flag because the application itself wouldn't need the functionality to retrieve a deleted document. During investigations it was found that the deleted_at field in the documents table was not being set when documents were being deleted by pressing the Delete button for uploading documents. This is due to the `SoftDestroy` method not being able to find FK associated tables when the model contains the `belongs_to` relationships. The `user_uploads` table has one such association with the `documents` table so the `deleted_at` field was not being set. This BL adds an additional call to `SoftDestroy` to tell it to also soft delete the record in the `documents` table.

## Verification Steps for the Author

These are to be checked by the author.

- [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
- [ ] Have the Agility acceptance criteria been met for this change?

## Verification Steps for Reviewers

These are to be checked by a reviewer.

- [ ] Has the branch been pulled in and checked out?
- [ ] Have the BL acceptance criteria been met for this change?
- [ ] Was the CircleCI build successful?
- [ ] Has the code been reviewed from a standards and best practices point of view?

### Setup to Run the Code

- [Instructions for starting storybook](https://transcom.github.io/mymove-docs/docs/frontend/setup/storybook)
- [Instructions for starting the MilMove application](https://transcom.github.io/mymove-docs/docs/getting-started/application-setup/)
- [Instructions for running tests](https://transcom.github.io/mymove-docs/docs/getting-started/development/testing)

### How to test
Basic idea is to test upload then delete then upload again everywhere possible and verify there aren't any errors. Then also test downloading the AOA and Payment packets without error.

1. Create a new Customer
2. Upload your Order then delete and upload again
3. Create a PPM shipment
4. Ask for an advance
5. Then upload, delete, upload again when given the chance to
6. Submit the PPM
7. Login as a SC
8. Approve the shipment
9. Download the AOA packet verify no errors
10. Login as the Customer
11. Upload your weight tickets, delete, upload again
12. Make sure you add at least one moving expense
13. Upload your document, delete, upload again
14. Submit you PPM
15. Login as SC approve the documents
16. Verify you can download the Payment Packet without errors

### Frontend

- [ ] There are no aXe warnings for UI.
- [ ] This works in [Supported Browsers and their phone views](https://transcom.github.io/mymove-docs/docs/adrs/Browser-Support/#minimum-browser-requirements) (Chrome, Firefox, Edge).
- [ ] There are no new console errors in the browser devtools.
- [ ] There are no new console errors in the test output.
- [ ] If this PR adds a new component to Storybook, it ensures the component is fully responsive, OR if it is intentionally not, a wrapping div using the `officeApp` class or custom `min-width` styling is used to hide any states the would not be visible to the user.
- [ ] This change meets the standards for [Section 508 compliance](https://www.ssa.gov/accessibility/andi/help/install.html).

### Backend

- [ ] Code follows the guidelines for [Logging](https://transcom.github.io/mymove-docs/docs/getting-started/development/logging).
- [ ] The requirements listed in [Querying the Database Safely](https://transcom.github.io/mymove-docs/docs/backend/guides/golang-guide#querying-the-database-safely) have been satisfied.

### Database

#### Any new migrations/schema changes:

- [ ] Follows our guidelines for [Zero-Downtime Deploys](https://transcom.github.io/mymove-docs/docs/backend/setup/database-migrations#zero-downtime-migrations).
- [ ] Have been communicated to #g-database.
- [ ] Secure migrations have been tested following the instructions in our [docs](https://transcom.github.io/mymove-docs/docs/backend/setup/database-migrations#secure-migrations).

## Screenshots
