### PR TITLE
Int b 23451

### DIFF
--- a/pkg/services/payment_request/upload_creator.go
+++ b/pkg/services/payment_request/upload_creator.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io"
 	"path"
-	"time"
 
 	"github.com/gofrs/uuid"
 
@@ -15,11 +14,7 @@ import (
 	"github.com/transcom/mymove/pkg/services"
 	"github.com/transcom/mymove/pkg/storage"
 	"github.com/transcom/mymove/pkg/uploader"
-)
-
-const (
-	// VersionTimeFormat is the Go time format for creating a version number.
-	VersionTimeFormat string = "20060102150405"
+	"github.com/transcom/mymove/pkg/utils"
 )
 
 type paymentRequestUploadCreator struct {
@@ -44,7 +39,7 @@ func (p *paymentRequestUploadCreator) assembleUploadFilePathName(appCtx appconte
 		}
 	}
 
-	newfilename := filename + "-" + time.Now().Format(VersionTimeFormat)
+	newfilename := utils.AppendTimestampToFilename(filename)
 	uploadFilePath := fmt.Sprintf("/payment-request-uploads/mto-%s/payment-request-%s", paymentRequest.MoveTaskOrderID, paymentRequest.ID)
 	uploadFileName := path.Join(uploadFilePath, newfilename)
 

--- a/pkg/utils/utility.go
+++ b/pkg/utils/utility.go
@@ -1,10 +1,29 @@
 package utils
 
 import (
+	"fmt"
+	"path/filepath"
 	"strings"
+	"time"
+)
+
+const (
+	// VersionTimeFormat is the Go time format for creating a version number.
+	VersionTimeFormat string = "20060102150405"
 )
 
 // checks if string is null, empty, or whitespace
 func IsNullOrWhiteSpace(s *string) bool {
 	return s == nil || len(strings.TrimSpace(*s)) == 0
+}
+
+func AppendTimestampToFilename(fileName string) string {
+	now := time.Now()
+	timestamp := now.Format(VersionTimeFormat) // ISO Format
+
+	ext := filepath.Ext(fileName)
+	name := strings.TrimSuffix(fileName, ext)
+
+	newFileName := fmt.Sprintf("%s-%s%s", name, timestamp, ext)
+	return newFileName
 }

--- a/pkg/utils/utility_test.go
+++ b/pkg/utils/utility_test.go
@@ -1,12 +1,23 @@
 package utils_test
 
 import (
+	"regexp"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/suite"
+
 	"github.com/transcom/mymove/pkg/testingsuite"
 	"github.com/transcom/mymove/pkg/utils"
 )
 
 type UtilitySuite struct {
-	*testingsuite.PopTestSuite
+	testingsuite.BaseTestSuite
+}
+
+func TestUtilitySuite(t *testing.T) {
+	suite.Run(t, &UtilitySuite{})
 }
 
 func (suite *UtilitySuite) TestStringIsNilEmptyOrWhitespace() {
@@ -30,5 +41,42 @@ func (suite *UtilitySuite) TestStringIsNilEmptyOrWhitespace() {
 		testString := "hello"
 		actual := utils.IsNullOrWhiteSpace(&testString)
 		suite.False(actual)
+	})
+}
+
+func (suite *UtilitySuite) TestAppendTimestampToFilename() {
+	originalFilename := "example.txt"
+	result := utils.AppendTimestampToFilename(originalFilename)
+
+	suite.Run("Produces correct formatting", func() {
+		expectedPattern := `^example-\d{14}\.txt$`
+		matched, err := regexp.MatchString(expectedPattern, result)
+		suite.NoError(err, "Error in regex matching")
+		suite.True(matched, "Format must match expected pattern")
+	})
+
+	suite.Run("Current timestamp", func() {
+		parts := regexp.MustCompile(`-(\d{14})\.`).FindStringSubmatch(result)
+
+		suite.Len(parts, 2, "Could not extract timestamp from result")
+
+		timestamp, err := time.Parse(utils.VersionTimeFormat, parts[1])
+		suite.NoError(err, "Error parsing timestamp")
+
+		timeWithin2Seconds := time.Since(timestamp) <= 2*time.Second
+		suite.True(timeWithin2Seconds, "Timestamp should be now()")
+	})
+
+	suite.Run("Preserve original name and extension", func() {
+		suite.True(strings.HasPrefix(result, "example-"), "Prefix does not match original filename")
+		suite.True(strings.HasSuffix(result, ".txt"), "Suffix does not match original filename extension")
+	})
+
+	suite.Run("Handle filename without extension", func() {
+		result := utils.AppendTimestampToFilename("noextension")
+		expectedPattern := `^noextension-\d{14}$`
+		matched, err := regexp.MatchString(expectedPattern, result)
+		suite.NoError(err, "Error matching regex")
+		suite.True(matched, "Result does not match expected pattern")
 	})
 }

--- a/playwright/tests/office/servicescounseling/servicesCounselingFlows.spec.js
+++ b/playwright/tests/office/servicescounseling/servicesCounselingFlows.spec.js
@@ -6,6 +6,7 @@
 
 // @ts-check
 import { DEPARTMENT_INDICATOR_OPTIONS } from '../../utils/office/officeTest';
+import { appendTimestampToFilenamePrefix } from '../../utils/playwrightUtility';
 
 import { test, expect } from './servicesCounselingTestFixture';
 
@@ -192,7 +193,9 @@ test.describe('Services counselor user', () => {
       await expect(page.getByText('Uploading')).toBeVisible();
       await expect(page.getByText('Uploading')).not.toBeVisible();
       await expect(page.getByText('Upload complete')).not.toBeVisible();
-      await expect(page.getByTestId('uploads-table').getByText('AF Orders Sample.pdf')).toBeVisible();
+
+      const filenameWithTimestamp = appendTimestampToFilenamePrefix('AF Orders Sample');
+      await expect(page.getByTestId('uploads-table').getByText(filenameWithTimestamp)).toBeVisible();
       await page.getByTestId('openMenu').click();
       await expect(page.getByTestId('DocViewerMenu').getByTestId('button')).toHaveCount(4);
       await page.getByTestId('closeMenu').click();
@@ -203,7 +206,7 @@ test.describe('Services counselor user', () => {
       await firstDeleteButton.click();
       await page.getByTestId('confirm-delete').click();
       await expect(page.getByText('Yes, delete')).not.toBeVisible();
-      await expect(page.getByTestId('uploads-table').getByText('AF Orders Sample.pdf')).not.toBeVisible();
+      await expect(page.getByTestId('uploads-table').getByText(filenameWithTimestamp)).not.toBeVisible();
       await page.getByTestId('openMenu').click();
       await expect(page.getByTestId('DocViewerMenu').getByTestId('button')).toHaveCount(3);
       await page.getByTestId('closeMenu').click();
@@ -216,7 +219,7 @@ test.describe('Services counselor user', () => {
       await expect(page.getByText('Uploading')).toBeVisible();
       await expect(page.getByText('Uploading')).not.toBeVisible();
       await expect(page.getByText('Upload complete')).not.toBeVisible();
-      await expect(page.getByTestId('uploads-table').getByText('AF Orders Sample.pdf')).toBeVisible();
+      await expect(page.getByTestId('uploads-table').getByText(filenameWithTimestamp)).toBeVisible();
       await page.getByTestId('openMenu').click();
       await expect(page.getByTestId('DocViewerMenu').getByTestId('button')).toHaveCount(4);
       await page.getByTestId('closeMenu').click();
@@ -227,7 +230,7 @@ test.describe('Services counselor user', () => {
       await firstDeleteButtonAmended.click();
       await page.getByTestId('confirm-delete').click();
       await expect(page.getByText('Yes, delete')).not.toBeVisible();
-      await expect(page.getByTestId('uploads-table').getByText('AF Orders Sample.pdf')).not.toBeVisible();
+      await expect(page.getByTestId('uploads-table').getByText(filenameWithTimestamp)).not.toBeVisible();
       await page.getByTestId('openMenu').click();
       await expect(page.getByTestId('DocViewerMenu').getByTestId('button')).toHaveCount(3);
       await page.getByTestId('closeMenu').click();
@@ -245,7 +248,9 @@ test.describe('Services counselor user', () => {
       await expect(page.getByText('Uploading')).toBeVisible();
       await expect(page.getByText('Uploading')).not.toBeVisible();
       await expect(page.getByText('Upload complete')).not.toBeVisible();
-      await expect(page.getByTestId('uploads-table').getByText('AF Orders Sample.pdf')).toBeVisible();
+      await expect(
+        page.getByTestId('uploads-table').getByText(appendTimestampToFilenamePrefix('AF Orders Sample')),
+      ).toBeVisible();
       await expect(page.getByText('No supporting documents have been uploaded.')).not.toBeVisible();
       await page.getByTestId('openMenu').click();
       await expect(page.getByTestId('DocViewerMenu').getByTestId('button')).toHaveCount(1);

--- a/playwright/tests/office/servicescounseling/servicesCounselingInternational.spec.js
+++ b/playwright/tests/office/servicescounseling/servicesCounselingInternational.spec.js
@@ -1,4 +1,5 @@
 import { DEPARTMENT_INDICATOR_OPTIONS } from '../../utils/office/officeTest';
+import { appendTimestampToFilenamePrefix, formatDate } from '../../utils/playwrightUtility';
 
 import { test, expect } from './servicesCounselingTestFixture';
 
@@ -6,16 +7,6 @@ const createCustomerFF = process.env.FEATURE_FLAG_COUNSELOR_MOVE_CREATE;
 const alaskaFF = process.env.FEATURE_FLAG_ENABLE_ALASKA;
 const LocationLookup1 = 'BEVERLY HILLS, CA 90210 (LOS ANGELES)';
 const LocationLookup2 = 'BEVERLY HILLS, CA 90212 (LOS ANGELES)';
-
-/**
- * @param {Date} date
- */
-function formatDate(date) {
-  const day = date.toLocaleString('default', { day: '2-digit' });
-  const month = date.toLocaleString('default', { month: 'short' });
-  const year = date.toLocaleString('default', { year: 'numeric' });
-  return `${day} ${month} ${year}`;
-}
 
 test.describe('Services counselor user', () => {
   test.describe('Can create a customer with an international Alaska move', () => {
@@ -79,7 +70,7 @@ test.describe('Services counselor user', () => {
       await page.getByLabel('Report by date').fill('1/25/2025');
       await page.getByLabel('Report by date').blur();
       const originLocation = 'Tinker AFB, OK 73145';
-      await page.getByLabel('Current duty location').fill('Tinker');
+      await page.getByLabel('Current duty location').fill(originLocation);
       await expect(page.getByText(originLocation, { exact: true })).toBeVisible();
       await page.keyboard.press('Enter');
       await page.getByLabel('Counseling office').selectOption({ label: 'PPPO Tinker AFB - USAF' });
@@ -101,12 +92,14 @@ test.describe('Services counselor user', () => {
       await expect(page.getByTestId('documentAlertMessage')).toContainText('Uploading');
       await expect(page.getByTestId('documentAlertMessage')).not.toBeVisible();
       await expect(page.getByText('Upload complete')).not.toBeVisible();
-      await expect(page.getByTestId('uploads-table').getByText('AF Orders Sample.pdf')).toBeVisible();
+      await expect(
+        page.getByTestId('uploads-table').getByText(appendTimestampToFilenamePrefix('AF Orders Sample')),
+      ).toBeVisible();
       await page.getByRole('button', { name: 'Done' }).click();
       await page.getByLabel('Department indicator').selectOption(DEPARTMENT_INDICATOR_OPTIONS.ARMY);
       await page.getByLabel('Orders number').fill('123456');
       await page.getByLabel('Orders type detail').selectOption('Shipment of HHG Permitted');
-      await page.getByLabel('TAC').nth(0).fill('TEST');
+      await page.getByTestId('hhgTacInput').fill('TEST');
       await expect(page.getByRole('button', { name: 'Save' })).toBeEnabled();
       await page.getByRole('button', { name: 'Save' }).click();
 

--- a/playwright/tests/office/servicescounseling/servicesCounselingTestFixture.js
+++ b/playwright/tests/office/servicescounseling/servicesCounselingTestFixture.js
@@ -261,7 +261,7 @@ export class ServiceCounselorPage extends OfficePage {
         filepond
           .locator('../..')
           .locator('p')
-          .getByText(/sampleWeightTicket\.jpg-\d{14}/, { exact: false }),
+          .getByText(/sampleWeightTicket-\d{14}\.jpg/, { exact: false }),
       ).toBeVisible();
 
       await this.page.getByLabel('Full weight').clear();
@@ -282,7 +282,7 @@ export class ServiceCounselorPage extends OfficePage {
       await this.uploadFileViaFilepond(filepond, 'constructedWeight.xlsx');
 
       // weight estimator file should be converted to .pdf so we verify it was
-      const re = /constructedWeight.+\.pdf-\d{14}$/;
+      const re = /constructedWeight.+-\d{14}\.pdf$/;
 
       // wait for the file to be visible in the uploads
       await expect(filepond.locator('../..').locator('p').getByText(re, { exact: false })).toBeVisible();
@@ -301,7 +301,7 @@ export class ServiceCounselorPage extends OfficePage {
         emptyFilepond
           .locator('../..')
           .locator('p')
-          .getByText(/sampleWeightTicket\.jpg-\d{14}/, { exact: false }),
+          .getByText(/sampleWeightTicket-\d{14}\.jpg/, { exact: false }),
       ).toBeVisible();
 
       await this.page.getByLabel('Full Weight').clear();
@@ -320,7 +320,7 @@ export class ServiceCounselorPage extends OfficePage {
         fullFilepond
           .locator('../..')
           .locator('p')
-          .getByText(/sampleWeightTicket\.jpg-\d{14}/, { exact: false }),
+          .getByText(/sampleWeightTicket-\d{14}\.jpg/, { exact: false }),
       ).toBeVisible();
     }
 
@@ -347,7 +347,7 @@ export class ServiceCounselorPage extends OfficePage {
           ownershipFilepond
             .locator('../..')
             .locator('p')
-            .getByText(/trailerOwnership\.pdf-\d{14}/, { exact: false }),
+            .getByText(/trailerOwnership-\d{14}\.pdf/, { exact: false }),
         ).toBeVisible();
       } else {
         // the page design makes it hard to click without using a css locator

--- a/playwright/tests/utils/playwrightUtility.js
+++ b/playwright/tests/utils/playwrightUtility.js
@@ -2,4 +2,27 @@ export const findOptionWithinOpenedDropdown = (page, searchTerm) => {
   return page.locator('[id^="react-select"][id*="listbox"]').locator(`[id*="option"]:has(:text("${searchTerm}"))`);
 };
 
+/**
+ * @returns a filename prefix appended with timestamp
+ *
+ * @param {string} prefix // filename prefix to append timestamp with '-{10 digit ISO timestamp}'
+ */
+export const appendTimestampToFilenamePrefix = (prefix) => {
+  const timestamp = new Date()
+    .toISOString()
+    .replace(/[-T:.Z]/g, '')
+    .slice(0, 10); // 10 instead of 14 ignores time to give us a general timeframe to account for processing delays
+  return `${prefix}-${timestamp}`;
+};
+
+/**
+ * @param {Date} date
+ */
+export function formatDate(date) {
+  const day = date.toLocaleString('default', { day: '2-digit' });
+  const month = date.toLocaleString('default', { month: 'short' });
+  const year = date.toLocaleString('default', { year: 'numeric' });
+  return `${day} ${month} ${year}`;
+}
+
 export default findOptionWithinOpenedDropdown;

--- a/src/components/DocumentViewerFileManager/DocumentViewerFileManager.jsx
+++ b/src/components/DocumentViewerFileManager/DocumentViewerFileManager.jsx
@@ -21,6 +21,7 @@ import Hint from 'components/Hint';
 import UploadsTable from 'components/UploadsTable/UploadsTable';
 import DeleteDocumentFileConfirmationModal from 'components/ConfirmationModals/DeleteDocumentFileConfirmationModal';
 import { PPM_DOCUMENT_TYPES, MOVE_DOCUMENT_TYPE } from 'shared/constants';
+import { appendTimestampToFilename } from 'shared/utils';
 import { ShipmentShape } from 'types';
 
 const DocumentViewerFileManager = ({
@@ -50,24 +51,6 @@ const DocumentViewerFileManager = ({
 
   const moveId = move?.id;
   const moveCode = move?.locator;
-
-  function appendTimestampToFilename(file) {
-    // Create a date-time stamp in the format "yyyymmddhh24miss"
-    const now = new Date();
-    const timestamp =
-      now.getFullYear().toString() +
-      (now.getMonth() + 1).toString().padStart(2, '0') +
-      now.getDate().toString().padStart(2, '0') +
-      now.getHours().toString().padStart(2, '0') +
-      now.getMinutes().toString().padStart(2, '0') +
-      now.getSeconds().toString().padStart(2, '0');
-
-    // Create a new filename with the timestamp prepended
-    const newFileName = `${file.name}-${timestamp}`;
-
-    // Create and return a new File object with the new filename
-    return new File([file], newFileName, { type: file.type });
-  }
 
   useEffect(() => {
     if (documentType === MOVE_DOCUMENT_TYPE.ORDERS) {

--- a/src/components/DocumentViewerFileManager/DocumentViewerFileManager.test.jsx
+++ b/src/components/DocumentViewerFileManager/DocumentViewerFileManager.test.jsx
@@ -251,11 +251,9 @@ describe('DocumentViewerFileManager', () => {
     fireEvent.click(screen.getByText('Manage Orders'));
 
     const uploadButton = screen.getByTestId('file-upload-input');
-    const mockFile = new File(['content'], 'orders', { type: 'application/pdf' });
+    const mockFile = new File(['content'], 'weight_ticket.pdf', { type: 'application/pdf' });
 
     fireEvent.click(uploadButton);
-
-    await createUploadForDocument(mockFile, 'document-id');
 
     expect(createUploadForDocument).toHaveBeenCalledWith(mockFile, 'document-id');
   });
@@ -268,13 +266,11 @@ describe('DocumentViewerFileManager', () => {
     fireEvent.click(screen.getByText('Show Custom Title'));
 
     const uploadButton = screen.getByTestId('file-upload-input');
-    const mockFile = new File(['content'], 'weight_ticket', { type: 'application/pdf' });
+    const mockFile = new File(['content'], 'weight_ticket.pdf', { type: 'application/pdf' });
 
     fireEvent.click(uploadButton);
 
-    await createUploadForPPMDocument(mockFile, 'mtoShipment-id');
-
-    expect(createUploadForPPMDocument).toHaveBeenCalledWith(mockFile, 'mtoShipment-id');
+    expect(createUploadForPPMDocument).toHaveBeenCalledWith('ppm-id', 'document-id', mockFile, true);
   });
 
   it('uploads an amended orders document successfully', async () => {
@@ -285,13 +281,10 @@ describe('DocumentViewerFileManager', () => {
     fireEvent.click(screen.getByText('Manage Amended Orders'));
 
     const uploadButton = screen.getByTestId('file-upload-input');
-    const mockFile = new File(['content'], 'amended-orders', { type: 'application/pdf' });
-
+    const mockFile = new File(['content'], 'amended-orders.pdf', { type: 'application/pdf' });
     fireEvent.click(uploadButton);
 
-    await createUploadForAmdendedOrders(mockFile, 'document-id');
-
-    expect(createUploadForAmdendedOrders).toHaveBeenCalledWith(mockFile, 'document-id');
+    expect(createUploadForAmdendedOrders).toHaveBeenCalledWith(mockFile, 'order-id');
   });
 
   it('displays an error message when the upload fails', async () => {

--- a/src/pages/MyMove/AdditionalDocuments/AdditionalDocuments.jsx
+++ b/src/pages/MyMove/AdditionalDocuments/AdditionalDocuments.jsx
@@ -18,6 +18,7 @@ import { updateMove as updateMoveAction } from 'store/entities/actions';
 import LoadingPlaceholder from 'shared/LoadingPlaceholder';
 import scrollToTop from 'shared/scrollToTop';
 import NotificationScrollToTop from 'components/NotificationScrollToTop';
+import { appendTimestampToFilename } from 'shared/utils';
 
 const AdditionalDocuments = ({ moves, updateMove }) => {
   const { moveId } = useParams();
@@ -37,23 +38,7 @@ const AdditionalDocuments = ({ moves, updateMove }) => {
   };
 
   const handleUpload = async (file) => {
-    // Create a date-time stamp in the format "yyyymmddhh24miss"
-    const now = new Date();
-    const timestamp =
-      now.getFullYear().toString() +
-      (now.getMonth() + 1).toString().padStart(2, '0') +
-      now.getDate().toString().padStart(2, '0') +
-      now.getHours().toString().padStart(2, '0') +
-      now.getMinutes().toString().padStart(2, '0') +
-      now.getSeconds().toString().padStart(2, '0');
-
-    // Create a new filename with the timestamp prepended
-    const newFileName = `${file.name}-${timestamp}`;
-
-    // Create and return a new File object with the new filename
-    const newFile = new File([file], newFileName, { type: file.type });
-
-    return createUploadForAdditionalDocuments(newFile, moveId);
+    return createUploadForAdditionalDocuments(appendTimestampToFilename(file), moveId);
   };
 
   const handleUploadComplete = () => {

--- a/src/pages/MyMove/AmendOrders/AmendOrders.jsx
+++ b/src/pages/MyMove/AmendOrders/AmendOrders.jsx
@@ -28,6 +28,7 @@ import {
 } from 'store/entities/selectors';
 import { updateOrders as updateOrdersAction } from 'store/entities/actions';
 import { customerRoutes } from 'constants/routes';
+import { appendTimestampToFilename } from 'shared/utils';
 
 export const AmendOrders = ({ updateOrders, serviceMemberId, orders }) => {
   const [isLoading, setLoading] = useState(true);
@@ -47,7 +48,7 @@ export const AmendOrders = ({ updateOrders, serviceMemberId, orders }) => {
   };
 
   const handleUpload = (file) => {
-    return createUploadForAmendedOrdersDocument(file, orderId);
+    return createUploadForAmendedOrdersDocument(appendTimestampToFilename(file), orderId);
   };
 
   const handleUploadComplete = () => {

--- a/src/pages/MyMove/EditOrders.jsx
+++ b/src/pages/MyMove/EditOrders.jsx
@@ -28,6 +28,7 @@ import { ORDERS_TYPE_OPTIONS } from 'constants/orders';
 import { checkIfMoveIsLocked, FEATURE_FLAG_KEYS, MOVE_LOCKED_WARNING } from 'shared/constants';
 import { formatDateForSwagger } from 'shared/dates';
 import LoadingPlaceholder from 'shared/LoadingPlaceholder';
+import { appendTimestampToFilename } from 'shared/utils';
 
 const EditOrders = ({
   serviceMemberId,
@@ -119,24 +120,7 @@ const EditOrders = ({
 
   const handleUploadFile = (file) => {
     const documentId = currentOrder?.uploaded_orders?.id;
-
-    // Create a date-time stamp in the format "yyyymmddhh24miss"
-    const now = new Date();
-    const timestamp =
-      now.getFullYear().toString() +
-      (now.getMonth() + 1).toString().padStart(2, '0') +
-      now.getDate().toString().padStart(2, '0') +
-      now.getHours().toString().padStart(2, '0') +
-      now.getMinutes().toString().padStart(2, '0') +
-      now.getSeconds().toString().padStart(2, '0');
-
-    // Create a new filename with the timestamp prepended
-    const newFileName = `${file.name}-${timestamp}`;
-
-    // Create and return a new File object with the new filename
-    const newFile = new File([file], newFileName, { type: file.type });
-
-    return createUploadForDocument(newFile, documentId);
+    return createUploadForDocument(appendTimestampToFilename(file), documentId);
   };
 
   const handleUploadComplete = async () => {

--- a/src/pages/MyMove/PPM/Closeout/Expenses/Expenses.jsx
+++ b/src/pages/MyMove/PPM/Closeout/Expenses/Expenses.jsx
@@ -23,7 +23,7 @@ import {
 } from 'services/internalApi';
 import { updateMTOShipment } from 'store/entities/actions';
 import { formatDateForSwagger } from 'shared/dates';
-import { convertDollarsToCents } from 'shared/utils';
+import { convertDollarsToCents, appendTimestampToFilename } from 'shared/utils';
 import { APP_NAME } from 'constants/apps';
 
 const Expenses = () => {
@@ -68,24 +68,7 @@ const Expenses = () => {
 
   const handleCreateUpload = async (fieldName, file, setFieldTouched) => {
     const documentId = currentExpense[`${fieldName}Id`];
-
-    // Create a date-time stamp in the format "yyyymmddhh24miss"
-    const now = new Date();
-    const timestamp =
-      now.getFullYear().toString() +
-      (now.getMonth() + 1).toString().padStart(2, '0') +
-      now.getDate().toString().padStart(2, '0') +
-      now.getHours().toString().padStart(2, '0') +
-      now.getMinutes().toString().padStart(2, '0') +
-      now.getSeconds().toString().padStart(2, '0');
-
-    // Create a new filename with the timestamp prepended
-    const newFileName = `${file.name}-${timestamp}`;
-
-    // Create and return a new File object with the new filename
-    const newFile = new File([file], newFileName, { type: file.type });
-
-    createUploadForPPMDocument(mtoShipment.ppmShipment.id, documentId, newFile, false)
+    createUploadForPPMDocument(mtoShipment.ppmShipment.id, documentId, appendTimestampToFilename(file), false)
       .then((upload) => {
         mtoShipment.ppmShipment.movingExpenses[currentIndex][fieldName].uploads.push(upload);
         dispatch(updateMTOShipment(mtoShipment));

--- a/src/pages/MyMove/PPM/Closeout/ProGear/ProGear.jsx
+++ b/src/pages/MyMove/PPM/Closeout/ProGear/ProGear.jsx
@@ -28,6 +28,7 @@ import ProGearForm from 'components/Shared/PPM/Closeout/ProGearForm/ProGearForm'
 import { updateAllMoves, updateMTOShipment } from 'store/entities/actions';
 import { CUSTOMER_ERROR_MESSAGES } from 'constants/errorMessages';
 import { APP_NAME } from 'constants/apps';
+import { appendTimestampToFilename } from 'shared/utils';
 
 const ProGear = () => {
   const dispatch = useDispatch();
@@ -97,24 +98,7 @@ const ProGear = () => {
 
   const handleCreateUpload = async (fieldName, file, setFieldTouched) => {
     const documentId = currentProGearWeightTicket[`${fieldName}Id`];
-
-    // Create a date-time stamp in the format "yyyymmddhh24miss"
-    const now = new Date();
-    const timestamp =
-      now.getFullYear().toString() +
-      (now.getMonth() + 1).toString().padStart(2, '0') +
-      now.getDate().toString().padStart(2, '0') +
-      now.getHours().toString().padStart(2, '0') +
-      now.getMinutes().toString().padStart(2, '0') +
-      now.getSeconds().toString().padStart(2, '0');
-
-    // Create a new filename with the timestamp prepended
-    const newFileName = `${file.name}-${timestamp}`;
-
-    // Create and return a new File object with the new filename
-    const newFile = new File([file], newFileName, { type: file.type });
-
-    createUploadForPPMDocument(mtoShipment.ppmShipment.id, documentId, newFile, false)
+    createUploadForPPMDocument(mtoShipment.ppmShipment.id, documentId, appendTimestampToFilename(file), false)
       .then((upload) => {
         mtoShipment.ppmShipment.proGearWeightTickets[currentIndex][fieldName].uploads.push(upload);
         dispatch(updateMTOShipment(mtoShipment));

--- a/src/pages/MyMove/PPM/Closeout/WeightTickets/WeightTickets.jsx
+++ b/src/pages/MyMove/PPM/Closeout/WeightTickets/WeightTickets.jsx
@@ -27,6 +27,7 @@ import { updateAllMoves, updateMTOShipment } from 'store/entities/actions';
 import ErrorModal from 'shared/ErrorModal/ErrorModal';
 import { CUSTOMER_ERROR_MESSAGES } from 'constants/errorMessages';
 import { APP_NAME } from 'constants/apps';
+import { appendTimestampToFilename } from 'shared/utils';
 
 const WeightTickets = () => {
   const [errorMessage, setErrorMessage] = useState(null);
@@ -126,24 +127,7 @@ const WeightTickets = () => {
 
   const handleCreateUpload = async (fieldName, file, setFieldTouched) => {
     const documentId = currentWeightTicket[`${fieldName}Id`];
-
-    // Create a date-time stamp in the format "yyyymmddhh24miss"
-    const now = new Date();
-    const timestamp =
-      now.getFullYear().toString() +
-      (now.getMonth() + 1).toString().padStart(2, '0') +
-      now.getDate().toString().padStart(2, '0') +
-      now.getHours().toString().padStart(2, '0') +
-      now.getMinutes().toString().padStart(2, '0') +
-      now.getSeconds().toString().padStart(2, '0');
-
-    // Create a new filename with the timestamp prepended
-    const newFileName = `${file.name}-${timestamp}`;
-
-    // Create and return a new File object with the new filename
-    const newFile = new File([file], newFileName, { type: file.type });
-
-    createUploadForPPMDocument(mtoShipment.ppmShipment.id, documentId, newFile, true)
+    createUploadForPPMDocument(mtoShipment.ppmShipment.id, documentId, appendTimestampToFilename(file), true)
       .then((upload) => {
         mtoShipment.ppmShipment.weightTickets[currentIndex][fieldName].uploads.push(upload);
         dispatch(updateMTOShipment(mtoShipment));

--- a/src/pages/MyMove/UploadOrders.jsx
+++ b/src/pages/MyMove/UploadOrders.jsx
@@ -18,6 +18,7 @@ import WizardNavigation from 'components/Customer/WizardNavigation/WizardNavigat
 import { customerRoutes } from 'constants/routes';
 import formStyles from 'styles/form.module.scss';
 import { withContext } from 'shared/AppContext';
+import { appendTimestampToFilename } from 'shared/utils';
 
 const UploadOrders = ({ orders, updateOrders, updateAllMoves, serviceMemberId }) => {
   const filePondEl = useRef();
@@ -29,23 +30,7 @@ const UploadOrders = ({ orders, updateOrders, updateAllMoves, serviceMemberId })
 
   const handleUploadFile = (file) => {
     const documentId = currentOrders?.uploaded_orders?.id;
-
-    const now = new Date();
-    const timestamp =
-      now.getFullYear().toString() +
-      (now.getMonth() + 1).toString().padStart(2, '0') +
-      now.getDate().toString().padStart(2, '0') +
-      now.getHours().toString().padStart(2, '0') +
-      now.getMinutes().toString().padStart(2, '0') +
-      now.getSeconds().toString().padStart(2, '0');
-
-    // Create a new filename with the timestamp prepended
-    const newFileName = `${file.name}-${timestamp}`;
-
-    // Create and return a new File object with the new filename
-    const newFile = new File([file], newFileName, { type: file.type });
-
-    return createUploadForDocument(newFile, documentId);
+    return createUploadForDocument(appendTimestampToFilename(file), documentId);
   };
 
   const handleUploadComplete = async () => {

--- a/src/pages/MyMove/UploadOrders.test.jsx
+++ b/src/pages/MyMove/UploadOrders.test.jsx
@@ -7,6 +7,7 @@ import UploadOrders from './UploadOrders';
 
 import { deleteUpload, getAllMoves, getOrders, createUploadForDocument } from 'services/internalApi';
 import { renderWithProviders } from 'testUtils';
+import { appendTimestampToFilename } from 'shared/utils';
 import { customerRoutes } from 'constants/routes';
 import { selectOrdersForLoggedInUser, selectServiceMemberFromLoggedInUser } from 'store/entities/selectors';
 import { ORDERS_TYPE } from 'constants/orders';
@@ -498,17 +499,7 @@ describe('UploadOrders Component', () => {
       result.handleUploadFile ||
       ((file) => {
         const documentId = mockOrders[0].uploaded_orders.id;
-        const now = new Date();
-        const timestamp = `${now.getFullYear()}${(now.getMonth() + 1).toString().padStart(2, '0')}${now
-          .getDate()
-          .toString()
-          .padStart(2, '0')}${now.getHours().toString().padStart(2, '0')}${now
-          .getMinutes()
-          .toString()
-          .padStart(2, '0')}${now.getSeconds().toString().padStart(2, '0')}`;
-        const newFileName = `${file.name}-${timestamp}`;
-        const newFile = new File([file], newFileName, { type: file.type });
-        return createUploadForDocument(newFile, documentId);
+        return createUploadForDocument(appendTimestampToFilename(file), documentId);
       });
 
     // Step 6: Call the handleUploadFile mock
@@ -516,8 +507,7 @@ describe('UploadOrders Component', () => {
 
     // Step 7: Assert that the service was called with the new filename
     expect(createUploadForDocument).toHaveBeenCalledWith(expect.any(File), 'documentId');
-    expect(createUploadForDocument.mock.calls[0][0].name).toBe('testfile.txt-20221010123456'); // Expect the appended timestamp
-
+    expect(createUploadForDocument.mock.calls[0][0].name).toBe('testfile-20221010123456.txt'); // Expect the appended timestamp
     // Restore the original Date implementation
     jest.restoreAllMocks();
   });

--- a/src/shared/utils.js
+++ b/src/shared/utils.js
@@ -237,3 +237,14 @@ export function isPreceedingAddressPPMPrimaryDestinationComplete(addressValues) 
   }
   return false;
 }
+
+export function appendTimestampToFilename(file) {
+  const now = new Date();
+  const timestamp = now
+    .toISOString()
+    .replace(/[-T:.Z]/g, '')
+    .slice(0, 14);
+  const [name, extension = ''] = file.name?.split(/\.(?=[^.]+$)/) ?? '';
+  const newFileName = `${name}-${timestamp}${extension ? `.${extension}` : ''}`;
+  return new File([file], newFileName, { type: file.type });
+}

--- a/src/shared/utils.test.js
+++ b/src/shared/utils.test.js
@@ -142,3 +142,81 @@ describe('utils', () => {
     });
   });
 });
+
+describe('appendTimestampToFilename', () => {
+  // Define the fileTypeMap for reference in tests
+  const fileTypeMap = {
+    'application/pdf': 'pdf',
+    'image/png': 'png',
+    'image/jpeg': 'jpg',
+    'image/jpg': 'jpg',
+    'image/gif': 'gif',
+  };
+  let mockDate;
+  let expectedTimestamp;
+  beforeEach(() => {
+    // Generate a dynamic mock date (e.g., current time or random past date)
+    mockDate = new Date();
+    jest.spyOn(global, 'Date').mockImplementation(() => mockDate);
+    // Derive expected timestamp dynamically based on the function's logic
+    expectedTimestamp = mockDate
+      .toISOString()
+      .replace(/[-T:.Z]/g, '')
+      .slice(0, 14);
+  });
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+  it('appends timestamp to filename without extension', () => {
+    const file = new File([''], 'test-file', { type: 'application/octet-stream' });
+    const result = utils.appendTimestampToFilename(file);
+    expect(result.name).toBe(`test-file-${expectedTimestamp}`);
+    expect(result.type).toBe('application/octet-stream');
+    expect(result instanceof File).toBe(true);
+  });
+  it('handles filenames with multiple dots', () => {
+    const file = new File([''], 'test.file.with.dots.jpg', { type: 'image/jpeg' });
+    const result = utils.appendTimestampToFilename(file);
+    expect(result.name).toBe(`test.file.with.dots-${expectedTimestamp}.jpg`);
+    expect(result.type).toBe('image/jpeg');
+    expect(result instanceof File).toBe(true);
+  });
+  it('handles whitespace filename', () => {
+    const file = new File([''], ' .pdf', { type: 'image/pdf' });
+    const result = utils.appendTimestampToFilename(file);
+    expect(result.name).toBe(` -${expectedTimestamp}.pdf`);
+    expect(result.type).toBe('image/pdf');
+    expect(result instanceof File).toBe(true);
+  });
+  it('empty filename with extension', () => {
+    const file = new File([''], '.pdf', { type: 'image/pdf' });
+    const result = utils.appendTimestampToFilename(file);
+    expect(result.name).toBe(`-${expectedTimestamp}.pdf`);
+    expect(result.type).toBe('image/pdf');
+    expect(result instanceof File).toBe(true);
+  });
+  it('empty filename and no extension', () => {
+    const file = new File([''], '', { type: 'image/pdf' });
+    const result = utils.appendTimestampToFilename(file);
+    expect(result.name).toBe(`-${expectedTimestamp}`);
+    expect(result.type).toBe('image/pdf');
+    expect(result instanceof File).toBe(true);
+  });
+  it('filename no extension', () => {
+    const file = new File([''], 'helloworld', { type: 'image/pdf' });
+    const result = utils.appendTimestampToFilename(file);
+    expect(result.name).toBe(`helloworld-${expectedTimestamp}`);
+    expect(result.type).toBe('image/pdf');
+    expect(result instanceof File).toBe(true);
+  });
+  // Test each file type in fileTypeMap
+  Object.entries(fileTypeMap).forEach(([mimeType, extension]) => {
+    it(`appends timestamp to filename with ${extension} extension`, () => {
+      const file = new File([''], `test-file.${extension}`, { type: mimeType });
+      const result = utils.appendTimestampToFilename(file);
+      expect(result.name).toBe(`test-file-${expectedTimestamp}.${extension}`);
+      expect(result.type).toBe(mimeType);
+      expect(result instanceof File).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
## [Agility ticket](tbd)

## Summary
These changes fixes the issue where , the file extension is after the name and before the timestamp when a document is uploaded. This is causing users to have to select the app they would like their document to open in. These fix appends the date/timestamp to file name before the file extension. 
Note: These changes are only for the Customer, [B-23511](https://github.com/transcom/mymove/pull/15426) did all the work hence this story just calls the function 😄 .

Is there anything you would like reviewers to give additional scrutiny?

[this article](tbd) explains more about the approach used.

## Verification Steps for the Author

These are to be checked by the author.

- [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
- [ ] Have the Agility acceptance criteria been met for this change?

## Verification Steps for Reviewers

These are to be checked by a reviewer.

- [ ] Has the branch been pulled in and checked out?
- [ ] Have the BL acceptance criteria been met for this change?
- [ ] Was the CircleCI build successful?
- [ ] Has the code been reviewed from a standards and best practices point of view?

### Setup to Run the Code

- [Instructions for starting storybook](https://transcom.github.io/mymove-docs/docs/frontend/setup/storybook)
- [Instructions for starting the MilMove application](https://transcom.github.io/mymove-docs/docs/getting-started/application-setup/)
- [Instructions for running tests](https://transcom.github.io/mymove-docs/docs/getting-started/development/testing)

### How to test

1. Access the
2. Login as a
3.

### Frontend

- [ ] There are no aXe warnings for UI.
- [ ] This works in [Supported Browsers and their phone views](https://transcom.github.io/mymove-docs/docs/adrs/Browser-Support/#minimum-browser-requirements) (Chrome, Firefox, Edge).
- [ ] There are no new console errors in the browser devtools.
- [ ] There are no new console errors in the test output.
- [ ] If this PR adds a new component to Storybook, it ensures the component is fully responsive, OR if it is intentionally not, a wrapping div using the `officeApp` class or custom `min-width` styling is used to hide any states the would not be visible to the user.
- [ ] This change meets the standards for [Section 508 compliance](https://www.ssa.gov/accessibility/andi/help/install.html).

### Backend

- [ ] Code follows the guidelines for [Logging](https://transcom.github.io/mymove-docs/docs/getting-started/development/logging).
- [ ] The requirements listed in [Querying the Database Safely](https://transcom.github.io/mymove-docs/docs/backend/guides/golang-guide#querying-the-database-safely) have been satisfied.

### Database

#### Any new migrations/schema changes:

- [ ] Follows our guidelines for [Zero-Downtime Deploys](https://transcom.github.io/mymove-docs/docs/backend/setup/database-migrations#zero-downtime-migrations).
- [ ] Have been communicated to #g-database.
- [ ] Secure migrations have been tested following the instructions in our [docs](https://transcom.github.io/mymove-docs/docs/backend/setup/database-migrations#secure-migrations).

## Screenshots
[B-23452.docx](https://github.com/user-attachments/files/20124348/B-23452.docx)
