### PR TITLE
INT B-22621

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -152,7 +152,7 @@ stages:
   #build off prd variables
   - export ECR_REPOSITORY_URI=${PRD_ACCOUNT_ID}.dkr.ecr.${PRD_REGION}.amazonaws.com
   - export APP_DOCKER_FILE=Dockerfile
-  - export TASK_DOCKER_FILE=Dockerfile
+  - export TASK_DOCKER_FILE=Dockerfile.tasks
   #TODO: update exp to prod
   - export APP_ENVIRONMENT=prd
 

--- a/pkg/services/order/order_updater.go
+++ b/pkg/services/order/order_updater.go
@@ -488,6 +488,8 @@ func allowanceFromTOOPayload(appCtx appcontext.AppContext, existingOrder models.
 	if payload.WeightRestriction != nil {
 		weightRestriction := int(*payload.WeightRestriction)
 		order.Entitlement.WeightRestriction = &weightRestriction
+	} else {
+		order.Entitlement.WeightRestriction = nil
 	}
 
 	if payload.AccompaniedTour != nil {
@@ -596,6 +598,8 @@ func allowanceFromCounselingPayload(appCtx appcontext.AppContext, existingOrder 
 	if payload.WeightRestriction != nil {
 		weightRestriction := int(*payload.WeightRestriction)
 		order.Entitlement.WeightRestriction = &weightRestriction
+	} else {
+		order.Entitlement.WeightRestriction = nil
 	}
 
 	if payload.AccompaniedTour != nil {

--- a/pkg/services/order/order_updater_test.go
+++ b/pkg/services/order/order_updater_test.go
@@ -651,6 +651,36 @@ func (suite *OrderServiceSuite) TestUpdateAllowanceAsTOO() {
 		suite.Equal(*payload.DependentsUnderTwelve, int64(*updatedOrder.Entitlement.DependentsUnderTwelve))
 	})
 
+	suite.Run("Updates the allowance when weightRestriction is null", func() {
+		moveRouter := move.NewMoveRouter()
+		orderUpdater := NewOrderUpdater(moveRouter)
+		order := factory.BuildNeedsServiceCounselingMove(suite.DB(), []factory.Customization{
+			{
+				Model: models.Entitlement{
+					WeightRestriction: models.IntPointer(1000),
+				},
+			},
+		}, nil).Orders
+
+		eTag := etag.GenerateEtag(order.UpdatedAt)
+
+		payload := ghcmessages.UpdateAllowancePayload{
+			WeightRestriction: nil,
+		}
+
+		updatedOrder, _, err := orderUpdater.UpdateAllowanceAsTOO(suite.AppContextForTest(), order.ID, payload, eTag)
+		suite.NoError(err)
+
+		var orderInDB models.Order
+		err = suite.DB().Find(&orderInDB, order.ID)
+
+		fetchedSM := models.ServiceMember{}
+		_ = suite.DB().Find(&fetchedSM, order.ServiceMember.ID)
+
+		suite.NoError(err)
+		suite.Nil(updatedOrder.Entitlement.WeightRestriction)
+	})
+
 	suite.Run("Updates the allowance when all fields are valid with dependents", func() {
 		moveRouter := move.NewMoveRouter()
 		orderUpdater := NewOrderUpdater(moveRouter)
@@ -808,6 +838,36 @@ func (suite *OrderServiceSuite) TestUpdateAllowanceAsCounselor() {
 		suite.EqualValues(payload.Agency, fetchedSM.Affiliation)
 		suite.Equal(*updatedOrder.Entitlement.DBAuthorizedWeight, 16000)
 		suite.Equal(*payload.WeightRestriction, int64(*updatedOrder.Entitlement.WeightRestriction))
+	})
+
+	suite.Run("Updates the allowance when weightRestriction is null", func() {
+		moveRouter := move.NewMoveRouter()
+		orderUpdater := NewOrderUpdater(moveRouter)
+		order := factory.BuildNeedsServiceCounselingMove(suite.DB(), []factory.Customization{
+			{
+				Model: models.Entitlement{
+					WeightRestriction: models.IntPointer(1000),
+				},
+			},
+		}, nil).Orders
+
+		eTag := etag.GenerateEtag(order.UpdatedAt)
+
+		payload := ghcmessages.CounselingUpdateAllowancePayload{
+			WeightRestriction: nil,
+		}
+
+		updatedOrder, _, err := orderUpdater.UpdateAllowanceAsCounselor(suite.AppContextForTest(), order.ID, payload, eTag)
+		suite.NoError(err)
+
+		var orderInDB models.Order
+		err = suite.DB().Find(&orderInDB, order.ID)
+
+		fetchedSM := models.ServiceMember{}
+		_ = suite.DB().Find(&fetchedSM, order.ServiceMember.ID)
+
+		suite.NoError(err)
+		suite.Nil(updatedOrder.Entitlement.WeightRestriction)
 	})
 
 	suite.Run("Updates the allowance when all fields are valid with dependents present and authorized", func() {

--- a/pkg/services/order/order_updater_test.go
+++ b/pkg/services/order/order_updater_test.go
@@ -673,10 +673,6 @@ func (suite *OrderServiceSuite) TestUpdateAllowanceAsTOO() {
 
 		var orderInDB models.Order
 		err = suite.DB().Find(&orderInDB, order.ID)
-
-		fetchedSM := models.ServiceMember{}
-		_ = suite.DB().Find(&fetchedSM, order.ServiceMember.ID)
-
 		suite.NoError(err)
 		suite.Nil(updatedOrder.Entitlement.WeightRestriction)
 	})
@@ -862,10 +858,6 @@ func (suite *OrderServiceSuite) TestUpdateAllowanceAsCounselor() {
 
 		var orderInDB models.Order
 		err = suite.DB().Find(&orderInDB, order.ID)
-
-		fetchedSM := models.ServiceMember{}
-		_ = suite.DB().Find(&fetchedSM, order.ServiceMember.ID)
-
 		suite.NoError(err)
 		suite.Nil(updatedOrder.Entitlement.WeightRestriction)
 	})

--- a/scripts/rds-snapshot-app-db
+++ b/scripts/rds-snapshot-app-db
@@ -19,17 +19,35 @@ db_snapshot_identifier=$db_instance_identifier-$(date +%s)
 readonly db_snapshot_identifier
 readonly tags=("Key=Environment,Value=$environment" "Key=Tool,Value=$(basename "$0")")
 
+
 echo
 echo "Wait for concurrent database snapshots for ${db_instance_identifier} to complete before continuing ..."
-time aws rds wait db-snapshot-completed --cli-read-timeout 2100 --cli-connect-timeout 2100  --db-instance-identifier "$db_instance_identifier"
+time aws rds wait db-snapshot-completed  --db-instance-identifier "$db_instance_identifier"
+
 
 echo
 echo "Create database snapshot for ${db_instance_identifier} with identifier ${db_snapshot_identifier}"
-aws rds create-db-snapshot --cli-read-timeout 2100 --cli-connect-timeout 2100 --db-instance-identifier "$db_instance_identifier" --db-snapshot-identifier "$db_snapshot_identifier" --tags "${tags[@]}"
+
+
+aws rds create-db-snapshot --db-instance-identifier "$db_instance_identifier" --db-snapshot-identifier "$db_snapshot_identifier" --tags "${tags[@]}"
+
+#we want to loop while status is not available; check after initiating the create
+while true; do
+  db_description=$(aws rds describe-db-snapshots --db-snapshot-identifier "$db_snapshot_identifier")
+  db_status=$(echo "${db_description}" | jq -r ".DBSnapshots[].Status")
+  echo "${db_snapshot_identifier} -- ${db_status}"
+  if [[ "${db_status}" == "available" ]]; then
+    break
+  fi
+  sleep 15
+done
+
+
+#unnecessary confirm but will leave in
 
 echo
 echo "Wait for current database snapshot ${db_snapshot_identifier} to complete before continuing ..."
-time aws rds wait db-snapshot-completed --cli-read-timeout 2100 --cli-connect-timeout 2100  --db-snapshot-identifier "$db_snapshot_identifier"
+time aws rds wait db-snapshot-completed  --db-snapshot-identifier "$db_snapshot_identifier"
 
 echo
 echo "Describe the database snapshot ${db_snapshot_identifier}"

--- a/src/components/Office/AllowancesDetailForm/AllowancesDetailForm.jsx
+++ b/src/components/Office/AllowancesDetailForm/AllowancesDetailForm.jsx
@@ -21,7 +21,7 @@ const AllowancesDetailForm = ({ header, entitlements, branchOptions, formIsDisab
     entitlements?.dependentsTwelveAndOver ||
     entitlements?.dependentsUnderTwelve
   );
-  const { setFieldValue } = useFormikContext();
+  const { values, setFieldValue } = useFormikContext();
   const [isAdminWeightLocationChecked, setIsAdminWeightLocationChecked] = useState(entitlements?.weightRestriction > 0);
   useEffect(() => {
     // Functional component version of "componentDidMount"
@@ -37,20 +37,20 @@ const AllowancesDetailForm = ({ header, entitlements, branchOptions, formIsDisab
 
   useEffect(() => {
     if (!isAdminWeightLocationChecked) {
-      // Find the weight restriction input and reset its value to 0
-      const weightRestrictionInput = document.getElementById('weightRestrictionId');
-      if (weightRestrictionInput) {
-        weightRestrictionInput.value = '';
-      }
+      setFieldValue('weightRestriction', `${values.weightRestriction}`);
     }
-  }, [isAdminWeightLocationChecked]);
+  }, [setFieldValue, values.weightRestriction, isAdminWeightLocationChecked]);
 
   const handleAdminWeightLocationChange = (e) => {
     const isChecked = e.target.checked;
     setIsAdminWeightLocationChecked(isChecked);
 
     if (!isChecked) {
-      setFieldValue('weightRestriction', '');
+      setFieldValue('weightRestriction', `${values.weightRestriction}`);
+    } else if (isChecked && values.weightRestriction) {
+      setFieldValue('weightRestriction', `${values.weightRestriction}`);
+    } else {
+      setFieldValue('weightRestriction', null);
     }
   };
 
@@ -205,14 +205,13 @@ const AllowancesDetailForm = ({ header, entitlements, branchOptions, formIsDisab
         <MaskedTextField
           data-testid="weightRestrictionInput"
           id="weightRestrictionId"
-          defaultValue="0"
           name="weightRestriction"
           label="Weight Restriction (lbs)"
           mask={Number}
-          scale={0} // digits after point, 0 for integers
-          signed={false} // disallow negative
+          scale={0}
+          signed={false}
           thousandsSeparator=","
-          lazy={false} // immediate masking evaluation
+          lazy={false}
           isDisabled={formIsDisabled}
         />
       )}

--- a/src/components/Office/AllowancesDetailForm/AllowancesDetailForm.test.jsx
+++ b/src/components/Office/AllowancesDetailForm/AllowancesDetailForm.test.jsx
@@ -189,10 +189,12 @@ describe('AllowancesDetailForm additional tests', () => {
   });
 
   it('does not render the admin weight location section when the weightRestriction entitlement is null', async () => {
-    entitlements.weightRestriction = null;
     render(
       <Formik initialValues={initialValues}>
-        <AllowancesDetailForm entitlements={entitlements} branchOptions={branchOptions} />
+        <AllowancesDetailForm
+          entitlements={{ ...entitlements, weightRestriction: null }}
+          branchOptions={branchOptions}
+        />
       </Formik>,
     );
 

--- a/src/components/Office/AllowancesDetailForm/AllowancesDetailForm.test.jsx
+++ b/src/components/Office/AllowancesDetailForm/AllowancesDetailForm.test.jsx
@@ -12,6 +12,7 @@ const initialValues = {
   proGearWeightSpouse: '500',
   requiredMedicalEquipmentWeight: '1000',
   organizationalClothingAndIndividualEquipment: true,
+  weightRestriction: '500',
 };
 
 const initialValuesOconusAdditions = {
@@ -81,6 +82,7 @@ const entitlements = {
   storageInTransit: 90,
   totalWeight: 11000,
   totalDependents: 2,
+  weightRestriction: 500,
 };
 
 const entitlementOconusAdditions = {
@@ -179,11 +181,24 @@ describe('AllowancesDetailForm additional tests', () => {
 
     const adminWeightCheckbox = await screen.findByTestId('adminWeightLocation');
     expect(adminWeightCheckbox).toBeInTheDocument();
+    expect(screen.getByLabelText('Admin restricted weight location')).toBeChecked();
+
+    const weightRestrictionInput = screen.getByTestId('weightRestrictionInput');
+    expect(weightRestrictionInput).toBeInTheDocument();
+    expect(weightRestrictionInput).toHaveValue('500');
+  });
+
+  it('does not render the admin weight location section when the weightRestriction entitlement is null', async () => {
+    entitlements.weightRestriction = null;
+    render(
+      <Formik initialValues={initialValues}>
+        <AllowancesDetailForm entitlements={entitlements} branchOptions={branchOptions} />
+      </Formik>,
+    );
+
+    const adminWeightCheckbox = await screen.findByTestId('adminWeightLocation');
+    expect(adminWeightCheckbox).toBeInTheDocument();
     expect(screen.queryByTestId('weightRestrictionInput')).not.toBeInTheDocument();
-    await act(async () => {
-      adminWeightCheckbox.click();
-    });
-    expect(screen.getByTestId('weightRestrictionInput')).toBeInTheDocument();
   });
 
   it('displays the total weight allowance correctly', async () => {

--- a/src/pages/Office/MoveAllowances/MoveAllowances.jsx
+++ b/src/pages/Office/MoveAllowances/MoveAllowances.jsx
@@ -46,15 +46,14 @@ const validationSchema = Yup.object({
   weightRestriction: Yup.number()
     .transform((value) => (Number.isNaN(value) ? 0 : value))
     .when('adminRestrictedWeightLocation', {
-      is: true, // Apply rules only if adminRestrictedWeightLocation is true
+      is: true,
       then: (schema) =>
         schema
           .min(1, 'Weight restriction must be greater than 0')
           .max(18000, 'Weight restriction cannot exceed 18,000 lbs')
           .required('Weight restriction is required when Admin Restricted Weight Location is enabled'),
-      otherwise: (schema) => schema.notRequired().nullable(), // No validation when false
+      otherwise: (schema) => schema.notRequired().nullable(),
     }),
-
   adminRestrictedWeightLocation: Yup.boolean().notRequired(),
 });
 

--- a/src/pages/Office/MoveAllowances/MoveAllowances.jsx
+++ b/src/pages/Office/MoveAllowances/MoveAllowances.jsx
@@ -218,7 +218,7 @@ const MoveAllowances = () => {
               <Restricted to={permissionTypes.updateAllowances}>
                 <div className={styles.bottom}>
                   <div className={styles.buttonGroup}>
-                    <Button disabled={formik.isSubmitting} type="submit">
+                    <Button disabled={formik.isSubmitting || !formik.isValid} type="submit">
                       Save
                     </Button>
                     <Button type="button" secondary onClick={handleClose}>

--- a/src/pages/Office/ServicesCounselingMoveAllowances/ServicesCounselingMoveAllowances.test.jsx
+++ b/src/pages/Office/ServicesCounselingMoveAllowances/ServicesCounselingMoveAllowances.test.jsx
@@ -1,9 +1,11 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 
 import ServicesCounselingMoveAllowances from 'pages/Office/ServicesCounselingMoveAllowances/ServicesCounselingMoveAllowances';
 import { MockProviders } from 'testUtils';
 import { useOrdersDocumentQueries } from 'hooks/queries';
+import { permissionTypes } from 'constants/permissions';
 
 const mockOriginDutyLocation = {
   address: {
@@ -66,6 +68,7 @@ const useOrdersDocumentQueriesReturnValue = {
         storageInTransit: 2,
         totalDependents: 1,
         totalWeight: 5000,
+        weightRestriction: 500,
       },
       first_name: 'Leo',
       grade: 'E_1',
@@ -157,6 +160,46 @@ describe('MoveAllowances page', () => {
       expect(screen.getByLabelText('Dependents authorized')).toBeChecked();
 
       expect(screen.getByTestId('weightAllowance')).toHaveTextContent('5,000 lbs');
+    });
+
+    it('renders displays the allowances in the sidebar form and allows editing with correct permissions', async () => {
+      render(
+        <MockProviders permissions={[permissionTypes.updateAllowances]}>
+          <ServicesCounselingMoveAllowances />
+        </MockProviders>,
+      );
+
+      expect(await screen.findByTestId('proGearWeightInput')).toHaveDisplayValue('2,000');
+      expect(screen.getByTestId('proGearWeightSpouseInput')).toHaveDisplayValue('500');
+      expect(screen.getByTestId('rmeInput')).toHaveDisplayValue('1,000');
+      expect(screen.getByTestId('branchInput')).toHaveDisplayValue('Army');
+      expect(screen.getByTestId('sitInput')).toHaveDisplayValue('2');
+
+      expect(screen.getByLabelText('OCIE authorized (Army only)')).toBeChecked();
+      expect(screen.getByLabelText('Dependents authorized')).toBeChecked();
+
+      expect(screen.getByTestId('weightAllowance')).toHaveTextContent('5,000 lbs');
+      const adminWeightCheckbox = await screen.findByTestId('adminWeightLocation');
+      expect(adminWeightCheckbox).toBeChecked();
+      const weightRestrictionInput = screen.getByTestId('weightRestrictionInput');
+      expect(weightRestrictionInput).toHaveValue('500');
+
+      await userEvent.click(weightRestrictionInput);
+      await userEvent.clear(weightRestrictionInput);
+      await userEvent.type(weightRestrictionInput, '0');
+      fireEvent.blur(weightRestrictionInput);
+
+      await waitFor(() => {
+        expect(screen.getByText(/Weight restriction must be greater than 0/i)).toBeInTheDocument();
+      });
+
+      await userEvent.clear(weightRestrictionInput);
+
+      await waitFor(() => {
+        expect(
+          screen.getByText(/Weight restriction is required when Admin Restricted Weight Location is enabled/i),
+        ).toBeInTheDocument();
+      });
     });
   });
 });


### PR DESCRIPTION
## [Agility ticket](https://www13.v1host.com/USTRANSCOM38/assetdetail.v1?number=B-22621)

## Summary

A defect was found that was occurring when an office user was trying to update the allowances without changing anything and the save button was not working. This was because validation checks were occurring that we could not see - the only workaround was to check/uncheck the admin restricted weight box and it would submit.

This PR does the following:
- Changed up some validation checks to consider null values
- Only sending the weight restriction amount if the checkbox is checked - else we send null
- Accounting for null payload values in the backend to ensure we save null
- tests

### How to test

1. Access office app, pick any move
2. Go in as SC & TOO and ensure you can freely edit the allowances with and without touching the weight restriction checkbox/input
3. Also ensure everything saves as expected and saves null values when the checkbox ain't checked

## Screenshots
https://github.com/user-attachments/assets/f8003035-00b4-41ff-804e-7b6599ed1367
