### PR TITLE
INT I-13959

### DIFF
--- a/src/utils/formatMtoShipment.js
+++ b/src/utils/formatMtoShipment.js
@@ -296,9 +296,6 @@ export function formatMtoShipmentForDisplay({
 export function formatPpmShipmentForAPI(formValues) {
   let ppmShipmentValues = {
     ppmType: formValues.ppmType,
-    expectedDepartureDate: formatDateForSwagger(formValues.expectedDepartureDate),
-    pickupAddress: formatAddressForAPI(formValues.pickup.address),
-    destinationAddress: formatAddressForAPI(formValues.destination.address),
     sitExpected: !!formValues.sitExpected,
     estimatedWeight: Number(formValues.estimatedWeight || '0'),
     hasProGear: !!formValues.hasProGear,


### PR DESCRIPTION
## [Issue ticket](https://www13.v1host.com/USTRANSCOM38/assetdetail.v1?number=I-13959)

## Summary

This is an INT specific commit.

There was a merge conflict that wasn't caught during the merge process.

[B-22654](https://github.com/transcom/mymove/pull/14934/files#diff-617d73db48db38aa5ca9401a78867973c3d4404e3081c5904a24a7a165b52c22) added back in code that was removed in [B-22562](https://github.com/transcom/mymove/pull/14861)

Specifically in `formatMtoShipment.js` - this removes what needs to be removed to avoid getting errors when editing PPM shipments when they get to the advance screen

If this isn't removed, SCs are not allowed to go past the advance page after editing a PPM