### PR TITLE
Int b 21094 duplicate reweigh fix

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -86,10 +86,6 @@ stages:
 .setup_aws_vars_dp3: &setup_aws_vars_dp3
   - export SERVICE_RESERVATION_CPU=2048
   - export SERVICE_RESERVATION_MEM=4096
-  - unset AWS_ACCESS_KEY_ID
-  - unset AWS_SECRET_ACCESS_KEY
-  - unset AWS_ACCOUNT_ID
-  - unset AWS_DEFAULT_REGION
   - |
     if [[ "$DP3_ENV" == "exp" || "$DP3_ENV" == "loadtest" || "$DP3_ENV" == "demo" ]]; then
       export ENV=$(echo ${DP3_ENV} | tr '[:lower:]' '[:upper:]');
@@ -112,21 +108,12 @@ stages:
     fi
 
 .setup_aws_vars_com_dev: &setup_aws_vars_com_dev
-  - unset AWS_ACCESS_KEY_ID
-  - unset AWS_SECRET_ACCESS_KEY
-  - unset AWS_ACCOUNT_ID
-  - unset AWS_DEFAULT_REGION
-  - unset AWS_REGION
   - export AWS_REGION=$COM_REGION
   - export AWS_ACCOUNT_ID=$DEV_ACCOUNT_ID
   - export AWS_ACCESS_KEY_ID=$DEV_ACCESS_KEY_ID
   - export AWS_SECRET_ACCESS_KEY=$DEV_SECRET_KEY
 
 .setup_aws_vars_stg: &setup_aws_vars_stg
-  - unset AWS_ACCESS_KEY_ID
-  - unset AWS_SECRET_ACCESS_KEY
-  - unset AWS_ACCOUNT_ID
-  - unset AWS_DEFAULT_REGION
   - export AWS_DEFAULT_REGION=$STG_REGION
   - export AWS_ACCOUNT_ID=$STG_ACCOUNT_ID
   - export AWS_ACCESS_KEY_ID=$STG_ACCESS_KEY_ID
@@ -140,10 +127,6 @@ stages:
   - export TLS_CA=$STG_MOVE_MIL_DOD_TLS_CA
 
 .setup_aws_vars_prd: &setup_aws_vars_prd
-  - unset AWS_ACCESS_KEY_ID
-  - unset AWS_SECRET_ACCESS_KEY
-  - unset AWS_ACCOUNT_ID
-  - unset AWS_DEFAULT_REGION
   - export AWS_DEFAULT_REGION=$PRD_REGION
   - export AWS_ACCOUNT_ID=$PRD_ACCOUNT_ID
   - export AWS_ACCESS_KEY_ID=$PRD_ACCESS_KEY_ID

--- a/migrations/app/ddl_functions_manifest.txt
+++ b/migrations/app/ddl_functions_manifest.txt
@@ -2,5 +2,6 @@
 # If a migration is not recorded here, then it will error.
 # Naming convention: fn_some_function.up.sql  running <generate-ddl-migration some_function functions> will create this file.
 20250223023132_fn_get_counseling_offices.up.sql
+20250223023132_fn_get_counseling_offices.up.sql
 20250225183302_fn_prime_acknowledge_moves_shipments.up.sql
 20250225233157_fn_get_destination_queue.up.sql

--- a/migrations/app/ddl_tables_manifest.txt
+++ b/migrations/app/ddl_tables_manifest.txt
@@ -7,5 +7,7 @@
 20250224200700_tbl_ppm_shipments.up.sql
 20250225182052_tbl_B-22692_alter_moves.up.sql
 20250225183010_tbl_B-22692_alter_mto_shipments.up.sql
+20250225182052_tbl_B-22692_alter_moves.up.sql
+20250225183010_tbl_B-22692_alter_mto_shipments.up.sql
 20250227211221_tbl_re_country_prn_divisions.up.sql
 20250228174901_tbl_ppm_closeouts.up.sql


### PR DESCRIPTION
## [Agility ticket](https://www13.v1host.com/USTRANSCOM38/assetdetail.v1?number=B-21094)

## Previous INT PRs
#14364
#14845 

## Summary

Currently if a shipment's actual or estimated weights are edited while a reweigh is requested on the move, and the reweight weight hasn't been added yet, the Prime API/Sim will throw an error an refuse to update the shipment. This is caused by the app not allowing for multiple reweighs to be active at the same time for a move/shipment.

This branch adds a conditional to the getAutoReweighShipments function that skips the calculation if a reweigh is already active for that shipment.

### How to test

1. Create a move with at least 2 shipments and follow the usual flow to take it to prime counseling
2. As Prime, edit at least one shipment's actual/estimated to be within 10% of the limit (2,000 lbs with dependents for E-1, but you can just make it a very large number to be safe)
3. Verify that all shipments have a reweight requested on the Prime Sim's move details page.
4. Edit both the actual and estimated weights for one shipment before putting in an estimated weight and verify that no errors are thrown.
5. Add an estimated weight for the other shipment, then verify that you can also edit the estimated/actual weight for that shipment without errors.
