### PR TITLE
B-22549 INT  Submit move form bugfix

### DIFF
--- a/src/components/Customer/SubmitMoveForm/SubmitMoveForm.jsx
+++ b/src/components/Customer/SubmitMoveForm/SubmitMoveForm.jsx
@@ -18,11 +18,26 @@ const SubmitMoveForm = (props) => {
   const [hasReadTheAgreement, setHasReadTheAgreement] = useState(false);
   const [hasAcknowledgedTerms, sethasAcknowledgedTerms] = useState(false);
 
+  const normalizeString = (str) => {
+    return str
+      .toLowerCase()
+      .trim()
+      .replace(/\s+/g, ' ')
+      .replace(/[^\w\s]/gi, '');
+  };
+
+  const compareSignature = (signature, fullName) => {
+    const normalizedSignature = normalizeString(signature);
+    const normalizedFullName = normalizeString(fullName);
+
+    return normalizedSignature === normalizedFullName;
+  };
+
   const validationSchema = Yup.object().shape({
     signature: Yup.string()
       .required('Required')
       .test('matches-user-name', 'Typed signature must match your exact user name', (signature) => {
-        return signature.toLowerCase() === currentUser.toLowerCase();
+        return compareSignature(signature, currentUser);
       }),
     date: Yup.date().required(),
   });


### PR DESCRIPTION
Original Story: ## [B-22549](https://www13.v1host.com/USTRANSCOM38/assetdetail.v1?number=B-22549)
Referenced Issue: ## [I-14159](https://www13.v1host.com/USTRANSCOM38/Issue.mvc/Summary?oidToken=Issue%3A1101908)
## Summary

Updated the form validation for SubmitMoveForm to allow for any number of spaces (as long as there is at minimum one between the first and last name). Same methods of testing apply

### How to test

1. Login as a user to begin creating a new move Click on create move
2. Fill out all fields and proceed with creating a new move until reaching the submit screen with agreeement
3. "I have read and understand the agreement as shown above" and signature box, complete should be disabled,
4. Scroll to the bottom of the legal text, checkbox should enable then, but onlly if the bottom of the scroll box is reached (halfway, 3/4 the way should not work)
5. Click the agreement checkbox to enable the Signature box
7. Filling out the signature box exactly as the user name below it should allow the "Complete" button to be enabled
8. Try to misspell the name on the signature box, this should prevent the complete button from being enabled
9. Try to add an extra space on the signature box between the names, this should prevent the complete button from being enabled
10. Fill back in the correct name, complete button should re-enable then.

## Screenshots
Before
![image](https://github.com/user-attachments/assets/a694df1a-9684-4bf7-8a41-b79b071c545f)
After
![image](https://github.com/user-attachments/assets/f0f71c0f-3eff-4619-8cc4-6c7fe81d6d49)
