### PR TITLE
B 22540 INT - Create PPM_Closeouts Table

### DIFF
--- a/migrations/app/ddl_migrations/ddl_tables/20250228174901_tbl_ppm_closeouts.up.sql
+++ b/migrations/app/ddl_migrations/ddl_tables/20250228174901_tbl_ppm_closeouts.up.sql
@@ -1,0 +1,62 @@
+CREATE TABLE IF NOT EXISTS ppm_closeouts (
+    id UUID PRIMARY KEY NOT NULL,
+    ppm_shipment_id UUID REFERENCES ppm_shipments(id) ON DELETE CASCADE NOT NULL,
+    max_advance integer,
+	gtcc_paid_contracted_expense integer,
+	member_paid_contracted_expense integer,
+	gtcc_paid_packing_materials integer,
+	member_paid_packing_materials integer,
+	gtcc_paid_weighing_fee integer,
+	member_paid_weighing_fee integer,
+	gtcc_paid_rental_equipment integer,
+	member_paid_rental_equipment integer,
+	gtcc_paid_tolls integer,
+	member_paid_tolls integer,
+	gtcc_paid_oil integer,
+	member_paid_oil integer,
+	gtcc_paid_storage integer,
+	member_paid_storage integer,
+	gtcc_paid_other integer,
+	member_paid_other integer,
+	total_gtcc_paid_expenses integer,
+	total_member_paid_expenses integer,
+	remaining_incentive integer,
+	gtcc_paid_sit integer,
+	member_paid_sit integer,
+	gtcc_disbursement integer,
+	member_disbursement integer,
+    created_at TIMESTAMP NOT NULL,
+    updated_at TIMESTAMP NOT NULL
+);
+
+COMMENT on TABLE ppm_closeouts IS 'Stores dollar values paid out in PPM closeouts that are present on the shipment summary worksheet';
+
+COMMENT on COLUMN ppm_closeouts.ppm_shipment_id IS 'PPM shipment that is associated with this closeout.';
+COMMENT on COLUMN ppm_closeouts.max_advance IS 'Maximum value a customer can request as an advance. Stored in cents.';
+COMMENT on COLUMN ppm_closeouts.gtcc_paid_contracted_expense IS 'Amount paid for contracted expenses using the service member''s GTCC. Stored in cents.';
+COMMENT on COLUMN ppm_closeouts.member_paid_contracted_expense IS 'Amount paid for contracted expenses by the service member. Stored in cents.';
+COMMENT on COLUMN ppm_closeouts.gtcc_paid_packing_materials IS 'Amount paid for packing materials using the service member''s GTCC. Stored in cents.';
+COMMENT on COLUMN ppm_closeouts.member_paid_packing_materials IS 'Amount paid for packing materials by the service member. Stored in cents.';
+COMMENT on COLUMN ppm_closeouts.gtcc_paid_weighing_fee IS 'Amount paid for weighing fees using the service member''s GTCC. Stored in cents.';
+COMMENT on COLUMN ppm_closeouts.member_paid_weighing_fee IS 'Amount paid for weighing fees by the service member. Stored in cents.';
+COMMENT on COLUMN ppm_closeouts.gtcc_paid_rental_equipment IS 'Amount paid for rental equipment using the service member''s GTCC. Stored in cents.';
+COMMENT on COLUMN ppm_closeouts.member_paid_rental_equipment IS 'Amount paid for rental equipment by the service member. Stored in cents.';
+COMMENT on COLUMN ppm_closeouts.gtcc_paid_tolls IS 'Amount paid for tolls using the service member''s GTCC. Stored in cents.';
+COMMENT on COLUMN ppm_closeouts.member_paid_tolls IS 'Amount paid for tolls by the service member. Stored in cents.';
+COMMENT on COLUMN ppm_closeouts.gtcc_paid_oil IS 'Amount paid for oil using the service member''s GTCC. Stored in cents.';
+COMMENT on COLUMN ppm_closeouts.member_paid_oil IS 'Amount paid for oil by the service member. Stored in cents.';
+COMMENT on COLUMN ppm_closeouts.gtcc_paid_storage IS 'Amount paid for storage using the service member''s GTCC. Stored in cents.';
+COMMENT on COLUMN ppm_closeouts.member_paid_storage IS 'Amount paid for SIT by the service member. Stored in cents.';
+COMMENT on COLUMN ppm_closeouts.gtcc_paid_other IS 'Amount paid for other expenses using the service member''s GTCC. Stored in cents.';
+COMMENT on COLUMN ppm_closeouts.member_paid_other IS 'Amount paid for other expenses by the service member. Stored in cents.';
+COMMENT on COLUMN ppm_closeouts.total_gtcc_paid_expenses IS 'Total amount paid using the service member''s GTCC. Stored in cents.';
+COMMENT on COLUMN ppm_closeouts.total_member_paid_expenses IS 'Total amount paid by the service member. Stored in cents.';
+COMMENT on COLUMN ppm_closeouts.remaining_incentive IS 'Final PPM incentive less the advance recieved. Stored in cents.';
+COMMENT on COLUMN ppm_closeouts.gtcc_paid_sit IS 'Amount paid for SIT using the service member''s GTCC. Stored in cents.';
+COMMENT on COLUMN ppm_closeouts.member_paid_sit IS 'Evaluation report that is associated with the appeal.';
+COMMENT on COLUMN ppm_closeouts.gtcc_disbursement IS 'Amount disbursed for GTCC expenses. Stored in cents.';
+COMMENT on COLUMN ppm_closeouts.member_disbursement IS 'Amount disbursed for service member paid expenses. Stored in cents.';
+COMMENT on COLUMN ppm_closeouts.created_at IS 'Date that this closeout was created.';
+COMMENT on COLUMN ppm_closeouts.updated_at IS 'Date that this closeout was updated.';
+
+CREATE INDEX IF NOT EXISTS ppm_closeouts_ppm_shipment_id_idx ON ppm_closeouts (ppm_shipment_id);

--- a/migrations/app/ddl_tables_manifest.txt
+++ b/migrations/app/ddl_tables_manifest.txt
@@ -7,3 +7,4 @@
 20250224200700_tbl_ppm_shipments.up.sql
 20250225182052_tbl_B-22692_alter_moves.up.sql
 20250225183010_tbl_B-22692_alter_mto_shipments.up.sql
+20250228174901_tbl_ppm_closeouts.up.sql


### PR DESCRIPTION
## [B-22540](https://www13.v1host.com/USTRANSCOM38/assetdetail.v1?number=B-22540)

## Summary

Creates a new table for storing the values generated for the SSW for use by Advana.

A late backlog will populate the table on closeout.

Could be good to verify my comment are accurate.

## Verification Steps for the Author

These are to be checked by the author.

- [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
- [ ] Have the Agility acceptance criteria been met for this change?

## Verification Steps for Reviewers

These are to be checked by a reviewer.

- [ ] Has the branch been pulled in and checked out?
- [ ] Have the BL acceptance criteria been met for this change?
- [ ] Was the CircleCI build successful?
- [ ] Has the code been reviewed from a standards and best practices point of view?

### How to test

1. db_dev_migrate
2. Look for the ppm_closeouts table in your DB viewer of choice
3. Verify the columns match the AC.

### Database

#### Any new migrations/schema changes:

- [ ] Follows our guidelines for [Zero-Downtime Deploys](https://transcom.github.io/mymove-docs/docs/backend/setup/database-migrations#zero-downtime-migrations).
- [ ] Have been communicated to #g-database.
- [ ] Secure migrations have been tested following the instructions in our [docs](https://transcom.github.io/mymove-docs/docs/backend/setup/database-migrations#secure-migrations).

## Screenshots
