### PR TITLE
INT B-22606 I-13981

### DIFF
--- a/src/components/Office/RequestedShipments/ApprovedRequestedShipments.jsx
+++ b/src/components/Office/RequestedShipments/ApprovedRequestedShipments.jsx
@@ -19,6 +19,7 @@ import { SHIPMENT_OPTIONS_URL, FEATURE_FLAG_KEYS } from 'shared/constants';
 import Restricted from 'components/Restricted/Restricted';
 import { permissionTypes } from 'constants/permissions';
 import { isBooleanFlagEnabled } from 'utils/featureFlags';
+import { ORDERS_TYPE } from 'constants/orders';
 
 // nts defaults show preferred pickup date and pickup address, flagged items when collapsed
 // ntsr defaults shows preferred delivery date, storage facility address, delivery address, flagged items when collapsed
@@ -104,7 +105,8 @@ const ApprovedRequestedShipments = ({
     fetchData();
   }, []);
 
-  const { newDutyLocation, currentDutyLocation } = ordersInfo;
+  const { newDutyLocation, currentDutyLocation, ordersType } = ordersInfo;
+  const isLocalMove = ordersType === ORDERS_TYPE.LOCAL_MOVE;
   useEffect(() => {
     // Check if duty locations on the orders qualify as OCONUS to conditionally render the UB shipment option
     if (currentDutyLocation?.address?.isOconus || newDutyLocation?.address?.isOconus) {
@@ -125,7 +127,9 @@ const ApprovedRequestedShipments = ({
         {enableNTSR && <option value={SHIPMENT_OPTIONS_URL.NTSrelease}>NTS-release</option>}
         {enableBoat && <option value={SHIPMENT_OPTIONS_URL.BOAT}>Boat</option>}
         {enableMobileHome && <option value={SHIPMENT_OPTIONS_URL.MOBILE_HOME}>Mobile Home</option>}
-        {enableUB && isOconusMove && <option value={SHIPMENT_OPTIONS_URL.UNACCOMPANIED_BAGGAGE}>UB</option>}
+        {!isLocalMove && enableUB && isOconusMove && (
+          <option value={SHIPMENT_OPTIONS_URL.UNACCOMPANIED_BAGGAGE}>UB</option>
+        )}
       </>
     );
   };

--- a/src/components/Office/RequestedShipments/RequestedShipments.test.jsx
+++ b/src/components/Office/RequestedShipments/RequestedShipments.test.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { act } from 'react-dom/test-utils';
-import { render, screen, within } from '@testing-library/react';
+import { render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { generatePath } from 'react-router-dom';
@@ -19,6 +19,7 @@ import {
   serviceItemsEmpty,
   ppmOnlyShipments,
   closeoutOffice,
+  ordersInfoOCONUSLocalMove,
 } from './RequestedShipmentsTestData';
 import ApprovedRequestedShipments from './ApprovedRequestedShipments';
 import SubmittedRequestedShipments from './SubmittedRequestedShipments';
@@ -28,11 +29,17 @@ import { tooRoutes } from 'constants/routes';
 import { MockProviders } from 'testUtils';
 import { permissionTypes } from 'constants/permissions';
 import { configureStore } from 'shared/store';
+import { isBooleanFlagEnabled } from 'utils/featureFlags';
 
 const mockNavigate = jest.fn();
 jest.mock('react-router-dom', () => ({
   ...jest.requireActual('react-router-dom'),
   useNavigate: () => mockNavigate,
+}));
+
+jest.mock('utils/featureFlags', () => ({
+  ...jest.requireActual('utils/featureFlags'),
+  isBooleanFlagEnabled: jest.fn().mockImplementation(() => Promise.resolve()),
 }));
 
 const moveTaskOrder = {
@@ -411,6 +418,40 @@ describe('RequestedShipments', () => {
       });
       expect(screen.getByLabelText('Move management').checked).toEqual(true);
       expect(screen.getByRole('button', { name: 'Approve selected' })).toBeDisabled();
+    });
+    it('renders Add a new shipment Button and does not show UB when orders type is local move', async () => {
+      isBooleanFlagEnabled.mockImplementation(() => Promise.resolve(true));
+      render(
+        <MockProviders permissions={[permissionTypes.createTxoShipment]}>
+          <ApprovedRequestedShipments
+            ordersInfo={ordersInfoOCONUSLocalMove}
+            mtoShipments={shipments}
+            closeoutOffice={closeoutOffice}
+            mtoServiceItems={serviceItemsMSandCS}
+            moveCode="TE5TC0DE"
+          />
+        </MockProviders>,
+      );
+
+      // Get the combobox (dropdown button)
+      const combobox = await screen.getByRole('combobox', { name: 'Add a new shipment' });
+
+      expect(combobox).toBeInTheDocument();
+
+      // Simulate a user clicking the dropdown
+      await userEvent.click(combobox);
+
+      // Check if all expected options appear
+      await waitFor(() => {
+        expect(screen.getByRole('option', { name: 'HHG' })).toBeInTheDocument();
+        expect(screen.getByRole('option', { name: 'PPM' })).toBeInTheDocument();
+        expect(screen.getByRole('option', { name: 'NTS' })).toBeInTheDocument();
+        expect(screen.getByRole('option', { name: 'NTS-release' })).toBeInTheDocument();
+        expect(screen.getByRole('option', { name: 'Boat' })).toBeInTheDocument();
+        expect(screen.getByRole('option', { name: 'Mobile Home' })).toBeInTheDocument();
+      });
+      // UB option does not appear when orders type is local move
+      expect(screen.queryByRole('option', { name: 'UB' })).not.toBeInTheDocument();
     });
     it('displays approved basic service items for approved shipments', () => {
       render(

--- a/src/pages/Office/MoveDetails/MoveDetails.jsx
+++ b/src/pages/Office/MoveDetails/MoveDetails.jsx
@@ -410,6 +410,7 @@ const MoveDetails = ({
   if (isError) return <SomethingWentWrong />;
 
   const { customer, entitlement: allowances } = order;
+  const isLocalMove = order?.order_type === ORDERS_TYPE.LOCAL_MOVE;
 
   if (submittedShipments?.length > 0 && approvedOrCanceledShipments?.length > 0) {
     sections = ['requested-shipments', 'approved-shipments', ...sections];
@@ -486,7 +487,9 @@ const MoveDetails = ({
         <option value={SHIPMENT_OPTIONS_URL.NTSrelease}>NTS-release</option>
         {enableBoat && <option value={SHIPMENT_OPTIONS_URL.BOAT}>Boat</option>}
         {enableMobileHome && <option value={SHIPMENT_OPTIONS_URL.MOBILE_HOME}>Mobile Home</option>}
-        {enableUB && isOconusMove && <option value={SHIPMENT_OPTIONS_URL.UNACCOMPANIED_BAGGAGE}>UB</option>}
+        {!isLocalMove && enableUB && isOconusMove && (
+          <option value={SHIPMENT_OPTIONS_URL.UNACCOMPANIED_BAGGAGE}>UB</option>
+        )}
       </>
     );
   };

--- a/src/pages/Office/MoveDetails/MoveDetails.test.jsx
+++ b/src/pages/Office/MoveDetails/MoveDetails.test.jsx
@@ -1,7 +1,8 @@
 /* eslint-disable react/jsx-props-no-spreading */
 import React from 'react';
 import { mount } from 'enzyme';
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 
 import { ORDERS_TYPE, ORDERS_TYPE_DETAILS } from '../../../constants/orders';
 
@@ -10,6 +11,7 @@ import MoveDetails from './MoveDetails';
 import { MockProviders } from 'testUtils';
 import { useMoveDetailsQueries } from 'hooks/queries';
 import { permissionTypes } from 'constants/permissions';
+import { isBooleanFlagEnabled } from 'utils/featureFlags';
 
 jest.mock('hooks/queries', () => ({
   useMoveDetailsQueries: jest.fn(),
@@ -28,6 +30,11 @@ jest.mock('react-router-dom', () => ({
   ...jest.requireActual('react-router-dom'),
   useParams: () => ({ moveCode: mockRequestedMoveCode }),
   useNavigate: () => mockNavigate,
+}));
+
+jest.mock('utils/featureFlags', () => ({
+  ...jest.requireActual('utils/featureFlags'),
+  isBooleanFlagEnabled: jest.fn().mockImplementation(() => Promise.resolve(false)),
 }));
 
 const requestedMoveDetailsQuery = {
@@ -1297,6 +1304,87 @@ describe('MoveDetails page', () => {
       );
 
       expect(await screen.getByRole('combobox', { name: 'Add a new shipment' })).toBeInTheDocument();
+    });
+
+    it('renders add a new shipment button and does not show UB when orders type is local move', async () => {
+      const localMoveDetailsQuery = {
+        ...noRequestedAndNoApprovedMoveDetailsQuery,
+        order: {
+          ...noRequestedAndNoApprovedMoveDetailsQuery.order,
+          order_type: ORDERS_TYPE.LOCAL_MOVE,
+          originDutyLocation: {
+            address: {
+              isOconus: true,
+            },
+          },
+        },
+      };
+      useMoveDetailsQueries.mockReturnValue(localMoveDetailsQuery);
+      isBooleanFlagEnabled.mockImplementation(() => Promise.resolve(true));
+      render(
+        <MockProviders permissions={[permissionTypes.createTxoShipment]}>
+          <MoveDetails {...testProps} />
+        </MockProviders>,
+      );
+
+      // Get the combobox (dropdown button)
+      const combobox = await screen.getByRole('combobox', { name: 'Add a new shipment' });
+
+      expect(combobox).toBeInTheDocument();
+
+      // Simulate a user clicking the dropdown
+      await userEvent.click(combobox);
+
+      // Check if all expected options appear
+      await waitFor(() => {
+        expect(screen.getByRole('option', { name: 'HHG' })).toBeInTheDocument();
+        expect(screen.getByRole('option', { name: 'PPM' })).toBeInTheDocument();
+        expect(screen.getByRole('option', { name: 'NTS' })).toBeInTheDocument();
+        expect(screen.getByRole('option', { name: 'NTS-release' })).toBeInTheDocument();
+        expect(screen.getByRole('option', { name: 'Boat' })).toBeInTheDocument();
+        expect(screen.getByRole('option', { name: 'Mobile Home' })).toBeInTheDocument();
+      });
+      // UB option does not appear when orders type is local move
+      expect(screen.queryByRole('option', { name: 'UB' })).not.toBeInTheDocument();
+    });
+
+    it('renders add a new shipment button and shows UB when orders type is NOT local move', async () => {
+      const pcsMoveDetailsQuery = {
+        ...noRequestedAndNoApprovedMoveDetailsQuery,
+        order: {
+          ...noRequestedAndNoApprovedMoveDetailsQuery.order,
+          order_type: ORDERS_TYPE.PERMANENT_CHANGE_OF_STATION,
+          originDutyLocation: {
+            address: {
+              isOconus: true,
+            },
+          },
+        },
+      };
+      useMoveDetailsQueries.mockReturnValue(pcsMoveDetailsQuery);
+      isBooleanFlagEnabled.mockImplementation(() => Promise.resolve(true));
+      render(
+        <MockProviders permissions={[permissionTypes.createTxoShipment]}>
+          <MoveDetails {...testProps} />
+        </MockProviders>,
+      );
+
+      const combobox = await screen.getByRole('combobox', { name: 'Add a new shipment' });
+
+      expect(combobox).toBeInTheDocument();
+
+      await userEvent.click(combobox);
+
+      // Check if all expected options appear
+      await waitFor(() => {
+        expect(screen.getByRole('option', { name: 'HHG' })).toBeInTheDocument();
+        expect(screen.getByRole('option', { name: 'PPM' })).toBeInTheDocument();
+        expect(screen.getByRole('option', { name: 'NTS' })).toBeInTheDocument();
+        expect(screen.getByRole('option', { name: 'NTS-release' })).toBeInTheDocument();
+        expect(screen.getByRole('option', { name: 'Boat' })).toBeInTheDocument();
+        expect(screen.getByRole('option', { name: 'Mobile Home' })).toBeInTheDocument();
+      });
+      expect(screen.getByRole('option', { name: 'UB' })).toBeInTheDocument();
     });
 
     it('renders add new shipment button even when there are no shipments on the move', async () => {


### PR DESCRIPTION
## [Agility ticket](https://www13.v1host.com/USTRANSCOM38/assetdetail.v1?number=B-22606)
[Issue ticket](https://www13.v1host.com/USTRANSCOM38/Issue.mvc/Summary?oidToken=Issue%3A1077784)
[Previous INT PR](https://github.com/transcom/mymove/pull/14996)

## Summary

Looks like the TOO approved shipment button got past me. Added in local move check that disallows UB shipment selection.

### How to test

1. Ensure you have the UB flag on in your `envrc`
2. Log in as a TOO
3. Find a move that has approved shipments
4. Update the orders to be a local move with at least one OCONUS location
5. Click the add a new shipment
6. UB option should not be there