### PR TITLE
E-06376 change pdfcpu to nil bookmark fork fix

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -278,4 +278,4 @@ require (
 	pault.ag/go/piv v0.0.0-20190320181422-d9d61c70919c // indirect
 )
 
-replace github.com/pdfcpu/pdfcpu => github.com/transcom/pdfcpu v0.0.0-20250129175949-885d668e3444
+replace github.com/pdfcpu/pdfcpu => github.com/transcom/pdfcpu v0.0.0-20250130134615-83d2d75ad4cd

--- a/go.sum
+++ b/go.sum
@@ -629,8 +629,8 @@ github.com/tiaguinho/gosoap v1.4.4 h1:4XZlaqf/y2UAbCPFGcZS4uLKrEvnMr+5pccIyQAUVg
 github.com/tiaguinho/gosoap v1.4.4/go.mod h1:4vv86Jl19UkOeoJW/aawihXYNJ/Iy2NHkhgmBUJ2Ibk=
 github.com/toqueteos/webbrowser v1.2.0 h1:tVP/gpK69Fx+qMJKsLE7TD8LuGWPnEV71wBN9rrstGQ=
 github.com/toqueteos/webbrowser v1.2.0/go.mod h1:XWoZq4cyp9WeUeak7w7LXRUQf1F1ATJMir8RTqb4ayM=
-github.com/transcom/pdfcpu v0.0.0-20250129175949-885d668e3444 h1:cTX3oGavemLfOwik9iPsbVAPFu+FvOb70zX0I2HdXyA=
-github.com/transcom/pdfcpu v0.0.0-20250129175949-885d668e3444/go.mod h1:8EAma3IBIS7ssMiPlcNIPWwISTuP31WToXfGvc327vI=
+github.com/transcom/pdfcpu v0.0.0-20250130134615-83d2d75ad4cd h1:S7LmrtJ4oAMZxseXCDrB/Iu6qLx+JwPvEJO1AY+sThE=
+github.com/transcom/pdfcpu v0.0.0-20250130134615-83d2d75ad4cd/go.mod h1:8EAma3IBIS7ssMiPlcNIPWwISTuP31WToXfGvc327vI=
 github.com/urfave/cli v1.22.10 h1:p8Fspmz3iTctJstry1PYS3HVdllxnEzTEsgIgtxTrCk=
 github.com/urfave/cli v1.22.10/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
 github.com/vektra/mockery/v2 v2.45.1 h1:6HpdnKiLCjVtzlRLQPUNIM0u7yrvAoZ7VWF1TltJvTM=


### PR DESCRIPTION
## [E-06376](https://www13.v1host.com/USTRANSCOM38/assetdetail.v1?number=E-06376)

## Summary

Bookmarks didn't have nil checking, I made them have nil checking. Updated fork to have the fix

See the commit [here](https://github.com/transcom/pdfcpu/commit/83d2d75ad4cdf8d2194588c37b095be858daf0f3)

## How to test
Alright, if you want to. Here's the meat and potatoes..
1. Make sure you have pdfcpu installed via brew. `which pdfcpu`
2. If you do, great next step. If you don't, `brew install pdfcpu`
3. Clone the fork to your projects `git clone git@github.com:transcom/pdfcpu.git`
4. `cd` into the transcom fork
5. Build the binary `go build -o transcomPdfcpu ./cmd/pdfcpu`
6. Make the binary executable `chmod +x transcomPdfcpu`
7. Download the 2 files below
8. Run this to break it
9. `pdfcpu merge -m create output.pdf outlines-with-loop.pdf sample.pdf`
10. If that didn't break let me know
11. Run this to not break it and see that the fix works
12. `transcomPdfcpu merge -m create output.pdf outlines-with-loop.pdf sample.pdf`

### Files
[outlines-with-loop.pdf](https://github.com/user-attachments/files/18604589/outlines-with-loop.pdf)
[sample.pdf](https://github.com/user-attachments/files/18604590/sample.pdf)
