### PR TITLE
INT-B-22674 Return Prime Acknowledged At value in Prime API

### DIFF
--- a/pkg/gen/primeapi/embedded_spec.go
+++ b/pkg/gen/primeapi/embedded_spec.go
@@ -2105,6 +2105,12 @@ func init() {
             "PARTIAL"
           ]
         },
+        "primeAcknowledgedAt": {
+          "type": "string",
+          "format": "date-time",
+          "x-nullable": true,
+          "readOnly": true
+        },
         "referenceId": {
           "type": "string",
           "example": "1001-3456"
@@ -3166,6 +3172,12 @@ func init() {
         "ppmShipment": {
           "$ref": "#/definitions/PPMShipment"
         },
+        "primeAcknowledgedAt": {
+          "type": "string",
+          "format": "date-time",
+          "x-nullable": true,
+          "readOnly": true
+        },
         "primeActualWeight": {
           "description": "The actual weight of the shipment, provided after the Prime packs, picks up, and weighs a customer's shipment.",
           "type": "integer",
@@ -3401,6 +3413,12 @@ func init() {
             "PARTIAL",
             "FULL"
           ]
+        },
+        "primeAcknowledgedAt": {
+          "type": "string",
+          "format": "date-time",
+          "x-nullable": true,
+          "readOnly": true
         },
         "primeCounselingCompletedAt": {
           "type": "string",
@@ -7763,6 +7781,12 @@ func init() {
             "PARTIAL"
           ]
         },
+        "primeAcknowledgedAt": {
+          "type": "string",
+          "format": "date-time",
+          "x-nullable": true,
+          "readOnly": true
+        },
         "referenceId": {
           "type": "string",
           "example": "1001-3456"
@@ -8824,6 +8848,12 @@ func init() {
         "ppmShipment": {
           "$ref": "#/definitions/PPMShipment"
         },
+        "primeAcknowledgedAt": {
+          "type": "string",
+          "format": "date-time",
+          "x-nullable": true,
+          "readOnly": true
+        },
         "primeActualWeight": {
           "description": "The actual weight of the shipment, provided after the Prime packs, picks up, and weighs a customer's shipment.",
           "type": "integer",
@@ -9059,6 +9089,12 @@ func init() {
             "PARTIAL",
             "FULL"
           ]
+        },
+        "primeAcknowledgedAt": {
+          "type": "string",
+          "format": "date-time",
+          "x-nullable": true,
+          "readOnly": true
         },
         "primeCounselingCompletedAt": {
           "type": "string",

--- a/pkg/gen/primemessages/list_move.go
+++ b/pkg/gen/primemessages/list_move.go
@@ -71,6 +71,11 @@ type ListMove struct {
 	// Enum: [FULL PARTIAL]
 	PpmType string `json:"ppmType,omitempty"`
 
+	// prime acknowledged at
+	// Read Only: true
+	// Format: date-time
+	PrimeAcknowledgedAt *strfmt.DateTime `json:"primeAcknowledgedAt,omitempty"`
+
 	// reference Id
 	// Example: 1001-3456
 	ReferenceID string `json:"referenceId,omitempty"`
@@ -110,6 +115,10 @@ func (m *ListMove) Validate(formats strfmt.Registry) error {
 	}
 
 	if err := m.validatePpmType(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validatePrimeAcknowledgedAt(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -244,6 +253,18 @@ func (m *ListMove) validatePpmType(formats strfmt.Registry) error {
 	return nil
 }
 
+func (m *ListMove) validatePrimeAcknowledgedAt(formats strfmt.Registry) error {
+	if swag.IsZero(m.PrimeAcknowledgedAt) { // not required
+		return nil
+	}
+
+	if err := validate.FormatOf("primeAcknowledgedAt", "body", "date-time", m.PrimeAcknowledgedAt.String(), formats); err != nil {
+		return err
+	}
+
+	return nil
+}
+
 func (m *ListMove) validateUpdatedAt(formats strfmt.Registry) error {
 	if swag.IsZero(m.UpdatedAt) { // not required
 		return nil
@@ -289,6 +310,10 @@ func (m *ListMove) ContextValidate(ctx context.Context, formats strfmt.Registry)
 	}
 
 	if err := m.contextValidateMoveCode(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.contextValidatePrimeAcknowledgedAt(ctx, formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -380,6 +405,15 @@ func (m *ListMove) contextValidateETag(ctx context.Context, formats strfmt.Regis
 func (m *ListMove) contextValidateMoveCode(ctx context.Context, formats strfmt.Registry) error {
 
 	if err := validate.ReadOnly(ctx, "moveCode", "body", string(m.MoveCode)); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (m *ListMove) contextValidatePrimeAcknowledgedAt(ctx context.Context, formats strfmt.Registry) error {
+
+	if err := validate.ReadOnly(ctx, "primeAcknowledgedAt", "body", m.PrimeAcknowledgedAt); err != nil {
 		return err
 	}
 

--- a/pkg/gen/primemessages/m_t_o_shipment_without_service_items.go
+++ b/pkg/gen/primemessages/m_t_o_shipment_without_service_items.go
@@ -149,6 +149,11 @@ type MTOShipmentWithoutServiceItems struct {
 	// ppm shipment
 	PpmShipment *PPMShipment `json:"ppmShipment,omitempty"`
 
+	// prime acknowledged at
+	// Read Only: true
+	// Format: date-time
+	PrimeAcknowledgedAt *strfmt.DateTime `json:"primeAcknowledgedAt,omitempty"`
+
 	// The actual weight of the shipment, provided after the Prime packs, picks up, and weighs a customer's shipment.
 	// Example: 4500
 	// Minimum: 1
@@ -289,6 +294,10 @@ func (m *MTOShipmentWithoutServiceItems) Validate(formats strfmt.Registry) error
 	}
 
 	if err := m.validatePpmShipment(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validatePrimeAcknowledgedAt(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -597,6 +606,18 @@ func (m *MTOShipmentWithoutServiceItems) validatePpmShipment(formats strfmt.Regi
 			}
 			return err
 		}
+	}
+
+	return nil
+}
+
+func (m *MTOShipmentWithoutServiceItems) validatePrimeAcknowledgedAt(formats strfmt.Registry) error {
+	if swag.IsZero(m.PrimeAcknowledgedAt) { // not required
+		return nil
+	}
+
+	if err := validate.FormatOf("primeAcknowledgedAt", "body", "date-time", m.PrimeAcknowledgedAt.String(), formats); err != nil {
+		return err
 	}
 
 	return nil
@@ -912,6 +933,10 @@ func (m *MTOShipmentWithoutServiceItems) ContextValidate(ctx context.Context, fo
 		res = append(res, err)
 	}
 
+	if err := m.contextValidatePrimeAcknowledgedAt(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
 	if err := m.contextValidatePrimeEstimatedWeightRecordedDate(ctx, formats); err != nil {
 		res = append(res, err)
 	}
@@ -1120,6 +1145,15 @@ func (m *MTOShipmentWithoutServiceItems) contextValidatePpmShipment(ctx context.
 			}
 			return err
 		}
+	}
+
+	return nil
+}
+
+func (m *MTOShipmentWithoutServiceItems) contextValidatePrimeAcknowledgedAt(ctx context.Context, formats strfmt.Registry) error {
+
+	if err := validate.ReadOnly(ctx, "primeAcknowledgedAt", "body", m.PrimeAcknowledgedAt); err != nil {
+		return err
 	}
 
 	return nil

--- a/pkg/gen/primemessages/move_task_order.go
+++ b/pkg/gen/primemessages/move_task_order.go
@@ -113,6 +113,11 @@ type MoveTaskOrder struct {
 	// Enum: [PARTIAL FULL]
 	PpmType string `json:"ppmType,omitempty"`
 
+	// prime acknowledged at
+	// Read Only: true
+	// Format: date-time
+	PrimeAcknowledgedAt *strfmt.DateTime `json:"primeAcknowledgedAt,omitempty"`
+
 	// prime counseling completed at
 	// Read Only: true
 	// Format: date-time
@@ -180,6 +185,8 @@ func (m *MoveTaskOrder) UnmarshalJSON(raw []byte) error {
 		PpmEstimatedWeight int64 `json:"ppmEstimatedWeight,omitempty"`
 
 		PpmType string `json:"ppmType,omitempty"`
+
+		PrimeAcknowledgedAt *strfmt.DateTime `json:"primeAcknowledgedAt,omitempty"`
 
 		PrimeCounselingCompletedAt *strfmt.DateTime `json:"primeCounselingCompletedAt,omitempty"`
 
@@ -262,6 +269,9 @@ func (m *MoveTaskOrder) UnmarshalJSON(raw []byte) error {
 	// ppmType
 	result.PpmType = data.PpmType
 
+	// primeAcknowledgedAt
+	result.PrimeAcknowledgedAt = data.PrimeAcknowledgedAt
+
 	// primeCounselingCompletedAt
 	result.PrimeCounselingCompletedAt = data.PrimeCounselingCompletedAt
 
@@ -319,6 +329,8 @@ func (m MoveTaskOrder) MarshalJSON() ([]byte, error) {
 
 		PpmType string `json:"ppmType,omitempty"`
 
+		PrimeAcknowledgedAt *strfmt.DateTime `json:"primeAcknowledgedAt,omitempty"`
+
 		PrimeCounselingCompletedAt *strfmt.DateTime `json:"primeCounselingCompletedAt,omitempty"`
 
 		ReferenceID string `json:"referenceId,omitempty"`
@@ -363,6 +375,8 @@ func (m MoveTaskOrder) MarshalJSON() ([]byte, error) {
 		PpmEstimatedWeight: m.PpmEstimatedWeight,
 
 		PpmType: m.PpmType,
+
+		PrimeAcknowledgedAt: m.PrimeAcknowledgedAt,
 
 		PrimeCounselingCompletedAt: m.PrimeCounselingCompletedAt,
 
@@ -447,6 +461,10 @@ func (m *MoveTaskOrder) Validate(formats strfmt.Registry) error {
 	}
 
 	if err := m.validatePpmType(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validatePrimeAcknowledgedAt(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -703,6 +721,18 @@ func (m *MoveTaskOrder) validatePpmType(formats strfmt.Registry) error {
 	return nil
 }
 
+func (m *MoveTaskOrder) validatePrimeAcknowledgedAt(formats strfmt.Registry) error {
+	if swag.IsZero(m.PrimeAcknowledgedAt) { // not required
+		return nil
+	}
+
+	if err := validate.FormatOf("primeAcknowledgedAt", "body", "date-time", m.PrimeAcknowledgedAt.String(), formats); err != nil {
+		return err
+	}
+
+	return nil
+}
+
 func (m *MoveTaskOrder) validatePrimeCounselingCompletedAt(formats strfmt.Registry) error {
 	if swag.IsZero(m.PrimeCounselingCompletedAt) { // not required
 		return nil
@@ -792,6 +822,10 @@ func (m *MoveTaskOrder) ContextValidate(ctx context.Context, formats strfmt.Regi
 	}
 
 	if err := m.contextValidatePaymentRequests(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.contextValidatePrimeAcknowledgedAt(ctx, formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -982,6 +1016,15 @@ func (m *MoveTaskOrder) contextValidatePaymentRequests(ctx context.Context, form
 		} else if ce, ok := err.(*errors.CompositeError); ok {
 			return ce.ValidateName("paymentRequests")
 		}
+		return err
+	}
+
+	return nil
+}
+
+func (m *MoveTaskOrder) contextValidatePrimeAcknowledgedAt(ctx context.Context, formats strfmt.Registry) error {
+
+	if err := validate.ReadOnly(ctx, "primeAcknowledgedAt", "body", m.PrimeAcknowledgedAt); err != nil {
 		return err
 	}
 

--- a/pkg/gen/primev2api/embedded_spec.go
+++ b/pkg/gen/primev2api/embedded_spec.go
@@ -2117,6 +2117,12 @@ func init() {
         "ppmShipment": {
           "$ref": "#/definitions/PPMShipment"
         },
+        "primeAcknowledgedAt": {
+          "type": "string",
+          "format": "date-time",
+          "x-nullable": true,
+          "readOnly": true
+        },
         "primeActualWeight": {
           "description": "The actual weight of the shipment, provided after the Prime packs, picks up, and weighs a customer's shipment.",
           "type": "integer",
@@ -2356,6 +2362,12 @@ func init() {
             "PARTIAL",
             "FULL"
           ]
+        },
+        "primeAcknowledgedAt": {
+          "type": "string",
+          "format": "date-time",
+          "x-nullable": true,
+          "readOnly": true
         },
         "primeCounselingCompletedAt": {
           "type": "string",
@@ -6104,6 +6116,12 @@ func init() {
         "ppmShipment": {
           "$ref": "#/definitions/PPMShipment"
         },
+        "primeAcknowledgedAt": {
+          "type": "string",
+          "format": "date-time",
+          "x-nullable": true,
+          "readOnly": true
+        },
         "primeActualWeight": {
           "description": "The actual weight of the shipment, provided after the Prime packs, picks up, and weighs a customer's shipment.",
           "type": "integer",
@@ -6343,6 +6361,12 @@ func init() {
             "PARTIAL",
             "FULL"
           ]
+        },
+        "primeAcknowledgedAt": {
+          "type": "string",
+          "format": "date-time",
+          "x-nullable": true,
+          "readOnly": true
         },
         "primeCounselingCompletedAt": {
           "type": "string",

--- a/pkg/gen/primev2messages/m_t_o_shipment_without_service_items.go
+++ b/pkg/gen/primev2messages/m_t_o_shipment_without_service_items.go
@@ -149,6 +149,11 @@ type MTOShipmentWithoutServiceItems struct {
 	// ppm shipment
 	PpmShipment *PPMShipment `json:"ppmShipment,omitempty"`
 
+	// prime acknowledged at
+	// Read Only: true
+	// Format: date-time
+	PrimeAcknowledgedAt *strfmt.DateTime `json:"primeAcknowledgedAt,omitempty"`
+
 	// The actual weight of the shipment, provided after the Prime packs, picks up, and weighs a customer's shipment.
 	// Example: 4500
 	// Minimum: 1
@@ -289,6 +294,10 @@ func (m *MTOShipmentWithoutServiceItems) Validate(formats strfmt.Registry) error
 	}
 
 	if err := m.validatePpmShipment(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validatePrimeAcknowledgedAt(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -597,6 +606,18 @@ func (m *MTOShipmentWithoutServiceItems) validatePpmShipment(formats strfmt.Regi
 			}
 			return err
 		}
+	}
+
+	return nil
+}
+
+func (m *MTOShipmentWithoutServiceItems) validatePrimeAcknowledgedAt(formats strfmt.Registry) error {
+	if swag.IsZero(m.PrimeAcknowledgedAt) { // not required
+		return nil
+	}
+
+	if err := validate.FormatOf("primeAcknowledgedAt", "body", "date-time", m.PrimeAcknowledgedAt.String(), formats); err != nil {
+		return err
 	}
 
 	return nil
@@ -912,6 +933,10 @@ func (m *MTOShipmentWithoutServiceItems) ContextValidate(ctx context.Context, fo
 		res = append(res, err)
 	}
 
+	if err := m.contextValidatePrimeAcknowledgedAt(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
 	if err := m.contextValidatePrimeEstimatedWeightRecordedDate(ctx, formats); err != nil {
 		res = append(res, err)
 	}
@@ -1120,6 +1145,15 @@ func (m *MTOShipmentWithoutServiceItems) contextValidatePpmShipment(ctx context.
 			}
 			return err
 		}
+	}
+
+	return nil
+}
+
+func (m *MTOShipmentWithoutServiceItems) contextValidatePrimeAcknowledgedAt(ctx context.Context, formats strfmt.Registry) error {
+
+	if err := validate.ReadOnly(ctx, "primeAcknowledgedAt", "body", m.PrimeAcknowledgedAt); err != nil {
+		return err
 	}
 
 	return nil

--- a/pkg/gen/primev2messages/move_task_order.go
+++ b/pkg/gen/primev2messages/move_task_order.go
@@ -117,6 +117,11 @@ type MoveTaskOrder struct {
 	// Enum: [PARTIAL FULL]
 	PpmType string `json:"ppmType,omitempty"`
 
+	// prime acknowledged at
+	// Read Only: true
+	// Format: date-time
+	PrimeAcknowledgedAt *strfmt.DateTime `json:"primeAcknowledgedAt,omitempty"`
+
 	// prime counseling completed at
 	// Read Only: true
 	// Format: date-time
@@ -186,6 +191,8 @@ func (m *MoveTaskOrder) UnmarshalJSON(raw []byte) error {
 		PpmEstimatedWeight int64 `json:"ppmEstimatedWeight,omitempty"`
 
 		PpmType string `json:"ppmType,omitempty"`
+
+		PrimeAcknowledgedAt *strfmt.DateTime `json:"primeAcknowledgedAt,omitempty"`
 
 		PrimeCounselingCompletedAt *strfmt.DateTime `json:"primeCounselingCompletedAt,omitempty"`
 
@@ -271,6 +278,9 @@ func (m *MoveTaskOrder) UnmarshalJSON(raw []byte) error {
 	// ppmType
 	result.PpmType = data.PpmType
 
+	// primeAcknowledgedAt
+	result.PrimeAcknowledgedAt = data.PrimeAcknowledgedAt
+
 	// primeCounselingCompletedAt
 	result.PrimeCounselingCompletedAt = data.PrimeCounselingCompletedAt
 
@@ -330,6 +340,8 @@ func (m MoveTaskOrder) MarshalJSON() ([]byte, error) {
 
 		PpmType string `json:"ppmType,omitempty"`
 
+		PrimeAcknowledgedAt *strfmt.DateTime `json:"primeAcknowledgedAt,omitempty"`
+
 		PrimeCounselingCompletedAt *strfmt.DateTime `json:"primeCounselingCompletedAt,omitempty"`
 
 		ReferenceID string `json:"referenceId,omitempty"`
@@ -376,6 +388,8 @@ func (m MoveTaskOrder) MarshalJSON() ([]byte, error) {
 		PpmEstimatedWeight: m.PpmEstimatedWeight,
 
 		PpmType: m.PpmType,
+
+		PrimeAcknowledgedAt: m.PrimeAcknowledgedAt,
 
 		PrimeCounselingCompletedAt: m.PrimeCounselingCompletedAt,
 
@@ -460,6 +474,10 @@ func (m *MoveTaskOrder) Validate(formats strfmt.Registry) error {
 	}
 
 	if err := m.validatePpmType(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validatePrimeAcknowledgedAt(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -716,6 +734,18 @@ func (m *MoveTaskOrder) validatePpmType(formats strfmt.Registry) error {
 	return nil
 }
 
+func (m *MoveTaskOrder) validatePrimeAcknowledgedAt(formats strfmt.Registry) error {
+	if swag.IsZero(m.PrimeAcknowledgedAt) { // not required
+		return nil
+	}
+
+	if err := validate.FormatOf("primeAcknowledgedAt", "body", "date-time", m.PrimeAcknowledgedAt.String(), formats); err != nil {
+		return err
+	}
+
+	return nil
+}
+
 func (m *MoveTaskOrder) validatePrimeCounselingCompletedAt(formats strfmt.Registry) error {
 	if swag.IsZero(m.PrimeCounselingCompletedAt) { // not required
 		return nil
@@ -809,6 +839,10 @@ func (m *MoveTaskOrder) ContextValidate(ctx context.Context, formats strfmt.Regi
 	}
 
 	if err := m.contextValidatePaymentRequests(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.contextValidatePrimeAcknowledgedAt(ctx, formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -1008,6 +1042,15 @@ func (m *MoveTaskOrder) contextValidatePaymentRequests(ctx context.Context, form
 		} else if ce, ok := err.(*errors.CompositeError); ok {
 			return ce.ValidateName("paymentRequests")
 		}
+		return err
+	}
+
+	return nil
+}
+
+func (m *MoveTaskOrder) contextValidatePrimeAcknowledgedAt(ctx context.Context, formats strfmt.Registry) error {
+
+	if err := validate.ReadOnly(ctx, "primeAcknowledgedAt", "body", m.PrimeAcknowledgedAt); err != nil {
 		return err
 	}
 

--- a/pkg/gen/primev3api/embedded_spec.go
+++ b/pkg/gen/primev3api/embedded_spec.go
@@ -2322,6 +2322,12 @@ func init() {
         "ppmShipment": {
           "$ref": "#/definitions/PPMShipment"
         },
+        "primeAcknowledgedAt": {
+          "type": "string",
+          "format": "date-time",
+          "x-nullable": true,
+          "readOnly": true
+        },
         "primeActualWeight": {
           "description": "The actual weight of the shipment, provided after the Prime packs, picks up, and weighs a customer's shipment.",
           "type": "integer",
@@ -2615,6 +2621,12 @@ func init() {
             "PARTIAL",
             "FULL"
           ]
+        },
+        "primeAcknowledgedAt": {
+          "type": "string",
+          "format": "date-time",
+          "x-nullable": true,
+          "readOnly": true
         },
         "primeCounselingCompletedAt": {
           "type": "string",
@@ -7019,6 +7031,12 @@ func init() {
         "ppmShipment": {
           "$ref": "#/definitions/PPMShipment"
         },
+        "primeAcknowledgedAt": {
+          "type": "string",
+          "format": "date-time",
+          "x-nullable": true,
+          "readOnly": true
+        },
         "primeActualWeight": {
           "description": "The actual weight of the shipment, provided after the Prime packs, picks up, and weighs a customer's shipment.",
           "type": "integer",
@@ -7312,6 +7330,12 @@ func init() {
             "PARTIAL",
             "FULL"
           ]
+        },
+        "primeAcknowledgedAt": {
+          "type": "string",
+          "format": "date-time",
+          "x-nullable": true,
+          "readOnly": true
         },
         "primeCounselingCompletedAt": {
           "type": "string",

--- a/pkg/gen/primev3messages/m_t_o_shipment_without_service_items.go
+++ b/pkg/gen/primev3messages/m_t_o_shipment_without_service_items.go
@@ -167,6 +167,11 @@ type MTOShipmentWithoutServiceItems struct {
 	// ppm shipment
 	PpmShipment *PPMShipment `json:"ppmShipment,omitempty"`
 
+	// prime acknowledged at
+	// Read Only: true
+	// Format: date-time
+	PrimeAcknowledgedAt *strfmt.DateTime `json:"primeAcknowledgedAt,omitempty"`
+
 	// The actual weight of the shipment, provided after the Prime packs, picks up, and weighs a customer's shipment.
 	// Example: 4500
 	// Minimum: 1
@@ -333,6 +338,10 @@ func (m *MTOShipmentWithoutServiceItems) Validate(formats strfmt.Registry) error
 	}
 
 	if err := m.validatePpmShipment(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validatePrimeAcknowledgedAt(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -768,6 +777,18 @@ func (m *MTOShipmentWithoutServiceItems) validatePpmShipment(formats strfmt.Regi
 	return nil
 }
 
+func (m *MTOShipmentWithoutServiceItems) validatePrimeAcknowledgedAt(formats strfmt.Registry) error {
+	if swag.IsZero(m.PrimeAcknowledgedAt) { // not required
+		return nil
+	}
+
+	if err := validate.FormatOf("primeAcknowledgedAt", "body", "date-time", m.PrimeAcknowledgedAt.String(), formats); err != nil {
+		return err
+	}
+
+	return nil
+}
+
 func (m *MTOShipmentWithoutServiceItems) validatePrimeActualWeight(formats strfmt.Registry) error {
 	if swag.IsZero(m.PrimeActualWeight) { // not required
 		return nil
@@ -1162,6 +1183,10 @@ func (m *MTOShipmentWithoutServiceItems) ContextValidate(ctx context.Context, fo
 		res = append(res, err)
 	}
 
+	if err := m.contextValidatePrimeAcknowledgedAt(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
 	if err := m.contextValidatePrimeEstimatedWeightRecordedDate(ctx, formats); err != nil {
 		res = append(res, err)
 	}
@@ -1504,6 +1529,15 @@ func (m *MTOShipmentWithoutServiceItems) contextValidatePpmShipment(ctx context.
 			}
 			return err
 		}
+	}
+
+	return nil
+}
+
+func (m *MTOShipmentWithoutServiceItems) contextValidatePrimeAcknowledgedAt(ctx context.Context, formats strfmt.Registry) error {
+
+	if err := validate.ReadOnly(ctx, "primeAcknowledgedAt", "body", m.PrimeAcknowledgedAt); err != nil {
+		return err
 	}
 
 	return nil

--- a/pkg/gen/primev3messages/move_task_order.go
+++ b/pkg/gen/primev3messages/move_task_order.go
@@ -117,6 +117,11 @@ type MoveTaskOrder struct {
 	// Enum: [PARTIAL FULL]
 	PpmType string `json:"ppmType,omitempty"`
 
+	// prime acknowledged at
+	// Read Only: true
+	// Format: date-time
+	PrimeAcknowledgedAt *strfmt.DateTime `json:"primeAcknowledgedAt,omitempty"`
+
 	// prime counseling completed at
 	// Read Only: true
 	// Format: date-time
@@ -186,6 +191,8 @@ func (m *MoveTaskOrder) UnmarshalJSON(raw []byte) error {
 		PpmEstimatedWeight int64 `json:"ppmEstimatedWeight,omitempty"`
 
 		PpmType string `json:"ppmType,omitempty"`
+
+		PrimeAcknowledgedAt *strfmt.DateTime `json:"primeAcknowledgedAt,omitempty"`
 
 		PrimeCounselingCompletedAt *strfmt.DateTime `json:"primeCounselingCompletedAt,omitempty"`
 
@@ -271,6 +278,9 @@ func (m *MoveTaskOrder) UnmarshalJSON(raw []byte) error {
 	// ppmType
 	result.PpmType = data.PpmType
 
+	// primeAcknowledgedAt
+	result.PrimeAcknowledgedAt = data.PrimeAcknowledgedAt
+
 	// primeCounselingCompletedAt
 	result.PrimeCounselingCompletedAt = data.PrimeCounselingCompletedAt
 
@@ -330,6 +340,8 @@ func (m MoveTaskOrder) MarshalJSON() ([]byte, error) {
 
 		PpmType string `json:"ppmType,omitempty"`
 
+		PrimeAcknowledgedAt *strfmt.DateTime `json:"primeAcknowledgedAt,omitempty"`
+
 		PrimeCounselingCompletedAt *strfmt.DateTime `json:"primeCounselingCompletedAt,omitempty"`
 
 		ReferenceID string `json:"referenceId,omitempty"`
@@ -376,6 +388,8 @@ func (m MoveTaskOrder) MarshalJSON() ([]byte, error) {
 		PpmEstimatedWeight: m.PpmEstimatedWeight,
 
 		PpmType: m.PpmType,
+
+		PrimeAcknowledgedAt: m.PrimeAcknowledgedAt,
 
 		PrimeCounselingCompletedAt: m.PrimeCounselingCompletedAt,
 
@@ -460,6 +474,10 @@ func (m *MoveTaskOrder) Validate(formats strfmt.Registry) error {
 	}
 
 	if err := m.validatePpmType(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validatePrimeAcknowledgedAt(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -716,6 +734,18 @@ func (m *MoveTaskOrder) validatePpmType(formats strfmt.Registry) error {
 	return nil
 }
 
+func (m *MoveTaskOrder) validatePrimeAcknowledgedAt(formats strfmt.Registry) error {
+	if swag.IsZero(m.PrimeAcknowledgedAt) { // not required
+		return nil
+	}
+
+	if err := validate.FormatOf("primeAcknowledgedAt", "body", "date-time", m.PrimeAcknowledgedAt.String(), formats); err != nil {
+		return err
+	}
+
+	return nil
+}
+
 func (m *MoveTaskOrder) validatePrimeCounselingCompletedAt(formats strfmt.Registry) error {
 	if swag.IsZero(m.PrimeCounselingCompletedAt) { // not required
 		return nil
@@ -809,6 +839,10 @@ func (m *MoveTaskOrder) ContextValidate(ctx context.Context, formats strfmt.Regi
 	}
 
 	if err := m.contextValidatePaymentRequests(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.contextValidatePrimeAcknowledgedAt(ctx, formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -1008,6 +1042,15 @@ func (m *MoveTaskOrder) contextValidatePaymentRequests(ctx context.Context, form
 		} else if ce, ok := err.(*errors.CompositeError); ok {
 			return ce.ValidateName("paymentRequests")
 		}
+		return err
+	}
+
+	return nil
+}
+
+func (m *MoveTaskOrder) contextValidatePrimeAcknowledgedAt(ctx context.Context, formats strfmt.Registry) error {
+
+	if err := validate.ReadOnly(ctx, "primeAcknowledgedAt", "body", m.PrimeAcknowledgedAt); err != nil {
 		return err
 	}
 

--- a/pkg/handlers/primeapi/payloads/model_to_payload.go
+++ b/pkg/handlers/primeapi/payloads/model_to_payload.go
@@ -63,6 +63,7 @@ func MoveTaskOrder(appCtx appcontext.AppContext, moveTaskOrder *models.Move) *pr
 		MtoShipments:                                   *mtoShipments,
 		UpdatedAt:                                      strfmt.DateTime(moveTaskOrder.UpdatedAt),
 		ETag:                                           etag.GenerateEtag(moveTaskOrder.UpdatedAt),
+		PrimeAcknowledgedAt:                            handlers.FmtDateTimePtr(moveTaskOrder.PrimeAcknowledgedAt),
 	}
 
 	if moveTaskOrder.PPMType != nil {
@@ -117,6 +118,7 @@ func ListMove(move *models.Move, appCtx appcontext.AppContext, moveOrderAmendmen
 			Total:          handlers.FmtInt64(0),
 			AvailableSince: handlers.FmtInt64(0),
 		},
+		PrimeAcknowledgedAt: handlers.FmtDateTimePtr(move.PrimeAcknowledgedAt),
 	}
 
 	if move.PPMType != nil {
@@ -625,6 +627,7 @@ func MTOShipmentWithoutServiceItems(mtoShipment *models.MTOShipment) *primemessa
 		OriginSitAuthEndDate:             (*strfmt.Date)(mtoShipment.OriginSITAuthEndDate),
 		DestinationSitAuthEndDate:        (*strfmt.Date)(mtoShipment.DestinationSITAuthEndDate),
 		MarketCode:                       MarketCode(&mtoShipment.MarketCode),
+		PrimeAcknowledgedAt:              handlers.FmtDateTimePtr(mtoShipment.PrimeAcknowledgedAt),
 	}
 
 	// Set up address payloads

--- a/pkg/handlers/primeapi/payloads/model_to_payload_test.go
+++ b/pkg/handlers/primeapi/payloads/model_to_payload_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/transcom/mymove/pkg/gen/primemessages"
 	"github.com/transcom/mymove/pkg/handlers"
 	"github.com/transcom/mymove/pkg/models"
+	"github.com/transcom/mymove/pkg/services"
 	"github.com/transcom/mymove/pkg/services/entitlements"
 	"github.com/transcom/mymove/pkg/storage/test"
 	"github.com/transcom/mymove/pkg/unit"
@@ -23,6 +24,7 @@ func (suite *PayloadsSuite) TestMoveTaskOrder() {
 	ordersID, _ := uuid.NewV4()
 	referenceID := "testID"
 	primeTime := time.Now()
+	primeAcknowledgedAt := time.Now().AddDate(0, 0, -3)
 	submittedAt := time.Now()
 	excessWeightQualifiedAt := time.Now()
 	excessUnaccompaniedBaggageWeightQualifiedAt := time.Now()
@@ -67,6 +69,7 @@ func (suite *PayloadsSuite) TestMoveTaskOrder() {
 		ShipmentGBLOC: models.MoveToGBLOCs{
 			models.MoveToGBLOC{GBLOC: &shipmentGBLOC},
 		},
+		PrimeAcknowledgedAt: &primeAcknowledgedAt,
 	}
 
 	suite.Run("Success - Returns a basic move payload with no payment requests, service items or shipments", func() {
@@ -93,6 +96,7 @@ func (suite *PayloadsSuite) TestMoveTaskOrder() {
 		suite.Equal(basicMove.Orders.ServiceMember.BackupContacts[0].Name, returnedModel.Order.Customer.BackupContact.Name)
 		suite.Equal(basicMove.Orders.ServiceMember.BackupContacts[0].Phone, returnedModel.Order.Customer.BackupContact.Phone)
 		suite.Equal(basicMove.Orders.ServiceMember.BackupContacts[0].Email, returnedModel.Order.Customer.BackupContact.Email)
+		suite.Equal(handlers.FmtDateTimePtr(basicMove.PrimeAcknowledgedAt), returnedModel.PrimeAcknowledgedAt)
 	})
 }
 
@@ -448,17 +452,33 @@ func (suite *PayloadsSuite) TestValidationError() {
 }
 
 func (suite *PayloadsSuite) TestMTOShipment() {
-	mtoShipment := &models.MTOShipment{}
-
-	mtoShipment.MTOServiceItems = nil
-	payload := MTOShipment(mtoShipment)
+	primeAcknowledgeAt := time.Now().AddDate(0, 0, -5)
+	mtoShipment := factory.BuildMTOShipment(nil, []factory.Customization{
+		{
+			Model: models.MTOShipment{
+				PrimeAcknowledgedAt: &primeAcknowledgeAt,
+				Status:              models.MTOShipmentStatusApproved,
+			},
+		},
+	}, nil)
+	payload := MTOShipment(&mtoShipment)
 	suite.NotNil(payload)
 	suite.Empty(payload.MtoServiceItems())
+	suite.Equal(strfmt.UUID(mtoShipment.ID.String()), payload.ID)
+	suite.Equal(handlers.FmtDatePtr(mtoShipment.ActualPickupDate), payload.ActualPickupDate)
+	suite.Equal(handlers.FmtDatePtr(mtoShipment.RequestedDeliveryDate), payload.RequestedDeliveryDate)
+	suite.Equal(handlers.FmtDatePtr(mtoShipment.RequestedPickupDate), payload.RequestedPickupDate)
+	suite.Equal(string(mtoShipment.Status), payload.Status)
+	suite.Equal(strfmt.DateTime(mtoShipment.UpdatedAt), payload.UpdatedAt)
+	suite.Equal(strfmt.DateTime(mtoShipment.CreatedAt), payload.CreatedAt)
+	suite.Equal(etag.GenerateEtag(mtoShipment.UpdatedAt), payload.ETag)
+	suite.Equal(handlers.FmtDateTimePtr(mtoShipment.PrimeAcknowledgedAt), payload.PrimeAcknowledgedAt)
 
+	mtoShipment = models.MTOShipment{}
 	mtoShipment.MTOServiceItems = models.MTOServiceItems{
 		models.MTOServiceItem{},
 	}
-	payload = MTOShipment(mtoShipment)
+	payload = MTOShipment(&mtoShipment)
 	suite.NotNil(payload)
 	suite.NotEmpty(payload.MtoServiceItems())
 }
@@ -1515,5 +1535,113 @@ func (suite *PayloadsSuite) TestVLocation() {
 		suite.Equal(state, payload.State, "Expected State to match")
 		suite.Equal(postalCode, payload.PostalCode, "Expected PostalCode to match")
 		suite.Equal(county, *(payload.County), "Expected County to match")
+	})
+}
+
+func (suite *PayloadsSuite) TestListMoves() {
+	suite.Run("Correctly maps Move Prime Acknowledge At date", func() {
+		yesterday := time.Now().AddDate(0, 1, -1)
+		address1 := factory.BuildAddress(suite.DB(), []factory.Customization{
+			{
+				Model: models.Address{
+					PostalCode: "90210",
+				},
+			},
+		}, nil)
+		dutyLocation1 := factory.BuildDutyLocation(suite.DB(), []factory.Customization{
+			{
+				Model:    address1,
+				LinkOnly: true,
+			},
+		}, nil)
+		orders1 := factory.BuildOrder(suite.DB(), []factory.Customization{
+			{
+				Model:    dutyLocation1,
+				LinkOnly: true,
+				Type:     &factory.DutyLocations.NewDutyLocation,
+			},
+		}, nil)
+		move1 := factory.BuildAvailableToPrimeMove(suite.DB(), []factory.Customization{
+			{
+				Model: models.Move{
+					PrimeAcknowledgedAt: &yesterday,
+				},
+			},
+			{
+				Model:    orders1,
+				LinkOnly: true,
+			},
+		}, nil)
+
+		address2 := factory.BuildAddress(suite.DB(), []factory.Customization{
+			{
+				Model: models.Address{
+					PostalCode: "62225",
+				},
+			},
+		}, nil)
+		dutyLocation2 := factory.BuildDutyLocation(suite.DB(), []factory.Customization{
+			{
+				Model:    address2,
+				LinkOnly: true,
+			},
+		}, nil)
+		orders2 := factory.BuildOrder(suite.DB(), []factory.Customization{
+			{
+				Model:    dutyLocation2,
+				LinkOnly: true,
+				Type:     &factory.DutyLocations.NewDutyLocation,
+			},
+		}, nil)
+		move2 := factory.BuildAvailableToPrimeMove(suite.DB(), []factory.Customization{
+			{
+				Model:    orders2,
+				LinkOnly: true,
+			},
+		}, nil)
+
+		moves := models.Moves{
+			move1,
+			move2,
+		}
+		moveOrderAmendmentAvailableSinceCounts := make(services.MoveOrderAmendmentAvailableSinceCounts, 0)
+
+		payload := ListMoves(&moves, suite.AppContextForTest(), moveOrderAmendmentAvailableSinceCounts)
+		suite.NotNil(payload)
+		suite.Equal(2, len(payload))
+
+		// Move 1
+		suite.Equal(strfmt.UUID(move1.ID.String()), payload[0].ID)
+		suite.Equal(move1.Locator, payload[0].MoveCode)
+		suite.Equal(strfmt.DateTime(move1.CreatedAt), payload[0].CreatedAt)
+		suite.Equal(handlers.FmtDateTimePtr(move1.AvailableToPrimeAt), payload[0].AvailableToPrimeAt)
+		suite.Equal(handlers.FmtDateTimePtr(move1.ApprovedAt), payload[0].ApprovedAt)
+		gbloc, err := move1.GetDestinationGBLOC(suite.DB())
+		suite.NotNil(gbloc)
+		suite.NoError(err)
+		suite.Equal(gbloc, payload[0].DestinationGBLOC)
+		suite.Equal(move1.Orders.NewDutyLocation.Address.PostalCode, payload[0].DestinationPostalCode)
+		suite.Equal(strfmt.UUID(move1.Orders.ID.String()), payload[0].OrderID)
+		suite.Equal(*move1.ReferenceID, payload[0].ReferenceID)
+		suite.Equal(strfmt.DateTime(move1.UpdatedAt), payload[0].UpdatedAt)
+		suite.Equal(etag.GenerateEtag(move1.UpdatedAt), payload[0].ETag)
+		suite.Equal(handlers.FmtDateTimePtr(move1.PrimeAcknowledgedAt), payload[0].PrimeAcknowledgedAt)
+
+		// Move 2
+		suite.Equal(move2.Locator, payload[1].MoveCode)
+		suite.Equal(strfmt.UUID(move2.ID.String()), payload[1].ID)
+		suite.Equal(strfmt.DateTime(move2.CreatedAt), payload[1].CreatedAt)
+		suite.Equal(handlers.FmtDateTimePtr(move2.AvailableToPrimeAt), payload[1].AvailableToPrimeAt)
+		suite.Equal(handlers.FmtDateTimePtr(move2.ApprovedAt), payload[1].ApprovedAt)
+		gbloc, err = move2.GetDestinationGBLOC(suite.DB())
+		suite.NotNil(gbloc)
+		suite.NoError(err)
+		suite.Equal(gbloc, payload[1].DestinationGBLOC)
+		suite.Equal(move2.Orders.NewDutyLocation.Address.PostalCode, payload[1].DestinationPostalCode)
+		suite.Equal(strfmt.UUID(move2.Orders.ID.String()), payload[1].OrderID)
+		suite.Equal(*move2.ReferenceID, payload[1].ReferenceID)
+		suite.Equal(strfmt.DateTime(move2.UpdatedAt), payload[1].UpdatedAt)
+		suite.Equal(etag.GenerateEtag(move2.UpdatedAt), payload[1].ETag)
+		suite.Nil(payload[1].PrimeAcknowledgedAt)
 	})
 }

--- a/pkg/handlers/primeapiv2/payloads/model_to_payload.go
+++ b/pkg/handlers/primeapiv2/payloads/model_to_payload.go
@@ -61,6 +61,7 @@ func MoveTaskOrder(appCtx appcontext.AppContext, moveTaskOrder *models.Move) *pr
 		ContractNumber:                                 moveTaskOrder.Contractor.ContractNumber,
 		UpdatedAt:                                      strfmt.DateTime(moveTaskOrder.UpdatedAt),
 		ETag:                                           etag.GenerateEtag(moveTaskOrder.UpdatedAt),
+		PrimeAcknowledgedAt:                            handlers.FmtDateTimePtr(moveTaskOrder.PrimeAcknowledgedAt),
 	}
 
 	if moveTaskOrder.PPMType != nil {
@@ -554,6 +555,7 @@ func MTOShipmentWithoutServiceItems(mtoShipment *models.MTOShipment) *primev2mes
 		OriginSitAuthEndDate:             (*strfmt.Date)(mtoShipment.OriginSITAuthEndDate),
 		DestinationSitAuthEndDate:        (*strfmt.Date)(mtoShipment.DestinationSITAuthEndDate),
 		MarketCode:                       MarketCode(&mtoShipment.MarketCode),
+		PrimeAcknowledgedAt:              handlers.FmtDateTimePtr(mtoShipment.PrimeAcknowledgedAt),
 	}
 
 	// Set up address payloads

--- a/pkg/handlers/primeapiv2/payloads/model_to_payload_test.go
+++ b/pkg/handlers/primeapiv2/payloads/model_to_payload_test.go
@@ -22,6 +22,7 @@ func (suite *PayloadsSuite) TestMoveTaskOrder() {
 	ordersID, _ := uuid.NewV4()
 	referenceID := "testID"
 	primeTime := time.Now()
+	primeAcknowledgedAt := time.Now().AddDate(0, 0, -3)
 	submittedAt := time.Now()
 	excessWeightQualifiedAt := time.Now()
 	excessUnaccompaniedBaggageWeightQualifiedAt := time.Now()
@@ -77,6 +78,7 @@ func (suite *PayloadsSuite) TestMoveTaskOrder() {
 		ShipmentGBLOC: models.MoveToGBLOCs{
 			models.MoveToGBLOC{GBLOC: &shipmentGBLOC},
 		},
+		PrimeAcknowledgedAt: &primeAcknowledgedAt,
 	}
 
 	suite.Run("Success - Returns a basic move payload with no payment requests, service items or shipments", func() {
@@ -107,6 +109,7 @@ func (suite *PayloadsSuite) TestMoveTaskOrder() {
 		suite.Equal(basicMove.Orders.ServiceMember.BackupContacts[0].Name, returnedModel.Order.Customer.BackupContact.Name)
 		suite.Equal(basicMove.Orders.ServiceMember.BackupContacts[0].Phone, returnedModel.Order.Customer.BackupContact.Phone)
 		suite.Equal(basicMove.Orders.ServiceMember.BackupContacts[0].Email, returnedModel.Order.Customer.BackupContact.Email)
+		suite.Equal(handlers.FmtDateTimePtr(basicMove.PrimeAcknowledgedAt), returnedModel.PrimeAcknowledgedAt)
 	})
 }
 
@@ -441,17 +444,33 @@ func (suite *PayloadsSuite) TestValidationError() {
 }
 
 func (suite *PayloadsSuite) TestMTOShipment() {
-	mtoShipment := &models.MTOShipment{}
-
-	mtoShipment.MTOServiceItems = nil
-	payload := MTOShipment(mtoShipment)
+	primeAcknowledgeAt := time.Now().AddDate(0, 0, -5)
+	mtoShipment := factory.BuildMTOShipment(nil, []factory.Customization{
+		{
+			Model: models.MTOShipment{
+				PrimeAcknowledgedAt: &primeAcknowledgeAt,
+				Status:              models.MTOShipmentStatusApproved,
+			},
+		},
+	}, nil)
+	payload := MTOShipment(&mtoShipment)
 	suite.NotNil(payload)
 	suite.Empty(payload.MtoServiceItems())
+	suite.Equal(strfmt.UUID(mtoShipment.ID.String()), payload.ID)
+	suite.Equal(handlers.FmtDatePtr(mtoShipment.ActualPickupDate), payload.ActualPickupDate)
+	suite.Equal(handlers.FmtDatePtr(mtoShipment.RequestedDeliveryDate), payload.RequestedDeliveryDate)
+	suite.Equal(handlers.FmtDatePtr(mtoShipment.RequestedPickupDate), payload.RequestedPickupDate)
+	suite.Equal(string(mtoShipment.Status), payload.Status)
+	suite.Equal(strfmt.DateTime(mtoShipment.UpdatedAt), payload.UpdatedAt)
+	suite.Equal(strfmt.DateTime(mtoShipment.CreatedAt), payload.CreatedAt)
+	suite.Equal(etag.GenerateEtag(mtoShipment.UpdatedAt), payload.ETag)
+	suite.Equal(handlers.FmtDateTimePtr(mtoShipment.PrimeAcknowledgedAt), payload.PrimeAcknowledgedAt)
 
+	mtoShipment = models.MTOShipment{}
 	mtoShipment.MTOServiceItems = models.MTOServiceItems{
 		models.MTOServiceItem{},
 	}
-	payload = MTOShipment(mtoShipment)
+	payload = MTOShipment(&mtoShipment)
 	suite.NotNil(payload)
 	suite.NotEmpty(payload.MtoServiceItems())
 }

--- a/pkg/handlers/primeapiv3/payloads/model_to_payload.go
+++ b/pkg/handlers/primeapiv3/payloads/model_to_payload.go
@@ -63,6 +63,7 @@ func MoveTaskOrder(appCtx appcontext.AppContext, moveTaskOrder *models.Move) *pr
 		ContractNumber:                                 moveTaskOrder.Contractor.ContractNumber,
 		UpdatedAt:                                      strfmt.DateTime(moveTaskOrder.UpdatedAt),
 		ETag:                                           etag.GenerateEtag(moveTaskOrder.UpdatedAt),
+		PrimeAcknowledgedAt:                            handlers.FmtDateTimePtr(moveTaskOrder.PrimeAcknowledgedAt),
 	}
 
 	if moveTaskOrder.PPMType != nil {
@@ -681,6 +682,7 @@ func MTOShipmentWithoutServiceItems(mtoShipment *models.MTOShipment) *primev3mes
 		TertiaryDeliveryAddress:          Address(mtoShipment.TertiaryDeliveryAddress),
 		TertiaryPickupAddress:            Address(mtoShipment.TertiaryPickupAddress),
 		MarketCode:                       MarketCode(&mtoShipment.MarketCode),
+		PrimeAcknowledgedAt:              handlers.FmtDateTimePtr(mtoShipment.PrimeAcknowledgedAt),
 	}
 
 	// Set up address payloads

--- a/swagger-def/definitions/prime/MTOShipmentWithoutServiceItems.yaml
+++ b/swagger-def/definitions/prime/MTOShipmentWithoutServiceItems.yaml
@@ -241,3 +241,8 @@ properties:
       - 'i'
     example: 'd'
     description: 'Single-letter designator for domestic (d) or international (i) shipments'
+  primeAcknowledgedAt:
+    format: date-time
+    type: string
+    x-nullable: true
+    readOnly: true

--- a/swagger-def/definitions/prime/MoveTaskOrder.yaml
+++ b/swagger-def/definitions/prime/MoveTaskOrder.yaml
@@ -100,3 +100,8 @@ properties:
   eTag:
     type: string
     readOnly: true
+  primeAcknowledgedAt:
+    format: date-time
+    type: string
+    x-nullable: true
+    readOnly: true

--- a/swagger-def/definitions/prime/v2/MTOShipmentWithoutServiceItems.yaml
+++ b/swagger-def/definitions/prime/v2/MTOShipmentWithoutServiceItems.yaml
@@ -245,3 +245,8 @@ properties:
       - 'i'
     example: 'd'
     description: 'Single-letter designator for domestic (d) or international (i) shipments'
+  primeAcknowledgedAt:
+    format: date-time
+    type: string
+    x-nullable: true
+    readOnly: true

--- a/swagger-def/definitions/prime/v2/MoveTaskOrder.yaml
+++ b/swagger-def/definitions/prime/v2/MoveTaskOrder.yaml
@@ -103,3 +103,8 @@ properties:
   eTag:
     type: string
     readOnly: true
+  primeAcknowledgedAt:
+    format: date-time
+    type: string
+    x-nullable: true
+    readOnly: true

--- a/swagger-def/definitions/prime/v3/MTOShipmentWithoutServiceItems.yaml
+++ b/swagger-def/definitions/prime/v3/MTOShipmentWithoutServiceItems.yaml
@@ -253,3 +253,8 @@ properties:
     $ref: 'RateArea.yaml'
   destinationRateArea:
     $ref: 'RateArea.yaml'
+  primeAcknowledgedAt:
+    format: date-time
+    type: string
+    x-nullable: true
+    readOnly: true

--- a/swagger-def/definitions/prime/v3/MoveTaskOrder.yaml
+++ b/swagger-def/definitions/prime/v3/MoveTaskOrder.yaml
@@ -103,3 +103,8 @@ properties:
   eTag:
     type: string
     readOnly: true
+  primeAcknowledgedAt:
+    format: date-time
+    type: string
+    x-nullable: true
+    readOnly: true

--- a/swagger-def/prime.yaml
+++ b/swagger-def/prime.yaml
@@ -1851,6 +1851,11 @@ definitions:
         format: date-time
         type: string
         readOnly: true
+      primeAcknowledgedAt:
+        format: date-time
+        type: string
+        x-nullable: true
+        readOnly: true
       ppmType:
         type: string
         enum:

--- a/swagger/prime.yaml
+++ b/swagger/prime.yaml
@@ -2319,6 +2319,11 @@ definitions:
         format: date-time
         type: string
         readOnly: true
+      primeAcknowledgedAt:
+        format: date-time
+        type: string
+        x-nullable: true
+        readOnly: true
       ppmType:
         type: string
         enum:
@@ -2435,6 +2440,11 @@ definitions:
         x-nullable: true
       eTag:
         type: string
+        readOnly: true
+      primeAcknowledgedAt:
+        format: date-time
+        type: string
+        x-nullable: true
         readOnly: true
   MTOServiceItemBasic:
     description: Describes a basic service item subtype of a MTOServiceItem.
@@ -5234,6 +5244,11 @@ definitions:
         description: >-
           Single-letter designator for domestic (d) or international (i)
           shipments
+      primeAcknowledgedAt:
+        format: date-time
+        type: string
+        x-nullable: true
+        readOnly: true
   MTOShipmentsWithoutServiceObjects:
     description: A list of shipments without their associated service items.
     items:

--- a/swagger/prime_v2.yaml
+++ b/swagger/prime_v2.yaml
@@ -3325,6 +3325,11 @@ definitions:
         description: >-
           Single-letter designator for domestic (d) or international (i)
           shipments
+      primeAcknowledgedAt:
+        format: date-time
+        type: string
+        x-nullable: true
+        readOnly: true
   MTOShipmentsWithoutServiceObjects:
     description: A list of shipments without their associated service items.
     items:
@@ -3435,6 +3440,11 @@ definitions:
         readOnly: true
       eTag:
         type: string
+        readOnly: true
+      primeAcknowledgedAt:
+        format: date-time
+        type: string
+        x-nullable: true
         readOnly: true
   ClientError:
     type: object

--- a/swagger/prime_v3.yaml
+++ b/swagger/prime_v3.yaml
@@ -3875,6 +3875,11 @@ definitions:
         $ref: '#/definitions/RateArea'
       destinationRateArea:
         $ref: '#/definitions/RateArea'
+      primeAcknowledgedAt:
+        format: date-time
+        type: string
+        x-nullable: true
+        readOnly: true
   MTOShipmentsWithoutServiceObjects:
     description: A list of shipments without their associated service items.
     items:
@@ -3985,6 +3990,11 @@ definitions:
         readOnly: true
       eTag:
         type: string
+        readOnly: true
+      primeAcknowledgedAt:
+        format: date-time
+        type: string
+        x-nullable: true
         readOnly: true
   ClientError:
     type: object


### PR DESCRIPTION
## [Agility ticket](https://www13.v1host.com/USTRANSCOM38/story.mvc/Summary?oidToken=Story%3A1067372)

## Summary
This story is to return the `primeAcknowledgedAt` value for a move or shipment in both the `listMoves` and the `getMoveTaskOrder` prime endpoints. This will give the prime user the ability to verify a move or shipment has the primeAcknowledgeAt value stored in milmove.


## Verification Steps for the Author

These are to be checked by the author.
- [ ] Have the Agility acceptance criteria been met for this change?

## Verification Steps for Reviewers

These are to be checked by a reviewer.

- [ ] Has the branch been pulled in and checked out?
- [ ] Have the BL acceptance criteria been met for this change?
- [ ] Was the Gitlab build successful?
- [ ] Has the code been reviewed from a standards and best practices point of view?

### How to test

1. Start your local client and server.
2. Login to the office app as a Prime Simulator.
3. You will need moves and shipments with the prime_acknowledged_at column populated, so you have a couple options. 
 Option 1: You can populate some values using the `acknowledgeMovesAndShipments` prime endpoint (follow the test steps in the upstream pr [here](https://github.com/transcom/mymove/pull/14957).
 Option 2: You can update some values using DBeaver: 
`update moves set prime_acknowledged_at = now()  where id = '[YOUR ID HERE]';`
`update mto_shipments set prime_acknowledged_at = now()  where id = '[YOUR ID HERE]';`
4. Open another browser tab and navigate to the [listMoves](http://officelocal:3000/swagger-ui/prime.html#/moveTaskOrder/listMoves) endpoint.
5. Add a value for the `since` param that will include your move you previously set the `prime_acknowledge_at` value for and click Execute.
6. Verify that the `primeAcknowledgedAt` value is present in the response and matches the value you supplied in step 3.
7. Open another browser tab and navigate to the [getMoveTaskOrder](http://officelocal:3000/swagger-ui/prime_v3.html#/moveTaskOrder/getMoveTaskOrder) endpoint.
8. Enter the move id or locator value for the move you previously set the `prime_acknowledge_at` value for.
9. Verify that the `primeAcknowledgedAt` value is present in the response and matches the values you supplied in step 3. The value should be in the both the move and mtoShipment payload assuming you supplied both with values.


### Backend

- [ ] Code follows the guidelines for [Logging](https://transcom.github.io/mymove-docs/docs/getting-started/development/logging).
- [ ] The requirements listed in [Querying the Database Safely](https://transcom.github.io/mymove-docs/docs/backend/guides/golang-guide#querying-the-database-safely) have been satisfied.

## Screenshots
**listMoves**
![Screenshot 2025-03-11 at 3 56 47 PM](https://github.com/user-attachments/assets/030090a1-b3ea-4b83-bbd8-201c95d2239d)

**getMoveTaskOrder move**
![Screenshot 2025-03-11 at 4 01 37 PM](https://github.com/user-attachments/assets/c6e42e27-47c4-4b3f-b4aa-5cbd27bea724)

**getMoveTaskOrder shipment**
![Screenshot 2025-03-11 at 4 02 16 PM](https://github.com/user-attachments/assets/f5ef60be-19cf-468b-97c9-4c8957ad7af3)
