### PR TITLE
B-22544 Remove Safety Order Type When Creating a New Move for Existing Custom…

### DIFF
--- a/migrations/app/ddl_tables_manifest.txt
+++ b/migrations/app/ddl_tables_manifest.txt
@@ -3,6 +3,7 @@
 # Naming convention: tbl_some_table.up.sql  running <generate-ddl-migration some_table tables> will create this file.
 20250221195354_tbl_alter_entitlements_B-22651.up.sql
 20250221195633_tbl_alter_office_users_B-21966.up.sql
+20250221195354_tbl_alter_entitlements_B-22651.up.sql
 20250224162949_B-22706_tbl_update_moves.up.sql
 20250224200700_tbl_ppm_shipments.up.sql
 20250225182052_tbl_B-22692_alter_moves.up.sql

--- a/migrations/app/ddl_tables_manifest.txt
+++ b/migrations/app/ddl_tables_manifest.txt
@@ -3,7 +3,6 @@
 # Naming convention: tbl_some_table.up.sql  running <generate-ddl-migration some_table tables> will create this file.
 20250221195354_tbl_alter_entitlements_B-22651.up.sql
 20250221195633_tbl_alter_office_users_B-21966.up.sql
-20250221195354_tbl_alter_entitlements_B-22651.up.sql
 20250224162949_B-22706_tbl_update_moves.up.sql
 20250224200700_tbl_ppm_shipments.up.sql
 20250225182052_tbl_B-22692_alter_moves.up.sql

--- a/pkg/services/office_user/customer/customer_searcher.go
+++ b/pkg/services/office_user/customer/customer_searcher.go
@@ -77,9 +77,9 @@ func (s customerSearcher) SearchCustomers(appCtx appcontext.AppContext, params *
 		LEFT JOIN orders ON orders.service_member_id = service_members.id`
 
 	if !privileges.HasPrivilege(models.PrivilegeTypeSafety) {
-		rawquery += ` WHERE ((orders.orders_type != 'SAFETY' or orders.orders_type IS NULL) AND`
+		rawquery += ` WHERE ((orders.orders_type != 'SAFETY' OR orders.orders_type IS NULL) AND`
 	} else {
-		rawquery += ` WHERE (`
+		rawquery += ` WHERE (orders.orders_type != 'SAFETY' AND`
 	}
 
 	if params.Edipi != nil {

--- a/pkg/services/office_user/customer/customer_searcher_test.go
+++ b/pkg/services/office_user/customer/customer_searcher_test.go
@@ -159,6 +159,70 @@ func (suite CustomerServiceSuite) TestCustomerSearch() {
 		suite.Len(customers, 0)
 	})
 
+	suite.Run("search with a customer name does not return safety moves for Service Counselors with privileges", func() {
+		privilegedUserSC := factory.BuildOfficeUserWithPrivileges(suite.DB(), []factory.Customization{
+			{
+				Model: models.OfficeUser{
+					Email: "officeuser1@example.com",
+				},
+			},
+			{
+				Model: models.User{
+					Privileges: []models.Privilege{
+						{
+							PrivilegeType: models.PrivilegeSearchTypeSafety,
+						},
+					},
+					Roles: []roles.Role{
+						{
+							RoleType: roles.RoleTypeServicesCounselor,
+						},
+					},
+				},
+			},
+		}, nil)
+
+		session := auth.Session{
+			ApplicationName: auth.OfficeApp,
+			Roles:           privilegedUserSC.User.Roles,
+			OfficeUserID:    privilegedUserSC.ID,
+			IDToken:         "fake_token",
+			AccessToken:     "fakeAccessToken",
+		}
+
+		serviceMember1 := factory.BuildServiceMember(suite.DB(), []factory.Customization{
+			{
+				Model: models.ServiceMember{
+					FirstName: models.StringPointer("Page"),
+					LastName:  models.StringPointer("McConnell"),
+					Edipi:     models.StringPointer("1018231018"),
+				},
+			},
+		}, nil)
+
+		safetyServiceMember := factory.BuildMove(suite.DB(), []factory.Customization{
+			{
+				Model: models.ServiceMember{
+					FirstName: models.StringPointer("Page"),
+					LastName:  models.StringPointer("McConnell"),
+					Edipi:     models.StringPointer("1018231018"),
+				},
+			},
+			{
+				Model: models.Order{
+					OrdersType: "SAFETY",
+				},
+			},
+		}, nil)
+
+		customers, _, err := searcher.SearchCustomers(suite.AppContextWithSessionForTest(&session), &services.SearchCustomersParams{CustomerName: models.StringPointer("Page McConnel")})
+		suite.NoError(err)
+		suite.Len(customers, 1)
+		suite.Equal(serviceMember1.Edipi, customers[0].Edipi)
+		suite.NotNil(serviceMember1)
+		suite.NotNil(safetyServiceMember)
+	})
+
 	suite.Run("search as HQ role", func() {
 		hqUser := factory.BuildOfficeUserWithRoles(suite.DB(), nil, []roles.RoleType{roles.RoleTypeHQ})
 		session := auth.Session{

--- a/src/components/Office/AddOrdersForm/AddOrdersForm.test.jsx
+++ b/src/components/Office/AddOrdersForm/AddOrdersForm.test.jsx
@@ -197,6 +197,11 @@ describe('CreateMoveCustomerInfo Component', () => {
 
     await userEvent.selectOptions(ordersTypeDropdown, ORDERS_TYPE.STUDENT_TRAVEL);
     expect(ordersTypeDropdown).toHaveValue(ORDERS_TYPE.STUDENT_TRAVEL);
+
+    // Saftey option should not be available for non safety moves
+    const options = ordersTypeDropdown.querySelectorAll('option');
+    const isSafetyOptionPresent = Array.from(options).some((option) => option.value === ORDERS_TYPE.SAFETY);
+    expect(isSafetyOptionPresent).toBe(false);
   });
 
   it('shows an error message if trying to submit an invalid form', async () => {

--- a/src/pages/Office/ServicesCounselingAddOrders/ServicesCounselingAddOrders.jsx
+++ b/src/pages/Office/ServicesCounselingAddOrders/ServicesCounselingAddOrders.jsx
@@ -79,7 +79,7 @@ const ServicesCounselingAddOrders = ({ userPrivileges, canAddOrders, setCanAddOr
   }, []);
 
   const isSafetyPrivileged =
-    isSafetyMoveFF && isSafetyMoveSelected !== false
+    isSafetyMoveFF && isSafetyMoveSelected !== undefined
       ? userPrivileges?.some((privilege) => privilege.privilegeType === elevatedPrivilegeTypes.SAFETY)
       : false;
 


### PR DESCRIPTION
## [Agility ticket](https://www13.v1host.com/USTRANSCOM38/assetdetail.v1?number=B-22544)

## Summary
Remove the "Safety" order type as an option when a Services Counselor (SC) is creating a move for a customer with an existing profile. As well as exclude Safety Move customer from the Customer Search result.

### How to test
1. Create a User with a non safety move.
2. Create a safety move for that same user by clicking "create customer" on the customer search screen
4. Login as a SC with safety privileges
5. Navigate to Move Search and search that Customers Name
6. Verify both the safety and non safety moves are displayed in the search results
7. Navigate to Customer Search and search that Customers Name
8. Verify that no safety moves return in the search
9. Select "Create new move" for an existing non safety user  
10. Verify "Safety" is not an order type
11. Navigate to Customer Search and search for a new Customers Name
12.  select "Create new User"
13. When on the  "Create Customer Profile" verify the order type is "Safety"
14. Login as SC without safety privileges
15. Navigate to Customer Search and search that Customers Name
16. Verify that no safety moves return in the search
17. Navigate to Move Search and search that Customers Name
18.  Verify that no safety moves return in the search
