### PR TITLE
INT B-21982

### DIFF
--- a/migrations/app/migrations_manifest.txt
+++ b/migrations/app/migrations_manifest.txt
@@ -1089,3 +1089,4 @@
 20250121153007_update_pricing_proc_to_handle_international_shuttle.up.sql
 20250121184450_upd_duty_loc_B-22242.up.sql
 20250123210535_update_re_intl_transit_times_for_ak_hhg.up.sql
+20250206173204_add_hawaii_data.up.sql

--- a/migrations/app/schema/20250206173204_add_hawaii_data.up.sql
+++ b/migrations/app/schema/20250206173204_add_hawaii_data.up.sql
@@ -1,0 +1,364 @@
+-- insert Hawaii rate areas
+INSERT INTO re_oconus_rate_areas (id,rate_area_id,country_id,us_post_region_cities_id, created_at,updated_at,active) VALUES
+	 ('f041907c-080c-4e27-886f-4af7a2b8c559','71755cc7-0844-4523-a0ac-da9a1e743ad1'::uuid,'791899e6-cd77-46f2-981b-176ecb8d7098'::uuid,'6e3f3e59-adf9-404d-9a27-5c556593f02d'::uuid,now(),now(),true),
+	 ('49bff3e2-d795-4fb2-8061-6f7f7dc871f3','71755cc7-0844-4523-a0ac-da9a1e743ad1'::uuid,'791899e6-cd77-46f2-981b-176ecb8d7098'::uuid,'64b913ec-97f7-403d-b3de-b52da877947b'::uuid,now(),now(),true),
+	 ('e3ff1ee1-2d39-4fac-9bb4-b5355030ba99','71755cc7-0844-4523-a0ac-da9a1e743ad1'::uuid,'791899e6-cd77-46f2-981b-176ecb8d7098'::uuid,'3c7bc566-7627-474a-a7e2-8b61c00383c1'::uuid,now(),now(),true),
+	 ('a25de140-fac9-4303-9d83-769ed4205668','71755cc7-0844-4523-a0ac-da9a1e743ad1'::uuid,'791899e6-cd77-46f2-981b-176ecb8d7098'::uuid,'93d86d63-1f55-4ed8-8db0-6f19e5f6599b'::uuid,now(),now(),true),
+	 ('b68a62a1-69e0-4a15-bcbf-8d31c4464fbd','71755cc7-0844-4523-a0ac-da9a1e743ad1'::uuid,'791899e6-cd77-46f2-981b-176ecb8d7098'::uuid,'4ddb8033-4877-4e88-9e84-606e23b7131e'::uuid,now(),now(),true),
+	 ('35387756-cea0-402b-a95c-be54e0094496','71755cc7-0844-4523-a0ac-da9a1e743ad1'::uuid,'791899e6-cd77-46f2-981b-176ecb8d7098'::uuid,'30d784ec-eded-4883-855c-2000d630774e'::uuid,now(),now(),true),
+	 ('ff0167d9-ef93-43c8-9495-ba5bed8a0f69','71755cc7-0844-4523-a0ac-da9a1e743ad1'::uuid,'791899e6-cd77-46f2-981b-176ecb8d7098'::uuid,'563b5084-b7bc-4b37-8406-8c2dbf09cec4'::uuid,now(),now(),true),
+	 ('956270a4-f850-4d94-b361-54d7104c381e','71755cc7-0844-4523-a0ac-da9a1e743ad1'::uuid,'791899e6-cd77-46f2-981b-176ecb8d7098'::uuid,'e82091dd-f4d5-40dc-ac78-73ce3dbba151'::uuid,now(),now(),true),
+	 ('02c23633-7ee1-443a-9ecf-a1e422a28e6c','71755cc7-0844-4523-a0ac-da9a1e743ad1'::uuid,'791899e6-cd77-46f2-981b-176ecb8d7098'::uuid,'0556a422-ebdf-4041-906f-eebb3679b5af'::uuid,now(),now(),true),
+	 ('3e45d573-1df1-4d43-a5f0-45844bff3185','71755cc7-0844-4523-a0ac-da9a1e743ad1'::uuid,'791899e6-cd77-46f2-981b-176ecb8d7098'::uuid,'99cbe9bd-4b8e-4ef9-ada1-a9b3b41d38f8'::uuid,now(),now(),true);
+INSERT INTO re_oconus_rate_areas (id,rate_area_id,country_id,us_post_region_cities_id, created_at,updated_at,active) VALUES
+	 ('6c26fd7c-44f5-40cf-ac88-e3202c752884','71755cc7-0844-4523-a0ac-da9a1e743ad1'::uuid,'791899e6-cd77-46f2-981b-176ecb8d7098'::uuid,'84e4594d-b21e-4b40-9ed0-37d6d332f55b'::uuid,now(),now(),true),
+	 ('a52e2e8c-6251-4a94-9f3d-ecf8d18d097f','71755cc7-0844-4523-a0ac-da9a1e743ad1'::uuid,'791899e6-cd77-46f2-981b-176ecb8d7098'::uuid,'d87f4b53-70dd-432b-996d-6b4de56cd579'::uuid,now(),now(),true),
+	 ('49f630f7-de16-40be-b15a-aa8eee7a0a09','71755cc7-0844-4523-a0ac-da9a1e743ad1'::uuid,'791899e6-cd77-46f2-981b-176ecb8d7098'::uuid,'6d4680f2-bd63-4af9-9abf-b5d4f5682423'::uuid,now(),now(),true),
+	 ('8e854111-4805-46c6-92a2-aa7673a94b41','71755cc7-0844-4523-a0ac-da9a1e743ad1'::uuid,'791899e6-cd77-46f2-981b-176ecb8d7098'::uuid,'e7c8daed-ad79-4c28-aa7f-7f348df929c7'::uuid,now(),now(),true),
+	 ('9a41d67f-10b2-48d8-8e3c-2f20d6744dc2','71755cc7-0844-4523-a0ac-da9a1e743ad1'::uuid,'791899e6-cd77-46f2-981b-176ecb8d7098'::uuid,'1719c3b4-e99f-4ac4-a5d0-2126aab7cd8c'::uuid,now(),now(),true),
+	 ('76a161e0-40ee-4e6c-8138-8c78cefc0b73','71755cc7-0844-4523-a0ac-da9a1e743ad1'::uuid,'791899e6-cd77-46f2-981b-176ecb8d7098'::uuid,'e40bea96-389c-44f9-8ab4-407208ca7828'::uuid,now(),now(),true),
+	 ('4e0ef4d5-124a-4f20-b2a4-f6d0d31bf8eb','71755cc7-0844-4523-a0ac-da9a1e743ad1'::uuid,'791899e6-cd77-46f2-981b-176ecb8d7098'::uuid,'9a297e12-fb3e-4454-b689-74fa82638c08'::uuid,now(),now(),true),
+	 ('ed1aa4d4-99fd-4a2a-b757-c9d06e04484b','71755cc7-0844-4523-a0ac-da9a1e743ad1'::uuid,'791899e6-cd77-46f2-981b-176ecb8d7098'::uuid,'4c7443d1-25db-42db-99a7-cc08873e288b'::uuid,now(),now(),true),
+	 ('7ff933f8-cede-4bf0-a918-2403d6b902a5','71755cc7-0844-4523-a0ac-da9a1e743ad1'::uuid,'791899e6-cd77-46f2-981b-176ecb8d7098'::uuid,'4e312da4-f0db-4dec-ab96-6bc6531f3ce6'::uuid,now(),now(),true),
+	 ('bdf97313-d164-4d9b-bec3-9aff052fa094','71755cc7-0844-4523-a0ac-da9a1e743ad1'::uuid,'791899e6-cd77-46f2-981b-176ecb8d7098'::uuid,'5ca476cf-16f7-4ffa-b339-cfb0eff9f21d'::uuid,now(),now(),true);
+INSERT INTO re_oconus_rate_areas (id,rate_area_id,country_id,us_post_region_cities_id, created_at,updated_at,active) VALUES
+	 ('d6d7872d-1751-44d0-86e1-217e7e129afe','71755cc7-0844-4523-a0ac-da9a1e743ad1'::uuid,'791899e6-cd77-46f2-981b-176ecb8d7098'::uuid,'de3d79a4-bb38-400d-b478-0fb5389fa6b5'::uuid,now(),now(),true),
+	 ('1100147f-9baf-4a12-879e-dd40aadf073b','71755cc7-0844-4523-a0ac-da9a1e743ad1'::uuid,'791899e6-cd77-46f2-981b-176ecb8d7098'::uuid,'91a847de-4602-42ff-8602-e6ba64fbe06f'::uuid,now(),now(),true),
+	 ('c0abc8fa-f8c6-48e5-a49f-cc5714f6f509','71755cc7-0844-4523-a0ac-da9a1e743ad1'::uuid,'791899e6-cd77-46f2-981b-176ecb8d7098'::uuid,'fc58a7c3-81ed-4362-b18b-2a3a798db953'::uuid,now(),now(),true),
+	 ('9ba33b41-15de-4743-b8f8-75367d0126e7','71755cc7-0844-4523-a0ac-da9a1e743ad1'::uuid,'791899e6-cd77-46f2-981b-176ecb8d7098'::uuid,'4f7347b7-441a-493d-bc70-ea421589c374'::uuid,now(),now(),true),
+	 ('3188e86d-944a-42c1-b3b5-3bf7e360fb71','71755cc7-0844-4523-a0ac-da9a1e743ad1'::uuid,'791899e6-cd77-46f2-981b-176ecb8d7098'::uuid,'1bd23977-93cc-4441-bb3d-5e46deb33be4'::uuid,now(),now(),true),
+	 ('fc281a01-a7cd-41a0-86d9-716ab4864c08','71755cc7-0844-4523-a0ac-da9a1e743ad1'::uuid,'791899e6-cd77-46f2-981b-176ecb8d7098'::uuid,'4b9ea4cb-5feb-4226-851e-086418dfe224'::uuid,now(),now(),true),
+	 ('fb6d3db2-4079-48fe-9a67-170e200c9a8d','71755cc7-0844-4523-a0ac-da9a1e743ad1'::uuid,'791899e6-cd77-46f2-981b-176ecb8d7098'::uuid,'640de451-a487-4d24-9c8b-6405f1431a38'::uuid,now(),now(),true),
+	 ('3bb35faa-229f-4721-82a2-becc9c98ae04','71755cc7-0844-4523-a0ac-da9a1e743ad1'::uuid,'791899e6-cd77-46f2-981b-176ecb8d7098'::uuid,'97508ed1-fde5-422c-b5ca-f7350bac5b72'::uuid,now(),now(),true),
+	 ('313905e6-f237-4e1d-ab01-be6dfdddfa92','71755cc7-0844-4523-a0ac-da9a1e743ad1'::uuid,'791899e6-cd77-46f2-981b-176ecb8d7098'::uuid,'0d09ac18-0ee4-4905-879f-8b2d6b5112f7'::uuid,now(),now(),true),
+	 ('0ed0a302-5016-4ccd-a6ba-5b28258af8dc','71755cc7-0844-4523-a0ac-da9a1e743ad1'::uuid,'791899e6-cd77-46f2-981b-176ecb8d7098'::uuid,'24baeda8-d21b-437f-bd43-8da4d6241011'::uuid,now(),now(),true);
+INSERT INTO re_oconus_rate_areas (id,rate_area_id,country_id,us_post_region_cities_id, created_at,updated_at,active) VALUES
+	 ('846616d3-34e1-4304-b778-3bf8b3052c32','71755cc7-0844-4523-a0ac-da9a1e743ad1'::uuid,'791899e6-cd77-46f2-981b-176ecb8d7098'::uuid,'affb1936-8b01-41e5-bb7d-558476520092'::uuid,now(),now(),true),
+	 ('f3b6f9da-4bfd-4ac5-a9e2-b4973adf372c','71755cc7-0844-4523-a0ac-da9a1e743ad1'::uuid,'791899e6-cd77-46f2-981b-176ecb8d7098'::uuid,'87a96b8b-cc4b-416c-a0ab-f31868e90796'::uuid,now(),now(),true),
+	 ('b42c8d98-71b3-464f-b868-6ab743ad7d3a','71755cc7-0844-4523-a0ac-da9a1e743ad1'::uuid,'791899e6-cd77-46f2-981b-176ecb8d7098'::uuid,'6779b457-5e01-40bd-a584-76602c234bf0'::uuid,now(),now(),true),
+	 ('41e52c48-4b52-4498-b898-22af6fcd5452','71755cc7-0844-4523-a0ac-da9a1e743ad1'::uuid,'791899e6-cd77-46f2-981b-176ecb8d7098'::uuid,'74792dae-6e22-4dc2-8185-6fc56fad958c'::uuid,now(),now(),true),
+	 ('036d9855-ae02-4836-9405-f332d3654838','71755cc7-0844-4523-a0ac-da9a1e743ad1'::uuid,'791899e6-cd77-46f2-981b-176ecb8d7098'::uuid,'9b8e278b-6a25-4bdf-831a-cea032d0f647'::uuid,now(),now(),true),
+	 ('5bad5f3a-861a-448d-8747-66bfc77b9859','71755cc7-0844-4523-a0ac-da9a1e743ad1'::uuid,'791899e6-cd77-46f2-981b-176ecb8d7098'::uuid,'f9dfe9b6-fe0e-405a-b88f-4e085a940843'::uuid,now(),now(),true),
+	 ('c7132b2f-8e28-4ee3-af04-d6137f14944a','71755cc7-0844-4523-a0ac-da9a1e743ad1'::uuid,'791899e6-cd77-46f2-981b-176ecb8d7098'::uuid,'274a633f-5cd7-4429-accb-56e77c0b9ac2'::uuid,now(),now(),true),
+	 ('05775275-180d-4562-8cd5-9b20403e0824','71755cc7-0844-4523-a0ac-da9a1e743ad1'::uuid,'791899e6-cd77-46f2-981b-176ecb8d7098'::uuid,'cb071d07-649b-422e-99d4-a52ba1dbdccf'::uuid,now(),now(),true),
+	 ('5c8029b9-85c3-452b-95cf-00d3d66bda7a','71755cc7-0844-4523-a0ac-da9a1e743ad1'::uuid,'791899e6-cd77-46f2-981b-176ecb8d7098'::uuid,'f0a8fb3b-7e36-43bc-9c23-488ea507c42b'::uuid,now(),now(),true),
+	 ('b08f70e8-702b-454a-bc58-b0b10e1b603e','71755cc7-0844-4523-a0ac-da9a1e743ad1'::uuid,'791899e6-cd77-46f2-981b-176ecb8d7098'::uuid,'8e667d68-60dc-4b13-87b5-0e7d4ac6b71b'::uuid,now(),now(),true);
+INSERT INTO re_oconus_rate_areas (id,rate_area_id,country_id,us_post_region_cities_id, created_at,updated_at,active) VALUES
+	 ('20b866a6-d146-439b-b87b-d22412cda747','71755cc7-0844-4523-a0ac-da9a1e743ad1'::uuid,'791899e6-cd77-46f2-981b-176ecb8d7098'::uuid,'1e3fd71e-0ac7-4fe3-9cf3-3d040473a10b'::uuid,now(),now(),true),
+	 ('5dde8586-790a-40d6-9a46-e6cd725d1d5e','71755cc7-0844-4523-a0ac-da9a1e743ad1'::uuid,'791899e6-cd77-46f2-981b-176ecb8d7098'::uuid,'d64af573-bfcb-4c39-bc32-c89632c26913'::uuid,now(),now(),true),
+	 ('fedaa7ae-99a0-4981-9a07-835c0d094e1c','71755cc7-0844-4523-a0ac-da9a1e743ad1'::uuid,'791899e6-cd77-46f2-981b-176ecb8d7098'::uuid,'712527f7-731f-4421-9b1c-9c58a64654b0'::uuid,now(),now(),true),
+	 ('73bf3243-c29b-4b4e-9341-5aaf99616e56','71755cc7-0844-4523-a0ac-da9a1e743ad1'::uuid,'791899e6-cd77-46f2-981b-176ecb8d7098'::uuid,'8f87c288-1ed2-4bd5-a397-607585e22768'::uuid,now(),now(),true),
+	 ('3c6ab532-1a18-4f78-9b95-deb1905d2d34','71755cc7-0844-4523-a0ac-da9a1e743ad1'::uuid,'791899e6-cd77-46f2-981b-176ecb8d7098'::uuid,'70934bce-e2fe-47d9-bb99-55f1e3c4fc00'::uuid,now(),now(),true),
+	 ('af3a2ad4-585b-4947-bb40-3ae575013ed5','71755cc7-0844-4523-a0ac-da9a1e743ad1'::uuid,'791899e6-cd77-46f2-981b-176ecb8d7098'::uuid,'fa790c20-9da9-45f5-af4c-11438f4fb735'::uuid,now(),now(),true),
+	 ('01e44612-45b9-4964-9de9-843e7a3c0044','71755cc7-0844-4523-a0ac-da9a1e743ad1'::uuid,'791899e6-cd77-46f2-981b-176ecb8d7098'::uuid,'e169dc8c-bb76-4290-9282-3aa4189c8970'::uuid,now(),now(),true),
+	 ('6a0ce7ea-2daa-4f06-95bf-3c6222c5a8b3','71755cc7-0844-4523-a0ac-da9a1e743ad1'::uuid,'791899e6-cd77-46f2-981b-176ecb8d7098'::uuid,'af62f613-8e38-4178-9e79-020136b1fe76'::uuid,now(),now(),true),
+	 ('e164aac9-e9aa-4831-8ef1-98660215705b','71755cc7-0844-4523-a0ac-da9a1e743ad1'::uuid,'791899e6-cd77-46f2-981b-176ecb8d7098'::uuid,'481ec192-416e-49f0-ba7b-f565d5986eb3'::uuid,now(),now(),true),
+	 ('670a550c-7243-4318-b8d4-e4efcfa32539','71755cc7-0844-4523-a0ac-da9a1e743ad1'::uuid,'791899e6-cd77-46f2-981b-176ecb8d7098'::uuid,'5a821f96-fb5d-48dc-8eeb-642d3ed6f3ef'::uuid,now(),now(),true);
+INSERT INTO re_oconus_rate_areas (id,rate_area_id,country_id,us_post_region_cities_id, created_at,updated_at,active) VALUES
+	 ('e25c2146-7ade-4552-a66d-d3bc948f39c0','71755cc7-0844-4523-a0ac-da9a1e743ad1'::uuid,'791899e6-cd77-46f2-981b-176ecb8d7098'::uuid,'87048c04-81cb-4ef4-a536-2fcff23eee0a'::uuid,now(),now(),true),
+	 ('d32022a5-f00b-461b-8a3b-0c69df06a94f','71755cc7-0844-4523-a0ac-da9a1e743ad1'::uuid,'791899e6-cd77-46f2-981b-176ecb8d7098'::uuid,'7133a5d8-0c5d-429b-b43f-36308a712b72'::uuid,now(),now(),true),
+	 ('66861383-84f0-46c0-9597-c8765152601d','71755cc7-0844-4523-a0ac-da9a1e743ad1'::uuid,'791899e6-cd77-46f2-981b-176ecb8d7098'::uuid,'64fbd65a-c742-48f0-9342-b5e1340cffb6'::uuid,now(),now(),true),
+	 ('9b52d7a7-8ebe-4cef-a49d-2e03eb87878c','71755cc7-0844-4523-a0ac-da9a1e743ad1'::uuid,'791899e6-cd77-46f2-981b-176ecb8d7098'::uuid,'07a388d8-2a3d-43fe-baa6-91282a179617'::uuid,now(),now(),true),
+	 ('05c41080-8f3d-41bc-8350-25c9c50dc8bf','71755cc7-0844-4523-a0ac-da9a1e743ad1'::uuid,'791899e6-cd77-46f2-981b-176ecb8d7098'::uuid,'9f70610f-4a16-4636-ac8d-1a068075ef30'::uuid,now(),now(),true),
+	 ('97b37859-0f6c-48ff-bec0-403cca95712f','71755cc7-0844-4523-a0ac-da9a1e743ad1'::uuid,'791899e6-cd77-46f2-981b-176ecb8d7098'::uuid,'7b121c37-3133-4daa-af24-26ad005b15d8'::uuid,now(),now(),true),
+	 ('f0ae37b7-bcc1-4107-bdc7-43d21605d0c6','71755cc7-0844-4523-a0ac-da9a1e743ad1'::uuid,'791899e6-cd77-46f2-981b-176ecb8d7098'::uuid,'d12a6235-1399-453e-afd3-00fd9cf7faff'::uuid,now(),now(),true),
+	 ('de8e5560-246b-45bb-a1df-0e9a0f0ab7ad','71755cc7-0844-4523-a0ac-da9a1e743ad1'::uuid,'791899e6-cd77-46f2-981b-176ecb8d7098'::uuid,'d6448f66-ae16-4ab3-af2a-7988e65c2c45'::uuid,now(),now(),true),
+	 ('de85bbee-084e-42d2-ab68-677a927edb2a','71755cc7-0844-4523-a0ac-da9a1e743ad1'::uuid,'791899e6-cd77-46f2-981b-176ecb8d7098'::uuid,'8cab537e-1a01-49dc-9b44-c1dbe2226047'::uuid,now(),now(),true),
+	 ('733e38ca-86e1-454f-87a4-884f8b17df21','71755cc7-0844-4523-a0ac-da9a1e743ad1'::uuid,'791899e6-cd77-46f2-981b-176ecb8d7098'::uuid,'2929ef2d-4373-4880-8017-85e8863afa04'::uuid,now(),now(),true);
+INSERT INTO re_oconus_rate_areas (id,rate_area_id,country_id,us_post_region_cities_id, created_at,updated_at,active) VALUES
+	 ('8b2f2560-f26c-43d9-98ca-322a3e73b0bb','71755cc7-0844-4523-a0ac-da9a1e743ad1'::uuid,'791899e6-cd77-46f2-981b-176ecb8d7098'::uuid,'a62608f7-f9e0-4272-a051-4bd7014f9484'::uuid,now(),now(),true),
+	 ('f5b7df58-dd68-4d24-8f7a-907895dbb151','71755cc7-0844-4523-a0ac-da9a1e743ad1'::uuid,'791899e6-cd77-46f2-981b-176ecb8d7098'::uuid,'ca858eba-ed95-4478-8ea2-ed5c99b75259'::uuid,now(),now(),true),
+	 ('d7843a4e-0c70-466b-b01d-5909b1f62c11','71755cc7-0844-4523-a0ac-da9a1e743ad1'::uuid,'791899e6-cd77-46f2-981b-176ecb8d7098'::uuid,'462d1ef8-0d79-4e0b-b09c-ff349796c6b8'::uuid,now(),now(),true),
+	 ('8d211696-7337-4c65-be73-9a88049476e4','71755cc7-0844-4523-a0ac-da9a1e743ad1'::uuid,'791899e6-cd77-46f2-981b-176ecb8d7098'::uuid,'cdb689fd-8000-4445-adb4-70c0941fe601'::uuid,now(),now(),true),
+	 ('3821b597-e99a-432d-afa0-1aa74b802b94','71755cc7-0844-4523-a0ac-da9a1e743ad1'::uuid,'791899e6-cd77-46f2-981b-176ecb8d7098'::uuid,'10d1be45-6fdf-43a3-bfd3-930e493ff8fd'::uuid,now(),now(),true),
+	 ('5918a6de-11ae-43f1-ba68-23cd71da6e7b','71755cc7-0844-4523-a0ac-da9a1e743ad1'::uuid,'791899e6-cd77-46f2-981b-176ecb8d7098'::uuid,'0b5abf65-b844-4b1e-88cf-17c7469bb2a0'::uuid,now(),now(),true),
+	 ('76e8e46c-ab0d-4c67-95b6-d00185dd2832','71755cc7-0844-4523-a0ac-da9a1e743ad1'::uuid,'791899e6-cd77-46f2-981b-176ecb8d7098'::uuid,'9689a42b-27ad-4c44-88ee-af317acaee70'::uuid,now(),now(),true),
+	 ('7b33ae55-5463-4b57-97e6-a7443a1e0904','71755cc7-0844-4523-a0ac-da9a1e743ad1'::uuid,'791899e6-cd77-46f2-981b-176ecb8d7098'::uuid,'fa0344ac-7814-4c97-b22e-68721c0686a9'::uuid,now(),now(),true),
+	 ('766fcf2c-9145-4f79-b502-d0ffaf96ef17','71755cc7-0844-4523-a0ac-da9a1e743ad1'::uuid,'791899e6-cd77-46f2-981b-176ecb8d7098'::uuid,'b28b69f2-3139-434a-8647-5ecb68b52d62'::uuid,now(),now(),true),
+	 ('e1e1bf33-bd47-4ac7-9128-1f5c02d0db7e','71755cc7-0844-4523-a0ac-da9a1e743ad1'::uuid,'791899e6-cd77-46f2-981b-176ecb8d7098'::uuid,'fbb7608d-d1a2-4928-a57d-8fca190b1d05'::uuid,now(),now(),true);
+INSERT INTO re_oconus_rate_areas (id,rate_area_id,country_id,us_post_region_cities_id, created_at,updated_at,active) VALUES
+	 ('8df33232-52a9-480f-afb8-df27cd099bd2','71755cc7-0844-4523-a0ac-da9a1e743ad1'::uuid,'791899e6-cd77-46f2-981b-176ecb8d7098'::uuid,'28e21fa2-10e5-421d-a744-f9a7941f5fe3'::uuid,now(),now(),true),
+	 ('8415fff3-ccac-4ae8-82ac-e54f04ca4082','71755cc7-0844-4523-a0ac-da9a1e743ad1'::uuid,'791899e6-cd77-46f2-981b-176ecb8d7098'::uuid,'1eb608e7-fd23-4d17-9731-6a48b69fd886'::uuid,now(),now(),true),
+	 ('9d2ef3a3-9e55-4797-9b58-35429c3849a8','71755cc7-0844-4523-a0ac-da9a1e743ad1'::uuid,'791899e6-cd77-46f2-981b-176ecb8d7098'::uuid,'5279030c-7331-4466-8d81-8ff94420a0cd'::uuid,now(),now(),true),
+	 ('3e99cabc-75cd-4152-b519-cddfbd4294aa','71755cc7-0844-4523-a0ac-da9a1e743ad1'::uuid,'791899e6-cd77-46f2-981b-176ecb8d7098'::uuid,'61e3f4b5-66e1-449d-aab2-6a91a715cd01'::uuid,now(),now(),true),
+	 ('616c1ea1-ac8f-4ccf-a28d-80078015ba0e','71755cc7-0844-4523-a0ac-da9a1e743ad1'::uuid,'791899e6-cd77-46f2-981b-176ecb8d7098'::uuid,'5ae811db-96b7-48c8-954e-d0252872668e'::uuid,now(),now(),true),
+	 ('e33e15dd-d3aa-480d-a70c-8de943b1dccc','71755cc7-0844-4523-a0ac-da9a1e743ad1'::uuid,'791899e6-cd77-46f2-981b-176ecb8d7098'::uuid,'5d3cb00b-2b90-47d1-b841-01ef70d334d6'::uuid,now(),now(),true),
+	 ('1bdbc429-b5d6-4483-821e-a31839e63ad2','71755cc7-0844-4523-a0ac-da9a1e743ad1'::uuid,'791899e6-cd77-46f2-981b-176ecb8d7098'::uuid,'3829f26e-b286-4205-9f94-106d461425c9'::uuid,now(),now(),true),
+	 ('0d327bc0-5315-44d1-848c-1f02667a81db','71755cc7-0844-4523-a0ac-da9a1e743ad1'::uuid,'791899e6-cd77-46f2-981b-176ecb8d7098'::uuid,'83f0986d-0f31-4870-8d43-d00d58f45aff'::uuid,now(),now(),true),
+	 ('7088fd82-8a7f-47c3-a80b-b5255a795f6b','71755cc7-0844-4523-a0ac-da9a1e743ad1'::uuid,'791899e6-cd77-46f2-981b-176ecb8d7098'::uuid,'848b1555-6920-4aa8-b44d-8fc4f08ab7a0'::uuid,now(),now(),true),
+	 ('54045203-93a8-4011-a9b2-84673cc5176d','71755cc7-0844-4523-a0ac-da9a1e743ad1'::uuid,'791899e6-cd77-46f2-981b-176ecb8d7098'::uuid,'7cea3c34-3f16-44ed-905d-af85ef732efb'::uuid,now(),now(),true);
+INSERT INTO re_oconus_rate_areas (id,rate_area_id,country_id,us_post_region_cities_id, created_at,updated_at,active) VALUES
+	 ('f6b671cf-c344-46ba-bf68-08fcba2ebd84','71755cc7-0844-4523-a0ac-da9a1e743ad1'::uuid,'791899e6-cd77-46f2-981b-176ecb8d7098'::uuid,'1ffe2a07-0271-4873-a98e-372e4d7ed4c6'::uuid,now(),now(),true),
+	 ('26e71f17-7713-46d9-a059-5e07978b9b50','71755cc7-0844-4523-a0ac-da9a1e743ad1'::uuid,'791899e6-cd77-46f2-981b-176ecb8d7098'::uuid,'6083c976-172c-4024-96b6-d1bd034352e9'::uuid,now(),now(),true),
+	 ('f7c97962-b0f9-4671-b9d8-06c6195bcde0','71755cc7-0844-4523-a0ac-da9a1e743ad1'::uuid,'791899e6-cd77-46f2-981b-176ecb8d7098'::uuid,'cf358ecf-fbc4-41b8-8872-1d8fc7b732d7'::uuid,now(),now(),true),
+	 ('20e947f3-a7d1-423c-ae79-9886857d5dcc','71755cc7-0844-4523-a0ac-da9a1e743ad1'::uuid,'791899e6-cd77-46f2-981b-176ecb8d7098'::uuid,'253cefff-4e1a-4b20-9d21-05654e30132c'::uuid,now(),now(),true),
+	 ('49e0f65d-1545-424d-b1c9-e5e3d0067fe9','71755cc7-0844-4523-a0ac-da9a1e743ad1'::uuid,'791899e6-cd77-46f2-981b-176ecb8d7098'::uuid,'fa9bae80-8d1a-443a-902a-2e527a0d00ce'::uuid,now(),now(),true),
+	 ('9f0d1cb8-4a5d-42f4-8766-c3ad7f029084','71755cc7-0844-4523-a0ac-da9a1e743ad1'::uuid,'791899e6-cd77-46f2-981b-176ecb8d7098'::uuid,'fd3c4223-7dcf-4efc-a80e-5aba50156140'::uuid,now(),now(),true),
+	 ('e4392356-88c7-4841-a415-920aa9cdc7ca','71755cc7-0844-4523-a0ac-da9a1e743ad1'::uuid,'791899e6-cd77-46f2-981b-176ecb8d7098'::uuid,'24d4d08c-7676-4d05-aaf2-16e03a5d764f'::uuid,now(),now(),true),
+	 ('f549cddf-ec33-4772-b259-5e12aa2f66b9','71755cc7-0844-4523-a0ac-da9a1e743ad1'::uuid,'791899e6-cd77-46f2-981b-176ecb8d7098'::uuid,'7f3e06ad-b892-42c5-880e-a70fb9ba7c84'::uuid,now(),now(),true),
+	 ('788cb14b-30e1-447d-95cc-358e29f01d8d','71755cc7-0844-4523-a0ac-da9a1e743ad1'::uuid,'791899e6-cd77-46f2-981b-176ecb8d7098'::uuid,'09e92a39-2407-4a64-891b-ed81f7d61048'::uuid,now(),now(),true),
+	 ('46d6bc67-b8e5-4e11-834e-eaaa62cad46e','71755cc7-0844-4523-a0ac-da9a1e743ad1'::uuid,'791899e6-cd77-46f2-981b-176ecb8d7098'::uuid,'6895d267-67a1-4cde-8d46-e96d2142faf5'::uuid,now(),now(),true);
+INSERT INTO re_oconus_rate_areas (id,rate_area_id,country_id,us_post_region_cities_id, created_at,updated_at,active) VALUES
+	 ('67d1f1ab-782a-452f-a607-ba2e6a9a87aa','71755cc7-0844-4523-a0ac-da9a1e743ad1'::uuid,'791899e6-cd77-46f2-981b-176ecb8d7098'::uuid,'e5c12a89-96fa-4fd5-8448-ffb546c0ad82'::uuid,now(),now(),true),
+	 ('51a17659-2fd7-49c3-9971-8fd1e341fcba','71755cc7-0844-4523-a0ac-da9a1e743ad1'::uuid,'791899e6-cd77-46f2-981b-176ecb8d7098'::uuid,'6b63cd86-8dc5-498e-a541-782789aa6edd'::uuid,now(),now(),true),
+	 ('646aaf79-c655-443d-a02f-81764d2965c0','71755cc7-0844-4523-a0ac-da9a1e743ad1'::uuid,'791899e6-cd77-46f2-981b-176ecb8d7098'::uuid,'48c74f64-68a1-43fc-90e0-d9843d645b65'::uuid,now(),now(),true),
+	 ('ecb1f2a7-525e-490a-8e88-b53a6681aa96','71755cc7-0844-4523-a0ac-da9a1e743ad1'::uuid,'791899e6-cd77-46f2-981b-176ecb8d7098'::uuid,'900cfeee-f5bb-41b3-976f-6a223d230b23'::uuid,now(),now(),true),
+	 ('bf597a56-1728-4325-9734-1138799d6332','71755cc7-0844-4523-a0ac-da9a1e743ad1'::uuid,'791899e6-cd77-46f2-981b-176ecb8d7098'::uuid,'e8283abd-d3bb-4d11-b66c-ea57d001fa7e'::uuid,now(),now(),true),
+	 ('8608f8da-6f62-41ea-8c3d-024c1bcc7daa','71755cc7-0844-4523-a0ac-da9a1e743ad1'::uuid,'791899e6-cd77-46f2-981b-176ecb8d7098'::uuid,'8498acbd-27f2-4095-8a27-b01743bfa6e1'::uuid,now(),now(),true),
+	 ('df227441-2e7f-456f-82c5-b4772c7cc5f6','71755cc7-0844-4523-a0ac-da9a1e743ad1'::uuid,'791899e6-cd77-46f2-981b-176ecb8d7098'::uuid,'d1dd9288-32ce-436f-800a-2f08bd1a9702'::uuid,now(),now(),true),
+	 ('10177e21-4c50-44a6-956b-3eedeac77094','71755cc7-0844-4523-a0ac-da9a1e743ad1'::uuid,'791899e6-cd77-46f2-981b-176ecb8d7098'::uuid,'9c6a995f-5cfc-4bcd-b1fb-bad1b4512fdf'::uuid,now(),now(),true),
+	 ('373f38ab-0a7b-40c9-8cc5-0df01d1d87de','71755cc7-0844-4523-a0ac-da9a1e743ad1'::uuid,'791899e6-cd77-46f2-981b-176ecb8d7098'::uuid,'63b50a6f-a019-492a-84f4-3768f20bd5f2'::uuid,now(),now(),true),
+	 ('14b7aa87-7a4e-4e47-b2e4-fa1ed8cdd2a8','71755cc7-0844-4523-a0ac-da9a1e743ad1'::uuid,'791899e6-cd77-46f2-981b-176ecb8d7098'::uuid,'2f870d5b-0d5a-4ccf-8f11-cab82d5cf1e6'::uuid,now(),now(),true);
+INSERT INTO re_oconus_rate_areas (id,rate_area_id,country_id,us_post_region_cities_id, created_at,updated_at,active) VALUES
+	 ('05b15308-4fbd-4e03-ab59-437b9f37e69a','71755cc7-0844-4523-a0ac-da9a1e743ad1'::uuid,'791899e6-cd77-46f2-981b-176ecb8d7098'::uuid,'f24af83c-8734-48c0-9796-c944a36e137d'::uuid,now(),now(),true),
+	 ('b36bffda-b020-4e49-bb6e-971d17116bde','71755cc7-0844-4523-a0ac-da9a1e743ad1'::uuid,'791899e6-cd77-46f2-981b-176ecb8d7098'::uuid,'384cf248-0a91-47e2-bab3-cdd6c3816843'::uuid,now(),now(),true),
+	 ('89c8ec3e-af9d-4376-9b47-2a68589abcb4','71755cc7-0844-4523-a0ac-da9a1e743ad1'::uuid,'791899e6-cd77-46f2-981b-176ecb8d7098'::uuid,'e7bbfe8c-ed10-4c50-a91b-9bf308f0a92a'::uuid,now(),now(),true),
+	 ('ba61f387-aa0f-434c-aa61-5c15982d4ce4','71755cc7-0844-4523-a0ac-da9a1e743ad1'::uuid,'791899e6-cd77-46f2-981b-176ecb8d7098'::uuid,'592f383e-b566-4b0b-a8e7-cad06a61302f'::uuid,now(),now(),true),
+	 ('09795f49-0694-4cfb-a711-8aa4edc64ef4','71755cc7-0844-4523-a0ac-da9a1e743ad1'::uuid,'791899e6-cd77-46f2-981b-176ecb8d7098'::uuid,'3098d832-1e05-485a-bdc2-75b249940c75'::uuid,now(),now(),true),
+	 ('e54eb89b-88e8-469d-964e-faad60eafdef','71755cc7-0844-4523-a0ac-da9a1e743ad1'::uuid,'791899e6-cd77-46f2-981b-176ecb8d7098'::uuid,'b8204250-497a-4550-b2ac-cfa205acb252'::uuid,now(),now(),true),
+	 ('19e2ad86-e55a-4ba5-bae1-f86e922933e3','71755cc7-0844-4523-a0ac-da9a1e743ad1'::uuid,'791899e6-cd77-46f2-981b-176ecb8d7098'::uuid,'698046a6-9284-4405-9abd-8a987dca3fc5'::uuid,now(),now(),true),
+	 ('d1689b93-68e7-44d5-abd5-c3063bc4e670','71755cc7-0844-4523-a0ac-da9a1e743ad1'::uuid,'791899e6-cd77-46f2-981b-176ecb8d7098'::uuid,'27323f14-a2d8-4953-8bdc-ed68fcb9f5de'::uuid,now(),now(),true),
+	 ('64bd4440-9ee4-4a80-bcbd-5701ab160e73','71755cc7-0844-4523-a0ac-da9a1e743ad1'::uuid,'791899e6-cd77-46f2-981b-176ecb8d7098'::uuid,'b668cee2-78c2-4065-9af0-400793b58262'::uuid,now(),now(),true),
+	 ('00f9ac3e-b9c2-4cf5-af47-6b4799f7333f','71755cc7-0844-4523-a0ac-da9a1e743ad1'::uuid,'791899e6-cd77-46f2-981b-176ecb8d7098'::uuid,'5cee3d06-1fb5-49b4-816f-63fa7b79719e'::uuid,now(),now(),true);
+INSERT INTO re_oconus_rate_areas (id,rate_area_id,country_id,us_post_region_cities_id, created_at,updated_at,active) VALUES
+	 ('9771ac15-d640-4826-b055-c296696842e8','71755cc7-0844-4523-a0ac-da9a1e743ad1'::uuid,'791899e6-cd77-46f2-981b-176ecb8d7098'::uuid,'aef986d9-8f48-4ce7-b82a-d6fa1b5fb052'::uuid,now(),now(),true),
+	 ('91b89a8b-81f9-4380-b94c-6f7a33f8b4d9','71755cc7-0844-4523-a0ac-da9a1e743ad1'::uuid,'791899e6-cd77-46f2-981b-176ecb8d7098'::uuid,'077558ed-d9ef-479f-8163-6fa629437697'::uuid,now(),now(),true),
+	 ('5996d817-ab35-4477-8b77-832fe18a1abd','71755cc7-0844-4523-a0ac-da9a1e743ad1'::uuid,'791899e6-cd77-46f2-981b-176ecb8d7098'::uuid,'1944531b-e876-4217-8c0f-ffc79e1ed814'::uuid,now(),now(),true),
+	 ('f1795fad-656d-4600-ad09-05629eba7d43','71755cc7-0844-4523-a0ac-da9a1e743ad1'::uuid,'791899e6-cd77-46f2-981b-176ecb8d7098'::uuid,'526ce089-31f1-4648-aacb-757c1aa0a1ed'::uuid,now(),now(),true),
+	 ('f899cc7f-96e6-4b26-af04-0d6edb9e01b2','71755cc7-0844-4523-a0ac-da9a1e743ad1'::uuid,'791899e6-cd77-46f2-981b-176ecb8d7098'::uuid,'7abfb152-f97d-4004-b3a3-d7dcba9dabee'::uuid,now(),now(),true),
+	 ('97425b50-7fab-4178-94c9-bf913585ac80','71755cc7-0844-4523-a0ac-da9a1e743ad1'::uuid,'791899e6-cd77-46f2-981b-176ecb8d7098'::uuid,'35c7c653-1c14-46c0-a485-7c487862acd4'::uuid,now(),now(),true),
+	 ('70f5543b-82cb-4171-9c55-58e479ebaaa1','71755cc7-0844-4523-a0ac-da9a1e743ad1'::uuid,'791899e6-cd77-46f2-981b-176ecb8d7098'::uuid,'3ace2df3-045a-4a39-9a8a-364f96686af9'::uuid,now(),now(),true),
+	 ('bae425c4-2ab4-4fdb-8b96-b0654894ebbc','71755cc7-0844-4523-a0ac-da9a1e743ad1'::uuid,'791899e6-cd77-46f2-981b-176ecb8d7098'::uuid,'ca928d85-d169-4e56-8412-840675dd08a8'::uuid,now(),now(),true),
+	 ('736ab44f-3497-42f7-891d-845c868e7a29','71755cc7-0844-4523-a0ac-da9a1e743ad1'::uuid,'791899e6-cd77-46f2-981b-176ecb8d7098'::uuid,'e17a9675-4d71-470e-8ee5-6f88605c0c2a'::uuid,now(),now(),true),
+	 ('f118e38a-f46d-47d2-879d-c08b84781de8','71755cc7-0844-4523-a0ac-da9a1e743ad1'::uuid,'791899e6-cd77-46f2-981b-176ecb8d7098'::uuid,'069ecbb5-d5a3-4c19-af40-9a1bce621bb8'::uuid,now(),now(),true);
+INSERT INTO re_oconus_rate_areas (id,rate_area_id,country_id,us_post_region_cities_id, created_at,updated_at,active) VALUES
+	 ('c74ddc03-0e4b-4645-99d2-7c711b3ab5c4','71755cc7-0844-4523-a0ac-da9a1e743ad1'::uuid,'791899e6-cd77-46f2-981b-176ecb8d7098'::uuid,'3689739b-c24e-4355-a612-6e3c3be7d16c'::uuid,now(),now(),true),
+	 ('7b49bb85-c6bf-4cf3-8726-7256658e2ffb','71755cc7-0844-4523-a0ac-da9a1e743ad1'::uuid,'791899e6-cd77-46f2-981b-176ecb8d7098'::uuid,'b6713466-1a6c-4d57-901d-bef1323cd973'::uuid,now(),now(),true),
+	 ('bf1b7d0b-6477-4784-9a62-aebb13921de9','71755cc7-0844-4523-a0ac-da9a1e743ad1'::uuid,'791899e6-cd77-46f2-981b-176ecb8d7098'::uuid,'018308a0-e7d0-43be-9c90-d13293102af5'::uuid,now(),now(),true),
+	 ('2323d966-5d75-46df-b6df-eb43c616ba89','71755cc7-0844-4523-a0ac-da9a1e743ad1'::uuid,'791899e6-cd77-46f2-981b-176ecb8d7098'::uuid,'73be3c75-eb0f-4525-87c2-97d63494ca92'::uuid,now(),now(),true),
+	 ('7607c8ed-de3f-414e-ae11-e85fca9bd847','71755cc7-0844-4523-a0ac-da9a1e743ad1'::uuid,'791899e6-cd77-46f2-981b-176ecb8d7098'::uuid,'9fcecf37-9044-4c24-b2e1-9193a8bfec2d'::uuid,now(),now(),true),
+	 ('c7e39bbe-048a-442a-a8c9-ec58de94caec','71755cc7-0844-4523-a0ac-da9a1e743ad1'::uuid,'791899e6-cd77-46f2-981b-176ecb8d7098'::uuid,'20528efa-9329-477f-bd8a-d4546abdce54'::uuid,now(),now(),true),
+	 ('17a3c0ed-5cfb-4b60-8436-f0843e2d8624','71755cc7-0844-4523-a0ac-da9a1e743ad1'::uuid,'791899e6-cd77-46f2-981b-176ecb8d7098'::uuid,'71449390-b1fd-43ed-a72d-da805ff4fdbb'::uuid,now(),now(),true),
+	 ('a3e5aad3-27d5-4e50-853d-504a3f15c08e','71755cc7-0844-4523-a0ac-da9a1e743ad1'::uuid,'791899e6-cd77-46f2-981b-176ecb8d7098'::uuid,'928f17db-ff7d-46b8-a3b0-31587db2d334'::uuid,now(),now(),true),
+	 ('c43a5bf3-0d45-4001-9565-b78a0c59c9d3','71755cc7-0844-4523-a0ac-da9a1e743ad1'::uuid,'791899e6-cd77-46f2-981b-176ecb8d7098'::uuid,'ad6ed769-a4d8-41a2-b9be-aa500546f8fa'::uuid,now(),now(),true),
+	 ('919ed6b0-7939-4476-a7a8-6b49b820849c','71755cc7-0844-4523-a0ac-da9a1e743ad1'::uuid,'791899e6-cd77-46f2-981b-176ecb8d7098'::uuid,'6dc3eafe-ee75-4ed9-9019-933dd155b1fc'::uuid,now(),now(),true);
+INSERT INTO re_oconus_rate_areas (id,rate_area_id,country_id,us_post_region_cities_id, created_at,updated_at,active) VALUES
+	 ('43197d2c-728b-4204-8786-851da9fe9be8','71755cc7-0844-4523-a0ac-da9a1e743ad1'::uuid,'791899e6-cd77-46f2-981b-176ecb8d7098'::uuid,'17e33fff-b934-46d0-84a6-9f0a89ecd6f7'::uuid,now(),now(),true),
+	 ('ec36f031-4c35-4e24-ba08-83e03846be85','71755cc7-0844-4523-a0ac-da9a1e743ad1'::uuid,'791899e6-cd77-46f2-981b-176ecb8d7098'::uuid,'244446bd-416c-4a6c-8d27-469db94417aa'::uuid,now(),now(),true),
+	 ('64f29707-3503-40d0-96b7-6299381f1c60','71755cc7-0844-4523-a0ac-da9a1e743ad1'::uuid,'791899e6-cd77-46f2-981b-176ecb8d7098'::uuid,'c37d1d9e-cc49-4a98-9524-ac453e275c74'::uuid,now(),now(),true),
+	 ('e7d88312-1da3-42b0-a487-2e2bf623842e','71755cc7-0844-4523-a0ac-da9a1e743ad1'::uuid,'791899e6-cd77-46f2-981b-176ecb8d7098'::uuid,'4be1d1fd-19b8-43c6-9f8f-3779f46fe518'::uuid,now(),now(),true),
+	 ('ccb55592-003a-4135-802f-8d443422bc8b','71755cc7-0844-4523-a0ac-da9a1e743ad1'::uuid,'791899e6-cd77-46f2-981b-176ecb8d7098'::uuid,'e9b38982-6164-47f9-b940-3c9e25951236'::uuid,now(),now(),true),
+	 ('435c4a00-bc26-4cc3-8dd4-f2eb4e31c895','71755cc7-0844-4523-a0ac-da9a1e743ad1'::uuid,'791899e6-cd77-46f2-981b-176ecb8d7098'::uuid,'e474d48b-c435-4977-b290-63b40802d2d0'::uuid,now(),now(),true),
+	 ('69cc680a-75a9-4b10-9847-51fbaf1caee1','71755cc7-0844-4523-a0ac-da9a1e743ad1'::uuid,'791899e6-cd77-46f2-981b-176ecb8d7098'::uuid,'910d037a-c995-418c-84ec-d460ac422ae3'::uuid,now(),now(),true),
+	 ('391bd5cd-ab81-4eb0-b123-21a410c71cd5','71755cc7-0844-4523-a0ac-da9a1e743ad1'::uuid,'791899e6-cd77-46f2-981b-176ecb8d7098'::uuid,'7497eff0-0583-4c95-9a29-5937527e1d68'::uuid,now(),now(),true),
+	 ('d6ab4627-4d4f-41db-9baf-fec5f2487651','71755cc7-0844-4523-a0ac-da9a1e743ad1'::uuid,'791899e6-cd77-46f2-981b-176ecb8d7098'::uuid,'b0f6a629-8120-43b1-8a04-c9c9d741a39a'::uuid,now(),now(),true),
+	 ('714c5707-aba2-455d-ad9a-dcf3b0b8b66c','71755cc7-0844-4523-a0ac-da9a1e743ad1'::uuid,'791899e6-cd77-46f2-981b-176ecb8d7098'::uuid,'632268db-5eb3-48fc-83c1-d6ab47b6a8a5'::uuid,now(),now(),true);
+INSERT INTO re_oconus_rate_areas (id,rate_area_id,country_id,us_post_region_cities_id, created_at,updated_at,active) VALUES
+	 ('05554ee7-30d4-4bb3-bd8c-e0c478f4a037','71755cc7-0844-4523-a0ac-da9a1e743ad1'::uuid,'791899e6-cd77-46f2-981b-176ecb8d7098'::uuid,'9a1b9b7b-4319-4aee-b8aa-f0b98d94a528'::uuid,now(),now(),true),
+	 ('f91a9353-16a2-4fbf-83db-54b06bc68381','71755cc7-0844-4523-a0ac-da9a1e743ad1'::uuid,'791899e6-cd77-46f2-981b-176ecb8d7098'::uuid,'0799c023-f508-4c68-a5b4-0654f002ab83'::uuid,now(),now(),true),
+	 ('bb4c4e1e-828f-4a25-9dc2-81887e5553be','71755cc7-0844-4523-a0ac-da9a1e743ad1'::uuid,'791899e6-cd77-46f2-981b-176ecb8d7098'::uuid,'1841c945-89e8-414e-b570-864783247c28'::uuid,now(),now(),true),
+	 ('fa941444-f49d-4f51-b025-d3c6b63242a7','71755cc7-0844-4523-a0ac-da9a1e743ad1'::uuid,'791899e6-cd77-46f2-981b-176ecb8d7098'::uuid,'80fcfb21-83f7-4738-91e9-69a435972474'::uuid,now(),now(),true),
+	 ('eca65b4d-3981-46d9-9e10-a8d20c85c303','71755cc7-0844-4523-a0ac-da9a1e743ad1'::uuid,'791899e6-cd77-46f2-981b-176ecb8d7098'::uuid,'208b9fae-a5e7-4cc1-ba9e-15dceedee24b'::uuid,now(),now(),true),
+	 ('cad3dad4-4025-478b-b3db-44b2f2886115','71755cc7-0844-4523-a0ac-da9a1e743ad1'::uuid,'791899e6-cd77-46f2-981b-176ecb8d7098'::uuid,'7a0135b7-06bd-4c1e-849b-1d0201a886e2'::uuid,now(),now(),true),
+	 ('f15f99d4-4a96-4603-8dbf-d3af72be8db0','71755cc7-0844-4523-a0ac-da9a1e743ad1'::uuid,'791899e6-cd77-46f2-981b-176ecb8d7098'::uuid,'56ad34b3-961d-487e-a265-9f2cc4c58fec'::uuid,now(),now(),true),
+	 ('5897d064-bbb0-4ac4-a283-5fa7b91cdfd6','71755cc7-0844-4523-a0ac-da9a1e743ad1'::uuid,'791899e6-cd77-46f2-981b-176ecb8d7098'::uuid,'a0846cf9-2ae8-44d1-ad1f-e4e80770e41c'::uuid,now(),now(),true),
+	 ('bd4ca5db-cabb-44e7-8fdc-9a5d060161c7','71755cc7-0844-4523-a0ac-da9a1e743ad1'::uuid,'791899e6-cd77-46f2-981b-176ecb8d7098'::uuid,'749a1b35-b966-48ee-9be9-59ea581be394'::uuid,now(),now(),true),
+	 ('4c286583-5039-4455-bc9f-36ed842f9aa5','71755cc7-0844-4523-a0ac-da9a1e743ad1'::uuid,'791899e6-cd77-46f2-981b-176ecb8d7098'::uuid,'470d34d6-da01-4fdf-949d-6b47ed2969d0'::uuid,now(),now(),true);
+INSERT INTO re_oconus_rate_areas (id,rate_area_id,country_id,us_post_region_cities_id, created_at,updated_at,active) VALUES
+	 ('428a26d5-3dc7-44f6-8043-183b0bb60ee0','71755cc7-0844-4523-a0ac-da9a1e743ad1'::uuid,'791899e6-cd77-46f2-981b-176ecb8d7098'::uuid,'a2df67b1-5b0b-4ab0-b9a0-11ff7ed8e0bf'::uuid,now(),now(),true),
+	 ('86ff314b-0702-478a-aa19-c8cdb2f0fc2f','71755cc7-0844-4523-a0ac-da9a1e743ad1'::uuid,'791899e6-cd77-46f2-981b-176ecb8d7098'::uuid,'80b7c3a1-f3ee-4e41-aeaa-ac1ab429d7ef'::uuid,now(),now(),true),
+	 ('1e564ac9-c298-4a6e-b503-02db1459a621','71755cc7-0844-4523-a0ac-da9a1e743ad1'::uuid,'791899e6-cd77-46f2-981b-176ecb8d7098'::uuid,'345360d0-c3e9-4d87-b60b-59ab4b50c9ff'::uuid,now(),now(),true),
+	 ('458174be-38b9-4acb-bd8b-7fb9012cd271','71755cc7-0844-4523-a0ac-da9a1e743ad1'::uuid,'791899e6-cd77-46f2-981b-176ecb8d7098'::uuid,'02bd132f-3620-4d55-ae47-d4a776b96235'::uuid,now(),now(),true),
+	 ('0f86385c-8c84-4597-9c4e-3e8272c1df45','71755cc7-0844-4523-a0ac-da9a1e743ad1'::uuid,'791899e6-cd77-46f2-981b-176ecb8d7098'::uuid,'8e786192-31cf-4fcd-98c1-05de9a64d81b'::uuid,now(),now(),true),
+	 ('83658135-4bdb-4d86-9359-6733fd7ef3ad','71755cc7-0844-4523-a0ac-da9a1e743ad1'::uuid,'791899e6-cd77-46f2-981b-176ecb8d7098'::uuid,'cd40843e-74d0-485f-ab78-c6c95d24b61a'::uuid,now(),now(),true),
+	 ('c7e65080-7667-48b9-8794-013cdc1c72ec','71755cc7-0844-4523-a0ac-da9a1e743ad1'::uuid,'791899e6-cd77-46f2-981b-176ecb8d7098'::uuid,'f5a873a9-d1a0-4e6a-93fe-64cfdd0a957e'::uuid,now(),now(),true),
+	 ('80f818a0-1047-466a-a3c1-ce2fc905f205','71755cc7-0844-4523-a0ac-da9a1e743ad1'::uuid,'791899e6-cd77-46f2-981b-176ecb8d7098'::uuid,'53d28592-dfbf-47d0-8543-1d45f206f8c0'::uuid,now(),now(),true),
+	 ('13342500-620c-41db-af42-dcecf468ee43','71755cc7-0844-4523-a0ac-da9a1e743ad1'::uuid,'791899e6-cd77-46f2-981b-176ecb8d7098'::uuid,'550ed19a-fc56-42e7-a344-a5dc5c987037'::uuid,now(),now(),true),
+	 ('c2c17c57-3d88-444d-b6ba-69a3d0d734f0','71755cc7-0844-4523-a0ac-da9a1e743ad1'::uuid,'791899e6-cd77-46f2-981b-176ecb8d7098'::uuid,'70f511da-6726-48a1-8991-4d33686419b7'::uuid,now(),now(),true);
+INSERT INTO re_oconus_rate_areas (id,rate_area_id,country_id,us_post_region_cities_id, created_at,updated_at,active) VALUES
+	 ('950daf0c-0174-4e2f-b03b-05c088520cff','71755cc7-0844-4523-a0ac-da9a1e743ad1'::uuid,'791899e6-cd77-46f2-981b-176ecb8d7098'::uuid,'7895e2e6-5877-465c-80b0-03da0c4bf3c2'::uuid,now(),now(),true),
+	 ('9133dbe1-d08b-478e-8dbe-109fc05ca427','71755cc7-0844-4523-a0ac-da9a1e743ad1'::uuid,'791899e6-cd77-46f2-981b-176ecb8d7098'::uuid,'20b97576-a136-4ce3-a430-88ba601ee993'::uuid,now(),now(),true),
+	 ('c1a175cd-c7d1-45ff-a49a-2a6cc4613e9f','71755cc7-0844-4523-a0ac-da9a1e743ad1'::uuid,'791899e6-cd77-46f2-981b-176ecb8d7098'::uuid,'f4d874b1-2445-439f-8c70-b10b8732fe11'::uuid,now(),now(),true);
+
+
+-- insert Hawaii GBLOC associations
+INSERT INTO gbloc_aors (id,jppso_regions_id,oconus_rate_area_id,department_indicator,shipment_type,is_active,created_at,updated_at) VALUES
+     ('0b7f145f-0add-4aa3-bc51-a28a2f79b111','97611c2a-3ef6-4883-bf9a-3a7709f2acdd'::uuid,'f041907c-080c-4e27-886f-4af7a2b8c559'::uuid,NULL,NULL,true,now(),now()),
+     ('df2f72e1-29f6-4219-9255-16c9c6098fcf','97611c2a-3ef6-4883-bf9a-3a7709f2acdd'::uuid,'49bff3e2-d795-4fb2-8061-6f7f7dc871f3'::uuid,NULL,NULL,true,now(),now()),
+     ('979afabc-346c-4481-b91c-eb1ed5061874','97611c2a-3ef6-4883-bf9a-3a7709f2acdd'::uuid,'e3ff1ee1-2d39-4fac-9bb4-b5355030ba99'::uuid,NULL,NULL,true,now(),now()),
+     ('9e294d37-1e1f-418a-9153-7a77ce5e6aaf','97611c2a-3ef6-4883-bf9a-3a7709f2acdd'::uuid,'a25de140-fac9-4303-9d83-769ed4205668'::uuid,NULL,NULL,true,now(),now()),
+     ('a5f78d7f-f0a4-4190-829f-50bc0888a3f5','97611c2a-3ef6-4883-bf9a-3a7709f2acdd'::uuid,'b68a62a1-69e0-4a15-bcbf-8d31c4464fbd'::uuid,NULL,NULL,true,now(),now()),
+     ('28ca264b-f2e0-42fe-a4c8-d0a91045fea0','97611c2a-3ef6-4883-bf9a-3a7709f2acdd'::uuid,'35387756-cea0-402b-a95c-be54e0094496'::uuid,NULL,NULL,true,now(),now()),
+     ('1ba7ca65-ffbe-4049-897f-ef34b619f54d','97611c2a-3ef6-4883-bf9a-3a7709f2acdd'::uuid,'ff0167d9-ef93-43c8-9495-ba5bed8a0f69'::uuid,NULL,NULL,true,now(),now()),
+     ('3bc8655a-3c05-4c96-b317-a2d21f52c5f1','97611c2a-3ef6-4883-bf9a-3a7709f2acdd'::uuid,'956270a4-f850-4d94-b361-54d7104c381e'::uuid,NULL,NULL,true,now(),now()),
+     ('39c53018-0418-4c19-8b66-334e7f689b45','97611c2a-3ef6-4883-bf9a-3a7709f2acdd'::uuid,'02c23633-7ee1-443a-9ecf-a1e422a28e6c'::uuid,NULL,NULL,true,now(),now()),
+     ('feb1c2fa-b793-4029-8426-e9de4384d969','97611c2a-3ef6-4883-bf9a-3a7709f2acdd'::uuid,'3e45d573-1df1-4d43-a5f0-45844bff3185'::uuid,NULL,NULL,true,now(),now());
+INSERT INTO gbloc_aors (id,jppso_regions_id,oconus_rate_area_id,department_indicator,shipment_type,is_active,created_at,updated_at) VALUES
+     ('d2c3e83d-a568-4b8e-9424-2f068c844066','97611c2a-3ef6-4883-bf9a-3a7709f2acdd'::uuid,'6c26fd7c-44f5-40cf-ac88-e3202c752884'::uuid,NULL,NULL,true,now(),now()),
+     ('d1a64f83-a974-4741-a7a4-17c4747460d0','97611c2a-3ef6-4883-bf9a-3a7709f2acdd'::uuid,'a52e2e8c-6251-4a94-9f3d-ecf8d18d097f'::uuid,NULL,NULL,true,now(),now()),
+     ('58a79e8b-8dec-4de1-836b-c12bc987071a','97611c2a-3ef6-4883-bf9a-3a7709f2acdd'::uuid,'49f630f7-de16-40be-b15a-aa8eee7a0a09'::uuid,NULL,NULL,true,now(),now()),
+     ('078eae9d-9cdb-40fa-aa9b-788dd5391536','97611c2a-3ef6-4883-bf9a-3a7709f2acdd'::uuid,'8e854111-4805-46c6-92a2-aa7673a94b41'::uuid,NULL,NULL,true,now(),now()),
+     ('b4db50d9-8480-4914-9983-d1f7b06ae4e5','97611c2a-3ef6-4883-bf9a-3a7709f2acdd'::uuid,'9a41d67f-10b2-48d8-8e3c-2f20d6744dc2'::uuid,NULL,NULL,true,now(),now()),
+     ('6851d85a-6bed-42ef-9287-66b6b7e02616','97611c2a-3ef6-4883-bf9a-3a7709f2acdd'::uuid,'76a161e0-40ee-4e6c-8138-8c78cefc0b73'::uuid,NULL,NULL,true,now(),now()),
+     ('6adc1f68-be6c-438a-959b-396448a69917','97611c2a-3ef6-4883-bf9a-3a7709f2acdd'::uuid,'4e0ef4d5-124a-4f20-b2a4-f6d0d31bf8eb'::uuid,NULL,NULL,true,now(),now()),
+     ('0d3e608e-8ab9-4be3-a0ee-b91f83ad916d','97611c2a-3ef6-4883-bf9a-3a7709f2acdd'::uuid,'ed1aa4d4-99fd-4a2a-b757-c9d06e04484b'::uuid,NULL,NULL,true,now(),now()),
+     ('f30c24bf-9111-4ffe-acbe-e9bf53fe8ef3','97611c2a-3ef6-4883-bf9a-3a7709f2acdd'::uuid,'7ff933f8-cede-4bf0-a918-2403d6b902a5'::uuid,NULL,NULL,true,now(),now()),
+     ('301e01f6-1b04-499c-9d5b-224271487551','97611c2a-3ef6-4883-bf9a-3a7709f2acdd'::uuid,'bdf97313-d164-4d9b-bec3-9aff052fa094'::uuid,NULL,NULL,true,now(),now());
+INSERT INTO gbloc_aors (id,jppso_regions_id,oconus_rate_area_id,department_indicator,shipment_type,is_active,created_at,updated_at) VALUES
+     ('361645a1-3345-40ac-b03d-9a60828018a8','97611c2a-3ef6-4883-bf9a-3a7709f2acdd'::uuid,'d6d7872d-1751-44d0-86e1-217e7e129afe'::uuid,NULL,NULL,true,now(),now()),
+     ('1a121ea0-1026-4904-a97d-efdc92bc2fab','97611c2a-3ef6-4883-bf9a-3a7709f2acdd'::uuid,'1100147f-9baf-4a12-879e-dd40aadf073b'::uuid,NULL,NULL,true,now(),now()),
+     ('352d8604-a837-4731-a8d1-92082d8f5576','97611c2a-3ef6-4883-bf9a-3a7709f2acdd'::uuid,'c0abc8fa-f8c6-48e5-a49f-cc5714f6f509'::uuid,NULL,NULL,true,now(),now()),
+     ('b5dd300a-faa8-4ab7-8276-c9e7e5bf4506','97611c2a-3ef6-4883-bf9a-3a7709f2acdd'::uuid,'9ba33b41-15de-4743-b8f8-75367d0126e7'::uuid,NULL,NULL,true,now(),now()),
+     ('9450a528-7898-4b73-91a0-573257cf8288','97611c2a-3ef6-4883-bf9a-3a7709f2acdd'::uuid,'3188e86d-944a-42c1-b3b5-3bf7e360fb71'::uuid,NULL,NULL,true,now(),now()),
+     ('87f6667b-06f3-4beb-9570-2c6b320efb16','97611c2a-3ef6-4883-bf9a-3a7709f2acdd'::uuid,'fc281a01-a7cd-41a0-86d9-716ab4864c08'::uuid,NULL,NULL,true,now(),now()),
+     ('1f7b2bf7-6bb5-4a80-bacf-4e726150358d','97611c2a-3ef6-4883-bf9a-3a7709f2acdd'::uuid,'fb6d3db2-4079-48fe-9a67-170e200c9a8d'::uuid,NULL,NULL,true,now(),now()),
+     ('f9a42eaa-a002-4159-a40d-2d45187c95dd','97611c2a-3ef6-4883-bf9a-3a7709f2acdd'::uuid,'3bb35faa-229f-4721-82a2-becc9c98ae04'::uuid,NULL,NULL,true,now(),now()),
+     ('28298fc7-f185-43fb-9f47-5e64717f7131','97611c2a-3ef6-4883-bf9a-3a7709f2acdd'::uuid,'313905e6-f237-4e1d-ab01-be6dfdddfa92'::uuid,NULL,NULL,true,now(),now()),
+     ('7ef4d9e8-7647-488a-b803-2dd68a78a487','97611c2a-3ef6-4883-bf9a-3a7709f2acdd'::uuid,'0ed0a302-5016-4ccd-a6ba-5b28258af8dc'::uuid,NULL,NULL,true,now(),now());
+INSERT INTO gbloc_aors (id,jppso_regions_id,oconus_rate_area_id,department_indicator,shipment_type,is_active,created_at,updated_at) VALUES
+     ('e175dc40-d8d4-4f06-a362-ac50c4fe1890','97611c2a-3ef6-4883-bf9a-3a7709f2acdd'::uuid,'846616d3-34e1-4304-b778-3bf8b3052c32'::uuid,NULL,NULL,true,now(),now()),
+     ('09125d7c-4192-45c4-b60e-1d34d2236dc1','97611c2a-3ef6-4883-bf9a-3a7709f2acdd'::uuid,'f3b6f9da-4bfd-4ac5-a9e2-b4973adf372c'::uuid,NULL,NULL,true,now(),now()),
+     ('0d08e371-109d-4465-8185-3f3a9d992d14','97611c2a-3ef6-4883-bf9a-3a7709f2acdd'::uuid,'b42c8d98-71b3-464f-b868-6ab743ad7d3a'::uuid,NULL,NULL,true,now(),now()),
+     ('cc097b12-3720-4b38-9819-32e1c66aae83','97611c2a-3ef6-4883-bf9a-3a7709f2acdd'::uuid,'41e52c48-4b52-4498-b898-22af6fcd5452'::uuid,NULL,NULL,true,now(),now()),
+     ('5d7c1eff-2565-41e9-ae94-3792726606d7','97611c2a-3ef6-4883-bf9a-3a7709f2acdd'::uuid,'036d9855-ae02-4836-9405-f332d3654838'::uuid,NULL,NULL,true,now(),now()),
+     ('59738b80-7b6d-4de5-a02f-a03f30e28a21','97611c2a-3ef6-4883-bf9a-3a7709f2acdd'::uuid,'5bad5f3a-861a-448d-8747-66bfc77b9859'::uuid,NULL,NULL,true,now(),now()),
+     ('5506f869-0bb8-4333-bd92-fb067257287e','97611c2a-3ef6-4883-bf9a-3a7709f2acdd'::uuid,'c7132b2f-8e28-4ee3-af04-d6137f14944a'::uuid,NULL,NULL,true,now(),now()),
+     ('d085b83d-e5dd-4736-b2de-65024d9a770f','97611c2a-3ef6-4883-bf9a-3a7709f2acdd'::uuid,'05775275-180d-4562-8cd5-9b20403e0824'::uuid,NULL,NULL,true,now(),now()),
+     ('3d6e0a5e-3f5d-46a5-859c-5d2681277de5','97611c2a-3ef6-4883-bf9a-3a7709f2acdd'::uuid,'5c8029b9-85c3-452b-95cf-00d3d66bda7a'::uuid,NULL,NULL,true,now(),now()),
+     ('bf0fa527-ac28-4c28-937e-0c9ecd6e6b0a','97611c2a-3ef6-4883-bf9a-3a7709f2acdd'::uuid,'b08f70e8-702b-454a-bc58-b0b10e1b603e'::uuid,NULL,NULL,true,now(),now());
+INSERT INTO gbloc_aors (id,jppso_regions_id,oconus_rate_area_id,department_indicator,shipment_type,is_active,created_at,updated_at) VALUES
+     ('bedd5f6b-0b3b-4cd8-8724-4c20757af6d0','97611c2a-3ef6-4883-bf9a-3a7709f2acdd'::uuid,'20b866a6-d146-439b-b87b-d22412cda747'::uuid,NULL,NULL,true,now(),now()),
+     ('0d4479de-6229-40ca-a8bf-a844ff6b7653','97611c2a-3ef6-4883-bf9a-3a7709f2acdd'::uuid,'5dde8586-790a-40d6-9a46-e6cd725d1d5e'::uuid,NULL,NULL,true,now(),now()),
+     ('104c0668-9649-4b05-9224-96677c4313d1','97611c2a-3ef6-4883-bf9a-3a7709f2acdd'::uuid,'fedaa7ae-99a0-4981-9a07-835c0d094e1c'::uuid,NULL,NULL,true,now(),now()),
+     ('2622a62b-bcf6-49df-a985-da16972b2565','97611c2a-3ef6-4883-bf9a-3a7709f2acdd'::uuid,'73bf3243-c29b-4b4e-9341-5aaf99616e56'::uuid,NULL,NULL,true,now(),now()),
+     ('03d65ff1-3441-45c9-bb15-353af13566aa','97611c2a-3ef6-4883-bf9a-3a7709f2acdd'::uuid,'3c6ab532-1a18-4f78-9b95-deb1905d2d34'::uuid,NULL,NULL,true,now(),now()),
+     ('6e2a2921-cd88-4e0f-ba51-ba80a0d11f0b','97611c2a-3ef6-4883-bf9a-3a7709f2acdd'::uuid,'af3a2ad4-585b-4947-bb40-3ae575013ed5'::uuid,NULL,NULL,true,now(),now()),
+     ('01ff6dc1-080a-44f6-b5dd-a2adbc817c72','97611c2a-3ef6-4883-bf9a-3a7709f2acdd'::uuid,'01e44612-45b9-4964-9de9-843e7a3c0044'::uuid,NULL,NULL,true,now(),now()),
+     ('f772ac89-acf5-49a5-8539-a35ad5bb406c','97611c2a-3ef6-4883-bf9a-3a7709f2acdd'::uuid,'6a0ce7ea-2daa-4f06-95bf-3c6222c5a8b3'::uuid,NULL,NULL,true,now(),now()),
+     ('21407cef-1b02-46e1-add0-714241bb0965','97611c2a-3ef6-4883-bf9a-3a7709f2acdd'::uuid,'e164aac9-e9aa-4831-8ef1-98660215705b'::uuid,NULL,NULL,true,now(),now()),
+     ('82f0ed7b-9c68-41a4-ae6e-932c0aa037e5','97611c2a-3ef6-4883-bf9a-3a7709f2acdd'::uuid,'670a550c-7243-4318-b8d4-e4efcfa32539'::uuid,NULL,NULL,true,now(),now());
+INSERT INTO gbloc_aors (id,jppso_regions_id,oconus_rate_area_id,department_indicator,shipment_type,is_active,created_at,updated_at) VALUES
+     ('b27b3565-7a34-4f76-bb9d-bd4764a3c046','97611c2a-3ef6-4883-bf9a-3a7709f2acdd'::uuid,'e25c2146-7ade-4552-a66d-d3bc948f39c0'::uuid,NULL,NULL,true,now(),now()),
+     ('f78103a7-62d4-4825-bd47-f2bf8a5f386a','97611c2a-3ef6-4883-bf9a-3a7709f2acdd'::uuid,'d32022a5-f00b-461b-8a3b-0c69df06a94f'::uuid,NULL,NULL,true,now(),now()),
+     ('4275485b-c5cd-443e-8eab-b25db7aca167','97611c2a-3ef6-4883-bf9a-3a7709f2acdd'::uuid,'66861383-84f0-46c0-9597-c8765152601d'::uuid,NULL,NULL,true,now(),now()),
+     ('7ea4019d-19dc-4e0e-92e7-149772385368','97611c2a-3ef6-4883-bf9a-3a7709f2acdd'::uuid,'9b52d7a7-8ebe-4cef-a49d-2e03eb87878c'::uuid,NULL,NULL,true,now(),now()),
+     ('127ed1f9-05bc-401b-ace7-854662eda3e4','97611c2a-3ef6-4883-bf9a-3a7709f2acdd'::uuid,'05c41080-8f3d-41bc-8350-25c9c50dc8bf'::uuid,NULL,NULL,true,now(),now()),
+     ('aa0a3c08-abb7-4d70-9b80-00eb525b7329','97611c2a-3ef6-4883-bf9a-3a7709f2acdd'::uuid,'97b37859-0f6c-48ff-bec0-403cca95712f'::uuid,NULL,NULL,true,now(),now()),
+     ('a4d57e99-c781-4bfb-af80-902294551ca0','97611c2a-3ef6-4883-bf9a-3a7709f2acdd'::uuid,'f0ae37b7-bcc1-4107-bdc7-43d21605d0c6'::uuid,NULL,NULL,true,now(),now()),
+     ('7cb0e3ef-d141-44ad-a6ff-32264d563cdb','97611c2a-3ef6-4883-bf9a-3a7709f2acdd'::uuid,'de8e5560-246b-45bb-a1df-0e9a0f0ab7ad'::uuid,NULL,NULL,true,now(),now()),
+     ('01729d8d-c001-4a23-9e60-11c8c5d64cbe','97611c2a-3ef6-4883-bf9a-3a7709f2acdd'::uuid,'de85bbee-084e-42d2-ab68-677a927edb2a'::uuid,NULL,NULL,true,now(),now()),
+     ('ff651ae1-ff18-4e0c-9080-145c444d873e','97611c2a-3ef6-4883-bf9a-3a7709f2acdd'::uuid,'733e38ca-86e1-454f-87a4-884f8b17df21'::uuid,NULL,NULL,true,now(),now());
+INSERT INTO gbloc_aors (id,jppso_regions_id,oconus_rate_area_id,department_indicator,shipment_type,is_active,created_at,updated_at) VALUES
+     ('f130def4-2be3-4f26-81e8-a75381e52ad1','97611c2a-3ef6-4883-bf9a-3a7709f2acdd'::uuid,'8b2f2560-f26c-43d9-98ca-322a3e73b0bb'::uuid,NULL,NULL,true,now(),now()),
+     ('111ff46a-e1cc-4eaf-9cd4-e33fc021d3d3','97611c2a-3ef6-4883-bf9a-3a7709f2acdd'::uuid,'f5b7df58-dd68-4d24-8f7a-907895dbb151'::uuid,NULL,NULL,true,now(),now()),
+     ('380e1bb4-0138-4a5b-badf-353a08cd58c5','97611c2a-3ef6-4883-bf9a-3a7709f2acdd'::uuid,'d7843a4e-0c70-466b-b01d-5909b1f62c11'::uuid,NULL,NULL,true,now(),now()),
+     ('71ef938f-769d-404d-9c2a-a48cf954d1e4','97611c2a-3ef6-4883-bf9a-3a7709f2acdd'::uuid,'8d211696-7337-4c65-be73-9a88049476e4'::uuid,NULL,NULL,true,now(),now()),
+     ('14774917-4376-4191-a925-23a5322154f2','97611c2a-3ef6-4883-bf9a-3a7709f2acdd'::uuid,'3821b597-e99a-432d-afa0-1aa74b802b94'::uuid,NULL,NULL,true,now(),now()),
+     ('9f42b8d1-0d5d-43a8-b7b1-bac5b91e6145','97611c2a-3ef6-4883-bf9a-3a7709f2acdd'::uuid,'5918a6de-11ae-43f1-ba68-23cd71da6e7b'::uuid,NULL,NULL,true,now(),now()),
+     ('ec6cea21-f2b3-4176-8abd-6179ec3f190e','97611c2a-3ef6-4883-bf9a-3a7709f2acdd'::uuid,'76e8e46c-ab0d-4c67-95b6-d00185dd2832'::uuid,NULL,NULL,true,now(),now()),
+     ('b3377895-ca73-482f-91c3-c986c22b545c','97611c2a-3ef6-4883-bf9a-3a7709f2acdd'::uuid,'7b33ae55-5463-4b57-97e6-a7443a1e0904'::uuid,NULL,NULL,true,now(),now()),
+     ('c97bb442-5839-4521-b95e-cfecbe4d0125','97611c2a-3ef6-4883-bf9a-3a7709f2acdd'::uuid,'766fcf2c-9145-4f79-b502-d0ffaf96ef17'::uuid,NULL,NULL,true,now(),now()),
+     ('3305fccd-efac-4717-a1f6-1f31daf0a0a5','97611c2a-3ef6-4883-bf9a-3a7709f2acdd'::uuid,'e1e1bf33-bd47-4ac7-9128-1f5c02d0db7e'::uuid,NULL,NULL,true,now(),now());
+INSERT INTO gbloc_aors (id,jppso_regions_id,oconus_rate_area_id,department_indicator,shipment_type,is_active,created_at,updated_at) VALUES
+     ('e6508bd6-32eb-4f53-8405-57cdef069e78','97611c2a-3ef6-4883-bf9a-3a7709f2acdd'::uuid,'8df33232-52a9-480f-afb8-df27cd099bd2'::uuid,NULL,NULL,true,now(),now()),
+     ('671d7baa-8b6c-4b71-a3fc-166d138cfaaa','97611c2a-3ef6-4883-bf9a-3a7709f2acdd'::uuid,'8415fff3-ccac-4ae8-82ac-e54f04ca4082'::uuid,NULL,NULL,true,now(),now()),
+     ('14f91fd9-bc46-439d-b788-6b6553085f80','97611c2a-3ef6-4883-bf9a-3a7709f2acdd'::uuid,'9d2ef3a3-9e55-4797-9b58-35429c3849a8'::uuid,NULL,NULL,true,now(),now()),
+     ('614c349e-4450-45d6-b14c-86b9aa118c63','97611c2a-3ef6-4883-bf9a-3a7709f2acdd'::uuid,'3e99cabc-75cd-4152-b519-cddfbd4294aa'::uuid,NULL,NULL,true,now(),now()),
+     ('481b28f2-994e-403e-9391-6352d3f0f0bd','97611c2a-3ef6-4883-bf9a-3a7709f2acdd'::uuid,'616c1ea1-ac8f-4ccf-a28d-80078015ba0e'::uuid,NULL,NULL,true,now(),now()),
+     ('57eb8a31-2606-4d23-8a23-f7576069a23e','97611c2a-3ef6-4883-bf9a-3a7709f2acdd'::uuid,'e33e15dd-d3aa-480d-a70c-8de943b1dccc'::uuid,NULL,NULL,true,now(),now()),
+     ('d7e38c2b-b1c2-4d22-9650-397266536d20','97611c2a-3ef6-4883-bf9a-3a7709f2acdd'::uuid,'1bdbc429-b5d6-4483-821e-a31839e63ad2'::uuid,NULL,NULL,true,now(),now()),
+     ('2e270943-5d8b-445c-8545-8eeb1d8cb8c2','97611c2a-3ef6-4883-bf9a-3a7709f2acdd'::uuid,'0d327bc0-5315-44d1-848c-1f02667a81db'::uuid,NULL,NULL,true,now(),now()),
+     ('7466d6e1-e3e8-46cc-a6c0-b6dcabea653a','97611c2a-3ef6-4883-bf9a-3a7709f2acdd'::uuid,'7088fd82-8a7f-47c3-a80b-b5255a795f6b'::uuid,NULL,NULL,true,now(),now()),
+     ('e3f744cf-8a28-4ffb-b177-71aecc96575d','97611c2a-3ef6-4883-bf9a-3a7709f2acdd'::uuid,'54045203-93a8-4011-a9b2-84673cc5176d'::uuid,NULL,NULL,true,now(),now());
+INSERT INTO gbloc_aors (id,jppso_regions_id,oconus_rate_area_id,department_indicator,shipment_type,is_active,created_at,updated_at) VALUES
+     ('209d6646-d917-4e2f-a69a-9ae914cdd129','97611c2a-3ef6-4883-bf9a-3a7709f2acdd'::uuid,'f6b671cf-c344-46ba-bf68-08fcba2ebd84'::uuid,NULL,NULL,true,now(),now()),
+     ('8dfa8159-1ba0-44d1-a340-c3152dd4679d','97611c2a-3ef6-4883-bf9a-3a7709f2acdd'::uuid,'26e71f17-7713-46d9-a059-5e07978b9b50'::uuid,NULL,NULL,true,now(),now()),
+     ('fdaa6dde-ebc1-431c-93d9-65963dac2960','97611c2a-3ef6-4883-bf9a-3a7709f2acdd'::uuid,'f7c97962-b0f9-4671-b9d8-06c6195bcde0'::uuid,NULL,NULL,true,now(),now()),
+     ('5faa2cb2-8dff-4fca-83f9-b5ab22a7296a','97611c2a-3ef6-4883-bf9a-3a7709f2acdd'::uuid,'20e947f3-a7d1-423c-ae79-9886857d5dcc'::uuid,NULL,NULL,true,now(),now()),
+     ('3946aae4-063f-423d-9932-8b04ca15b931','97611c2a-3ef6-4883-bf9a-3a7709f2acdd'::uuid,'49e0f65d-1545-424d-b1c9-e5e3d0067fe9'::uuid,NULL,NULL,true,now(),now()),
+     ('b5113518-3412-4062-a91a-775adbe277b6','97611c2a-3ef6-4883-bf9a-3a7709f2acdd'::uuid,'9f0d1cb8-4a5d-42f4-8766-c3ad7f029084'::uuid,NULL,NULL,true,now(),now()),
+     ('40063586-641d-447a-8932-6862103e0596','97611c2a-3ef6-4883-bf9a-3a7709f2acdd'::uuid,'e4392356-88c7-4841-a415-920aa9cdc7ca'::uuid,NULL,NULL,true,now(),now()),
+     ('8e33e711-ff66-4a2e-8201-7898ae73ea26','97611c2a-3ef6-4883-bf9a-3a7709f2acdd'::uuid,'f549cddf-ec33-4772-b259-5e12aa2f66b9'::uuid,NULL,NULL,true,now(),now()),
+     ('90440c26-70b7-4988-b1f7-f69d3abd5eb5','97611c2a-3ef6-4883-bf9a-3a7709f2acdd'::uuid,'788cb14b-30e1-447d-95cc-358e29f01d8d'::uuid,NULL,NULL,true,now(),now()),
+     ('353b2723-2f0e-4623-8622-2e6071b0b403','97611c2a-3ef6-4883-bf9a-3a7709f2acdd'::uuid,'46d6bc67-b8e5-4e11-834e-eaaa62cad46e'::uuid,NULL,NULL,true,now(),now());
+INSERT INTO gbloc_aors (id,jppso_regions_id,oconus_rate_area_id,department_indicator,shipment_type,is_active,created_at,updated_at) VALUES
+     ('221a4c6c-8084-45c8-8ac3-2474e13eadff','97611c2a-3ef6-4883-bf9a-3a7709f2acdd'::uuid,'67d1f1ab-782a-452f-a607-ba2e6a9a87aa'::uuid,NULL,NULL,true,now(),now()),
+     ('79d5bfe2-b124-4e81-9a07-b0169eff1b9d','97611c2a-3ef6-4883-bf9a-3a7709f2acdd'::uuid,'51a17659-2fd7-49c3-9971-8fd1e341fcba'::uuid,NULL,NULL,true,now(),now()),
+     ('2e102552-37d0-4c22-ae7d-b9e931b34dc1','97611c2a-3ef6-4883-bf9a-3a7709f2acdd'::uuid,'646aaf79-c655-443d-a02f-81764d2965c0'::uuid,NULL,NULL,true,now(),now()),
+     ('0198b34d-5528-4934-bf47-22024ed34e3d','97611c2a-3ef6-4883-bf9a-3a7709f2acdd'::uuid,'ecb1f2a7-525e-490a-8e88-b53a6681aa96'::uuid,NULL,NULL,true,now(),now()),
+     ('016e0c1e-f890-4372-8968-a4da81c7be7c','97611c2a-3ef6-4883-bf9a-3a7709f2acdd'::uuid,'bf597a56-1728-4325-9734-1138799d6332'::uuid,NULL,NULL,true,now(),now()),
+     ('47d78518-39ad-455f-8a44-fe974cce5c0e','97611c2a-3ef6-4883-bf9a-3a7709f2acdd'::uuid,'8608f8da-6f62-41ea-8c3d-024c1bcc7daa'::uuid,NULL,NULL,true,now(),now()),
+     ('03979a62-cf11-4ec4-840b-f3863701b2d0','97611c2a-3ef6-4883-bf9a-3a7709f2acdd'::uuid,'df227441-2e7f-456f-82c5-b4772c7cc5f6'::uuid,NULL,NULL,true,now(),now()),
+     ('880e545d-a6f1-46ce-a3d9-703a95c55b9c','97611c2a-3ef6-4883-bf9a-3a7709f2acdd'::uuid,'10177e21-4c50-44a6-956b-3eedeac77094'::uuid,NULL,NULL,true,now(),now()),
+     ('b9a799fb-fffe-4739-bc73-d2232fc08bb3','97611c2a-3ef6-4883-bf9a-3a7709f2acdd'::uuid,'373f38ab-0a7b-40c9-8cc5-0df01d1d87de'::uuid,NULL,NULL,true,now(),now()),
+     ('f6d8da90-1a28-4dbc-9aca-ff3c1cf838db','97611c2a-3ef6-4883-bf9a-3a7709f2acdd'::uuid,'14b7aa87-7a4e-4e47-b2e4-fa1ed8cdd2a8'::uuid,NULL,NULL,true,now(),now());
+INSERT INTO gbloc_aors (id,jppso_regions_id,oconus_rate_area_id,department_indicator,shipment_type,is_active,created_at,updated_at) VALUES
+     ('910ddece-59c3-482c-ae9b-d23f3478a06b','97611c2a-3ef6-4883-bf9a-3a7709f2acdd'::uuid,'05b15308-4fbd-4e03-ab59-437b9f37e69a'::uuid,NULL,NULL,true,now(),now()),
+     ('40db8097-6261-4507-9c87-371d8f4ac794','97611c2a-3ef6-4883-bf9a-3a7709f2acdd'::uuid,'b36bffda-b020-4e49-bb6e-971d17116bde'::uuid,NULL,NULL,true,now(),now()),
+     ('b4bccff5-4836-43f7-9ab9-f8e05b65a528','97611c2a-3ef6-4883-bf9a-3a7709f2acdd'::uuid,'89c8ec3e-af9d-4376-9b47-2a68589abcb4'::uuid,NULL,NULL,true,now(),now()),
+     ('953326d7-6244-47f0-ac10-a336445eadfe','97611c2a-3ef6-4883-bf9a-3a7709f2acdd'::uuid,'ba61f387-aa0f-434c-aa61-5c15982d4ce4'::uuid,NULL,NULL,true,now(),now()),
+     ('c02b62dc-e3be-447c-ae20-ef7d419a5757','97611c2a-3ef6-4883-bf9a-3a7709f2acdd'::uuid,'09795f49-0694-4cfb-a711-8aa4edc64ef4'::uuid,NULL,NULL,true,now(),now()),
+     ('41ed482c-5381-48bb-acbb-f296e238f067','97611c2a-3ef6-4883-bf9a-3a7709f2acdd'::uuid,'e54eb89b-88e8-469d-964e-faad60eafdef'::uuid,NULL,NULL,true,now(),now()),
+     ('e1f11e3e-e8f4-4fbb-83e2-2a76bee64c24','97611c2a-3ef6-4883-bf9a-3a7709f2acdd'::uuid,'19e2ad86-e55a-4ba5-bae1-f86e922933e3'::uuid,NULL,NULL,true,now(),now()),
+     ('25750162-53a8-45b1-9008-4b01cdf1afca','97611c2a-3ef6-4883-bf9a-3a7709f2acdd'::uuid,'d1689b93-68e7-44d5-abd5-c3063bc4e670'::uuid,NULL,NULL,true,now(),now()),
+     ('38e423ae-f98f-409a-b662-1f1b90715b8c','97611c2a-3ef6-4883-bf9a-3a7709f2acdd'::uuid,'64bd4440-9ee4-4a80-bcbd-5701ab160e73'::uuid,NULL,NULL,true,now(),now()),
+     ('12425939-589e-4ebe-b67d-48dd2a086115','97611c2a-3ef6-4883-bf9a-3a7709f2acdd'::uuid,'00f9ac3e-b9c2-4cf5-af47-6b4799f7333f'::uuid,NULL,NULL,true,now(),now());
+INSERT INTO gbloc_aors (id,jppso_regions_id,oconus_rate_area_id,department_indicator,shipment_type,is_active,created_at,updated_at) VALUES
+     ('816cab83-2e6a-4643-81b8-e6698d68eab0','97611c2a-3ef6-4883-bf9a-3a7709f2acdd'::uuid,'9771ac15-d640-4826-b055-c296696842e8'::uuid,NULL,NULL,true,now(),now()),
+     ('4653a73a-17e8-4e90-8f0d-19f40025c82e','97611c2a-3ef6-4883-bf9a-3a7709f2acdd'::uuid,'91b89a8b-81f9-4380-b94c-6f7a33f8b4d9'::uuid,NULL,NULL,true,now(),now()),
+     ('3780c556-4aa0-4ada-a5ef-3ab6c2f9c969','97611c2a-3ef6-4883-bf9a-3a7709f2acdd'::uuid,'5996d817-ab35-4477-8b77-832fe18a1abd'::uuid,NULL,NULL,true,now(),now()),
+     ('14abdfc1-7c4f-4b48-a60b-da7daf82e00d','97611c2a-3ef6-4883-bf9a-3a7709f2acdd'::uuid,'f1795fad-656d-4600-ad09-05629eba7d43'::uuid,NULL,NULL,true,now(),now()),
+     ('51cc866b-4d6d-4c16-8b9f-6ebac7d7c45f','97611c2a-3ef6-4883-bf9a-3a7709f2acdd'::uuid,'f899cc7f-96e6-4b26-af04-0d6edb9e01b2'::uuid,NULL,NULL,true,now(),now()),
+     ('ffe1e0c3-648f-4cb6-a696-a165f31a6c1e','97611c2a-3ef6-4883-bf9a-3a7709f2acdd'::uuid,'97425b50-7fab-4178-94c9-bf913585ac80'::uuid,NULL,NULL,true,now(),now()),
+     ('74b41148-97d2-4d61-8794-f93e119c9730','97611c2a-3ef6-4883-bf9a-3a7709f2acdd'::uuid,'70f5543b-82cb-4171-9c55-58e479ebaaa1'::uuid,NULL,NULL,true,now(),now()),
+     ('8e733754-e830-476d-acde-c85a129c2704','97611c2a-3ef6-4883-bf9a-3a7709f2acdd'::uuid,'bae425c4-2ab4-4fdb-8b96-b0654894ebbc'::uuid,NULL,NULL,true,now(),now()),
+     ('96824049-1a8a-47a7-b9e3-1afd090741bf','97611c2a-3ef6-4883-bf9a-3a7709f2acdd'::uuid,'736ab44f-3497-42f7-891d-845c868e7a29'::uuid,NULL,NULL,true,now(),now()),
+     ('09c670b5-220a-4ea6-8ddf-5baeea1ce9f2','97611c2a-3ef6-4883-bf9a-3a7709f2acdd'::uuid,'f118e38a-f46d-47d2-879d-c08b84781de8'::uuid,NULL,NULL,true,now(),now());
+INSERT INTO gbloc_aors (id,jppso_regions_id,oconus_rate_area_id,department_indicator,shipment_type,is_active,created_at,updated_at) VALUES
+     ('ef4b04d4-b472-4105-b6c8-00c1f314ab17','97611c2a-3ef6-4883-bf9a-3a7709f2acdd'::uuid,'c74ddc03-0e4b-4645-99d2-7c711b3ab5c4'::uuid,NULL,NULL,true,now(),now()),
+     ('c9fc02c1-d1a7-48c5-b4eb-3e0598534820','97611c2a-3ef6-4883-bf9a-3a7709f2acdd'::uuid,'7b49bb85-c6bf-4cf3-8726-7256658e2ffb'::uuid,NULL,NULL,true,now(),now()),
+     ('354777b7-8b85-4e4d-89bf-3152c75d7571','97611c2a-3ef6-4883-bf9a-3a7709f2acdd'::uuid,'bf1b7d0b-6477-4784-9a62-aebb13921de9'::uuid,NULL,NULL,true,now(),now()),
+     ('68562095-8f5c-4edf-ba21-29d99215ab11','97611c2a-3ef6-4883-bf9a-3a7709f2acdd'::uuid,'2323d966-5d75-46df-b6df-eb43c616ba89'::uuid,NULL,NULL,true,now(),now()),
+     ('2d810fbe-c240-46f6-ba1e-792c4f25bb47','97611c2a-3ef6-4883-bf9a-3a7709f2acdd'::uuid,'7607c8ed-de3f-414e-ae11-e85fca9bd847'::uuid,NULL,NULL,true,now(),now()),
+     ('5bece096-75d3-4f26-bf4e-561701fe7ce2','97611c2a-3ef6-4883-bf9a-3a7709f2acdd'::uuid,'c7e39bbe-048a-442a-a8c9-ec58de94caec'::uuid,NULL,NULL,true,now(),now()),
+     ('bf728fd7-dee8-428c-a753-c91d96dbf26b','97611c2a-3ef6-4883-bf9a-3a7709f2acdd'::uuid,'17a3c0ed-5cfb-4b60-8436-f0843e2d8624'::uuid,NULL,NULL,true,now(),now()),
+     ('61e2274a-2bd7-422f-94bc-f2beeb1fb84b','97611c2a-3ef6-4883-bf9a-3a7709f2acdd'::uuid,'a3e5aad3-27d5-4e50-853d-504a3f15c08e'::uuid,NULL,NULL,true,now(),now()),
+     ('a3a5fb63-aa87-464a-a439-7851fcbca270','97611c2a-3ef6-4883-bf9a-3a7709f2acdd'::uuid,'c43a5bf3-0d45-4001-9565-b78a0c59c9d3'::uuid,NULL,NULL,true,now(),now()),
+     ('24de42d0-4689-4d7d-b94c-8596ae12c7a6','97611c2a-3ef6-4883-bf9a-3a7709f2acdd'::uuid,'919ed6b0-7939-4476-a7a8-6b49b820849c'::uuid,NULL,NULL,true,now(),now());
+INSERT INTO gbloc_aors (id,jppso_regions_id,oconus_rate_area_id,department_indicator,shipment_type,is_active,created_at,updated_at) VALUES
+     ('e611b59a-bd7d-4a84-a12b-d4a96ac2ec47','97611c2a-3ef6-4883-bf9a-3a7709f2acdd'::uuid,'43197d2c-728b-4204-8786-851da9fe9be8'::uuid,NULL,NULL,true,now(),now()),
+     ('c013b9b9-6d4e-40d9-88d2-332fcf421595','97611c2a-3ef6-4883-bf9a-3a7709f2acdd'::uuid,'ec36f031-4c35-4e24-ba08-83e03846be85'::uuid,NULL,NULL,true,now(),now()),
+     ('d649b940-429b-443f-b81c-385fb789ac64','97611c2a-3ef6-4883-bf9a-3a7709f2acdd'::uuid,'64f29707-3503-40d0-96b7-6299381f1c60'::uuid,NULL,NULL,true,now(),now()),
+     ('5f70407d-8c97-43b8-aebf-8b876f55f2b2','97611c2a-3ef6-4883-bf9a-3a7709f2acdd'::uuid,'e7d88312-1da3-42b0-a487-2e2bf623842e'::uuid,NULL,NULL,true,now(),now()),
+     ('b2f26584-e32d-4eb0-b721-f79e4b986666','97611c2a-3ef6-4883-bf9a-3a7709f2acdd'::uuid,'ccb55592-003a-4135-802f-8d443422bc8b'::uuid,NULL,NULL,true,now(),now()),
+     ('0a291f21-8ec8-490e-aea3-21ddcaf155fa','97611c2a-3ef6-4883-bf9a-3a7709f2acdd'::uuid,'435c4a00-bc26-4cc3-8dd4-f2eb4e31c895'::uuid,NULL,NULL,true,now(),now()),
+     ('edc42ed1-66dd-4d85-8db0-3ed3c8b9c694','97611c2a-3ef6-4883-bf9a-3a7709f2acdd'::uuid,'69cc680a-75a9-4b10-9847-51fbaf1caee1'::uuid,NULL,NULL,true,now(),now()),
+     ('dbdcb0a7-2827-42b3-9ecf-beaaeeccc219','97611c2a-3ef6-4883-bf9a-3a7709f2acdd'::uuid,'391bd5cd-ab81-4eb0-b123-21a410c71cd5'::uuid,NULL,NULL,true,now(),now()),
+     ('6a8697c6-cb7b-4fb7-95cc-acf6ad909193','97611c2a-3ef6-4883-bf9a-3a7709f2acdd'::uuid,'d6ab4627-4d4f-41db-9baf-fec5f2487651'::uuid,NULL,NULL,true,now(),now()),
+     ('9d21922c-e067-4aa6-b8a1-0e0d0b30d1ec','97611c2a-3ef6-4883-bf9a-3a7709f2acdd'::uuid,'714c5707-aba2-455d-ad9a-dcf3b0b8b66c'::uuid,NULL,NULL,true,now(),now());
+INSERT INTO gbloc_aors (id,jppso_regions_id,oconus_rate_area_id,department_indicator,shipment_type,is_active,created_at,updated_at) VALUES
+     ('edcdda55-d1cc-4137-bcee-c35403795032','97611c2a-3ef6-4883-bf9a-3a7709f2acdd'::uuid,'05554ee7-30d4-4bb3-bd8c-e0c478f4a037'::uuid,NULL,NULL,true,now(),now()),
+     ('34cd246e-f618-4204-b761-c6202da4e999','97611c2a-3ef6-4883-bf9a-3a7709f2acdd'::uuid,'f91a9353-16a2-4fbf-83db-54b06bc68381'::uuid,NULL,NULL,true,now(),now()),
+     ('4cb5c010-6c43-468a-88a7-3e1e4aad1e93','97611c2a-3ef6-4883-bf9a-3a7709f2acdd'::uuid,'bb4c4e1e-828f-4a25-9dc2-81887e5553be'::uuid,NULL,NULL,true,now(),now()),
+     ('56bed37c-d397-4405-a507-36e48b7be94c','97611c2a-3ef6-4883-bf9a-3a7709f2acdd'::uuid,'fa941444-f49d-4f51-b025-d3c6b63242a7'::uuid,NULL,NULL,true,now(),now()),
+     ('0198017d-0822-4b77-adac-eb83690d3262','97611c2a-3ef6-4883-bf9a-3a7709f2acdd'::uuid,'eca65b4d-3981-46d9-9e10-a8d20c85c303'::uuid,NULL,NULL,true,now(),now()),
+     ('97ce133d-103a-47d8-bdd6-f25b24e258fd','97611c2a-3ef6-4883-bf9a-3a7709f2acdd'::uuid,'cad3dad4-4025-478b-b3db-44b2f2886115'::uuid,NULL,NULL,true,now(),now()),
+     ('bf618f8e-9047-4cb2-afc4-84c756084be7','97611c2a-3ef6-4883-bf9a-3a7709f2acdd'::uuid,'f15f99d4-4a96-4603-8dbf-d3af72be8db0'::uuid,NULL,NULL,true,now(),now()),
+     ('7fe6d143-070b-48c5-b138-404386a53e79','97611c2a-3ef6-4883-bf9a-3a7709f2acdd'::uuid,'5897d064-bbb0-4ac4-a283-5fa7b91cdfd6'::uuid,NULL,NULL,true,now(),now()),
+     ('e2321d3b-2648-4cc1-9651-f7b00ff5da11','97611c2a-3ef6-4883-bf9a-3a7709f2acdd'::uuid,'bd4ca5db-cabb-44e7-8fdc-9a5d060161c7'::uuid,NULL,NULL,true,now(),now()),
+     ('a03bffce-29fe-48e3-baed-e7a42641d663','97611c2a-3ef6-4883-bf9a-3a7709f2acdd'::uuid,'4c286583-5039-4455-bc9f-36ed842f9aa5'::uuid,NULL,NULL,true,now(),now());
+INSERT INTO gbloc_aors (id,jppso_regions_id,oconus_rate_area_id,department_indicator,shipment_type,is_active,created_at,updated_at) VALUES
+     ('0069ba48-0a2a-47f5-b669-b055f95382c3','97611c2a-3ef6-4883-bf9a-3a7709f2acdd'::uuid,'428a26d5-3dc7-44f6-8043-183b0bb60ee0'::uuid,NULL,NULL,true,now(),now()),
+     ('b4b6187e-e576-43dc-82bb-d2978b6b8e8d','97611c2a-3ef6-4883-bf9a-3a7709f2acdd'::uuid,'86ff314b-0702-478a-aa19-c8cdb2f0fc2f'::uuid,NULL,NULL,true,now(),now()),
+     ('c51bb0b0-1d56-4dff-bb7c-a3bab342926b','97611c2a-3ef6-4883-bf9a-3a7709f2acdd'::uuid,'1e564ac9-c298-4a6e-b503-02db1459a621'::uuid,NULL,NULL,true,now(),now()),
+     ('95d14542-3ea7-4263-a5a4-2fb9827ec6ed','97611c2a-3ef6-4883-bf9a-3a7709f2acdd'::uuid,'458174be-38b9-4acb-bd8b-7fb9012cd271'::uuid,NULL,NULL,true,now(),now()),
+     ('1c872bd1-3d94-4976-9358-701c9ab76bd6','97611c2a-3ef6-4883-bf9a-3a7709f2acdd'::uuid,'0f86385c-8c84-4597-9c4e-3e8272c1df45'::uuid,NULL,NULL,true,now(),now()),
+     ('1f6f5329-dde1-487b-8b2a-182f0a68e2c1','97611c2a-3ef6-4883-bf9a-3a7709f2acdd'::uuid,'83658135-4bdb-4d86-9359-6733fd7ef3ad'::uuid,NULL,NULL,true,now(),now()),
+     ('6b861ecd-979b-4f11-b413-97f1ea253215','97611c2a-3ef6-4883-bf9a-3a7709f2acdd'::uuid,'c7e65080-7667-48b9-8794-013cdc1c72ec'::uuid,NULL,NULL,true,now(),now()),
+     ('1a9c0ae9-f5c4-48f3-bd49-1b1ff202be56','97611c2a-3ef6-4883-bf9a-3a7709f2acdd'::uuid,'80f818a0-1047-466a-a3c1-ce2fc905f205'::uuid,NULL,NULL,true,now(),now()),
+     ('cf9c449f-e2b3-4716-ae41-48c9a1d605f0','97611c2a-3ef6-4883-bf9a-3a7709f2acdd'::uuid,'13342500-620c-41db-af42-dcecf468ee43'::uuid,NULL,NULL,true,now(),now()),
+     ('71a21ed8-da0e-461c-9bf7-39945d06068a','97611c2a-3ef6-4883-bf9a-3a7709f2acdd'::uuid,'c2c17c57-3d88-444d-b6ba-69a3d0d734f0'::uuid,NULL,NULL,true,now(),now());
+INSERT INTO gbloc_aors (id,jppso_regions_id,oconus_rate_area_id,department_indicator,shipment_type,is_active,created_at,updated_at) VALUES
+     ('87a10170-ce98-4ddc-bb17-0a7996ae7385','97611c2a-3ef6-4883-bf9a-3a7709f2acdd'::uuid,'950daf0c-0174-4e2f-b03b-05c088520cff'::uuid,NULL,NULL,true,now(),now()),
+     ('4073c7fa-822b-4f03-b4a6-213e600199ff','97611c2a-3ef6-4883-bf9a-3a7709f2acdd'::uuid,'9133dbe1-d08b-478e-8dbe-109fc05ca427'::uuid,NULL,NULL,true,now(),now()),
+     ('6f8eacf4-dd13-491e-a3bd-4c1bc49d38bc','97611c2a-3ef6-4883-bf9a-3a7709f2acdd'::uuid,'c1a175cd-c7d1-45ff-a49a-2a6cc4613e9f'::uuid,NULL,NULL,true,now(),now());


### PR DESCRIPTION
## [Agility ticket](https://www13.v1host.com/USTRANSCOM38/assetdetail.v1?number=B-21982)

## Summary

Adding Hawaii rate areas & GBLOC associations - nothin' fancy

### How to test

1. Run the migrations
2. Turn the hawaii flag on in your `envrc`
3. Run `direnv allow`
4. Fire up your server & client
5. Confirm you can find hawaii things in the city finder
6. Confirm you can find hawaii duty locations when adding orders
7. Confirm you can assign hawaii transpo offices to users in the admin app