### PR TITLE
B-21322 INT Update move history labels

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM harbor.csde.caci.com/docker.io/debian:stable AS build-env
+FROM harbor.csde.caci.com/docker.io/library/debian:stable AS build-env
 
 COPY config/tls/dod-wcf-root-ca-1.pem /usr/local/share/ca-certificates/dod-wcf-root-ca-1.pem.crt
 COPY config/tls/dod-wcf-intermediate-ca-1.pem /usr/local/share/ca-certificates/dod-wcf-intermediate-ca-1.pem.crt

--- a/Dockerfile.dp3
+++ b/Dockerfile.dp3
@@ -1,4 +1,4 @@
-FROM harbor.csde.caci.com/docker.io/debian:stable AS build-env
+FROM harbor.csde.caci.com/docker.io/library/debian:stable AS build-env
 
 # hadolint ignore=DL3007
 FROM gcr.io/distroless/base-debian12@sha256:74ddbf52d93fafbdd21b399271b0b4aac1babf8fa98cab59e5692e01169a1348

--- a/Dockerfile.migrations
+++ b/Dockerfile.migrations
@@ -1,4 +1,4 @@
-FROM harbor.csde.caci.com/docker.io/debian:stable AS build-env
+FROM harbor.csde.caci.com/docker.io/library/debian:stable AS build-env
 
 COPY config/tls/dod-wcf-root-ca-1.pem /usr/local/share/ca-certificates/dod-wcf-root-ca-1.pem.crt
 COPY config/tls/dod-wcf-intermediate-ca-1.pem /usr/local/share/ca-certificates/dod-wcf-intermediate-ca-1.pem.crt

--- a/Dockerfile.tasks
+++ b/Dockerfile.tasks
@@ -1,4 +1,4 @@
-FROM harbor.csde.caci.com/docker.io/debian:stable AS build-env
+FROM harbor.csde.caci.com/docker.io/library/debian:stable AS build-env
 
 COPY config/tls/dod-wcf-root-ca-1.pem /usr/local/share/ca-certificates/dod-wcf-root-ca-1.pem.crt
 COPY config/tls/dod-wcf-intermediate-ca-1.pem /usr/local/share/ca-certificates/dod-wcf-intermediate-ca-1.pem.crt

--- a/src/constants/MoveHistory/EventTemplates/UpdatePaymentRequest/updatePaymentRequest.test.jsx
+++ b/src/constants/MoveHistory/EventTemplates/UpdatePaymentRequest/updatePaymentRequest.test.jsx
@@ -28,6 +28,18 @@ describe('when a payment request has an update', () => {
     },
   };
 
+  const historyRecord3 = {
+    action: 'UPDATE',
+    tableName: 'payment_requests',
+    eventName: '',
+    changedValues: {
+      status: 'PAID',
+    },
+    oldValues: {
+      payment_request_number: '4462-6355-3',
+    },
+  };
+
   const historyRecordWithError = {
     action: 'UPDATE',
     tableName: 'payment_requests',
@@ -56,8 +68,9 @@ describe('when a payment request has an update', () => {
   describe('should display the proper labeled details when payment status is changed', () => {
     it.each([
       ['Status', ': Sent to GEX', historyRecord],
-      ['Status', ': Received', historyRecord2],
-      ['Status', ': EDI error', historyRecordWithError],
+      ['Status', ': TPPS Received', historyRecord2],
+      ['Status', ': TPPS Paid', historyRecord3],
+      ['Status', ': EDI Error', historyRecordWithError],
     ])('label `%s` should have value `%s`', (label, value, record) => {
       const template = getTemplate(record);
       render(template.getDetails(record));

--- a/src/constants/MoveHistory/EventTemplates/UpdatePaymentRequest/updatePaymentRequestJobRunner.test.jsx
+++ b/src/constants/MoveHistory/EventTemplates/UpdatePaymentRequest/updatePaymentRequestJobRunner.test.jsx
@@ -26,6 +26,17 @@ describe('when a payment request has an update', () => {
     },
   };
 
+  const historyRecord3 = {
+    action: 'UPDATE',
+    tableName: 'payment_requests',
+    changedValues: {
+      status: 'PAID',
+    },
+    oldValues: {
+      payment_request_number: '4462-6355-3',
+    },
+  };
+
   const historyRecordWithError = {
     action: 'UPDATE',
     tableName: 'payment_requests',
@@ -54,8 +65,9 @@ describe('when a payment request has an update', () => {
   describe('should display the proper labeled details when payment status is changed', () => {
     it.each([
       ['Status', ': Sent to GEX', historyRecord],
-      ['Status', ': Received', historyRecord2],
-      ['Status', ': EDI error', historyRecordWithError],
+      ['Status', ': TPPS Received', historyRecord2],
+      ['Status', ': TPPS Paid', historyRecord3],
+      ['Status', ': EDI Error', historyRecordWithError],
     ])('label `%s` should have value `%s`', (label, value, record) => {
       const template = getTemplate(record);
       render(template.getDetails(record));

--- a/src/constants/paymentRequestStatus.js
+++ b/src/constants/paymentRequestStatus.js
@@ -10,12 +10,12 @@ export default {
 };
 
 export const PAYMENT_REQUEST_STATUS_LABELS = {
-  PENDING: 'Payment requested',
+  PENDING: 'Payment Requested',
   REVIEWED: 'Reviewed',
   SENT_TO_GEX: 'Sent to GEX',
-  TPPS_RECEIVED: 'Received',
+  TPPS_RECEIVED: 'TPPS Received',
   REVIEWED_AND_ALL_SERVICE_ITEMS_REJECTED: 'Rejected',
-  PAID: 'Paid',
-  EDI_ERROR: 'EDI error',
+  PAID: 'TPPS Paid',
+  EDI_ERROR: 'EDI Error',
   DEPRECATED: 'Deprecated',
 };

--- a/src/pages/Office/PaymentRequestQueue/PaymentRequestQueue.test.jsx
+++ b/src/pages/Office/PaymentRequestQueue/PaymentRequestQueue.test.jsx
@@ -214,7 +214,7 @@ describe('PaymentRequestQueue', () => {
     expect(firstPaymentRequest.find('td.customerName').text()).toBe('Spacemen, Leo');
     expect(firstPaymentRequest.find('td.edipi').text()).toBe('3305957632');
     expect(firstPaymentRequest.find('td.emplid').text()).toBe('1253694');
-    expect(firstPaymentRequest.find('td.status').text()).toBe('Payment requested');
+    expect(firstPaymentRequest.find('td.status').text()).toBe('Payment Requested');
     expect(firstPaymentRequest.find('td.age').text()).toBe('Less than 1 day');
     expect(firstPaymentRequest.find('td.submittedAt').text()).toBe('15 Oct 2020');
     expect(firstPaymentRequest.find('td.locator').text()).toBe('R993T7');
@@ -227,7 +227,7 @@ describe('PaymentRequestQueue', () => {
     expect(secondPaymentRequest.find('td.customerName').text()).toBe('Booga, Ooga');
     expect(secondPaymentRequest.find('td.edipi').text()).toBe('1234567');
     expect(secondPaymentRequest.find('td.emplid').text()).toBe('');
-    expect(secondPaymentRequest.find('td.status').text()).toBe('Payment requested');
+    expect(secondPaymentRequest.find('td.status').text()).toBe('Payment Requested');
     expect(secondPaymentRequest.find('td.age').text()).toBe('Less than 1 day');
     expect(secondPaymentRequest.find('td.submittedAt').text()).toBe('17 Oct 2020');
     expect(secondPaymentRequest.find('td.locator').text()).toBe('0OOGAB');
@@ -444,7 +444,7 @@ describe('PaymentRequestQueue', () => {
       </MockProviders>,
     );
     // expect Payment requested status to appear in the TIO queue
-    expect(screen.getAllByText('Payment requested')).toHaveLength(2);
+    expect(screen.getAllByText('Payment Requested')).toHaveLength(2);
     // expect other statuses NOT to appear in the TIO queue
     expect(screen.queryByText('Deprecated')).not.toBeInTheDocument();
     expect(screen.queryByText('Error')).not.toBeInTheDocument();

--- a/src/utils/formatters.js
+++ b/src/utils/formatters.js
@@ -601,6 +601,22 @@ export const constructSCOrderOconusFields = (values) => {
   };
 };
 
+export const userName = (user) => {
+  let formattedUser = '';
+  if (user.firstName && user.lastName) {
+    formattedUser += `${user.lastName}, `;
+    formattedUser += ` ${user.firstName}`;
+  } else {
+    if (user.firstName) {
+      formattedUser += ` ${user.firstName}`;
+    }
+    if (user.lastName) {
+      formattedUser += ` ${user.lastName}`;
+    }
+  }
+  return formattedUser;
+};
+
 export const formatAssignedOfficeUserFromContext = (historyRecord) => {
   const { changedValues, context, oldValues } = historyRecord;
   const newValues = {};
@@ -627,23 +643,6 @@ export const formatAssignedOfficeUserFromContext = (historyRecord) => {
   }
   return newValues;
 };
-
-export const userName = (user) => {
-  let formattedUser = '';
-  if (user.firstName && user.lastName) {
-    formattedUser += `${user.lastName}, `;
-    formattedUser += ` ${user.firstName}`;
-  } else {
-    if (user.firstName) {
-      formattedUser += ` ${user.firstName}`;
-    }
-    if (user.lastName) {
-      formattedUser += ` ${user.lastName}`;
-    }
-  }
-  return formattedUser;
-};
-
 /**
  * @description Converts a string to title case (capitalizes the first letter of each word)
  * @param {string} str - The input string to format.

--- a/src/utils/formatters.test.js
+++ b/src/utils/formatters.test.js
@@ -237,7 +237,7 @@ describe('formatters', () => {
 
   describe('paymentRequestStatusReadable', () => {
     it('returns expected string for PENDING', () => {
-      expect(formatters.paymentRequestStatusReadable(PAYMENT_REQUEST_STATUS.PENDING)).toEqual('Payment requested');
+      expect(formatters.paymentRequestStatusReadable(PAYMENT_REQUEST_STATUS.PENDING)).toEqual('Payment Requested');
     });
 
     it('returns expected string for REVIEWED', () => {
@@ -249,15 +249,15 @@ describe('formatters', () => {
     });
 
     it('returns expected string for TPPS_RECEIVED', () => {
-      expect(formatters.paymentRequestStatusReadable(PAYMENT_REQUEST_STATUS.TPPS_RECEIVED)).toEqual('Received');
+      expect(formatters.paymentRequestStatusReadable(PAYMENT_REQUEST_STATUS.TPPS_RECEIVED)).toEqual('TPPS Received');
     });
 
     it('returns expected string for PAID', () => {
-      expect(formatters.paymentRequestStatusReadable(PAYMENT_REQUEST_STATUS.PAID)).toEqual('Paid');
+      expect(formatters.paymentRequestStatusReadable(PAYMENT_REQUEST_STATUS.PAID)).toEqual('TPPS Paid');
     });
 
     it('returns expected string for EDI_ERROR', () => {
-      expect(formatters.paymentRequestStatusReadable(PAYMENT_REQUEST_STATUS.EDI_ERROR)).toEqual('EDI error');
+      expect(formatters.paymentRequestStatusReadable(PAYMENT_REQUEST_STATUS.EDI_ERROR)).toEqual('EDI Error');
     });
 
     it('returns expected string for DEPRECATED', () => {


### PR DESCRIPTION
## [Agility ticket](https://www13.v1host.com/USTRANSCOM38/assetdetail.v1?number=B-21322)

## Summary

Small enhancement to knock out for the payment request statuses of TPPS Received and TPPS Paid, showing TPPS in the move history log rather than just Received or Paid.