### PR TITLE
INT-B-22239 show deleted agent in move history

### DIFF
--- a/src/constants/MoveHistory/EventTemplates/UpdateMTOShipment/UpdateMTOShipmentAgent.module.scss
+++ b/src/constants/MoveHistory/EventTemplates/UpdateMTOShipment/UpdateMTOShipmentAgent.module.scss
@@ -1,0 +1,7 @@
+@import 'shared/styles/colors';
+
+.shipmentType {
+  display: block;
+  color: $base;
+  margin-bottom: 8px 0;
+}

--- a/src/constants/MoveHistory/EventTemplates/UpdateMTOShipment/updateMTOShipmentAgent.jsx
+++ b/src/constants/MoveHistory/EventTemplates/UpdateMTOShipment/updateMTOShipmentAgent.jsx
@@ -1,6 +1,9 @@
 import React from 'react';
 
+import styles from './UpdateMTOShipmentAgent.module.scss';
+
 import { formatMoveHistoryAgent } from 'utils/formatters';
+import fieldMappings from 'constants/MoveHistory/Database/FieldMappings';
 import o from 'constants/MoveHistory/UIDisplay/Operations';
 import a from 'constants/MoveHistory/Database/Actions';
 import t from 'constants/MoveHistory/Database/Tables';
@@ -26,10 +29,34 @@ const formatChangedValues = (historyRecord) => {
   return { ...historyRecord, changedValues: newChangedValues };
 };
 
+const formatDeletedAgentRecord = (historyRecord) => {
+  const mtoShipmentLabel = getMtoShipmentLabel(historyRecord);
+  const historyLabel = `${mtoShipmentLabel.shipment_type} shipment #${mtoShipmentLabel.shipment_locator}`;
+  const agentTypeFieldName = historyRecord.oldValues.agent_type.toLowerCase();
+  const agentType = fieldMappings[agentTypeFieldName];
+  const agent = formatMoveHistoryAgent(historyRecord.oldValues)[agentTypeFieldName];
+
+  return (
+    <>
+      <span className={styles.shipmentType}>
+        Deleted {agentType} on {historyLabel}
+      </span>
+      <div>
+        <b>{agentType}</b>: {agent}
+      </div>
+    </>
+  );
+};
+
 export default {
   action: a.UPDATE,
   eventName: o.updateMTOShipment,
   tableName: t.mto_agents,
   getEventNameDisplay: () => 'Updated shipment',
-  getDetails: (historyRecord) => <LabeledDetails historyRecord={formatChangedValues(historyRecord)} />,
+  getDetails: (historyRecord) => {
+    if (historyRecord.changedValues.deleted_at) {
+      return formatDeletedAgentRecord(historyRecord);
+    }
+    return <LabeledDetails historyRecord={formatChangedValues(historyRecord)} />;
+  },
 };

--- a/src/constants/MoveHistory/EventTemplates/UpdateMTOShipment/updateMTOShipmentAgent.test.jsx
+++ b/src/constants/MoveHistory/EventTemplates/UpdateMTOShipment/updateMTOShipmentAgent.test.jsx
@@ -41,6 +41,46 @@ describe('when given an mto shipment agents update with mto agents table history
       },
       context: [{ shipment_type: 'HHG', shipment_locator: 'RQ38D4-01', shipment_id_abbr: 'a1b2c' }],
     },
+    DELETED_RECEIVING_AGENT: {
+      action: 'UPDATE',
+      eventName: 'updateMTOShipment',
+      tableName: 'mto_agents',
+      changedValues: {
+        deleted_at: '2025-01-21T15:39:24.890356+00:00',
+        email: null,
+        first_name: null,
+        last_name: null,
+        phone: null,
+      },
+      oldValues: {
+        agent_type: 'RECEIVING_AGENT',
+        email: 'john.smith@email.com',
+        first_name: 'John',
+        last_name: 'Smith',
+        phone: '555-765-4321',
+      },
+      context: [{ shipment_type: 'HHG', shipment_locator: 'RQ38D4-01', shipment_id_abbr: 'a1b2c' }],
+    },
+    DELETED_RELEASING_AGENT: {
+      action: 'UPDATE',
+      eventName: 'updateMTOShipment',
+      tableName: 'mto_agents',
+      changedValues: {
+        deleted_at: '2025-01-21T16:39:24.890356+00:00',
+        email: null,
+        first_name: null,
+        last_name: null,
+        phone: null,
+      },
+      oldValues: {
+        agent_type: 'RELEASING_AGENT',
+        email: 'jane.smith@email.com',
+        first_name: 'Jane',
+        last_name: 'Smith',
+        phone: '555-123-4567',
+      },
+      context: [{ shipment_type: 'NTS', shipment_locator: 'RQ38D4-01', shipment_id_abbr: 'a1b2c' }],
+    },
   };
 
   describe('when agent type is Releasing', () => {
@@ -75,12 +115,30 @@ describe('when given an mto shipment agents update with mto agents table history
       expect(screen.getAllByText('HHG shipment #RQ38D4-01'));
     });
 
-    it('it displays the proper labeled details for the given releasing agent', () => {
+    it('it displays the proper labeled details for the given receiving agent', () => {
       const template = getTemplate(historyRecord.RECEIVE);
 
       render(template.getDetails(historyRecord.RECEIVE));
       expect(screen.getByText('Receiving agent')).toBeInTheDocument();
       expect(screen.getByText(': Nancy Drew, 555-555-5555, nancy@email.com')).toBeInTheDocument();
+    });
+  });
+
+  describe('when agent is deleted', () => {
+    it('displays deleted receiving agent', () => {
+      const template = getTemplate(historyRecord.DELETED_RECEIVING_AGENT);
+      render(template.getDetails(historyRecord.DELETED_RECEIVING_AGENT));
+      expect(screen.getByText('Deleted Receiving agent on HHG shipment #RQ38D4-01')).toBeInTheDocument();
+      expect(screen.getByText('Receiving agent')).toBeInTheDocument();
+      expect(screen.getByText(': John Smith, 555-765-4321, john.smith@email.com')).toBeInTheDocument();
+    });
+
+    it('displays deleted releasing agent', () => {
+      const template = getTemplate(historyRecord.DELETED_RELEASING_AGENT);
+      render(template.getDetails(historyRecord.DELETED_RELEASING_AGENT));
+      expect(screen.getByText('Deleted Releasing agent on NTS shipment #RQ38D4-01')).toBeInTheDocument();
+      expect(screen.getByText('Releasing agent')).toBeInTheDocument();
+      expect(screen.getByText(': Jane Smith, 555-123-4567, jane.smith@email.com')).toBeInTheDocument();
     });
   });
 });


### PR DESCRIPTION
## [Agility ticket](https://www13.v1host.com/USTRANSCOM38/story.mvc/Summary?oidToken=Story%3A1053908)

## Summary
Currently when a Releasing/Receiving Agent is deleted from a shipment, the Move history shows only that the shipment was updated. It does not indicate anything regarding the deletion of the agent. This is not very helpful in knowing what action occurred on the shipment. To make the history of deleting agents more helpful, we are adding logic to 1) indicate that an agent was deleted 2) display the deleted agent's information.

## Verification Steps for the Author

These are to be checked by the author.

- [ ] Have the Agility acceptance criteria been met for this change?

## Verification Steps for Reviewers

These are to be checked by a reviewer.

- [ ] Has the branch been pulled in and checked out?
- [ ] Have the BL acceptance criteria been met for this change?
- [ ] Was the CircleCI build successful?
- [ ] Has the code been reviewed from a standards and best practices point of view?

### How to test

1. Login to the office application as a TOO or Services Counselor.
2. Navigate to a move.
3. Click Edit shipment on any shipment.
4. Add a Releasing Agent and a Receiving Agent.
5. Save the Shipment.
6. Edit the shipment again.
7. Delete the first name, last name, phone, and email for the Releasing and Receiving Agents.
8. Save the shipment.
9. Click on the Move history.
10. Verify that the shipment has 2 rows indicating that the agent was deleted from the shipment.
11. Verify that the now deleted agent's information is displayed.

Additionally, feel free to make updates to an agent such as changing the name, email, phone fields and verify the history still shows the changes for that update correctly.

### Frontend

- [ ] There are no aXe warnings for UI.
- [ ] This works in [Supported Browsers and their phone views](https://transcom.github.io/mymove-docs/docs/adrs/Browser-Support/#minimum-browser-requirements) (Chrome, Firefox, Edge).
- [ ] There are no new console errors in the browser devtools.
- [ ] There are no new console errors in the test output.
- [ ] If this PR adds a new component to Storybook, it ensures the component is fully responsive, OR if it is intentionally not, a wrapping div using the `officeApp` class or custom `min-width` styling is used to hide any states the would not be visible to the user.
- [ ] This change meets the standards for [Section 508 compliance](https://www.ssa.gov/accessibility/andi/help/install.html).

## Screenshots
**Example of the current UI for deleted agent (not very helpful)**

![Screenshot 2025-01-24 at 8 39 38 AM](https://github.com/user-attachments/assets/f76f133f-10c6-4ba9-91fc-bca14056b3d8)


**Added Agents**

![Screenshot 2025-01-24 at 8 48 24 AM](https://github.com/user-attachments/assets/89bffc53-aafb-40a8-8e86-b14cf7ecf059)
![Screenshot 2025-01-24 at 8 48 51 AM](https://github.com/user-attachments/assets/192ece29-6889-4aeb-91e3-fe738bd738fa)


**Move history after deleting agents displays helpful information**

![Screenshot 2025-01-24 at 8 51 12 AM](https://github.com/user-attachments/assets/fa3acd32-453e-41a5-941b-4554267ea6ca)
