### PR TITLE
B-22816 MAIN: Update lines_of_accounting.valid_loa_for_tac

### DIFF
--- a/migrations/app/dml_migrations_manifest.txt
+++ b/migrations/app/dml_migrations_manifest.txt
@@ -4,3 +4,4 @@
 20250227160358_B-21966_add_data_to_office_users.up.sql
 20250227211521_update_re_countries.up.sql
 20250227211534_update_re_country_prn_divisions.up.sql
+20250320153050_B-22816_update_lines_of_accounting_valid_loa_for_tac.up.sql

--- a/migrations/app/schema/20250320153050_B-22816_update_lines_of_accounting_valid_loa_for_tac.up.sql
+++ b/migrations/app/schema/20250320153050_B-22816_update_lines_of_accounting_valid_loa_for_tac.up.sql
@@ -1,0 +1,22 @@
+--B-22816   Maria Traskowsky    Update lines_of_accounting.valid_loa_for_tac column
+
+-- Set temp timeout due to large file modification
+-- Time is 5 minutes in milliseconds
+SET statement_timeout = 300000;
+SET lock_timeout = 300000;
+SET idle_in_transaction_session_timeout = 300000;
+
+UPDATE lines_of_accounting
+SET valid_loa_for_tac =
+    CASE
+        WHEN loa_dpt_id IS NOT NULL
+         AND loa_baf_id IS NOT NULL
+         AND loa_trsy_sfx_tx IS NOT NULL
+         AND loa_obj_cls_id IS NOT NULL
+         AND loa_doc_id IS NOT NULL
+         AND loa_bgn_dt IS NOT NULL
+         AND loa_end_dt IS NOT NULL
+         AND loa_uic IS NOT NULL
+        THEN TRUE
+        ELSE FALSE
+    END;


### PR DESCRIPTION
> [!IMPORTANT]  
> Downstream to [B-22673](https://www13.v1host.com/USTRANSCOM38/story.mvc/Summary?oidToken=Story%3A1067030)

## [Agility ticket](https://www13.v1host.com/USTRANSCOM38/assetdetail.v1?number=B-22816)

## Summary

Retroactively applying the new invalid LOA criteria to existing LOAs.

To test:
1. Pull the branch, run the migrations.
2. Verify you see true and false values where expected. For ease of seeing this, you can use the query:
```
select valid_loa_for_tac, 
loa_dpt_id, 
loa_baf_id, 
loa_trsy_sfx_tx, 
loa_obj_cls_id, 
loa_doc_id, 
loa_bgn_dt, 
loa_end_dt, 
loa_uic 
from lines_of_accounting
```

You may see it not correctly populate the TRUE values with the devseed data, so you can run the migration locally and verify. Screenshot from running query directly in dbeaver:
![image](https://github.com/user-attachments/assets/5c82c671-f2ba-48c6-a921-c45504395740)
