### PR TITLE
B 22726 INT

### DIFF
--- a/pkg/services/shipment_summary_worksheet/shipment_summary_worksheet.go
+++ b/pkg/services/shipment_summary_worksheet/shipment_summary_worksheet.go
@@ -968,7 +968,11 @@ func formatDisbursement(expensesMap map[string]float64, ppmRemainingEntitlement 
 		disbursementGTCC = 0
 	} else {
 		// Disbursement Member is remaining entitlement plus member SIT minus GTCC Disbursement, not less than 0.
-		disbursementMember = ppmRemainingEntitlement + expensesMap["StorageMemberPaid"]
+		totalGTCCPaid := expensesMap["TotalGTCCPaid"] + expensesMap["StorageGTCCPaid"]
+		disbursementMember = ppmRemainingEntitlement - totalGTCCPaid + expensesMap["StorageMemberPaid"]
+		if disbursementMember < 0 {
+			disbursementMember = 0
+		}
 	}
 
 	// Return formatted values in string

--- a/pkg/services/shipment_summary_worksheet/shipment_summary_worksheet_test.go
+++ b/pkg/services/shipment_summary_worksheet/shipment_summary_worksheet_test.go
@@ -801,7 +801,7 @@ func (suite *ShipmentSummaryWorksheetServiceSuite) TestGTCCPaidRemainingPPMEntit
 			MovingExpenseType:      &storageExpense,
 			Amount:                 &amount,
 			PaidWithGTCC:           models.BoolPointer(true),
-			SITReimburseableAmount: models.CentPointer(unit.Cents(200)),
+			SITReimburseableAmount: models.CentPointer(unit.Cents(20000)),
 		},
 	}
 
@@ -809,8 +809,8 @@ func (suite *ShipmentSummaryWorksheetServiceSuite) TestGTCCPaidRemainingPPMEntit
 	id := uuid.Must(uuid.NewV4())
 	PPMShipments := []models.PPMShipment{
 		{
-			FinalIncentive:        models.CentPointer(unit.Cents(600)),
-			AdvanceAmountReceived: models.CentPointer(unit.Cents(100)),
+			FinalIncentive:        models.CentPointer(unit.Cents(60000)),
+			AdvanceAmountReceived: models.CentPointer(unit.Cents(10000)),
 			ID:                    id,
 			Shipment: models.MTOShipment{
 				ShipmentLocator: &locator,
@@ -840,8 +840,8 @@ func (suite *ShipmentSummaryWorksheetServiceSuite) TestGTCCPaidRemainingPPMEntit
 	mockPPMCloseoutFetcher := &mocks.PPMCloseoutFetcher{}
 	sswPPMComputer := NewSSWPPMComputer(mockPPMCloseoutFetcher)
 	sswPage2, _ := sswPPMComputer.FormatValuesShipmentSummaryWorksheetFormPage2(ssd, true, expensesMap)
-	suite.Equal("$5.00", sswPage2.PPMRemainingEntitlement)
-	suite.Equal(expectedDisbursementString(500, 500), sswPage2.Disbursement)
+	suite.Equal("$500.00", sswPage2.PPMRemainingEntitlement)
+	suite.Equal(expectedDisbursementString(10000, 40000), sswPage2.Disbursement)
 }
 func (suite *ShipmentSummaryWorksheetServiceSuite) TestGroupExpenses() {
 	paidWithGTCC := false


### PR DESCRIPTION
## [Agility ticket](https://www13.v1host.com/USTRANSCOM38/story.mvc/Summary?oidToken=Story%3A1067880&RoomContext=TeamRoom%3A848240&concept=TeamRoom)

## Summary

Fixes PPM Disbursement values in ppm packet

### How to test

1. Create a PPM
2. Approve PPM as SC
3. Upload PPM documents
    a. Add a SIT expense type (NOT PAID TO GTC)
    b. Add random expense (PAID TO GTC)
4. Review and approve documents as SC
5. Download packet as service member.
6. Make sure member disbursement = total - gtc paid + member paid sit

## Screenshots
![Screenshot 2025-02-18 at 9 44 21 PM](https://github.com/user-attachments/assets/87a54a90-31b1-4214-83e7-7145cf7c0817)

