### PR TITLE
B-22307 int deleted expense types

### DIFF
--- a/pkg/services/shipment_summary_worksheet/shipment_summary_worksheet.go
+++ b/pkg/services/shipment_summary_worksheet/shipment_summary_worksheet.go
@@ -1083,6 +1083,32 @@ func (SSWPPMComputer *SSWPPMComputer) FetchDataShipmentSummaryWorksheetFormData(
 		return nil, dbQErr
 	}
 
+	// the following checks are needed since we can't use "ExcludeDeletedScope()" in the big query above
+	// this is because not all of the tables being queried have "deleted_at" columns and this returns an error
+	if ppmShipment.WeightTickets != nil {
+		var filteredWeightTickets []models.WeightTicket
+		// We do not need to consider deleted weight tickets or uploads within them
+		for _, wt := range ppmShipment.WeightTickets {
+			if wt.DeletedAt == nil {
+				wt.EmptyDocument.UserUploads = wt.EmptyDocument.UserUploads.FilterDeleted()
+				wt.FullDocument.UserUploads = wt.FullDocument.UserUploads.FilterDeleted()
+				wt.ProofOfTrailerOwnershipDocument.UserUploads = wt.ProofOfTrailerOwnershipDocument.UserUploads.FilterDeleted()
+				filteredWeightTickets = append(filteredWeightTickets, wt)
+			}
+		}
+		ppmShipment.WeightTickets = filteredWeightTickets
+	}
+	// We do not need to consider deleted moving expenses
+	if len(ppmShipment.MovingExpenses) > 0 {
+		nonDeletedMovingExpenses := ppmShipment.MovingExpenses.FilterDeleted()
+		ppmShipment.MovingExpenses = nonDeletedMovingExpenses
+	}
+	// We do not need to consider deleted progear weight tickets
+	if len(ppmShipment.ProgearWeightTickets) > 0 {
+		nonDeletedProgearTickets := ppmShipment.ProgearWeightTickets.FilterDeleted()
+		ppmShipment.ProgearWeightTickets = nonDeletedProgearTickets
+	}
+
 	// Final actual weight is a calculated value we don't store. This needs to be fetched independently
 	// Requires WeightTickets eager preload
 	ppmShipmentFinalWeight := models.GetPPMNetWeight(ppmShipment)


### PR DESCRIPTION
## [B-22307](https://www13.v1host.com/USTRANSCOM38/story.mvc/Summary?oidToken=Story%3A1060155)

## Summary

This PR addresses an error when attempting to create AOA or payment packets when there are deleted Moving Expenses and/or Pro Gear.

Is there anything you would like reviewers to give additional scrutiny?

## Verification Steps for the Author

These are to be checked by the author.

- [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
- [ ] Have the Agility acceptance criteria been met for this change?

## Verification Steps for Reviewers

These are to be checked by a reviewer.

- [ ] Has the branch been pulled in and checked out?
- [ ] Have the BL acceptance criteria been met for this change?
- [ ] Was the CircleCI build successful?
- [ ] Has the code been reviewed from a standards and best practices point of view?

### Setup to Run the Code

- [Instructions for starting storybook](https://transcom.github.io/mymove-docs/docs/frontend/setup/storybook)
- [Instructions for starting the MilMove application](https://transcom.github.io/mymove-docs/docs/getting-started/application-setup/)
- [Instructions for running tests](https://transcom.github.io/mymove-docs/docs/getting-started/development/testing)

### How to test

Create a new PPM with an Advance as a Customer and submit it.
Login as a SC and approve the shipment.
Make sure you can download an AOA packet without errors.
Login as the Customer and click upload PPM documents.
Add a Moving Expense and fill out the fields but don't save it, instead click the back button.
Click the delete button for your newly added Moving Expense.
Add another Moving Expense and fill out and save it.
Add Pro Gear fill out but don't save, instead click the back button.
Delete the recently added Pro Gear.
Add another Pro Gear and fill out and save.
Submit the shipment.
Login as the SC and approve the documents.
Make sure you can download the Payment Packet without errors.
Login as the Customer verify you can download the Payment Packet without errors.

### Frontend

- [ ] There are no aXe warnings for UI.
- [ ] This works in [Supported Browsers and their phone views](https://transcom.github.io/mymove-docs/docs/adrs/Browser-Support/#minimum-browser-requirements) (Chrome, Firefox, Edge).
- [ ] There are no new console errors in the browser devtools.
- [ ] There are no new console errors in the test output.
- [ ] If this PR adds a new component to Storybook, it ensures the component is fully responsive, OR if it is intentionally not, a wrapping div using the `officeApp` class or custom `min-width` styling is used to hide any states the would not be visible to the user.
- [ ] This change meets the standards for [Section 508 compliance](https://www.ssa.gov/accessibility/andi/help/install.html).

### Backend

- [ ] Code follows the guidelines for [Logging](https://transcom.github.io/mymove-docs/docs/getting-started/development/logging).
- [ ] The requirements listed in [Querying the Database Safely](https://transcom.github.io/mymove-docs/docs/backend/guides/golang-guide#querying-the-database-safely) have been satisfied.

### Database

#### Any new migrations/schema changes:

- [ ] Follows our guidelines for [Zero-Downtime Deploys](https://transcom.github.io/mymove-docs/docs/backend/setup/database-migrations#zero-downtime-migrations).
- [ ] Have been communicated to #g-database.
- [ ] Secure migrations have been tested following the instructions in our [docs](https://transcom.github.io/mymove-docs/docs/backend/setup/database-migrations#secure-migrations).

## Screenshots
