### PR TITLE
pin pdfcpu to latest hash with overflow fix from pdfpcu issue 1077

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -62,7 +62,7 @@ require (
 	github.com/lib/pq v1.10.9
 	github.com/markbates/goth v1.79.0
 	github.com/namsral/flag v1.7.4-pre
-	github.com/pdfcpu/pdfcpu v0.9.1
+	github.com/pdfcpu/pdfcpu v0.9.2-0.20250122004437-b05d39596f8f
 	github.com/pkg/errors v0.9.1
 	github.com/pkg/sftp v1.13.7
 	github.com/pterm/pterm v0.12.79
@@ -259,7 +259,7 @@ require (
 	go.opentelemetry.io/proto/otlp v1.3.1 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	golang.org/x/exp v0.0.0-20230905200255-921286631fa9
-	golang.org/x/image v0.21.0 // indirect
+	golang.org/x/image v0.23.0 // indirect
 	golang.org/x/mod v0.20.0 // indirect
 	golang.org/x/sync v0.10.0 // indirect
 	golang.org/x/sys v0.28.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -511,8 +511,8 @@ github.com/opentracing/opentracing-go v1.2.0 h1:uEJPy/1a5RIPAJ0Ov+OIO8OxWu77jEv+
 github.com/opentracing/opentracing-go v1.2.0/go.mod h1:GxEUsuufX4nBwe+T+Wl9TAgYrxe9dPLANfrWvHYVTgc=
 github.com/patrickmn/go-cache v0.0.0-20180815053127-5633e0862627 h1:pSCLCl6joCFRnjpeojzOpEYs4q7Vditq8fySFG5ap3Y=
 github.com/patrickmn/go-cache v0.0.0-20180815053127-5633e0862627/go.mod h1:3Qf8kWWT7OJRJbdiICTKqZju1ZixQ/KpMGzzAfe6+WQ=
-github.com/pdfcpu/pdfcpu v0.9.1 h1:q8/KlBdHjkE7ZJU4ofhKG5Rjf7M6L324CVM6BMDySao=
-github.com/pdfcpu/pdfcpu v0.9.1/go.mod h1:fVfOloBzs2+W2VJCCbq60XIxc3yJHAZ0Gahv1oO0gyI=
+github.com/pdfcpu/pdfcpu v0.9.2-0.20250122004437-b05d39596f8f h1:pbR5oPqr7t9jhmy/804XHl/JjsxJuNHumdWA+lFkU4E=
+github.com/pdfcpu/pdfcpu v0.9.2-0.20250122004437-b05d39596f8f/go.mod h1:8EAma3IBIS7ssMiPlcNIPWwISTuP31WToXfGvc327vI=
 github.com/pelletier/go-toml/v2 v2.1.0 h1:FnwAJ4oYMvbT/34k9zzHuZNrhlz48GB3/s6at6/MHO4=
 github.com/pelletier/go-toml/v2 v2.1.0/go.mod h1:tJU2Z3ZkXwnxa4DPO899bsyIoywizdUvyaeZurnPPDc=
 github.com/peterbourgon/diskv/v3 v3.0.1 h1:x06SQA46+PKIUftmEujdwSEpIx8kR+M9eLYsUxeYveU=
@@ -730,8 +730,8 @@ golang.org/x/exp v0.0.0-20230905200255-921286631fa9 h1:GoHiUyI/Tp2nVkLI2mCxVkOjs
 golang.org/x/exp v0.0.0-20230905200255-921286631fa9/go.mod h1:S2oDrQGGwySpoQPVqRShND87VCbxmc6bL1Yd2oYrm6k=
 golang.org/x/image v0.0.0-20190910094157-69e4b8554b2a/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=
 golang.org/x/image v0.0.0-20191009234506-e7c1f5e7dbb8/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=
-golang.org/x/image v0.21.0 h1:c5qV36ajHpdj4Qi0GnE0jUc/yuo33OLFaa0d+crTD5s=
-golang.org/x/image v0.21.0/go.mod h1:vUbsLavqK/W303ZroQQVKQ+Af3Yl6Uz1Ppu5J/cLz78=
+golang.org/x/image v0.23.0 h1:HseQ7c2OpPKTPVzNjG5fwJsOTCiiwS4QdsYi5XU6H68=
+golang.org/x/image v0.23.0/go.mod h1:wJJBTdLfCCf3tiHa1fNxpZmUI4mmoZvwMCPP0ddoNKY=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
 golang.org/x/lint v0.0.0-20190227174305-5b3e6a55c961/go.mod h1:wehouNa3lNwaWXcvxsM5YxQ5yQlVC4a0KAMCusXpPoU=
 golang.org/x/lint v0.0.0-20190313153728-d0100b6bd8b3/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=

--- a/pkg/paperwork/generator.go
+++ b/pkg/paperwork/generator.go
@@ -225,16 +225,16 @@ func (g *Generator) GetPdfFileInfo(fileName string) (*pdfcpu.PDFInfo, error) {
 		return nil, err
 	}
 	defer file.Close()
-	return api.PDFInfo(file, fileName, nil, g.pdfConfig)
+	return api.PDFInfo(file, fileName, nil, false, g.pdfConfig)
 }
 
 func (g *Generator) GetPdfFileInfoForReadSeeker(rs io.ReadSeeker) (*pdfcpu.PDFInfo, error) {
-	return api.PDFInfo(rs, "", nil, g.pdfConfig)
+	return api.PDFInfo(rs, "", nil, false, g.pdfConfig)
 }
 
 // Get file information of a single PDF
 func (g *Generator) GetPdfFileInfoByContents(file afero.File) (*pdfcpu.PDFInfo, error) {
-	return api.PDFInfo(file, file.Name(), nil, g.pdfConfig)
+	return api.PDFInfo(file, file.Name(), nil, false, g.pdfConfig)
 }
 
 // CreateMergedPDFUpload converts Uploads to PDF and merges them into a single PDF

--- a/pkg/paperwork/generator_test.go
+++ b/pkg/paperwork/generator_test.go
@@ -123,7 +123,7 @@ func (suite *PaperworkSuite) TestPDFFromImages() {
 	files, err := os.ReadDir(tmpDir)
 	suite.FatalNil(err)
 
-	suite.Equal(4, len(files), "did not find 2 images")
+	suite.Equal(2, len(files), "did not find 2 images")
 
 	for _, file := range files {
 		checksum, sha256ForPathErr := suite.sha256ForPath(path.Join(tmpDir, file.Name()), nil)
@@ -182,7 +182,7 @@ func (suite *PaperworkSuite) TestPDFFromImagesNoRotation() {
 	files, err := os.ReadDir(tmpDir)
 	suite.FatalNil(err)
 
-	suite.Equal(4, len(files), "did not find 2 images")
+	suite.Equal(2, len(files), "did not find 2 images")
 
 	for _, file := range files {
 		checksum, sha256ForPathErr := suite.sha256ForPath(path.Join(tmpDir, file.Name()), nil)

--- a/pkg/services/paperwork/prime_download_user_upload_to_pdf_converter_test.go
+++ b/pkg/services/paperwork/prime_download_user_upload_to_pdf_converter_test.go
@@ -88,7 +88,7 @@ func (suite *PaperworkServiceSuite) TestPrimeDownloadMoveUploadPDFGeneratorUnpro
 }
 
 func (suite *PaperworkServiceSuite) pdfFileInfo(generator *paperwork.Generator, file afero.File) (*pdfcpu.PDFInfo, error) {
-	return api.PDFInfo(file, file.Name(), nil, generator.PdfConfiguration())
+	return api.PDFInfo(file, file.Name(), nil, false, generator.PdfConfiguration())
 }
 
 func (suite *PaperworkServiceSuite) setupOrdersDocument() (services.PrimeDownloadMoveUploadPDFGenerator, models.Order) {


### PR DESCRIPTION
## [E-06309](https://www13.v1host.com/USTRANSCOM38/assetdetail.v1?number=E-06309)

## Summary

Pdfcpu is still causing stack overflow in production ECS containers. As of 12 hours ago, Pdfcpu issue https://github.com/pdfcpu/pdfcpu/issues/1077 references the exact error we're encountering and mentions bookmarks. As we use bookmarks in our pdfcpu code, this PR points to the latest git sha with the fix. The fix hasn't been officially released yet, hence the sha instead of version tag.

## How to test
Generate a PPM-based AOA and Payment Packet. If the PDF generates for you just fine, this will be good.

When making your PPM as a customer, request an advance. Don't use seed data, the ppm packet will fail

## Screenshots

https://github.com/user-attachments/assets/aef65d51-bacc-47f7-8018-90c19d3ce13a


![image](https://github.com/user-attachments/assets/ca2a1f4f-7b65-4873-8fe7-1ef67174e4d9)
