### PR TITLE
Expanded query for finding an existing existing office user, added test

### DIFF
--- a/pkg/services/office_user/office_user_creator.go
+++ b/pkg/services/office_user/office_user_creator.go
@@ -171,8 +171,8 @@ func (o *officeUserCreator) checkAndUpdateRejectedOfficeUser(
 
 	// checking if the office user currently exists and has a previous status of rejected
 	var requestedOfficeUser models.OfficeUser
-	previouslyRejectedCheck := query.NewQueryFilter("email", "=", officeUser.Email)
-	fetchErr := o.builder.FetchOne(appCtx, &requestedOfficeUser, []services.QueryFilter{previouslyRejectedCheck})
+
+	fetchErr := appCtx.DB().Where("(status = 'REJECTED' and edipi = (?)) or email = (?)", officeUser.EDIPI, officeUser.Email).First(&requestedOfficeUser)
 	if fetchErr != nil && fetchErr != sql.ErrNoRows {
 		return nil, nil, fetchErr // Return the actual error if it's not a "no rows" error
 	} else if fetchErr == sql.ErrNoRows {


### PR DESCRIPTION
## [B-22271](https://www13.v1host.com/USTRANSCOM38/assetdetail.v1?number=B-22271)

## Summary

Expanded the query to check if rejected user account request already exists.

### How to test

1. On http://officelocal:3000 click request account, and fill out the form, but note down the information used for later
2. In http://adminlocal:3000, log in, under RequestedOfficeUsers, find the user account request you've created, and reject the request. Put anything for reason.
3. On officelocal create a new account request using the same info as before, except change the email used (like add a 2 or something easy to find)
4. Re-submit the request, there should be no error submitting this request.
5. On adminlocal, go back to RequestedOfficeUsers, and verify that the info submitted in the latest request matches the info in the new request.