### PR TITLE
INT B-22660

### DIFF
--- a/migrations/app/ddl_functions_manifest.txt
+++ b/migrations/app/ddl_functions_manifest.txt
@@ -1,3 +1,4 @@
 # This is the functions(procedures) migrations manifest.
 # If a migration is not recorded here, then it will error.
 # Naming convention: fn_some_function.up.sql  running <generate-ddl-migration some_function functions> will create this file.
+20250223023132_fn_get_counseling_offices.up.sql

--- a/migrations/app/ddl_migrations/ddl_functions/20250223023132_fn_get_counseling_offices.up.sql
+++ b/migrations/app/ddl_migrations/ddl_functions/20250223023132_fn_get_counseling_offices.up.sql
@@ -1,0 +1,171 @@
+--B-22660 Daniel Jordan added get_duty_location_info
+CREATE OR REPLACE FUNCTION get_duty_location_info(p_duty_location_id UUID)
+RETURNS TABLE (duty_addr_id UUID, is_oconus BOOLEAN)
+LANGUAGE plpgsql AS $$
+BEGIN
+    RETURN QUERY
+    SELECT dl.address_id, a.is_oconus
+    FROM duty_locations dl
+    JOIN addresses a ON a.id = dl.address_id
+    WHERE dl.id = p_duty_location_id;
+END;
+$$;
+
+--B-22660 Daniel Jordan added get_service_affiliation
+CREATE OR REPLACE FUNCTION get_service_affiliation(p_service_member_id UUID)
+RETURNS TEXT
+LANGUAGE plpgsql AS $$
+DECLARE
+    service_affiliation TEXT;
+BEGIN
+    SELECT affiliation INTO service_affiliation
+    FROM service_members
+    WHERE id = p_service_member_id;
+
+    RETURN service_affiliation;
+END;
+$$;
+
+--B-22660 Daniel Jordan added get_department_indicator
+CREATE OR REPLACE FUNCTION get_department_indicator(p_service_affiliation TEXT)
+RETURNS TEXT
+LANGUAGE plpgsql AS $$
+DECLARE
+    dept_indicator TEXT;
+BEGIN
+    IF p_service_affiliation IN ('AIR_FORCE', 'SPACE_FORCE') THEN
+        dept_indicator := 'AIR_AND_SPACE_FORCE';
+    ELSIF p_service_affiliation IN ('NAVY', 'MARINES') THEN
+        dept_indicator := 'NAVY_AND_MARINES';
+    ELSIF p_service_affiliation = 'ARMY' THEN
+        dept_indicator := 'ARMY';
+    ELSIF p_service_affiliation = 'COAST_GUARD' THEN
+        dept_indicator := 'COAST_GUARD';
+    ELSE
+        RAISE EXCEPTION 'Invalid affiliation: %', p_service_affiliation;
+    END IF;
+
+    RETURN dept_indicator;
+END;
+$$;
+
+--B-22660 Daniel Jordan added get_gbloc_indicator
+CREATE OR REPLACE FUNCTION get_gbloc_indicator(p_duty_addr_id UUID, p_dept_indicator TEXT)
+RETURNS TEXT
+LANGUAGE plpgsql AS $$
+DECLARE
+    gbloc_indicator TEXT;
+BEGIN
+    SELECT j.code INTO gbloc_indicator
+    FROM addresses a
+    JOIN v_locations v ON a.us_post_region_cities_id = v.uprc_id
+    JOIN re_oconus_rate_areas o ON v.uprc_id = o.us_post_region_cities_id
+    JOIN re_rate_areas r ON o.rate_area_id = r.id
+    JOIN gbloc_aors g ON o.id = g.oconus_rate_area_id
+    JOIN jppso_regions j ON g.jppso_regions_id = j.id
+    WHERE a.id = p_duty_addr_id
+        AND (g.department_indicator = p_dept_indicator OR g.department_indicator IS NULL)
+    LIMIT 1;
+
+    IF gbloc_indicator IS NULL THEN
+        RAISE EXCEPTION 'Cannot determine GBLOC for duty location';
+    END IF;
+
+    RETURN gbloc_indicator;
+END;
+$$;
+
+--B-22660 Daniel Jordan added fetch_counseling_offices_for_oconus
+CREATE OR REPLACE FUNCTION fetch_counseling_offices_for_oconus(p_duty_location_id UUID, p_gbloc_indicator TEXT)
+RETURNS TABLE (id UUID, name TEXT)
+LANGUAGE plpgsql AS $$
+BEGIN
+    RETURN QUERY
+    SELECT toff.id, toff.name
+    FROM duty_locations dl
+    JOIN addresses a ON dl.address_id = a.id
+    JOIN v_locations v ON (a.us_post_region_cities_id = v.uprc_id OR v.uprc_id IS NULL)
+         AND a.country_id = v.country_id
+    JOIN re_oconus_rate_areas r ON r.us_post_region_cities_id = v.uprc_id
+    JOIN gbloc_aors ga ON ga.oconus_rate_area_id = r.id
+    JOIN jppso_regions j ON ga.jppso_regions_id = j.id
+    JOIN transportation_offices toff ON j.code = toff.gbloc
+    JOIN addresses toff_addr ON toff.address_id = toff_addr.id
+    LEFT JOIN zip3_distances zd
+      ON (
+         (substring(a.postal_code, 1, 3) = zd.from_zip3 AND substring(toff_addr.postal_code, 1, 3) = zd.to_zip3)
+         OR
+         (substring(a.postal_code, 1, 3) = zd.to_zip3 AND substring(toff_addr.postal_code, 1, 3) = zd.from_zip3)
+      )
+    WHERE dl.provides_services_counseling = true
+      AND dl.id = p_duty_location_id
+      AND j.code = p_gbloc_indicator
+      AND toff.provides_ppm_closeout = true
+    ORDER BY COALESCE(zd.distance_miles, 0) ASC;
+END;
+$$;
+
+--B-22660 Daniel Jordan added fetch_counseling_offices_for_conus
+CREATE OR REPLACE FUNCTION fetch_counseling_offices_for_conus(p_duty_location_id UUID)
+RETURNS TABLE (id UUID, name TEXT)
+LANGUAGE plpgsql AS $$
+BEGIN
+    RETURN QUERY
+    SELECT
+        toff.id,
+        toff.name
+    FROM postal_code_to_gblocs pcg
+    JOIN addresses a ON pcg.postal_code = a.postal_code
+    JOIN duty_locations dl ON a.id = dl.address_id
+    JOIN transportation_offices toff ON pcg.gbloc = toff.gbloc
+    JOIN addresses toff_addr ON toff.address_id = toff_addr.id
+    JOIN duty_locations d2 ON toff.id = d2.transportation_office_id
+    JOIN re_us_post_regions rup ON toff_addr.postal_code = rup.uspr_zip_id
+    LEFT JOIN zip3_distances zd
+        ON (
+            (substring(a.postal_code, 1, 3) = zd.from_zip3 AND substring(toff_addr.postal_code, 1, 3) = zd.to_zip3)
+            OR
+            (substring(a.postal_code, 1, 3) = zd.to_zip3 AND substring(toff_addr.postal_code, 1, 3) = zd.from_zip3)
+        )
+    WHERE dl.provides_services_counseling = true
+      AND dl.id = p_duty_location_id
+      AND d2.provides_services_counseling = true
+    GROUP BY toff.id, toff.name, zd.distance_miles
+    ORDER BY COALESCE(zd.distance_miles, 0), toff.name ASC;
+END;
+$$;
+
+--B-22660 Daniel Jordan added get_counseling_offices
+CREATE OR REPLACE FUNCTION get_counseling_offices(
+    p_duty_location_id UUID,
+    p_service_member_id UUID
+)
+RETURNS TABLE (id UUID, name TEXT)
+LANGUAGE plpgsql AS $$
+DECLARE
+    is_address_oconus BOOLEAN;
+    duty_address_id UUID;
+    service_affiliation TEXT;
+    dept_indicator TEXT;
+    gbloc_indicator TEXT;
+BEGIN
+
+    SELECT duty_addr_id, is_oconus INTO duty_address_id, is_address_oconus
+    FROM get_duty_location_info(p_duty_location_id);
+
+    IF duty_address_id IS NULL THEN
+        RAISE EXCEPTION 'Duty location % not found when searching for counseling offices', p_duty_location_id;
+    END IF;
+
+    IF is_address_oconus THEN
+        service_affiliation := get_service_affiliation(p_service_member_id);
+        dept_indicator := get_department_indicator(service_affiliation);
+
+        gbloc_indicator := get_gbloc_indicator(duty_address_id, dept_indicator);
+
+        RETURN QUERY SELECT * FROM fetch_counseling_offices_for_oconus(p_duty_location_id, gbloc_indicator);
+    ELSE
+        RETURN QUERY SELECT * FROM fetch_counseling_offices_for_conus(p_duty_location_id);
+    END IF;
+END;
+$$;

--- a/pkg/models/transportation_office.go
+++ b/pkg/models/transportation_office.go
@@ -70,3 +70,17 @@ func FetchNearestTransportationOffice(tx *pop.Connection, long float32, lat floa
 
 	return to, nil
 }
+
+// GetCounselingOffices is a db function that returns all the transportation offices in the GBLOC
+// of the given duty location where provides_services_counseling = true
+func GetCounselingOffices(db *pop.Connection, dutyLocationID uuid.UUID, serviceMemberID uuid.UUID) (TransportationOffices, error) {
+	var officeList TransportationOffices
+
+	err := db.RawQuery("SELECT * FROM get_counseling_offices($1, $2)", dutyLocationID, serviceMemberID).
+		All(&officeList)
+	if err != nil {
+		return officeList, err
+	}
+
+	return officeList, nil
+}

--- a/pkg/models/transportation_office.go
+++ b/pkg/models/transportation_office.go
@@ -71,7 +71,7 @@ func FetchNearestTransportationOffice(tx *pop.Connection, long float32, lat floa
 	return to, nil
 }
 
-// GetCounselingOffices is a db function that returns all the transportation offices in the GBLOC
+// GetCounselingOffices calls a db function that returns all the transportation offices in the GBLOC
 // of the given duty location where provides_services_counseling = true
 func GetCounselingOffices(db *pop.Connection, dutyLocationID uuid.UUID, serviceMemberID uuid.UUID) (TransportationOffices, error) {
 	var officeList TransportationOffices

--- a/pkg/models/transportation_office_test.go
+++ b/pkg/models/transportation_office_test.go
@@ -10,8 +10,6 @@
 package models_test
 
 import (
-	"github.com/gofrs/uuid"
-
 	"github.com/transcom/mymove/pkg/factory"
 	m "github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/services/address"
@@ -83,12 +81,14 @@ func (suite *ModelSuite) Test_TransportationOffice() {
 }
 
 func (suite *ModelSuite) TestGetCounselingOffices() {
-	customAddress1 := m.Address{
-		ID:         uuid.Must(uuid.NewV4()),
-		PostalCode: "59801",
-	}
+	customAddress1 := factory.BuildAddress(suite.DB(), []factory.Customization{
+		{
+			Model: m.Address{
+				PostalCode: "59801",
+			},
+		},
+	}, nil)
 	factory.BuildDutyLocation(suite.DB(), []factory.Customization{
-		{Model: customAddress1, Type: &factory.Addresses.DutyLocationAddress},
 		{
 			Model: m.DutyLocation{
 				ProvidesServicesCounseling: false,
@@ -99,15 +99,22 @@ func (suite *ModelSuite) TestGetCounselingOffices() {
 				Name: "PPPO Holloman AFB - USAF",
 			},
 		},
+		{
+			Model:    customAddress1,
+			LinkOnly: true,
+			Type:     &factory.Addresses.DutyLocationAddress,
+		},
 	}, nil)
 
 	// duty locations in KKFA with provides_services_counseling = true
-	customAddress2 := m.Address{
-		ID:         uuid.Must(uuid.NewV4()),
-		PostalCode: "59801",
-	}
+	customAddress2 := factory.BuildAddress(suite.DB(), []factory.Customization{
+		{
+			Model: m.Address{
+				PostalCode: "59801",
+			},
+		},
+	}, nil)
 	factory.BuildDutyLocation(suite.DB(), []factory.Customization{
-		{Model: customAddress2, Type: &factory.Addresses.DutyLocationAddress},
 		{
 			Model: m.DutyLocation{
 				ProvidesServicesCounseling: true,
@@ -118,14 +125,21 @@ func (suite *ModelSuite) TestGetCounselingOffices() {
 				Name: "PPPO Hill AFB - USAF",
 			},
 		},
+		{
+			Model:    customAddress2,
+			LinkOnly: true,
+			Type:     &factory.Addresses.DutyLocationAddress,
+		},
 	}, nil)
 
-	customAddress3 := m.Address{
-		ID:         uuid.Must(uuid.NewV4()),
-		PostalCode: "59801",
-	}
+	customAddress3 := factory.BuildAddress(suite.DB(), []factory.Customization{
+		{
+			Model: m.Address{
+				PostalCode: "59801",
+			},
+		},
+	}, nil)
 	origDutyLocation := factory.BuildDutyLocation(suite.DB(), []factory.Customization{
-		{Model: customAddress3, Type: &factory.Addresses.DutyLocationAddress},
 		{
 			Model: m.DutyLocation{
 				ProvidesServicesCounseling: true,
@@ -138,15 +152,22 @@ func (suite *ModelSuite) TestGetCounselingOffices() {
 				ProvidesCloseout: true,
 			},
 		},
+		{
+			Model:    customAddress3,
+			LinkOnly: true,
+			Type:     &factory.Addresses.DutyLocationAddress,
+		},
 	}, nil)
 
 	// this one will not show in the return since it is not KKFA
-	customAddress4 := m.Address{
-		ID:         uuid.Must(uuid.NewV4()),
-		PostalCode: "20906",
-	}
+	customAddress4 := factory.BuildAddress(suite.DB(), []factory.Customization{
+		{
+			Model: m.Address{
+				PostalCode: "20906",
+			},
+		},
+	}, nil)
 	factory.BuildDutyLocation(suite.DB(), []factory.Customization{
-		{Model: customAddress4, Type: &factory.Addresses.DutyLocationAddress},
 		{
 			Model: m.DutyLocation{
 				ProvidesServicesCounseling: true,
@@ -158,6 +179,11 @@ func (suite *ModelSuite) TestGetCounselingOffices() {
 				Gbloc:            "BGCA",
 				ProvidesCloseout: true,
 			},
+		},
+		{
+			Model:    customAddress4,
+			LinkOnly: true,
+			Type:     &factory.Addresses.DutyLocationAddress,
 		},
 	}, nil)
 

--- a/pkg/services/transportation_office/transportation_office_fetcher.go
+++ b/pkg/services/transportation_office/transportation_office_fetcher.go
@@ -134,8 +134,10 @@ func ListDistinctGBLOCs(appCtx appcontext.AppContext) (models.GBLOCs, error) {
 	return gblocList, err
 }
 
+// return all the transportation offices in the GBLOC of the given duty location where provides_services_counseling = true
+// serviceMemberID is only provided when this function is called by the office handler
 func (o transportationOfficesFetcher) GetCounselingOffices(appCtx appcontext.AppContext, dutyLocationID uuid.UUID, serviceMemberID uuid.UUID) (*models.TransportationOffices, error) {
-	officeList, err := findCounselingOffice(appCtx, dutyLocationID, serviceMemberID)
+	officeList, err := models.GetCounselingOffices(appCtx.DB(), dutyLocationID, serviceMemberID)
 
 	if err != nil {
 		switch err {

--- a/pkg/services/transportation_office/transportation_office_fetcher_test.go
+++ b/pkg/services/transportation_office/transportation_office_fetcher_test.go
@@ -103,13 +103,14 @@ func (suite *TransportationOfficeServiceSuite) Test_SortedTransportationOffices(
 
 func (suite *TransportationOfficeServiceSuite) Test_FindCounselingOffices() {
 	suite.toFetcher = NewTransportationOfficesFetcher()
-	// duty location in KKFA with provides_services_counseling = false
-	customAddress1 := models.Address{
-		ID:         uuid.Must(uuid.NewV4()),
-		PostalCode: "59801",
-	}
+	customAddress1 := factory.BuildAddress(suite.DB(), []factory.Customization{
+		{
+			Model: models.Address{
+				PostalCode: "59801",
+			},
+		},
+	}, nil)
 	factory.BuildDutyLocation(suite.DB(), []factory.Customization{
-		{Model: customAddress1, Type: &factory.Addresses.DutyLocationAddress},
 		{
 			Model: models.DutyLocation{
 				ProvidesServicesCounseling: false,
@@ -120,15 +121,22 @@ func (suite *TransportationOfficeServiceSuite) Test_FindCounselingOffices() {
 				Name: "PPPO Holloman AFB - USAF",
 			},
 		},
+		{
+			Model:    customAddress1,
+			LinkOnly: true,
+			Type:     &factory.Addresses.DutyLocationAddress,
+		},
 	}, nil)
 
 	// duty locations in KKFA with provides_services_counseling = true
-	customAddress2 := models.Address{
-		ID:         uuid.Must(uuid.NewV4()),
-		PostalCode: "59801",
-	}
+	customAddress2 := factory.BuildAddress(suite.DB(), []factory.Customization{
+		{
+			Model: models.Address{
+				PostalCode: "59801",
+			},
+		},
+	}, nil)
 	factory.BuildDutyLocation(suite.DB(), []factory.Customization{
-		{Model: customAddress2, Type: &factory.Addresses.DutyLocationAddress},
 		{
 			Model: models.DutyLocation{
 				ProvidesServicesCounseling: true,
@@ -139,14 +147,21 @@ func (suite *TransportationOfficeServiceSuite) Test_FindCounselingOffices() {
 				Name: "PPPO Hill AFB - USAF",
 			},
 		},
+		{
+			Model:    customAddress2,
+			LinkOnly: true,
+			Type:     &factory.Addresses.DutyLocationAddress,
+		},
 	}, nil)
 
-	customAddress3 := models.Address{
-		ID:         uuid.Must(uuid.NewV4()),
-		PostalCode: "59801",
-	}
+	customAddress3 := factory.BuildAddress(suite.DB(), []factory.Customization{
+		{
+			Model: models.Address{
+				PostalCode: "59801",
+			},
+		},
+	}, nil)
 	origDutyLocation := factory.BuildDutyLocation(suite.DB(), []factory.Customization{
-		{Model: customAddress3, Type: &factory.Addresses.DutyLocationAddress},
 		{
 			Model: models.DutyLocation{
 				ProvidesServicesCounseling: true,
@@ -159,15 +174,22 @@ func (suite *TransportationOfficeServiceSuite) Test_FindCounselingOffices() {
 				ProvidesCloseout: true,
 			},
 		},
+		{
+			Model:    customAddress3,
+			LinkOnly: true,
+			Type:     &factory.Addresses.DutyLocationAddress,
+		},
 	}, nil)
 
 	// this one will not show in the return since it is not KKFA
-	customAddress4 := models.Address{
-		ID:         uuid.Must(uuid.NewV4()),
-		PostalCode: "20906",
-	}
+	customAddress4 := factory.BuildAddress(suite.DB(), []factory.Customization{
+		{
+			Model: models.Address{
+				PostalCode: "20906",
+			},
+		},
+	}, nil)
 	factory.BuildDutyLocation(suite.DB(), []factory.Customization{
-		{Model: customAddress4, Type: &factory.Addresses.DutyLocationAddress},
 		{
 			Model: models.DutyLocation{
 				ProvidesServicesCounseling: true,
@@ -179,6 +201,11 @@ func (suite *TransportationOfficeServiceSuite) Test_FindCounselingOffices() {
 				Gbloc:            "BGCA",
 				ProvidesCloseout: true,
 			},
+		},
+		{
+			Model:    customAddress4,
+			LinkOnly: true,
+			Type:     &factory.Addresses.DutyLocationAddress,
 		},
 	}, nil)
 

--- a/pkg/services/transportation_office/transportation_office_fetcher_test.go
+++ b/pkg/services/transportation_office/transportation_office_fetcher_test.go
@@ -102,7 +102,8 @@ func (suite *TransportationOfficeServiceSuite) Test_SortedTransportationOffices(
 }
 
 func (suite *TransportationOfficeServiceSuite) Test_FindCounselingOffices() {
-	// duty location in KKFA with provies services counseling false
+	suite.toFetcher = NewTransportationOfficesFetcher()
+	// duty location in KKFA with provides_services_counseling = false
 	customAddress1 := models.Address{
 		ID:         uuid.Must(uuid.NewV4()),
 		PostalCode: "59801",
@@ -121,7 +122,7 @@ func (suite *TransportationOfficeServiceSuite) Test_FindCounselingOffices() {
 		},
 	}, nil)
 
-	// duty location in KKFA with provides services counseling true
+	// duty locations in KKFA with provides_services_counseling = true
 	customAddress2 := models.Address{
 		ID:         uuid.Must(uuid.NewV4()),
 		PostalCode: "59801",
@@ -140,7 +141,6 @@ func (suite *TransportationOfficeServiceSuite) Test_FindCounselingOffices() {
 		},
 	}, nil)
 
-	// duty location in KKFA with provides services counseling true
 	customAddress3 := models.Address{
 		ID:         uuid.Must(uuid.NewV4()),
 		PostalCode: "59801",
@@ -161,7 +161,7 @@ func (suite *TransportationOfficeServiceSuite) Test_FindCounselingOffices() {
 		},
 	}, nil)
 
-	// duty location NOT in KKFA with provides services counseling true
+	// this one will not show in the return since it is not KKFA
 	customAddress4 := models.Address{
 		ID:         uuid.Must(uuid.NewV4()),
 		PostalCode: "20906",
@@ -191,12 +191,9 @@ func (suite *TransportationOfficeServiceSuite) Test_FindCounselingOffices() {
 		},
 	}, nil)
 
-	offices, err := findCounselingOffice(suite.AppContextForTest(), origDutyLocation.ID, serviceMember.ID)
-
+	offices, err := suite.toFetcher.GetCounselingOffices(suite.AppContextForTest(), origDutyLocation.ID, serviceMember.ID)
 	suite.NoError(err)
-	suite.Len(offices, 2)
-	suite.Equal(offices[0].Name, "PPPO Hill AFB - USAF")
-	suite.Equal(offices[1].Name, "PPPO Travis AFB - USAF")
+	suite.Len(*offices, 2)
 }
 
 func (suite *TransportationOfficeServiceSuite) Test_Oconus_AK_FindCounselingOffices() {
@@ -401,7 +398,6 @@ func (suite *TransportationOfficeServiceSuite) Test_Oconus_AK_FindCounselingOffi
 		suite.Nil(err)
 		suite.Equal(2, len(offices))
 	})
-
 }
 
 func (suite *TransportationOfficeServiceSuite) Test_GetTransportationOffice() {

--- a/src/components/Customer/EditOrdersForm/EditOrdersForm.stories.jsx
+++ b/src/components/Customer/EditOrdersForm/EditOrdersForm.stories.jsx
@@ -3,6 +3,7 @@ import React from 'react';
 import EditOrdersForm from './EditOrdersForm';
 
 import { ORDERS_TYPE } from 'constants/orders';
+import { MockProviders } from 'testUtils';
 
 const testInitialValues = {
   orders_type: ORDERS_TYPE.PERMANENT_CHANGE_OF_STATION,
@@ -101,49 +102,57 @@ const testProps = {
 };
 
 export const EmptyValues = (argTypes) => (
-  <EditOrdersForm
-    {...testProps}
-    initialValues={testProps.initialValues}
-    onSubmit={argTypes.onSubmit}
-    onCancel={argTypes.onCancel}
-    createUpload={argTypes.createUpload}
-    onUploadComplete={argTypes.onUploadComplete}
-    onDelete={argTypes.onDelete}
-  />
+  <MockProviders>
+    <EditOrdersForm
+      {...testProps}
+      initialValues={testProps.initialValues}
+      onSubmit={argTypes.onSubmit}
+      onCancel={argTypes.onCancel}
+      createUpload={argTypes.createUpload}
+      onUploadComplete={argTypes.onUploadComplete}
+      onDelete={argTypes.onDelete}
+    />
+  </MockProviders>
 );
 
 export const PrefillNoDependents = (argTypes) => (
-  <EditOrdersForm
-    {...testProps}
-    initialValues={testInitialValues}
-    onSubmit={argTypes.onSubmit}
-    onCancel={argTypes.onCancel}
-    createUpload={argTypes.createUpload}
-    onUploadComplete={argTypes.onUploadComplete}
-    onDelete={argTypes.onDelete}
-  />
+  <MockProviders>
+    <EditOrdersForm
+      {...testProps}
+      initialValues={testInitialValues}
+      onSubmit={argTypes.onSubmit}
+      onCancel={argTypes.onCancel}
+      createUpload={argTypes.createUpload}
+      onUploadComplete={argTypes.onUploadComplete}
+      onDelete={argTypes.onDelete}
+    />
+  </MockProviders>
 );
 
 export const PrefillYesDependents = (argTypes) => (
-  <EditOrdersForm
-    {...testProps}
-    initialValues={{ ...testInitialValues, has_dependents: 'yes' }}
-    onSubmit={argTypes.onSubmit}
-    onCancel={argTypes.onCancel}
-    createUpload={argTypes.createUpload}
-    onUploadComplete={argTypes.onUploadComplete}
-    onDelete={argTypes.onDelete}
-  />
+  <MockProviders>
+    <EditOrdersForm
+      {...testProps}
+      initialValues={{ ...testInitialValues, has_dependents: 'yes' }}
+      onSubmit={argTypes.onSubmit}
+      onCancel={argTypes.onCancel}
+      createUpload={argTypes.createUpload}
+      onUploadComplete={argTypes.onUploadComplete}
+      onDelete={argTypes.onDelete}
+    />
+  </MockProviders>
 );
 
 export const PCSOnly = (argTypes) => (
-  <EditOrdersForm
-    {...testProps}
-    ordersTypeOptions={[testProps.ordersTypeOptions[0]]}
-    onSubmit={argTypes.onSubmit}
-    onCancel={argTypes.onCancel}
-    createUpload={argTypes.createUpload}
-    onUploadComplete={argTypes.onUploadComplete}
-    onDelete={argTypes.onDelete}
-  />
+  <MockProviders>
+    <EditOrdersForm
+      {...testProps}
+      ordersTypeOptions={[testProps.ordersTypeOptions[0]]}
+      onSubmit={argTypes.onSubmit}
+      onCancel={argTypes.onCancel}
+      createUpload={argTypes.createUpload}
+      onUploadComplete={argTypes.onUploadComplete}
+      onDelete={argTypes.onDelete}
+    />
+  </MockProviders>
 );

--- a/src/components/Customer/EditOrdersForm/EditOrdersForm.test.jsx
+++ b/src/components/Customer/EditOrdersForm/EditOrdersForm.test.jsx
@@ -9,6 +9,7 @@ import EditOrdersForm from './EditOrdersForm';
 import { documentSizeLimitMsg } from 'shared/constants';
 import { showCounselingOffices } from 'services/internalApi';
 import { ORDERS_TYPE, ORDERS_TYPE_OPTIONS } from 'constants/orders';
+import { MockProviders } from 'testUtils';
 
 jest.setTimeout(60000);
 
@@ -265,7 +266,11 @@ describe('EditOrdersForm component', () => {
       [/Pay grade/, true, HTMLSelectElement],
       [/Current duty location/, false, HTMLInputElement],
     ])('rendering %s and is required is %s', async (formInput, required, inputType) => {
-      render(<EditOrdersForm {...testProps} />);
+      render(
+        <MockProviders>
+          <EditOrdersForm {...testProps} />
+        </MockProviders>,
+      );
 
       expect(await screen.findByLabelText(formInput)).toBeInstanceOf(inputType);
       if (required) {
@@ -276,7 +281,11 @@ describe('EditOrdersForm component', () => {
     it('rendering the upload area', async () => {
       showCounselingOffices.mockImplementation(() => Promise.resolve({}));
 
-      render(<EditOrdersForm {...testProps} />);
+      render(
+        <MockProviders>
+          <EditOrdersForm {...testProps} />
+        </MockProviders>,
+      );
 
       expect(await screen.findByText(documentSizeLimitMsg)).toBeInTheDocument();
     });
@@ -294,7 +303,11 @@ describe('EditOrdersForm component', () => {
     ])('rendering the %s option', async (selectionOption, expectedValue) => {
       isBooleanFlagEnabled.mockImplementation(() => Promise.resolve(true));
 
-      render(<EditOrdersForm {...testProps} />);
+      render(
+        <MockProviders>
+          <EditOrdersForm {...testProps} />
+        </MockProviders>,
+      );
 
       const ordersTypeDropdown = await screen.findByLabelText(/Orders type/);
       expect(ordersTypeDropdown).toBeInstanceOf(HTMLSelectElement);
@@ -309,33 +322,35 @@ describe('EditOrdersForm component', () => {
   it('allows new and current duty location to be the same', async () => {
     // Render the component
     render(
-      <EditOrdersForm
-        {...testProps}
-        initialValues={{
-          ...initialValues,
-          origin_duty_location: {
-            name: 'Luke AFB',
-            provides_services_counseling: false,
-            address: { isOconus: false },
-          },
-          new_duty_location: {
-            name: 'Luke AFB',
-            provides_services_counseling: false,
-            address: { isOconus: false },
-          },
-          counseling_office_id: '3e937c1f-5539-4919-954d-017989130584',
-          uploaded_orders: [
-            {
-              id: '123',
-              createdAt: '2020-11-08',
-              bytes: 1,
-              url: 'url',
-              filename: 'Test Upload',
-              contentType: 'application/pdf',
+      <MockProviders>
+        <EditOrdersForm
+          {...testProps}
+          initialValues={{
+            ...initialValues,
+            origin_duty_location: {
+              name: 'Luke AFB',
+              provides_services_counseling: false,
+              address: { isOconus: false },
             },
-          ],
-        }}
-      />,
+            new_duty_location: {
+              name: 'Luke AFB',
+              provides_services_counseling: false,
+              address: { isOconus: false },
+            },
+            counseling_office_id: '3e937c1f-5539-4919-954d-017989130584',
+            uploaded_orders: [
+              {
+                id: '123',
+                createdAt: '2020-11-08',
+                bytes: 1,
+                url: 'url',
+                filename: 'Test Upload',
+                contentType: 'application/pdf',
+              },
+            ],
+          }}
+        />
+      </MockProviders>,
     );
 
     await waitFor(() => expect(screen.queryByText('Loading, please wait...')).not.toBeInTheDocument());
@@ -360,7 +375,11 @@ describe('EditOrdersForm component', () => {
   });
 
   it('shows an error message if the form is invalid', async () => {
-    render(<EditOrdersForm {...testProps} initialValues={initialValues} />);
+    render(
+      <MockProviders>
+        <EditOrdersForm {...testProps} initialValues={initialValues} />
+      </MockProviders>,
+    );
     const submitButton = await screen.findByRole('button', { name: 'Save' });
 
     const ordersTypeDropdown = screen.getByLabelText(/Orders type/);
@@ -378,27 +397,29 @@ describe('EditOrdersForm component', () => {
   it('submits the form when its valid', async () => {
     // Not testing the upload interaction, so give uploaded orders to the props.
     render(
-      <EditOrdersForm
-        {...testProps}
-        initialValues={{
-          origin_duty_location: {
-            name: 'Altus AFB',
-            provides_services_counseling: true,
-            address: { isOconus: false },
-          },
-          counseling_office_id: '3e937c1f-5539-4919-954d-017989130584',
-          uploaded_orders: [
-            {
-              id: '123',
-              createdAt: '2020-11-08',
-              bytes: 1,
-              url: 'url',
-              filename: 'Test Upload',
-              contentType: 'application/pdf',
+      <MockProviders>
+        <EditOrdersForm
+          {...testProps}
+          initialValues={{
+            origin_duty_location: {
+              name: 'Altus AFB',
+              provides_services_counseling: true,
+              address: { isOconus: false },
             },
-          ],
-        }}
-      />,
+            counseling_office_id: '3e937c1f-5539-4919-954d-017989130584',
+            uploaded_orders: [
+              {
+                id: '123',
+                createdAt: '2020-11-08',
+                bytes: 1,
+                url: 'url',
+                filename: 'Test Upload',
+                contentType: 'application/pdf',
+              },
+            ],
+          }}
+        />
+      </MockProviders>,
     );
 
     await waitFor(() => expect(screen.queryByText('Loading, please wait...')).not.toBeInTheDocument());
@@ -469,7 +490,11 @@ describe('EditOrdersForm component', () => {
   });
 
   it('implements the onCancel handler when the Cancel button is clicked', async () => {
-    render(<EditOrdersForm {...testProps} />);
+    render(
+      <MockProviders>
+        <EditOrdersForm {...testProps} />
+      </MockProviders>,
+    );
 
     const cancelButton = await screen.findByRole('button', { name: 'Cancel' });
 
@@ -533,7 +558,11 @@ describe('EditOrdersForm component', () => {
     };
 
     it('pre-fills the inputs', async () => {
-      render(<EditOrdersForm {...testProps} initialValues={testInitialValues} />);
+      render(
+        <MockProviders>
+          <EditOrdersForm {...testProps} initialValues={testInitialValues} />
+        </MockProviders>,
+      );
 
       expect(await screen.findByRole('form')).toHaveFormValues({
         new_duty_location: 'Yuma AFB',
@@ -551,7 +580,11 @@ describe('EditOrdersForm component', () => {
     });
 
     it('renders the uploads table with an existing upload', async () => {
-      render(<EditOrdersForm {...testProps} initialValues={testInitialValues} />);
+      render(
+        <MockProviders>
+          <EditOrdersForm {...testProps} initialValues={testInitialValues} />
+        </MockProviders>,
+      );
 
       await waitFor(() => {
         expect(screen.queryByText('Test Upload')).toBeInTheDocument();
@@ -627,7 +660,11 @@ describe('EditOrdersForm component', () => {
 
       modifiedProps.initialValues[attributeName] = valueToReplaceIt;
 
-      render(<EditOrdersForm {...modifiedProps} />);
+      render(
+        <MockProviders>
+          <EditOrdersForm {...modifiedProps} />
+        </MockProviders>,
+      );
 
       const save = await screen.findByRole('button', { name: 'Save' });
       await waitFor(() => {
@@ -641,27 +678,29 @@ describe('EditOrdersForm component', () => {
   it('submits the form when temporary duty orders type is selected', async () => {
     // Not testing the upload interaction, so give uploaded orders to the props.
     render(
-      <EditOrdersForm
-        {...testProps}
-        initialValues={{
-          origin_duty_location: {
-            name: 'Altus AFB',
-            provides_services_counseling: true,
-            address: { isOconus: false },
-          },
-          counseling_office_id: '3e937c1f-5539-4919-954d-017989130584',
-          uploaded_orders: [
-            {
-              id: '123',
-              createdAt: '2020-11-08',
-              bytes: 1,
-              url: 'url',
-              filename: 'Test Upload',
-              contentType: 'application/pdf',
+      <MockProviders>
+        <EditOrdersForm
+          {...testProps}
+          initialValues={{
+            origin_duty_location: {
+              name: 'Altus AFB',
+              provides_services_counseling: true,
+              address: { isOconus: false },
             },
-          ],
-        }}
-      />,
+            counseling_office_id: '3e937c1f-5539-4919-954d-017989130584',
+            uploaded_orders: [
+              {
+                id: '123',
+                createdAt: '2020-11-08',
+                bytes: 1,
+                url: 'url',
+                filename: 'Test Upload',
+                contentType: 'application/pdf',
+              },
+            ],
+          }}
+        />
+      </MockProviders>,
     );
 
     await waitFor(() => expect(screen.queryByText('Loading, please wait...')).not.toBeInTheDocument());
@@ -701,8 +740,11 @@ describe('EditOrdersForm component', () => {
   it('has dependents is yes and disabled when order type is student travel', async () => {
     isBooleanFlagEnabled.mockImplementation(() => Promise.resolve(true));
 
-    render(<EditOrdersForm {...testProps} />);
-
+    render(
+      <MockProviders>
+        <EditOrdersForm {...testProps} />
+      </MockProviders>,
+    );
     await waitFor(() => expect(screen.queryByText('Loading, please wait...')).not.toBeInTheDocument());
 
     await userEvent.selectOptions(screen.getByLabelText(/Orders type/), ORDERS_TYPE.STUDENT_TRAVEL);
@@ -718,8 +760,11 @@ describe('EditOrdersForm component', () => {
   });
 
   it('has dependents is yes and disabled when order type is early return', async () => {
-    render(<EditOrdersForm {...testProps} />);
-
+    render(
+      <MockProviders>
+        <EditOrdersForm {...testProps} />
+      </MockProviders>,
+    );
     await waitFor(() => expect(screen.queryByText('Loading, please wait...')).not.toBeInTheDocument());
 
     await userEvent.selectOptions(screen.getByLabelText(/Orders type/), ORDERS_TYPE.EARLY_RETURN_OF_DEPENDENTS);
@@ -735,8 +780,11 @@ describe('EditOrdersForm component', () => {
   });
 
   it('has dependents becomes disabled and then re-enabled for order type student travel', async () => {
-    render(<EditOrdersForm {...testProps} />);
-
+    render(
+      <MockProviders>
+        <EditOrdersForm {...testProps} />
+      </MockProviders>,
+    );
     await waitFor(() => expect(screen.queryByText('Loading, please wait...')).not.toBeInTheDocument());
 
     // set order type to perm change and verify the "has dependents" state
@@ -770,8 +818,11 @@ describe('EditOrdersForm component', () => {
   });
 
   it('has dependents becomes disabled and then re-enabled for order type early return', async () => {
-    render(<EditOrdersForm {...testProps} />);
-
+    render(
+      <MockProviders>
+        <EditOrdersForm {...testProps} />
+      </MockProviders>,
+    );
     await waitFor(() => expect(screen.queryByText('Loading, please wait...')).not.toBeInTheDocument());
 
     // set order type to perm change and verify the "has dependents" state

--- a/src/components/Customer/OrdersInfoForm/OrdersInfoForm.jsx
+++ b/src/components/Customer/OrdersInfoForm/OrdersInfoForm.jsx
@@ -104,34 +104,28 @@ const OrdersInfoForm = ({ ordersTypeOptions, initialValues, onSubmit, onBack, se
         }
         setShowLoadingSpinner(false, null);
       }
-
-      // Check if either currentDutyLocation or newDutyLocation is OCONUS
-      if (currentDutyLocation?.address?.isOconus || newDutyLocation?.address?.isOconus) {
-        setIsOconusMove(true);
-      } else {
-        setIsOconusMove(false);
-      }
-
-      if (currentDutyLocation?.address && newDutyLocation?.address && enableUB) {
-        if (isOconusMove && hasDependents) {
-          setShowAccompaniedTourField(true);
-          setShowDependentAgeFields(true);
-        } else {
-          setShowAccompaniedTourField(false);
-          setShowDependentAgeFields(false);
-        }
-      }
     };
     fetchCounselingOffices();
-  }, [
-    currentDutyLocation,
-    newDutyLocation,
-    isOconusMove,
-    hasDependents,
-    enableUB,
-    setShowLoadingSpinner,
-    counselingOfficeOptions,
-  ]);
+  }, [counselingOfficeOptions, currentDutyLocation.id, setShowLoadingSpinner]);
+
+  useEffect(() => {
+    // Check if either currentDutyLocation or newDutyLocation is OCONUS
+    if (currentDutyLocation?.address?.isOconus || newDutyLocation?.address?.isOconus) {
+      setIsOconusMove(true);
+    } else {
+      setIsOconusMove(false);
+    }
+
+    if (currentDutyLocation?.address && newDutyLocation?.address && enableUB) {
+      if (isOconusMove && hasDependents) {
+        setShowAccompaniedTourField(true);
+        setShowDependentAgeFields(true);
+      } else {
+        setShowAccompaniedTourField(false);
+        setShowDependentAgeFields(false);
+      }
+    }
+  }, [currentDutyLocation, newDutyLocation, isOconusMove, hasDependents, enableUB]);
 
   useEffect(() => {
     const fetchData = async () => {
@@ -259,11 +253,6 @@ const OrdersInfoForm = ({ ordersTypeOptions, initialValues, onSubmit, onBack, se
               />
               {currentDutyLocation.provides_services_counseling && (
                 <div>
-                  <Label>
-                    Select an origin duty location that most closely represents your current physical location, not
-                    where your shipment will originate, if different. This will allow a nearby transportation office to
-                    assist you.
-                  </Label>
                   <DropdownInput
                     label="Counseling office"
                     name="counseling_office_id"
@@ -272,6 +261,11 @@ const OrdersInfoForm = ({ ordersTypeOptions, initialValues, onSubmit, onBack, se
                     required
                     options={counselingOfficeOptions}
                   />
+                  <Hint>
+                    Select an origin duty location that most closely represents your current physical location, not
+                    where your shipment will originate, if different. This will allow a nearby transportation office to
+                    assist you.
+                  </Hint>
                 </div>
               )}
               {isRetirementOrSeparation ? (

--- a/src/components/Office/AddOrdersForm/AddOrdersForm.jsx
+++ b/src/components/Office/AddOrdersForm/AddOrdersForm.jsx
@@ -22,6 +22,7 @@ import ConnectedFlashMessage from 'containers/FlashMessage/FlashMessage';
 import MaskedTextField from 'components/form/fields/MaskedTextField/MaskedTextField';
 import formStyles from 'styles/form.module.scss';
 import { showCounselingOffices } from 'services/ghcApi';
+import Hint from 'components/Hint';
 
 let originMeta;
 let newDutyMeta = '';
@@ -217,11 +218,6 @@ const AddOrdersForm = ({
               />
               {currentDutyLocation.provides_services_counseling && (
                 <div>
-                  <Label>
-                    Select an origin duty location that most closely represents the customers current physical location,
-                    not where their shipment will originate, if different. This will allow a nearby transportation
-                    office to assist them.
-                  </Label>
                   <DropdownInput
                     label="Counseling office"
                     name="counselingOfficeId"
@@ -231,6 +227,11 @@ const AddOrdersForm = ({
                     required
                     options={counselingOfficeOptions}
                   />
+                  <Hint>
+                    Select an origin duty location that most closely represents the customers current physical location,
+                    not where their shipment will originate, if different. This will allow a nearby transportation
+                    office to assist them.
+                  </Hint>
                 </div>
               )}
 

--- a/src/pages/MyMove/EditOrders.test.jsx
+++ b/src/pages/MyMove/EditOrders.test.jsx
@@ -15,6 +15,7 @@ import {
 } from 'store/entities/selectors';
 import { isBooleanFlagEnabled } from 'utils/featureFlags';
 import { ORDERS_TYPE } from 'constants/orders';
+import { setShowLoadingSpinner } from 'store/general/actions';
 
 const mockNavigate = jest.fn();
 jest.mock('react-router-dom', () => ({
@@ -53,6 +54,15 @@ jest.mock('services/internalApi', () => ({
 jest.mock('utils/featureFlags', () => ({
   ...jest.requireActual('utils/featureFlags'),
   isBooleanFlagEnabled: jest.fn().mockImplementation(() => Promise.resolve(false)),
+}));
+
+jest.mock('store/general/actions', () => ({
+  ...jest.requireActual('store/general/actions'),
+  setShowLoadingSpinner: jest.fn().mockImplementation(() => ({
+    type: '',
+    showSpinner: false,
+    loadingSpinnerMessage: '',
+  })),
 }));
 
 describe('EditOrders Page', () => {
@@ -438,6 +448,24 @@ describe('EditOrders Page', () => {
         }),
       );
     });
+  });
+
+  it('calls the loading spinner on page load', async () => {
+    renderWithProviders(<EditOrders {...testProps} />, {
+      path: customerRoutes.ORDERS_EDIT_PATH,
+      params: { moveId: 'testMoveId', orderId: 'testOrders1' },
+    });
+
+    // calls the loading spinner on load
+    await waitFor(() => {
+      expect(setShowLoadingSpinner).toHaveBeenCalled();
+    });
+
+    const h1 = await screen.findByRole('heading', { name: 'Orders', level: 1 });
+    expect(h1).toBeInTheDocument();
+
+    const editOrdersHeader = await screen.findByRole('heading', { name: 'Edit Orders:', level: 2 });
+    expect(editOrdersHeader).toBeInTheDocument();
   });
 
   afterEach(jest.clearAllMocks);


### PR DESCRIPTION
## [Agility ticket](https://www13.v1host.com/USTRANSCOM38/assetdetail.v1?number=B-22660)

## Summary

When customers are going to their edit orders form, the counseling offices for their current duty location are loading on page render - this was causing the counseling office dropdown to be blank for a few seconds while those offices load. This PR focuses on showing the loading spinner implemented in B-22661 while those offices load during the edit orders actions.

In addition to that being implemented, it was found that the query to fetch the counseling offices could be more query-efficient and I took the liberty of transitioning that from a backend hard coded query to a series of database functions. This will allow only one call being made to the database to get these offices instead of the previously implemented several. This will reduce costs of database interactions and hopefully improve efficiency of the application.

Also throwing in a UI improvement and moving the counseling office text to underneath the dropdown and improving styling with switching it to use the `Hint` component

### How to test

1. Access MM as customer
2. Create your orders/move
3. Go to the edit orders page
4. Should see the loading spinner
5. Save
6. Load it back up
7. Should see the loading spinner and data updated
8. Verify you can still see the loading spinner when you change duty locations as the counseling offices load

## Screenshots

https://github.com/user-attachments/assets/c9dd3ad0-7284-48b9-afdb-80bd97e7c880

https://github.com/user-attachments/assets/bf04fe87-123f-4972-ab44-bc4088de891d