### PR TITLE
B 22810 dest service item fix

### DIFF
--- a/pkg/handlers/ghcapi/internal/payloads/model_to_payload.go
+++ b/pkg/handlers/ghcapi/internal/payloads/model_to_payload.go
@@ -2196,7 +2196,8 @@ func queueIncludeShipmentStatus(status models.MTOShipmentStatus) bool {
 	return status == models.MTOShipmentStatusSubmitted ||
 		status == models.MTOShipmentStatusApproved ||
 		status == models.MTOShipmentStatusDiversionRequested ||
-		status == models.MTOShipmentStatusCancellationRequested
+		status == models.MTOShipmentStatusCancellationRequested ||
+		status == models.MTOShipmentStatusApprovalsRequested
 }
 
 func QueueAvailableOfficeUsers(officeUsers []models.OfficeUser) *ghcmessages.AvailableOfficeUsers {

--- a/pkg/models/mto_shipments.go
+++ b/pkg/models/mto_shipments.go
@@ -97,6 +97,8 @@ const (
 	MTOShipmentStatusCanceled MTOShipmentStatus = "CANCELED"
 	// MTOShipmentStatusDiversionRequested indicates that the TOO has requested that the Prime divert a shipment
 	MTOShipmentStatusDiversionRequested MTOShipmentStatus = "DIVERSION_REQUESTED"
+	// MoveStatusAPPROVALSREQUESTED captures enum value "APPROVALS REQUESTED"
+	MTOShipmentStatusApprovalsRequested MTOShipmentStatus = "APPROVALS REQUESTED"
 )
 
 // LOAType represents the possible TAC and SAC types for a mto shipment
@@ -210,6 +212,7 @@ func (m *MTOShipment) Validate(_ *pop.Connection) (*validate.Errors, error) {
 		string(MTOShipmentStatusCancellationRequested),
 		string(MTOShipmentStatusCanceled),
 		string(MTOShipmentStatusDiversionRequested),
+		string(MTOShipmentStatusApprovalsRequested),
 	}})
 	vs = append(vs, &validators.UUIDIsPresent{Field: m.MoveTaskOrderID, Name: "MoveTaskOrderID"})
 	if m.PrimeEstimatedWeight != nil {

--- a/pkg/services/mto_service_item/mto_service_item_creator.go
+++ b/pkg/services/mto_service_item/mto_service_item_creator.go
@@ -756,7 +756,7 @@ func (o *mtoServiceItemCreator) CreateMTOServiceItem(appCtx appcontext.AppContex
 				return fmt.Errorf("failed to update mtoShipment.PickupAddress: %#v %e", verrs, err)
 			}
 		}
-
+		//here
 		if _, err = o.moveRouter.ApproveOrRequestApproval(txnAppCtx, move); err != nil {
 			return err
 		}

--- a/pkg/services/mto_service_item/mto_service_item_updater.go
+++ b/pkg/services/mto_service_item/mto_service_item_updater.go
@@ -320,7 +320,7 @@ func (p *mtoServiceItemUpdater) approveOrRejectServiceItem(
 		if err != nil {
 			return err
 		}
-
+		// here
 		if _, err = p.moveRouter.ApproveOrRequestApproval(txnAppCtx, move); err != nil {
 			return err
 		}

--- a/pkg/services/mto_shipment/mto_shipment_updater.go
+++ b/pkg/services/mto_shipment/mto_shipment_updater.go
@@ -753,6 +753,8 @@ func (f *mtoShipmentUpdater) updateShipmentRecord(appCtx appcontext.AppContext, 
 				// if the move is in excess weight risk and the TOO has not acknowledge that, need to change move status to "Approvals Requested"
 				// this will trigger the TOO to acknowledged the excess right, which populates ExcessWeightAcknowledgedAt
 				if move.ExcessWeightQualifiedAt != nil && move.ExcessWeightAcknowledgedAt == nil || move.ExcessUnaccompaniedBaggageWeightQualifiedAt != nil && move.ExcessUnaccompaniedBaggageWeightAcknowledgedAt == nil {
+					newShipment.Status = models.MTOShipmentStatusApprovalsRequested
+
 					err = f.moveRouter.SendToOfficeUser(txnAppCtx, move)
 					if err != nil {
 						return err

--- a/pkg/services/mto_shipment/rules.go
+++ b/pkg/services/mto_shipment/rules.go
@@ -101,6 +101,10 @@ func checkUpdateAllowed() validator {
 				if isTOO {
 					return nil
 				}
+			case models.MTOShipmentStatusApprovalsRequested:
+				if isTOO {
+					return nil
+				}
 			default:
 				return err
 			}

--- a/pkg/services/shipment_address_update/shipment_address_update_requester.go
+++ b/pkg/services/shipment_address_update/shipment_address_update_requester.go
@@ -452,6 +452,8 @@ func (f *shipmentAddressUpdateRequester) RequestShipmentDeliveryAddressUpdate(ap
 
 		existingMoveStatus := move.Status
 		if updateNeedsTOOReview {
+			shipment.Status = models.MTOShipmentStatusApprovalsRequested
+
 			err = f.moveRouter.SendToOfficeUser(appCtx, &shipment.MoveTaskOrder)
 			if err != nil {
 				return err

--- a/pkg/services/sit_extension/sit_extension_creator.go
+++ b/pkg/services/sit_extension/sit_extension_creator.go
@@ -91,6 +91,16 @@ func (f *sitExtensionCreator) CreateSITExtension(appCtx appcontext.AppContext, s
 				return nil, err
 			}
 		}
+
+		shipment.Status = models.MTOShipmentStatusApprovalsRequested
+		verrs, err = appCtx.DB().ValidateAndUpdate(&shipment)
+		if verrs != nil && verrs.HasAny() {
+			return nil, apperror.NewInvalidInputError(
+				shipment.ID, err, verrs, "Invalid input found while updating shipment")
+		}
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	return sitExtension, nil


### PR DESCRIPTION
## [Agility ticket](https://www13.v1host.com/USTRANSCOM38/story.mvc/Summary?oidToken=Story%3A1074441&RoomContext=TeamRoom%3A848240&concept=TeamRoom)

## Summary

There was an issue where a move has remaining in the Task Order queue with only destination service items on it.  This only occurred when the move had both an HHG and PPM shipment.  The DB team decided the best solution for this and going forward was to give the shipment an Approvals Requested status along with the move itself having that same status.   Then we can start to look at the shipment level as well in these queue queries.


### How to test

1. Create a new move with both HHG and PPM shipments.
2. Get the move to Prime and add a Destination Service Item to the HHG shipment.
3. Log back in as the TOO and verify that the Move only shows up in the Destination Request queue.


