### PR TITLE
INT B-22848

### DIFF
--- a/src/components/form/fields/DropdownInput.jsx
+++ b/src/components/form/fields/DropdownInput.jsx
@@ -4,14 +4,25 @@ import { v4 as uuidv4 } from 'uuid';
 import { useField } from 'formik';
 import { Dropdown, FormGroup, Label } from '@trussworks/react-uswds';
 
+import styles from './DropdownInput.module.scss';
+
 import { ErrorMessage } from 'components/form/ErrorMessage';
 // import { OptionalTag } from 'components/form/OptionalTag';
 import { DropdownArrayOf } from 'types/form';
-import './DropdownInput.module.scss';
 
 export const DropdownInput = (props) => {
-  const { id, name, label, options, showDropdownPlaceholderText, isDisabled, disableErrorLabel, hint, ...inputProps } =
-    props;
+  const {
+    id,
+    name,
+    label,
+    options,
+    showDropdownPlaceholderText,
+    isDisabled,
+    disableErrorLabel,
+    hint,
+    showRequiredAsterisk,
+    ...inputProps
+  } = props;
   const [field, meta] = useField(props);
   const hasError = disableErrorLabel ? false : meta.touched && !!meta.error;
 
@@ -20,9 +31,14 @@ export const DropdownInput = (props) => {
 
   return (
     <FormGroup error={hasError}>
-      <div className="labelWrapper">
+      <div className={styles.labelWrapper}>
         <Label error={hasError} htmlFor={inputId.current} hint={hint}>
           {label}
+          {showRequiredAsterisk && (
+            <span data-testid="requiredAsterisk" className={styles.requiredAsterisk}>
+              *
+            </span>
+          )}
         </Label>
         {/* {optional && <OptionalTag />} */}
       </div>

--- a/src/components/form/fields/DropdownInput.module.scss
+++ b/src/components/form/fields/DropdownInput.module.scss
@@ -6,3 +6,7 @@ select:disabled {
   pointer-events: none;
 }
 
+.requiredAsterisk {
+  color: $color-red;
+  font-weight: bold;
+}

--- a/src/components/form/fields/DropdownInput.test.jsx
+++ b/src/components/form/fields/DropdownInput.test.jsx
@@ -51,5 +51,16 @@ describe('DropdownInput', () => {
     });
   });
 
+  describe('with showRequiredAsterisk prop', () => {
+    const wrapper = shallow(
+      <DropdownInput showRequiredAsterisk name="dropdown" label="label" options={[{ key: 'key', value: 'value' }]} />,
+    );
+
+    it('renders a required asterisk', () => {
+      const asterisk = wrapper.find('[data-testid="requiredAsterisk"]');
+      expect(asterisk.exists()).toBe(true);
+    });
+  });
+
   afterEach(jest.resetAllMocks);
 });

--- a/src/components/form/fields/MaskedTextField/MaskedTextField.jsx
+++ b/src/components/form/fields/MaskedTextField/MaskedTextField.jsx
@@ -40,6 +40,7 @@ const MaskedTextField = ({
   suffix,
   prefix,
   isDisabled,
+  showRequiredAsterisk,
   ...props
 }) => {
   const [field, metaProps, helpers] = useField({ id, name, validate, ...props });
@@ -62,6 +63,11 @@ const MaskedTextField = ({
       >
         <Label className={labelClassName} hint={labelHint} error={showError} htmlFor={id || name}>
           {label}
+          {showRequiredAsterisk && (
+            <span data-testid="requiredAsterisk" className={styles.requiredAsterisk}>
+              *
+            </span>
+          )}
         </Label>
         {description && (
           <div className={styles.description} id={`description_${descriptionRef.current}`}>
@@ -164,6 +170,7 @@ MaskedTextField.propTypes = {
   error: PropTypes.bool,
   errorMessage: PropTypes.string,
   isDisabled: PropTypes.bool,
+  showRequiredAsterisk: PropTypes.bool,
 };
 
 MaskedTextField.defaultProps = {
@@ -191,6 +198,7 @@ MaskedTextField.defaultProps = {
   error: false,
   errorMessage: '',
   isDisabled: false,
+  showRequiredAsterisk: false,
 };
 
 export default MaskedTextField;

--- a/src/components/form/fields/MaskedTextField/MaskedTextField.module.scss
+++ b/src/components/form/fields/MaskedTextField/MaskedTextField.module.scss
@@ -48,3 +48,8 @@ input:disabled {
   text-wrap: balance;
   margin-top: 1.6rem;
 }
+
+.requiredAsterisk {
+  color: $color-red;
+  font-weight: bold;
+}

--- a/src/components/form/fields/MaskedTextField/MaskedTextField.stories.jsx
+++ b/src/components/form/fields/MaskedTextField/MaskedTextField.stories.jsx
@@ -86,3 +86,19 @@ export const MaskedTextFieldWithOptionalTag = () => (
     )}
   </Formik>
 );
+
+export const MaskedTextFieldWithRequiredAsterisk = () => (
+  <Formik initialValues={{}}>
+    {() => (
+      <Form>
+        <MaskedTextField
+          id="input-type-text"
+          label="Text input label"
+          name="input-type-text"
+          type="text"
+          showRequiredAsterisk
+        />
+      </Form>
+    )}
+  </Formik>
+);

--- a/src/components/form/fields/MaskedTextField/MaskedTextField.test.jsx
+++ b/src/components/form/fields/MaskedTextField/MaskedTextField.test.jsx
@@ -38,7 +38,7 @@ describe('MaskedTextField', () => {
       expect(label.length).toBe(1);
       expect(label.prop('error')).toBe(true);
       expect(label.prop('htmlFor')).toBe('firstName');
-      expect(label.prop('children')).toBe('First Name');
+      expect(label.prop('children')).toContain('First Name');
     });
 
     it('render a IMaskInput', () => {
@@ -93,6 +93,24 @@ describe('MaskedTextField', () => {
     it('render a IMaskInput with expected unmasked prop value', () => {
       const textInput = wrapper.find(FormGroup).find(IMaskInput).getDOMNode();
       expect(textInput.value).toBe('8,000 lbs');
+    });
+  });
+
+  describe('with showRequiredAsterisk prop', () => {
+    const wrapper = shallow(
+      <MaskedTextField
+        className="sample-class"
+        name="firstName"
+        label="First Name"
+        type="text"
+        id="firstName"
+        showRequiredAsterisk
+      />,
+    );
+
+    it('renders a required asterisk', () => {
+      const asterisk = wrapper.find('[data-testid="requiredAsterisk"]');
+      expect(asterisk.exists()).toBe(true);
     });
   });
 

--- a/src/components/form/fields/TextField/TextField.jsx
+++ b/src/components/form/fields/TextField/TextField.jsx
@@ -5,6 +5,8 @@ import classnames from 'classnames';
 import { useField } from 'formik';
 import { FormGroup, Label, TextInput, Textarea, ErrorMessage } from '@trussworks/react-uswds';
 
+import styles from './TextField.module.scss';
+
 import { OptionalTag } from 'components/form/OptionalTag';
 import Hint from 'components/Hint';
 
@@ -36,6 +38,7 @@ const TextField = ({
   display,
   button,
   disablePaste,
+  showRequiredAsterisk,
   ...inputProps
 }) => {
   const [fieldProps, metaProps] = useField({ name, validate, type });
@@ -52,7 +55,15 @@ const TextField = ({
     switch (displayType) {
       case 'textarea':
         return (
-          <Textarea id={id} name={name} disabled={isDisabled} onPaste={pasteHandler} {...fieldProps} {...inputProps} />
+          <Textarea
+            id={id}
+            name={name}
+            disabled={isDisabled}
+            onPaste={pasteHandler}
+            {...fieldProps}
+            {...inputProps}
+            aria-describedby={showError ? `${id}-error` : undefined}
+          />
         );
       case 'readonly':
         return (
@@ -62,7 +73,15 @@ const TextField = ({
         );
       default:
         return (
-          <TextInput id={id} name={name} disabled={isDisabled} onPaste={pasteHandler} {...fieldProps} {...inputProps} />
+          <TextInput
+            id={id}
+            name={name}
+            disabled={isDisabled}
+            onPaste={pasteHandler}
+            {...fieldProps}
+            {...inputProps}
+            aria-describedby={showError ? `${id}-error` : undefined}
+          />
         );
     }
   };
@@ -72,12 +91,17 @@ const TextField = ({
       <div className="labelWrapper">
         <Label className={labelClassName} hint={labelHint} error={showError} htmlFor={id || name}>
           {label}
+          {showRequiredAsterisk && (
+            <span data-testid="requiredAsterisk" className={styles.requiredAsterisk}>
+              *
+            </span>
+          )}
         </Label>
         {optional && <OptionalTag />}
       </div>
 
       {showError && (
-        <ErrorMessage display={showError} className={errorClassName}>
+        <ErrorMessage id={`${id}-error`} role="alert" aria-live="assertive" className={errorClassName}>
           {metaProps.error ? metaProps.error : errorMessage}
         </ErrorMessage>
       )}

--- a/src/components/form/fields/TextField/TextField.module.scss
+++ b/src/components/form/fields/TextField/TextField.module.scss
@@ -1,0 +1,6 @@
+@import 'shared/styles/colors';
+
+.requiredAsterisk {
+    color: $color-red;
+    font-weight: bold;
+}

--- a/src/components/form/fields/TextField/TextField.stories.jsx
+++ b/src/components/form/fields/TextField/TextField.stories.jsx
@@ -116,3 +116,20 @@ export const TextFieldReadOnly = () => (
     )}
   </Formik>
 );
+
+export const TextFieldWithRequiredAsterisk = () => (
+  <Formik initialValues={{}}>
+    {() => (
+      <Form>
+        <TextField
+          id="input-type-text"
+          label="Text input label"
+          hint={labelHint}
+          name="input-type-text"
+          type="text"
+          showRequiredAsterisk
+        />
+      </Form>
+    )}
+  </Formik>
+);

--- a/src/components/form/fields/TextField/TextField.test.jsx
+++ b/src/components/form/fields/TextField/TextField.test.jsx
@@ -40,6 +40,32 @@ describe('TextField component', () => {
     expect(queryByLabelText('First Name')).toHaveAttribute('id', 'firstName');
   });
 
+  it('renders the required red asterisk when prop is provided', () => {
+    const mockMeta = {
+      touched: false,
+      error: '',
+      initialError: '',
+      initialTouched: false,
+      initialValue: '',
+      value: '',
+    };
+    const mockField = {
+      value: '',
+      checked: false,
+      onChange: jest.fn(),
+      onBlur: jest.fn(),
+      multiple: undefined,
+      name: 'firstName',
+    };
+
+    useField.mockReturnValue([mockField, mockMeta]);
+
+    const { getByTestId } = render(
+      <TextField name="firstName" label="First Name" type="text" id="firstName" required showRequiredAsterisk />,
+    );
+    expect(getByTestId('requiredAsterisk')).toBeInTheDocument();
+  });
+
   it('passes a custom className prop to the input element', () => {
     useField.mockReturnValue([{}, {}]);
 

--- a/src/pages/CreateAccount/CreateAccount.jsx
+++ b/src/pages/CreateAccount/CreateAccount.jsx
@@ -257,6 +257,7 @@ export const CreateAccount = ({ setShowLoadingSpinner }) => {
                           id="affiliation"
                           data-testid="affiliationInput"
                           required
+                          showRequiredAsterisk
                           onChange={(e) => {
                             handleChange(e);
                             handleBranchChange(e);
@@ -270,6 +271,7 @@ export const CreateAccount = ({ setShowLoadingSpinner }) => {
                           maxLength="10"
                           data-testid="edipiInput"
                           required
+                          showRequiredAsterisk
                         />
                         <TextField
                           label="Confirm DoD ID number"
@@ -278,6 +280,8 @@ export const CreateAccount = ({ setShowLoadingSpinner }) => {
                           maxLength="10"
                           data-testid="edipiConfirmationInput"
                           disablePaste
+                          required
+                          showRequiredAsterisk
                         />
                         {showEmplid && (
                           <>
@@ -289,6 +293,8 @@ export const CreateAccount = ({ setShowLoadingSpinner }) => {
                               inputMode="numeric"
                               pattern="[0-9]{7}"
                               data-testid="emplidInput"
+                              required
+                              showRequiredAsterisk
                             />
                             <TextField
                               label="Confirm EMPLID"
@@ -299,26 +305,51 @@ export const CreateAccount = ({ setShowLoadingSpinner }) => {
                               pattern="[0-9]{7}"
                               data-testid="emplidConfirmationInput"
                               disablePaste
+                              required
+                              showRequiredAsterisk
                             />
                           </>
                         )}
                         <StyledLine />
-                        <TextField label="First Name" name="firstName" id="firstName" data-testid="firstName" />
+                        <TextField
+                          label="First Name"
+                          name="firstName"
+                          id="firstName"
+                          data-testid="firstName"
+                          required
+                          showRequiredAsterisk
+                        />
                         <TextField
                           label="Middle Initial"
                           name="middleInitial"
                           id="middleInitial"
                           data-testid="middleInitial"
                         />
-                        <TextField label="Last Name" name="lastName" id="lastName" data-testid="lastName" />
+                        <TextField
+                          label="Last Name"
+                          name="lastName"
+                          id="lastName"
+                          data-testid="lastName"
+                          required
+                          showRequiredAsterisk
+                        />
                         <StyledLine />
-                        <TextField label="Email" name="email" id="email" data-testid="email" />
+                        <TextField
+                          label="Email"
+                          name="email"
+                          id="email"
+                          data-testid="email"
+                          required
+                          showRequiredAsterisk
+                        />
                         <TextField
                           label="Confirm Email"
                           name="emailConfirmation"
                           id="emailConfirmation"
                           disablePaste
                           data-testid="emailConfirmation"
+                          required
+                          showRequiredAsterisk
                         />
                         <StyledLine />
                         <MaskedTextField
@@ -329,6 +360,8 @@ export const CreateAccount = ({ setShowLoadingSpinner }) => {
                           minimum="12"
                           mask="000{-}000{-}0000"
                           data-testid="telephone"
+                          required
+                          showRequiredAsterisk
                         />
                         <MaskedTextField
                           label="Secondary Telephone"


### PR DESCRIPTION
## [Agility ticket](https://www13.v1host.com/USTRANSCOM38/assetdetail.v1?number=B-22848)

## Summary

Adding some 508 compliance to the registration form. This did require adding a `role="alert" aria-live="assertive"` to existing components in order to get screen reader capability improvement.

### How to test

1. Turn on `FEATURE_FLAG_CUSTOMER_REGISTRATION` in your `envrc`
2. Fire up your `server` and `client`
3. Click the `Create Account` button
4. You should now see some red asterisks for required fields
5. Verify 508 compliance by running ANDI after you have all of the errors displayed
6. Should see screen reader additions for the displayed errors and required text for all required fields

## Screenshots
![Screenshot 2025-03-13 at 11 34 25 AM](https://github.com/user-attachments/assets/cc339396-341c-4d3d-b376-ca075fe62d0f)

![Screenshot 2025-03-13 at 11 34 59 AM](https://github.com/user-attachments/assets/41590f23-747c-46a7-ad80-15ac40b186fc)
![Screenshot 2025-03-13 at 11 35 02 AM](https://github.com/user-attachments/assets/421a880d-054a-43fe-ac7e-bb4ce6c543ce)
![Screenshot 2025-03-13 at 11 35 06 AM](https://github.com/user-attachments/assets/16f4b091-3c67-4883-ab04-3dc619b2ce9c)
![Screenshot 2025-03-13 at 11 35 09 AM](https://github.com/user-attachments/assets/68bcf6a6-2724-4abc-a8c2-e9b36382ac2d)
![Screenshot 2025-03-13 at 11 35 13 AM](https://github.com/user-attachments/assets/9eebe252-5957-49f3-b777-dabf0f203065)
![Screenshot 2025-03-13 at 11 35 16 AM](https://github.com/user-attachments/assets/cbcf23ef-2e2f-4fb2-9a06-41e0161e7f7f)
![Screenshot 2025-03-13 at 11 35 20 AM](https://github.com/user-attachments/assets/4c151662-ab79-4391-ad47-fd43500f09e2)
![Screenshot 2025-03-13 at 11 35 23 AM](https://github.com/user-attachments/assets/fcf7deba-f536-4bd9-a939-8f135185cef3)
![Screenshot 2025-03-13 at 11 35 27 AM](https://github.com/user-attachments/assets/9dacc7a0-5112-4fad-831e-c51f1667dc2b)
![Screenshot 2025-03-13 at 11 35 30 AM](https://github.com/user-attachments/assets/c9213106-ac07-4bb1-b34c-cd80242a6d5e)
![Screenshot 2025-03-13 at 11 35 33 AM](https://github.com/user-attachments/assets/b1c9cb71-3e2c-429f-9337-15608b5798da)
![Screenshot 2025-03-13 at 11 35 36 AM](https://github.com/user-attachments/assets/4b888e56-2284-419f-9bce-d6d647a48e13)
