### PR TITLE
INT B-22206 & I-13751

### DIFF
--- a/pkg/payment_request/service_param_value_lookups/per_unit_cents_lookup.go
+++ b/pkg/payment_request/service_param_value_lookups/per_unit_cents_lookup.go
@@ -43,7 +43,7 @@ func (p PerUnitCentsLookup) lookup(appCtx appcontext.AppContext, s *ServiceItemP
 
 	case models.ReServiceCodeIHUPK:
 		// IHUPK: Need rate area ID for the destination address
-		rateAreaID, err := models.FetchRateAreaID(appCtx.DB(), *p.MTOShipment.PickupAddressID, &serviceID, contractID)
+		rateAreaID, err := models.FetchRateAreaID(appCtx.DB(), *p.MTOShipment.DestinationAddressID, &serviceID, contractID)
 		if err != nil {
 			return "", fmt.Errorf("error fetching rate area id for shipment ID: %s and service ID %s: %s", p.MTOShipment.ID, serviceID, err)
 		}


### PR DESCRIPTION
## [Agility ticket](https://www13.v1host.com/USTRANSCOM38/assetdetail.v1?number=B-22206)
[Issue ticket](https://www13.v1host.com/USTRANSCOM38/Issue.mvc/Summary?oidToken=Issue%3A1054008)

## Summary

For some reason we weren't able to see this locally, but there are differences in pricing in loadtest. Checked out the db and this should fix it - was using the wrong rate area when getting the `per_unit_price` but the db proc should be good.