### PR TITLE
B-21322 INT: Remove RECEIVED_BY_GEX from payment request status enum

### DIFF
--- a/migrations/app/migrations_manifest.txt
+++ b/migrations/app/migrations_manifest.txt
@@ -1097,3 +1097,4 @@
 20250207153450_add_fetch_documents_func.up.sql
 20250210175754_B22451_update_dest_queue_to_consider_sit_extensions.up.sql
 20250213151815_fix_spacing_fetch_documents.up.sql
+20250213214427_drop_received_by_gex_payment_request_status_type.up.sql

--- a/migrations/app/schema/20250213214427_drop_received_by_gex_payment_request_status_type.up.sql
+++ b/migrations/app/schema/20250213214427_drop_received_by_gex_payment_request_status_type.up.sql
@@ -1,0 +1,36 @@
+-- This migration removes unused payment request type of INTERNATIONAL_HHG
+-- all previous payment requests using type were updated to TPPS_RECEIVED in
+-- migrations/app/schema/20240725190050_update_payment_request_status_tpps_received.up.sql
+
+-- update again in case new payment requests have used this status
+UPDATE payment_requests SET status = 'TPPS_RECEIVED' where status = 'RECEIVED_BY_GEX';
+
+--- rename existing enum
+ALTER TYPE payment_request_status RENAME TO payment_request_status_temp;
+
+-- create a new enum with both old and new statuses - both old and new statuses must exist in the enum to do the update setting old to new
+CREATE TYPE payment_request_status AS ENUM(
+    'PENDING',
+    'REVIEWED',
+    'SENT_TO_GEX',
+    'PAID',
+    'REVIEWED_AND_ALL_SERVICE_ITEMS_REJECTED',
+    'EDI_ERROR',
+    'DEPRECATED',
+    'TPPS_RECEIVED'
+    );
+
+alter  table payment_requests alter column  status drop default;
+alter  table payment_requests alter column  status drop not null;
+
+-- alter the payment_requests status column to use the new enum
+ALTER TABLE payment_requests ALTER COLUMN status TYPE payment_request_status USING status::text::payment_request_status;
+
+
+-- get rid of the temp type
+DROP TYPE payment_request_status_temp;
+
+
+ALTER TABLE payment_requests
+ALTER COLUMN status SET DEFAULT 'PENDING',
+ALTER COLUMN status SET NOT NULL;


### PR DESCRIPTION
## [Agility ticket](tbd)

## Summary

7+ months ago we did [some work](https://github.com/transcom/mymove/pull/13350/files#diff-5f30678867b99d4403442e522c4173f60bc1db79882997d716cd2c4408dd0579) and replaced the payment request status of RECEIVED_BY_GEX status with TPPS_RECEIVED.

This work is just to remove it from the status enum. Easy peasy!

AC from 21322:
```
Given I am looking at the possible payment request status types on the backend
The Received by GEX status from has been removed

```

### How to test

1. Checkout the branch
2. Run migrations
3. Check the payment_requests.status drop down
4. Make sure RECEIVED_BY_GEX is gone
![image](https://github.com/user-attachments/assets/6100cfd4-8b22-49b4-bee7-fc59830ba180)
5. Ensure it's not used anywhere else - should have already been cleaned up [here](https://github.com/transcom/mymove/pull/13350/files#diff-5f30678867b99d4403442e522c4173f60bc1db79882997d716cd2c4408dd0579)