### PR TITLE
MAIN B-21519

### DIFF
--- a/pkg/services/payment_service_item/payment_service_item_status_updater_test.go
+++ b/pkg/services/payment_service_item/payment_service_item_status_updater_test.go
@@ -26,7 +26,6 @@ func (suite *PaymentServiceItemSuite) TestUpdatePaymentServiceItemStatus() {
 		suite.NotNil(updatedPaymentServiceItem.ApprovedAt)
 		suite.Nil(updatedPaymentServiceItem.RejectionReason)
 		suite.Nil(updatedPaymentServiceItem.DeniedAt)
-
 	})
 
 	suite.Run("Successfully rejects a payment service item", func() {
@@ -44,7 +43,23 @@ func (suite *PaymentServiceItemSuite) TestUpdatePaymentServiceItemStatus() {
 		suite.NotNil(updatedPaymentServiceItem.DeniedAt)
 		suite.Equal("reasons", *updatedPaymentServiceItem.RejectionReason)
 		suite.Nil(updatedPaymentServiceItem.ApprovedAt)
+	})
 
+	suite.Run("Successfully resets a payment service item to requested", func() {
+		paymentServiceItem := factory.BuildPaymentServiceItem(suite.DB(), nil, nil)
+		eTag := etag.GenerateEtag(paymentServiceItem.UpdatedAt)
+		updater := NewPaymentServiceItemStatusUpdater()
+
+		updatedPaymentServiceItem, verrs, err := updater.UpdatePaymentServiceItemStatus(suite.AppContextForTest(),
+			paymentServiceItem.ID, models.PaymentServiceItemStatusRequested, models.StringPointer("reasons"), eTag)
+
+		suite.NoError(err)
+		suite.NoVerrs(verrs)
+		suite.Equal(paymentServiceItem.ID, updatedPaymentServiceItem.ID)
+		suite.Equal(models.PaymentServiceItemStatusRequested, updatedPaymentServiceItem.Status)
+		suite.Nil(updatedPaymentServiceItem.DeniedAt)
+		suite.Nil(updatedPaymentServiceItem.RejectionReason)
+		suite.Nil(updatedPaymentServiceItem.ApprovedAt)
 	})
 
 	suite.Run("Fails if we can't find an existing paymentServiceItem", func() {

--- a/playwright/tests/office/txo/tioFlows.spec.js
+++ b/playwright/tests/office/txo/tioFlows.spec.js
@@ -402,6 +402,17 @@ test.describe('TIO user', () => {
 
       // Approve the first service item
       await tioFlowPage.approveServiceItem();
+      // testing the clear selection functionality
+      await expect(page.getByText('Clear selection')).toBeVisible();
+      await page.getByText('Clear selection').click();
+      // proceed without approving/rejecting
+      await page.getByText('Next').click();
+      await tioFlowPage.slowDown();
+      // go back to the previous page
+      await page.getByText('Previous').click();
+      // the service item should neither be approved/rejected so the clear selection should not be seen
+      await expect(page.getByText('Clear selection')).not.toBeVisible();
+      await tioFlowPage.approveServiceItem();
       await page.getByText('Next').click();
       await tioFlowPage.slowDown();
 
@@ -555,86 +566,6 @@ test.describe('TIO user', () => {
 
       // Verify sucess alert and tag
       await expect(page.getByText('Move unflagged for financial review.')).toBeVisible();
-    });
-
-    /**
-     * This test is being temporarily skipped until flakiness issues
-     * can be resolved. It was skipped in cypress and is not part of
-     * the initial playwright conversion. - ahobson 2023-01-05
-     */
-    test.skip('can add/edit TAC/SAC', async ({ page }) => {
-      // Payment Requests page
-      expect(page.url()).toContain('/payment-requests');
-      await expect(page.getByTestId('MovePaymentRequests')).toBeVisible();
-
-      // await expect(page.locator('button')).toContainText('Edit').click();
-      // await expect(page.locator('button')).toContainText('Add or edit codes').click();
-      // cy.url().should('include', `/moves/NTSTIO/orders`);
-
-      // await page.locator('form').within(() => {
-      //   await page.locator('input[data-testid="ntsTacInput"]').click().fill('E19A');
-      //   await page.locator('input[data-testid="ntsSacInput"]').click().fill('3L988AS098F');
-      //   // Edit orders page | Save
-      //   await expect(page.locator('button')).toContainText('Save').click();
-      // });
-      // cy.url().should('include', `/moves/NTSTIO/details`);
-      // await expect(page.getByText('Payment requests').click()).toBeVisible();
-      // cy.url().should('include', `/payment-requests`);
-      // await expect(page.locator('button')).toContainText('Edit').click();
-
-      // await page.locator('input#tacType-NTS').click({ force: true });
-      // await page.locator('input#sacType-NTS').click({ force: true });
-      // await page.locator('button[type="submit"]').click();
-
-      // await expect(page.locator('[data-testid="tac"]')).toContainText('E19A (NTS)');
-      // await expect(page.locator('[data-testid="sac"]')).toContainText('3L988AS098F (NTS)');
-    });
-
-    // ahobson - 2023-01-05 skipping this test as it is a subset of
-    // the test called 'can use a payment request page to update
-    // orders and review a payment request'
-    test.skip('can view and approve service items', async ({ page }) => {
-      // Payment Requests page
-      expect(page.url()).toContain('/payment-requests');
-      await expect(page.getByTestId('MovePaymentRequests')).toBeVisible();
-
-      await page.getByText('Review service items').first().click();
-
-      // await expect(page.locator('[data-testid="serviceItemName"]')).toContainText('Move management');
-      // await page.locator('[data-testid="approveRadio"]').click({ force: true });
-      // cy.wait('@patchPaymentServiceItemStatus');
-      // await expect(page.locator('button')).toContainText('Next').click();
-
-      // await expect(page.locator('[data-testid="serviceItemName"]')).toContainText('Domestic origin shuttle service');
-      // await page.locator('[data-testid="approveRadio"]').click({ force: true });
-      // cy.wait('@patchPaymentServiceItemStatus');
-      // await expect(page.locator('button')).toContainText('Next').click();
-
-      // await expect(page.locator('[data-testid="serviceItemName"]')).toContainText('Domestic origin shuttle service');
-      // await page.locator('[data-testid="approveRadio"]').click({ force: true });
-      // cy.wait('@patchPaymentServiceItemStatus');
-      // await expect(page.locator('button')).toContainText('Next').click();
-
-      // await expect(page.locator('[data-testid="serviceItemName"]')).toContainText('Domestic crating');
-      // await page.locator('[data-testid="approveRadio"]').click({ force: true });
-      // cy.wait('@patchPaymentServiceItemStatus');
-      // await expect(page.locator('button')).toContainText('Next').click();
-
-      // await expect(page.locator('[data-testid="serviceItemName"]')).toContainText('Domestic crating');
-      // await page.locator('[data-testid="approveRadio"]').click({ force: true });
-      // cy.wait('@patchPaymentServiceItemStatus');
-      // await expect(page.locator('button')).toContainText('Next').click();
-
-      // await expect(page.locator('[data-testid="serviceItemName"]')).toContainText('Domestic linehaul');
-      // await page.locator('[data-testid="approveRadio"]').click({ force: true });
-      // cy.wait('@patchPaymentServiceItemStatus');
-      // await expect(page.locator('button')).toContainText('Next').click();
-
-      // await expect(page.locator('[data-testid="accepted"]')).toContainText('$1,130.21');
-      // await expect(page.locator('button')).toContainText('Authorize payment').click();
-      // cy.wait(['@getMovePaymentRequests']);
-
-      // await expect(page.locator('[data-testid="tag"]')).toContainText('Reviewed');
     });
 
     test('is able to view Origin GBLOC', async ({ page }) => {


### PR DESCRIPTION
## [Agility ticket](https://www13.v1host.com/USTRANSCOM38/assetdetail.v1?number=B-21519)

## Summary

Previously the "clear selection" button for TIOs when reviewing payment requests was not functional. When clicked, it would clear it on the UI, but the backend was not clearing any data so it was not being retained when the page was reloading.

This was fixed with adding a `REQUESTED` status check to the service object:
```
 	case models.PaymentServiceItemStatusRequested:
		paymentServiceItem.RejectionReason = nil
		paymentServiceItem.DeniedAt = nil
		paymentServiceItem.ApprovedAt = nil
```

Also did a little refactor in there and changed it to a switch/case.

### How to test

1. Create a move
2. Approve as SC
3. Approve as TOO
4. Update weights/dates as Prime
5. Create a payment request as Prime
6. Review as TIO
7. Go through the flow of accepting/rejecting but use the "clear selection" button while you review
8. Back out of the review and confirm that the statuses change (requested should show as "needs review" when clicking the "clear selection" button)

## Screenshots
![Screenshot 2025-01-22 at 8 57 15 AM](https://github.com/user-attachments/assets/992d29e8-7b6a-462f-b5b6-e7d22519d4f0)
