### PR TITLE
Int b 22770

### DIFF
--- a/migrations/app/dml_migrations_manifest.txt
+++ b/migrations/app/dml_migrations_manifest.txt
@@ -7,3 +7,4 @@
 20250227211521_update_re_countries.up.sql
 20250227211534_update_re_country_prn_divisions.up.sql
 20250306215742_B-22770_upd_base_names.up.sql
+20250314180812_B-22770_upd_base_names_again.up.sql

--- a/migrations/app/schema/20250306215742_B-22770_upd_base_names.up.sql
+++ b/migrations/app/schema/20250306215742_B-22770_upd_base_names.up.sql
@@ -5,14 +5,14 @@ INSERT INTO public.addresses
 select 'c13715ec-68d9-4c77-ae9a-5a652ddd3787'::uuid, 'n/a', 'Fort Bragg', 'NC', '28307', now(), now(), 'CUMBERLAND', false, '791899e6-cd77-46f2-981b-176ecb8d7098'::uuid, 'c8898dc9-9ebb-4651-b9d4-6757a6a172fc'::uuid
 where not exists (select id from addresses where id = 'c13715ec-68d9-4c77-ae9a-5a652ddd3787');
 
-update duty_locations set name = 'Fort Bragg, NC 28307', address_id = 'c13715ec-68d9-4c77-ae9a-5a652ddd3787', updated_at = now() where id = 'fc916367-afd7-4035-b3d0-74b6be850cab';
+update duty_locations set name = 'Fort Bragg, NC 28307', address_id = 'c13715ec-68d9-4c77-ae9a-5a652ddd3787', updated_at = now() where name = 'Fort Liberty, NC 28307';
 
 INSERT INTO public.addresses
 (id, street_address_1, city, state, postal_code, created_at, updated_at, county, is_oconus, country_id, us_post_region_cities_id)
 select 'd8769fb0-e130-46b2-9191-509663bab4b4'::uuid, 'n/a', 'Fort Bragg', 'NC', '28310', now(), now(), 'CUMBERLAND', false, '791899e6-cd77-46f2-981b-176ecb8d7098'::uuid, '5888ab84-a8c6-4e8d-b3e6-7975e981241d'::uuid
 where not exists (select id from addresses where id = 'd8769fb0-e130-46b2-9191-509663bab4b4');
 
-update duty_locations set name = 'Fort Bragg, NC 28310', address_id = 'd8769fb0-e130-46b2-9191-509663bab4b4', updated_at = now() where id = 'a5a3eb41-d3e0-4c9a-a87b-695caf601486';
+update duty_locations set name = 'Fort Bragg, NC 28310', address_id = 'd8769fb0-e130-46b2-9191-509663bab4b4', updated_at = now() where name = 'Fort Liberty, NC 28310';
 
 update addresses set city = 'Fort Bragg', us_post_region_cities_id = '5888ab84-a8c6-4e8d-b3e6-7975e981241d' where id = '50ebc5c0-97f3-46e7-b2c7-a3f08b3b47b5';
 

--- a/migrations/app/schema/20250306215742_B-22770_upd_base_names.up.sql
+++ b/migrations/app/schema/20250306215742_B-22770_upd_base_names.up.sql
@@ -5,14 +5,14 @@ INSERT INTO public.addresses
 select 'c13715ec-68d9-4c77-ae9a-5a652ddd3787'::uuid, 'n/a', 'Fort Bragg', 'NC', '28307', now(), now(), 'CUMBERLAND', false, '791899e6-cd77-46f2-981b-176ecb8d7098'::uuid, 'c8898dc9-9ebb-4651-b9d4-6757a6a172fc'::uuid
 where not exists (select id from addresses where id = 'c13715ec-68d9-4c77-ae9a-5a652ddd3787');
 
-update duty_locations set name = 'Fort Bragg, NC 28307', address_id = 'c13715ec-68d9-4c77-ae9a-5a652ddd3787', updated_at = now() where name = 'Fort Liberty, NC 28307';
+update duty_locations set name = 'Fort Bragg, NC 28307', address_id = 'c13715ec-68d9-4c77-ae9a-5a652ddd3787', updated_at = now() where id = 'fc916367-afd7-4035-b3d0-74b6be850cab';
 
 INSERT INTO public.addresses
 (id, street_address_1, city, state, postal_code, created_at, updated_at, county, is_oconus, country_id, us_post_region_cities_id)
 select 'd8769fb0-e130-46b2-9191-509663bab4b4'::uuid, 'n/a', 'Fort Bragg', 'NC', '28310', now(), now(), 'CUMBERLAND', false, '791899e6-cd77-46f2-981b-176ecb8d7098'::uuid, '5888ab84-a8c6-4e8d-b3e6-7975e981241d'::uuid
 where not exists (select id from addresses where id = 'd8769fb0-e130-46b2-9191-509663bab4b4');
 
-update duty_locations set name = 'Fort Bragg, NC 28310', address_id = 'd8769fb0-e130-46b2-9191-509663bab4b4', updated_at = now() where name = 'Fort Liberty, NC 28310';
+update duty_locations set name = 'Fort Bragg, NC 28310', address_id = 'd8769fb0-e130-46b2-9191-509663bab4b4', updated_at = now() where id = 'a5a3eb41-d3e0-4c9a-a87b-695caf601486';
 
 update addresses set city = 'Fort Bragg', us_post_region_cities_id = '5888ab84-a8c6-4e8d-b3e6-7975e981241d' where id = '50ebc5c0-97f3-46e7-b2c7-a3f08b3b47b5';
 

--- a/migrations/app/schema/20250314180812_B-22770_upd_base_names_again.up.sql
+++ b/migrations/app/schema/20250314180812_B-22770_upd_base_names_again.up.sql
@@ -1,0 +1,4 @@
+--update duty loc by name in case uuids don't match in all envs
+update duty_locations set name = 'Fort Bragg, NC 28307', address_id = 'c13715ec-68d9-4c77-ae9a-5a652ddd3787', updated_at = now() where name = 'Fort Liberty, NC 28307';
+
+update duty_locations set name = 'Fort Bragg, NC 28310', address_id = 'd8769fb0-e130-46b2-9191-509663bab4b4', updated_at = now() where name = 'Fort Liberty, NC 28310';


### PR DESCRIPTION
## INT-B-22770

## Summary

Adding and removing duty locations and counseling offices.

## Verification Steps for the Author

These are to be checked by the author.

- [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
- [ ] Have the Agility acceptance criteria been met for this change?

## Verification Steps for Reviewers

The following duty locations should NOT be available for selection:
NAS Whidbey Island, WA 98638
Norcross, GA 30010
Virginia Beach, VA 23450
Seattle, WA 98175
Aurora, CO 80040
Raleigh, NC 27602
Washington, DC 20032
Austin, TX 78760
Columbus, GA 31908
Las Vegas, NV 89136
Orlando, FL 32854
Sacramento, CA 94294
Bell, CA 90202
San Diego, CA 92186
Dayton, OH 45413
Hammond, LA 70404
San Francisco, CA 94125
Jackson, MS 39205
Springfield, MO 65805
Madison, MS 39130
Colorado Springs, CO 80960
Tampa, FL 33601
Lincoln, NE 68542
Johnson City, TN 37605
Bay City, TX 77404
Tucson, AZ 85717
Beaufort, SC 29903
Evansville, IN 47703
Garland, TX 75049
Phoenix, AZ 85064
Kansas City, MO 64148
Goldsboro, NC 27532
Austin, TX 78715
Anchorage, AK 99510
Fort Liberty, NC 
Fort Moore, GA
Miami, FL 33124
Tacoma, WA 98412
Raleigh, NC 27619

The following duty locations should be available for selection:
NAS Whidbey Island, WA 98278
San Diego, CA 92173

When a pickup address for zip code 28307 or 28310 is selected
Then Fort Bragg, NC should be in the counseling office dropdown list

When a pickup address for zip code 31905 is selected
Then Fort Benning, GA should be in the counseling office dropdown list
