### PR TITLE
B-21350-INT Part 2: trim leading zeros in bulk assign modal

### DIFF
--- a/src/components/BulkAssignment/BulkAssignmentModal.jsx
+++ b/src/components/BulkAssignment/BulkAssignmentModal.jsx
@@ -218,7 +218,7 @@ export const BulkAssignmentModal = ({ onClose, onSubmit, title, submitText, clos
                                 id={user.officeUserId}
                                 data-testid="assignment"
                                 min={0}
-                                value={values.userData[i]?.moveAssignments || 0}
+                                value={values.userData[i]?.moveAssignments.toString() || 0}
                                 onChange={(event) => handleAssignmentChange(event, user, i)}
                               />
                             </td>


### PR DESCRIPTION
## [Agility ticket](https://www13.v1host.com/USTRANSCOM38/assetdetail.v1?number=B-21350)
## [INT PR 1](https://github.com/transcom/mymove/pull/14840)

## Summary
Tester noticed we were not trimming leading zeros in bulk assignment modal. Not sure if it was related to my changes or not but happy to include in the work for 21350 because I am just that kinda guy 😎 

## How to test
1. login as a supervisor office user
2. view your queue and click "Bulk Assignment"
3. confirm that when you click on an input and your cursor is to the right of the initialized '0' that when you enter a non-zero number, it'll update and trim the zero
4. confirm save works and all that jazz
5. login as other roles and confirm all that works too
6. try and break