### PR TITLE
INT B-22866

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -838,6 +838,7 @@ server_test:
     - echo "server test -- build gotestsum and run scripts for report"
     - make -j 2 bin/milmove bin/gotestsum
     - make server_test
+    - scripts/check-failed-test /builds/milmove/mymove/tmp/test-results/gotest/app/go-test-report.xml
   artifacts:
     paths:
       - /builds/milmove/mymove/bin/gotestsum

--- a/pkg/handlers/ghcapi/customer.go
+++ b/pkg/handlers/ghcapi/customer.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"database/sql"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"strings"
@@ -232,7 +233,40 @@ func (h CreateCustomerWithOktaOptionHandler) Handle(params customercodeop.Create
 				oktaUser, oktaErr = createOktaProfile(appCtx, params)
 				if oktaErr != nil {
 					appCtx.Logger().Error("error creating okta profile", zap.Error(oktaErr))
-					return customercodeop.NewCreateCustomerWithOktaOptionBadRequest(), oktaErr
+					rawErrMsg := oktaErr.Error()
+					// filtering the overly complex Okta error that gets sent back
+					const prefix = "API error (status "
+					if strings.HasPrefix(rawErrMsg, prefix) {
+						if idx := strings.Index(rawErrMsg, "): "); idx != -1 {
+							rawErrMsg = rawErrMsg[idx+3:]
+						}
+					}
+
+					var parsedErr models.OktaError
+					if err := json.Unmarshal([]byte(rawErrMsg), &parsedErr); err != nil {
+						// if unmarshalling fails, fall back to the original error message
+						parsedErr.ErrorSummary = rawErrMsg
+					}
+
+					var detail string
+					if len(parsedErr.ErrorCauses) > 0 {
+						detail = parsedErr.ErrorCauses[0].ErrorSummary
+					} else {
+						detail = parsedErr.ErrorSummary
+					}
+
+					// office users don't know that login means email so handling error returns to make it easier to understand
+					switch {
+					case strings.Contains(detail, "cac_edipi: An object with this field already exists in the current organization"):
+						detail = "An Okta user already exists with the DODID " + payload.Edipi
+					case strings.Contains(detail, "login: An object with this field already exists in the current organization"):
+						detail = "An Okta user already exists with the email " + payload.PersonalEmail
+					default:
+						detail = "Okta error - " + detail
+					}
+
+					payload := payloadForValidationError("Unable to create Okta profile", detail, h.GetTraceIDFromRequest(params.HTTPRequest), validate.NewErrors())
+					return customercodeop.NewCreateCustomerWithOktaOptionUnprocessableEntity().WithPayload(payload), oktaErr
 				}
 				oktaSub = oktaUser.ID
 			}
@@ -347,6 +381,7 @@ func createOktaProfile(appCtx appcontext.AppContext, params customercodeop.Creat
 	oktaEmail := payload.PersonalEmail
 	oktaFirstName := payload.FirstName
 	oktaLastName := payload.LastName
+	edipi := payload.Edipi
 	oktaPhone := payload.Telephone
 
 	// Creating the Profile struct
@@ -355,6 +390,7 @@ func createOktaProfile(appCtx appcontext.AppContext, params customercodeop.Creat
 		LastName:    oktaLastName,
 		Email:       oktaEmail,
 		Login:       oktaEmail,
+		CacEdipi:    edipi,
 		MobilePhone: *oktaPhone,
 	}
 
@@ -408,6 +444,7 @@ func createOktaProfile(appCtx appcontext.AppContext, params customercodeop.Creat
 		return nil, err
 	}
 	if resp.StatusCode != http.StatusOK {
+		err = fmt.Errorf("API error (status %d): %s", resp.StatusCode, string(response))
 		if resp.StatusCode == http.StatusInternalServerError {
 			return nil, err
 		}

--- a/pkg/models/okta.go
+++ b/pkg/models/okta.go
@@ -59,6 +59,16 @@ type CreatedOktaUser struct {
 	} `json:"profile"`
 }
 
+type OktaError struct {
+	ErrorCode    string `json:"errorCode"`
+	ErrorSummary string `json:"errorSummary"`
+	ErrorLink    string `json:"errorLink"`
+	ErrorId      string `json:"errorId"`
+	ErrorCauses  []struct {
+		ErrorSummary string `json:"errorSummary"`
+	} `json:"errorCauses"`
+}
+
 // ensures a valid email address
 func isValidEmail(email string) bool {
 	emailRegex := `^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$`

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -99,6 +99,7 @@ These scripts are primarily used for CircleCI workflows.
 | Script Name                        | Description                                                                                             |
 | ---------------------------------- | ------------------------------------------------------------------------------------------------------- |
 | `check-deployed-commit`            | checks that the deployed commit and given commit match.                                                 |
+| `check-failed-test`            | used for gitlab to check failed xml test results and exit 1.
 | `check-generated-code`             | checks that the generated code has not changed                                                          |
 | `check-tls-pair`                   | checks that the TLS CERT and KEY match using openssl                                                    |
 | `circleci-announce-broken-branch`  | announce that a branch is broken                                                                        |

--- a/scripts/check-failed-test
+++ b/scripts/check-failed-test
@@ -1,0 +1,23 @@
+#! /usr/bin/env bash
+
+#
+# Script to check xml for failed tests
+#
+
+set -eu -o pipefail
+
+if [ -z "$1" ]; then
+  echo "Usage: $0 [path/to/file.xml]"
+  exit 1
+fi
+
+if ! test -f "$1"; then
+  echo "FILE NOT FOUND: $1"
+  exit 1
+fi
+
+if grep "<failure" "$1"; then
+  # Grep found line = error
+  echo "LINT ERROR in $1"
+  exit 1
+fi


### PR DESCRIPTION
## [Agility ticket](https://www13.v1host.com/USTRANSCOM38/assetdetail.v1?number=B-22866)

## Summary

We were not previously sending the EDIPI to Okta when SCs are creating customers and also creating their Okta accounts. This was causing some issues with duplicate profiles when customers went ahead and created accounts for themselves and were good to do so because the DODID was not already taken in our Okta directory.

This BL fixes that issue by sending the EDIPI to Okta when SCs create Okta accounts on a service members behalf.

### How to test

1. Access office app
2. Go to create customer form as SC
3. Use an email that you already know is in Okta
4. Should receive a descriptive error
5. Use an EDIPI that you already know is in Okta
6. Should receive a descriptive error

## Screenshots
![Screenshot 2025-03-17 at 1 22 58 PM](https://github.com/user-attachments/assets/030ccb90-aef0-4b42-83f5-eb226c2d0e8e)

![Screenshot 2025-03-17 at 1 23 27 PM](https://github.com/user-attachments/assets/66b6d848-fc80-4117-befa-bcadbed1ed66)
