### PR TITLE
B-22480 - fix issue with null Prime API call and AK destination moves

### DIFF
--- a/pkg/models/move.go
+++ b/pkg/models/move.go
@@ -230,11 +230,15 @@ func (m Move) GetDestinationGBLOC(db *pop.Connection) (string, error) {
 			return "", errors.WithMessage(ErrInvalidOrderID, "Orders ID must have a value in order to get the destination GBLOC")
 		}
 
-		newGBLOCOconus, err := FetchAddressGbloc(db, *destinationAddress, m.Orders.ServiceMember)
-		if err != nil {
-			return "", err
+		if m.Orders.ServiceMember.Affiliation != nil {
+			newGBLOCOconus, err := FetchAddressGbloc(db, *destinationAddress, m.Orders.ServiceMember)
+			if err != nil {
+				return "", err
+			}
+			newGBLOC = *newGBLOCOconus
+		} else {
+			return "", errors.Errorf("ServiceMember.Affiliation cannot be NULL for GetDestinationGBLOC")
 		}
-		newGBLOC = *newGBLOCOconus
 	} else {
 		newGBLOCConus, err := FetchGBLOCForPostalCode(db, destinationAddress.PostalCode)
 		if err != nil {


### PR DESCRIPTION
## [Agility ticket](https://www13.v1host.com/USTRANSCOM38/story.mvc/Summary?oidToken=Story%3A1064010&RoomContext=TeamRoom%3A848240&concept=TeamRoom)
## [INT PR](https://github.com/transcom/mymove/pull/14787)

## Summary

An issue was found with the Prime API listMoves call when moves are available to the prime that have AK destination addresses.
This stemmed from code from B-21583.
This is causing Homesafe to not be able to access our staging environment.


### How to test

1. Create a move with AK destination.  
2. Get it so that it's available to the Prime, so past TOO Approval.
3. Login as prime and pull up Postman and run this.
http://primelocal:3000/prime/v1/moves?since=2025-02-01T18:30:47.116Z
4.  Verify that you get the 200 OK and list of moves.

