### PR TITLE
set pdfcpu fork to relaxed outline validation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -280,4 +280,4 @@ require (
 	pault.ag/go/piv v0.0.0-20190320181422-d9d61c70919c // indirect
 )
 
-replace github.com/pdfcpu/pdfcpu => github.com/transcom/pdfcpu v0.0.0-20250131173611-4b416bd62126
+replace github.com/pdfcpu/pdfcpu => github.com/transcom/pdfcpu v0.0.0-20250204205540-1a00605a1039

--- a/go.sum
+++ b/go.sum
@@ -633,8 +633,8 @@ github.com/tiaguinho/gosoap v1.4.4 h1:4XZlaqf/y2UAbCPFGcZS4uLKrEvnMr+5pccIyQAUVg
 github.com/tiaguinho/gosoap v1.4.4/go.mod h1:4vv86Jl19UkOeoJW/aawihXYNJ/Iy2NHkhgmBUJ2Ibk=
 github.com/toqueteos/webbrowser v1.2.0 h1:tVP/gpK69Fx+qMJKsLE7TD8LuGWPnEV71wBN9rrstGQ=
 github.com/toqueteos/webbrowser v1.2.0/go.mod h1:XWoZq4cyp9WeUeak7w7LXRUQf1F1ATJMir8RTqb4ayM=
-github.com/transcom/pdfcpu v0.0.0-20250131173611-4b416bd62126 h1:XbLtbZvPTc5bY6DuXF2ZHPLPmE3GVe3T/o8PzfmITCA=
-github.com/transcom/pdfcpu v0.0.0-20250131173611-4b416bd62126/go.mod h1:8EAma3IBIS7ssMiPlcNIPWwISTuP31WToXfGvc327vI=
+github.com/transcom/pdfcpu v0.0.0-20250204205540-1a00605a1039 h1:3D+dYz0iOcIcHF1+Q25B1TO53iBWHWtJQedY6mfXN1A=
+github.com/transcom/pdfcpu v0.0.0-20250204205540-1a00605a1039/go.mod h1:8EAma3IBIS7ssMiPlcNIPWwISTuP31WToXfGvc327vI=
 github.com/urfave/cli v1.22.10 h1:p8Fspmz3iTctJstry1PYS3HVdllxnEzTEsgIgtxTrCk=
 github.com/urfave/cli v1.22.10/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
 github.com/vektra/mockery/v2 v2.45.1 h1:6HpdnKiLCjVtzlRLQPUNIM0u7yrvAoZ7VWF1TltJvTM=


### PR DESCRIPTION
### Ticket?
No ticket, this is just a discovered problem

### Code changes?
Here, this commit in the fork https://github.com/transcom/pdfcpu/commit/1a00605a10398aba023555e11d26a15337be3579

## Summary
We apparently have some PDFs floating around that violate the "Outlines" PDF dictionary requirement. I set the fork to relax this validation as it does not negatively impact the file itself. It is the fault of the PDF writer of whoever made the faulty PDF, but since it still works when opening and such, we'll relax the validation. This is similar to the issue reported here https://github.com/pdfcpu/pdfcpu/issues/1089

## How to test
1. Make a PPM as a new customer
2. Upload this attachment as your orders [Testing Document.pdf](https://github.com/user-attachments/files/18663459/Testing.Document.pdf)
3. Proceed through the flow until you are told as the customer to upload PPM docs (weight tickets)
4. Upload this attachment as your EMPTY WEIGHT TICKET, yes the order matters [sample (1).pdf](https://github.com/user-attachments/files/18663461/sample.1.pdf)
5. Upload this attachment as your FULL WEIGHT TICKET, yes the order matters [outlines-with-loop (1).pdf](https://github.com/user-attachments/files/18663460/outlines-with-loop.1.pdf)
6. Finish the PPM closeout and then download your payment packet. It should NOT error 😃 
7. Want to break it? Do the steps above but in a different branch


