### PR TITLE
MAIN B-21939

### DIFF
--- a/src/pages/PrimeUI/MoveTaskOrder/MoveDetails.jsx
+++ b/src/pages/PrimeUI/MoveTaskOrder/MoveDetails.jsx
@@ -24,6 +24,7 @@ import scrollToTop from 'shared/scrollToTop';
 import { SERVICE_ITEMS_ALLOWED_UPDATE } from 'constants/serviceItems';
 import { MoveOrderDocumentType } from 'shared/constants';
 import { CHECK_SPECIAL_ORDERS_TYPES, SPECIAL_ORDERS_TYPES } from 'constants/orders';
+import { formatWeight } from 'utils/formatters';
 
 const MoveDetails = ({ setFlashMessage }) => {
   const { moveCodeOrID } = useParams();
@@ -206,6 +207,14 @@ const MoveDetails = ({ setFlashMessage }) => {
                   <div className={descriptionListStyles.row}>
                     <dt>Gun Safe:</dt>
                     <dd>{moveTaskOrder.order.entitlement.gunSafe ? 'yes' : 'no'}</dd>
+                  </div>
+                  <div className={descriptionListStyles.row}>
+                    <dt>Admin Restricted Weight:</dt>
+                    <dd>
+                      {moveTaskOrder.order.entitlement.weightRestriction > 0
+                        ? formatWeight(moveTaskOrder.order.entitlement.weightRestriction)
+                        : 'no'}
+                    </dd>
                   </div>
                   <div className={descriptionListStyles.row}>
                     <Button onClick={handleDownloadOrders}>Download Move Orders</Button>

--- a/src/pages/PrimeUI/MoveTaskOrder/MoveDetails.test.jsx
+++ b/src/pages/PrimeUI/MoveTaskOrder/MoveDetails.test.jsx
@@ -8,6 +8,7 @@ import { usePrimeSimulatorGetMove } from 'hooks/queries';
 import { MockProviders } from 'testUtils';
 import { completeCounseling, deleteShipment, downloadMoveOrder } from 'services/primeApi';
 import { primeSimulatorRoutes } from 'constants/routes';
+import { formatWeight } from 'utils/formatters';
 
 const mockRequestedMoveCode = 'LN4T89';
 
@@ -194,6 +195,7 @@ const moveTaskOrder = {
   order: {
     entitlement: {
       gunSafe: true,
+      weightRestriction: 500,
     },
   },
 };
@@ -224,6 +226,25 @@ const renderWithProviders = (component) => {
 };
 describe('PrimeUI MoveDetails page', () => {
   describe('check move details page load', () => {
+    it('renders move and entitlement detais on load', async () => {
+      usePrimeSimulatorGetMove.mockReturnValue(moveReturnValue);
+
+      renderWithProviders(<MoveDetails />);
+
+      await waitFor(() => {
+        expect(screen.getByText(/Move Code/)).toBeInTheDocument();
+        expect(screen.getByText(/Move Id/)).toBeInTheDocument();
+        const gunSafe = screen.getByText('Gun Safe:');
+        expect(gunSafe).toBeInTheDocument();
+        expect(gunSafe.nextElementSibling.textContent).toBe('yes');
+        const adminRestrictedWeight = screen.getByText('Admin Restricted Weight:');
+        expect(adminRestrictedWeight).toBeInTheDocument();
+        expect(adminRestrictedWeight.nextElementSibling.textContent).toBe(
+          formatWeight(moveTaskOrder.order.entitlement.weightRestriction),
+        );
+      });
+    });
+
     it('displays payment requests information', async () => {
       usePrimeSimulatorGetMove.mockReturnValue(moveReturnValue);
       renderWithProviders(<MoveDetails />);


### PR DESCRIPTION
[INT PR](https://github.com/transcom/mymove/pull/14758)

## [Agility ticket](https://www13.v1host.com/USTRANSCOM38/assetdetail.v1?number=B-21939)

## Summary

Updating the prime sim to show the admin restricted weight, should help with testing efforts in the future. Nothing cray cray here.

### How to test

1. Log in as Prime Sim
2. Find any move
3. Confirm you can see the "admin restricted weight" under the move details
4. Go in as TOO/SC, whatever, update the admin restricted weight to be... some number
5. Go back into that move as the prime sim
6. Confirm you can see that weight

## Screenshots
![Screenshot 2025-02-06 at 11 19 08 AM](https://github.com/user-attachments/assets/22f2eec1-1e93-4f6d-a80e-389476d28729)

![Screenshot 2025-02-06 at 11 24 16 AM](https://github.com/user-attachments/assets/01eb6d41-75c2-4377-aadb-e8621ef1c2c3)
