### PR TITLE
Disable loadtest flipt backup env var int

### DIFF
--- a/config/env/loadtest.app-client-tls.env
+++ b/config/env/loadtest.app-client-tls.env
@@ -9,7 +9,6 @@ DEVLOCAL_AUTH=false
 DOD_CA_PACKAGE=/config/tls/api.loadtest.dp3.us.chain.der.p7b
 DTOD_USE_MOCK=true
 EMAIL_BACKEND=ses
-FEATURE_FLAG_SERVER_URL=http://flipt.svc-loadtest.local:8080
 HEALTH_SERVER_ENABLED=true
 HERE_MAPS_GEOCODE_ENDPOINT=https://geocoder.api.here.com/6.2/geocode.json
 HERE_MAPS_ROUTING_ENDPOINT=https://route.api.here.com/routing/7.2/calculateroute.json

--- a/config/env/loadtest.app.env
+++ b/config/env/loadtest.app.env
@@ -10,7 +10,6 @@ DEVLOCAL_AUTH=true
 DOD_CA_PACKAGE=/config/tls/api.loadtest.dp3.us.chain.der.p7b
 DTOD_USE_MOCK=false
 EMAIL_BACKEND=ses
-FEATURE_FLAG_SERVER_URL=http://flipt.svc-loadtest.local:8080
 HEALTH_SERVER_ENABLED=true
 HERE_MAPS_GEOCODE_ENDPOINT=https://geocoder.api.here.com/6.2/geocode.json
 HERE_MAPS_ROUTING_ENDPOINT=https://route.api.here.com/routing/7.2/calculateroute.json


### PR DESCRIPTION
Prevent Flipt server from getting its URL from the env var if the param store doesn't have it.

This is needed because we need to enable the env var fetcher in loadtest because Flipt is down. The app chooses whether to use env var vs flipt fetcher based on if the URL is defined, not if the server is up.