### PR TITLE
B 23278 isolate permissions for active role main

### DIFF
--- a/pkg/auth/session.go
+++ b/pkg/auth/session.go
@@ -230,7 +230,10 @@ type Session struct {
 	OfficeUserID    uuid.UUID
 	AdminUserID     uuid.UUID
 	AdminUserRole   string
-	Roles           roles.Roles
+	// Note for future devs, in B-23278 it was decided by the PO to drop support for multi-role session use
+	// It is still possible and allowed for an office user to have multiple roles, just not utilize them all
+	// in the same session. They must swap roles on the frontend to receive a new role for the session
+	CurrentRole     roles.Role
 	Permissions     []string
 	AccessToken     string
 	ClientID        string

--- a/pkg/auth/session.go
+++ b/pkg/auth/session.go
@@ -233,7 +233,7 @@ type Session struct {
 	// Note for future devs, in B-23278 it was decided by the PO to drop support for multi-role session use
 	// It is still possible and allowed for an office user to have multiple roles, just not utilize them all
 	// in the same session. They must swap roles on the frontend to receive a new role for the session
-	CurrentRole     roles.Role
+	ActiveRole      roles.Role
 	Permissions     []string
 	AccessToken     string
 	ClientID        string

--- a/pkg/gen/internalapi/embedded_spec.go
+++ b/pkg/gen/internalapi/embedded_spec.go
@@ -4932,6 +4932,10 @@ func init() {
         "id"
       ],
       "properties": {
+        "activeRole": {
+          "x-nullable": true,
+          "$ref": "#/definitions/Role"
+        },
         "email": {
           "type": "string",
           "format": "x-email",
@@ -4949,6 +4953,13 @@ func init() {
           "format": "uuid",
           "example": "c56a4180-65aa-42ec-a945-5fd21dec0538"
         },
+        "inactiveRoles": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Role"
+          },
+          "x-nullable": true
+        },
         "office_user": {
           "$ref": "#/definitions/OfficeUser"
         },
@@ -4963,13 +4974,6 @@ func init() {
           "items": {
             "$ref": "#/definitions/Privilege"
           }
-        },
-        "roles": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/Role"
-          },
-          "x-nullable": true
         },
         "service_member": {
           "$ref": "#/definitions/ServiceMemberPayload"
@@ -14392,6 +14396,10 @@ func init() {
         "id"
       ],
       "properties": {
+        "activeRole": {
+          "x-nullable": true,
+          "$ref": "#/definitions/Role"
+        },
         "email": {
           "type": "string",
           "format": "x-email",
@@ -14409,6 +14417,13 @@ func init() {
           "format": "uuid",
           "example": "c56a4180-65aa-42ec-a945-5fd21dec0538"
         },
+        "inactiveRoles": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Role"
+          },
+          "x-nullable": true
+        },
         "office_user": {
           "$ref": "#/definitions/OfficeUser"
         },
@@ -14423,13 +14438,6 @@ func init() {
           "items": {
             "$ref": "#/definitions/Privilege"
           }
-        },
-        "roles": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/Role"
-          },
-          "x-nullable": true
         },
         "service_member": {
           "$ref": "#/definitions/ServiceMemberPayload"

--- a/pkg/gen/internalmessages/logged_in_user_payload.go
+++ b/pkg/gen/internalmessages/logged_in_user_payload.go
@@ -20,6 +20,9 @@ import (
 // swagger:model LoggedInUserPayload
 type LoggedInUserPayload struct {
 
+	// active role
+	ActiveRole *Role `json:"activeRole,omitempty"`
+
 	// email
 	// Example: john_bob@example.com
 	// Read Only: true
@@ -37,6 +40,9 @@ type LoggedInUserPayload struct {
 	// Format: uuid
 	ID *strfmt.UUID `json:"id"`
 
+	// inactive roles
+	InactiveRoles []*Role `json:"inactiveRoles"`
+
 	// office user
 	OfficeUser *OfficeUser `json:"office_user,omitempty"`
 
@@ -46,9 +52,6 @@ type LoggedInUserPayload struct {
 	// privileges
 	Privileges []*Privilege `json:"privileges"`
 
-	// roles
-	Roles []*Role `json:"roles"`
-
 	// service member
 	ServiceMember *ServiceMemberPayload `json:"service_member,omitempty"`
 }
@@ -57,11 +60,19 @@ type LoggedInUserPayload struct {
 func (m *LoggedInUserPayload) Validate(formats strfmt.Registry) error {
 	var res []error
 
+	if err := m.validateActiveRole(formats); err != nil {
+		res = append(res, err)
+	}
+
 	if err := m.validateEmail(formats); err != nil {
 		res = append(res, err)
 	}
 
 	if err := m.validateID(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateInactiveRoles(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -73,10 +84,6 @@ func (m *LoggedInUserPayload) Validate(formats strfmt.Registry) error {
 		res = append(res, err)
 	}
 
-	if err := m.validateRoles(formats); err != nil {
-		res = append(res, err)
-	}
-
 	if err := m.validateServiceMember(formats); err != nil {
 		res = append(res, err)
 	}
@@ -84,6 +91,25 @@ func (m *LoggedInUserPayload) Validate(formats strfmt.Registry) error {
 	if len(res) > 0 {
 		return errors.CompositeValidationError(res...)
 	}
+	return nil
+}
+
+func (m *LoggedInUserPayload) validateActiveRole(formats strfmt.Registry) error {
+	if swag.IsZero(m.ActiveRole) { // not required
+		return nil
+	}
+
+	if m.ActiveRole != nil {
+		if err := m.ActiveRole.Validate(formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("activeRole")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("activeRole")
+			}
+			return err
+		}
+	}
+
 	return nil
 }
 
@@ -107,6 +133,32 @@ func (m *LoggedInUserPayload) validateID(formats strfmt.Registry) error {
 
 	if err := validate.FormatOf("id", "body", "uuid", m.ID.String(), formats); err != nil {
 		return err
+	}
+
+	return nil
+}
+
+func (m *LoggedInUserPayload) validateInactiveRoles(formats strfmt.Registry) error {
+	if swag.IsZero(m.InactiveRoles) { // not required
+		return nil
+	}
+
+	for i := 0; i < len(m.InactiveRoles); i++ {
+		if swag.IsZero(m.InactiveRoles[i]) { // not required
+			continue
+		}
+
+		if m.InactiveRoles[i] != nil {
+			if err := m.InactiveRoles[i].Validate(formats); err != nil {
+				if ve, ok := err.(*errors.Validation); ok {
+					return ve.ValidateName("inactiveRoles" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("inactiveRoles" + "." + strconv.Itoa(i))
+				}
+				return err
+			}
+		}
+
 	}
 
 	return nil
@@ -157,32 +209,6 @@ func (m *LoggedInUserPayload) validatePrivileges(formats strfmt.Registry) error 
 	return nil
 }
 
-func (m *LoggedInUserPayload) validateRoles(formats strfmt.Registry) error {
-	if swag.IsZero(m.Roles) { // not required
-		return nil
-	}
-
-	for i := 0; i < len(m.Roles); i++ {
-		if swag.IsZero(m.Roles[i]) { // not required
-			continue
-		}
-
-		if m.Roles[i] != nil {
-			if err := m.Roles[i].Validate(formats); err != nil {
-				if ve, ok := err.(*errors.Validation); ok {
-					return ve.ValidateName("roles" + "." + strconv.Itoa(i))
-				} else if ce, ok := err.(*errors.CompositeError); ok {
-					return ce.ValidateName("roles" + "." + strconv.Itoa(i))
-				}
-				return err
-			}
-		}
-
-	}
-
-	return nil
-}
-
 func (m *LoggedInUserPayload) validateServiceMember(formats strfmt.Registry) error {
 	if swag.IsZero(m.ServiceMember) { // not required
 		return nil
@@ -206,11 +232,19 @@ func (m *LoggedInUserPayload) validateServiceMember(formats strfmt.Registry) err
 func (m *LoggedInUserPayload) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
 	var res []error
 
+	if err := m.contextValidateActiveRole(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
 	if err := m.contextValidateEmail(ctx, formats); err != nil {
 		res = append(res, err)
 	}
 
 	if err := m.contextValidateFirstName(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.contextValidateInactiveRoles(ctx, formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -222,10 +256,6 @@ func (m *LoggedInUserPayload) ContextValidate(ctx context.Context, formats strfm
 		res = append(res, err)
 	}
 
-	if err := m.contextValidateRoles(ctx, formats); err != nil {
-		res = append(res, err)
-	}
-
 	if err := m.contextValidateServiceMember(ctx, formats); err != nil {
 		res = append(res, err)
 	}
@@ -233,6 +263,27 @@ func (m *LoggedInUserPayload) ContextValidate(ctx context.Context, formats strfm
 	if len(res) > 0 {
 		return errors.CompositeValidationError(res...)
 	}
+	return nil
+}
+
+func (m *LoggedInUserPayload) contextValidateActiveRole(ctx context.Context, formats strfmt.Registry) error {
+
+	if m.ActiveRole != nil {
+
+		if swag.IsZero(m.ActiveRole) { // not required
+			return nil
+		}
+
+		if err := m.ActiveRole.ContextValidate(ctx, formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("activeRole")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("activeRole")
+			}
+			return err
+		}
+	}
+
 	return nil
 }
 
@@ -249,6 +300,31 @@ func (m *LoggedInUserPayload) contextValidateFirstName(ctx context.Context, form
 
 	if err := validate.ReadOnly(ctx, "first_name", "body", string(m.FirstName)); err != nil {
 		return err
+	}
+
+	return nil
+}
+
+func (m *LoggedInUserPayload) contextValidateInactiveRoles(ctx context.Context, formats strfmt.Registry) error {
+
+	for i := 0; i < len(m.InactiveRoles); i++ {
+
+		if m.InactiveRoles[i] != nil {
+
+			if swag.IsZero(m.InactiveRoles[i]) { // not required
+				return nil
+			}
+
+			if err := m.InactiveRoles[i].ContextValidate(ctx, formats); err != nil {
+				if ve, ok := err.(*errors.Validation); ok {
+					return ve.ValidateName("inactiveRoles" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("inactiveRoles" + "." + strconv.Itoa(i))
+				}
+				return err
+			}
+		}
+
 	}
 
 	return nil
@@ -290,31 +366,6 @@ func (m *LoggedInUserPayload) contextValidatePrivileges(ctx context.Context, for
 					return ve.ValidateName("privileges" + "." + strconv.Itoa(i))
 				} else if ce, ok := err.(*errors.CompositeError); ok {
 					return ce.ValidateName("privileges" + "." + strconv.Itoa(i))
-				}
-				return err
-			}
-		}
-
-	}
-
-	return nil
-}
-
-func (m *LoggedInUserPayload) contextValidateRoles(ctx context.Context, formats strfmt.Registry) error {
-
-	for i := 0; i < len(m.Roles); i++ {
-
-		if m.Roles[i] != nil {
-
-			if swag.IsZero(m.Roles[i]) { // not required
-				return nil
-			}
-
-			if err := m.Roles[i].ContextValidate(ctx, formats); err != nil {
-				if ve, ok := err.(*errors.Validation); ok {
-					return ve.ValidateName("roles" + "." + strconv.Itoa(i))
-				} else if ce, ok := err.(*errors.CompositeError); ok {
-					return ce.ValidateName("roles" + "." + strconv.Itoa(i))
 				}
 				return err
 			}

--- a/pkg/handlers/adminapi/admin_users_test.go
+++ b/pkg/handlers/adminapi/admin_users_test.go
@@ -33,7 +33,7 @@ func (suite *HandlerSuite) TestIndexAdminUsersHandler() {
 
 		queryBuilder := query.NewQueryBuilder()
 		handler := IndexAdminUsersHandler{
-			HandlerConfig:        suite.HandlerConfig(),
+			HandlerConfig:        suite.NewHandlerConfig(),
 			NewQueryFilter:       query.NewQueryFilter,
 			AdminUserListFetcher: adminuser.NewAdminUserListFetcher(queryBuilder),
 			NewPagination:        pagination.NewPagination,
@@ -65,7 +65,7 @@ func (suite *HandlerSuite) TestIndexAdminUsersHandler() {
 			mock.Anything,
 		).Return(0, expectedError).Once()
 		handler := IndexAdminUsersHandler{
-			HandlerConfig:        suite.HandlerConfig(),
+			HandlerConfig:        suite.NewHandlerConfig(),
 			NewQueryFilter:       newMockQueryFilterBuilder(&mocks.QueryFilter{}),
 			AdminUserListFetcher: adminUserListFetcher,
 			NewPagination:        pagination.NewPagination,
@@ -92,7 +92,7 @@ func (suite *HandlerSuite) TestGetAdminUserHandler() {
 
 		queryBuilder := query.NewQueryBuilder()
 		handler := GetAdminUserHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			adminuser.NewAdminUserFetcher(queryBuilder),
 			query.NewQueryFilter,
 		}
@@ -116,7 +116,7 @@ func (suite *HandlerSuite) TestGetAdminUserHandler() {
 			mock.Anything,
 		).Return(adminUser, nil).Once()
 		handler := GetAdminUserHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			adminUserFetcher,
 			newMockQueryFilterBuilder(&mocks.QueryFilter{}),
 		}
@@ -141,7 +141,7 @@ func (suite *HandlerSuite) TestGetAdminUserHandler() {
 			mock.Anything,
 		).Return(models.AdminUser{}, expectedError).Once()
 		handler := GetAdminUserHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			adminUserFetcher,
 			newMockQueryFilterBuilder(&mocks.QueryFilter{}),
 		}
@@ -185,7 +185,7 @@ func (suite *HandlerSuite) TestCreateAdminUserHandler() {
 			mock.Anything).Return(&adminUser, nil, nil).Once()
 
 		handler := CreateAdminUserHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			adminUserCreator,
 			newQueryFilter,
 		}
@@ -211,7 +211,7 @@ func (suite *HandlerSuite) TestCreateAdminUserHandler() {
 			mock.Anything).Return(&adminUser, nil, nil).Once()
 
 		handler := CreateAdminUserHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			adminUserCreator,
 			newQueryFilter,
 		}
@@ -244,7 +244,7 @@ func (suite *HandlerSuite) TestUpdateAdminUserHandler() {
 		).Return(&adminUser, nil, nil).Once()
 
 		handler := UpdateAdminUserHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			adminUserUpdater,
 			newQueryFilter,
 		}
@@ -277,7 +277,7 @@ func (suite *HandlerSuite) TestUpdateAdminUserHandler() {
 		).Return(nil, err, nil).Once()
 
 		handler := UpdateAdminUserHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			adminUserUpdater,
 			newQueryFilter,
 		}

--- a/pkg/handlers/adminapi/client_certs_test.go
+++ b/pkg/handlers/adminapi/client_certs_test.go
@@ -34,7 +34,7 @@ func (suite *HandlerSuite) TestIndexClientCertsHandler() {
 
 		queryBuilder := query.NewQueryBuilder()
 		handler := IndexClientCertsHandler{
-			HandlerConfig:         suite.HandlerConfig(),
+			HandlerConfig:         suite.NewHandlerConfig(),
 			NewQueryFilter:        query.NewQueryFilter,
 			ClientCertListFetcher: clientcert.NewClientCertListFetcher(queryBuilder),
 			NewPagination:         pagination.NewPagination,
@@ -71,7 +71,7 @@ func (suite *HandlerSuite) TestIndexClientCertsHandler() {
 			mock.Anything,
 		).Return(0, expectedError).Once()
 		handler := IndexUsersHandler{
-			HandlerConfig:  suite.HandlerConfig(),
+			HandlerConfig:  suite.NewHandlerConfig(),
 			NewQueryFilter: newQueryFilter,
 			ListFetcher:    clientCertListFetcher,
 			NewPagination:  pagination.NewPagination,
@@ -98,7 +98,7 @@ func (suite *HandlerSuite) TestGetClientCertHandler() {
 
 		queryBuilder := query.NewQueryBuilder()
 		handler := GetClientCertHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			clientcert.NewClientCertFetcher(queryBuilder),
 			query.NewQueryFilter,
 		}
@@ -122,7 +122,7 @@ func (suite *HandlerSuite) TestGetClientCertHandler() {
 			mock.Anything,
 		).Return(clientCert, nil).Once()
 		handler := GetClientCertHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			clientCertFetcher,
 			newMockQueryFilterBuilder(&mocks.QueryFilter{}),
 		}
@@ -147,7 +147,7 @@ func (suite *HandlerSuite) TestGetClientCertHandler() {
 			mock.Anything,
 		).Return(models.ClientCert{}, expectedError).Once()
 		handler := GetClientCertHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			clientCertFetcher,
 			newMockQueryFilterBuilder(&mocks.QueryFilter{}),
 		}
@@ -190,7 +190,7 @@ func (suite *HandlerSuite) TestCreateClientCertificateHandler() {
 			&clientCert).Return(&clientCert, nil, nil).Once()
 
 		handler := CreateClientCertHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			clientCertCreator,
 		}
 
@@ -217,7 +217,7 @@ func (suite *HandlerSuite) TestCreateClientCertificateHandler() {
 			&clientCert).Return(&models.ClientCert{}, nil, expectedError).Once()
 
 		handler := CreateClientCertHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			clientCertCreator,
 		}
 
@@ -251,7 +251,7 @@ func (suite *HandlerSuite) TestUpdateClientCertificateHandler() {
 		).Return(&clientCert, nil, nil).Once()
 
 		handler := UpdateClientCertHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			clientCertUpdater,
 			newQueryFilter,
 		}
@@ -282,7 +282,7 @@ func (suite *HandlerSuite) TestUpdateClientCertificateHandler() {
 		).Return(nil, err, nil).Once()
 
 		handler := UpdateClientCertHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			clientCertUpdater,
 			newQueryFilter,
 		}
@@ -312,7 +312,7 @@ func (suite *HandlerSuite) TestDeleteClientCertificateHandler() {
 			clientCert.ID,
 		).Return(&clientCert, nil, nil).Once()
 		handler := RemoveClientCertHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			clientCertRemover,
 			newQueryFilter,
 		}
@@ -340,7 +340,7 @@ func (suite *HandlerSuite) TestDeleteClientCertificateHandler() {
 			clientCert.ID,
 		).Return(nil, err, nil).Once()
 		handler := RemoveClientCertHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			clientCertRemover,
 			newQueryFilter,
 		}

--- a/pkg/handlers/adminapi/edi_errors_test.go
+++ b/pkg/handlers/adminapi/edi_errors_test.go
@@ -66,7 +66,7 @@ func (suite *HandlerSuite) TestFetchEdiErrorsHandler() {
 		mockFetcher.On("FetchEdiErrors", mock.Anything, mock.Anything).Return(expectedEdiErrors, len(expectedEdiErrors), nil)
 
 		handler := FetchEdiErrorsHandler{
-			HandlerConfig:   suite.HandlerConfig(),
+			HandlerConfig:   suite.NewHandlerConfig(),
 			ediErrorFetcher: mockFetcher,
 			NewPagination:   pagination.NewPagination,
 		}
@@ -108,7 +108,7 @@ func (suite *HandlerSuite) TestFetchEdiErrorsHandlerFailure() {
 	mockFetcher.On("FetchEdiErrors", mock.Anything, mock.Anything).Return(models.EdiErrors{}, 0, expectedErr)
 
 	handler := FetchEdiErrorsHandler{
-		HandlerConfig:   suite.HandlerConfig(),
+		HandlerConfig:   suite.NewHandlerConfig(),
 		ediErrorFetcher: mockFetcher,
 		NewPagination:   pagination.NewPagination,
 	}
@@ -151,7 +151,7 @@ func (suite *HandlerSuite) TestGetEdiErrorHandler() {
 		mockFetcher.On("FetchEdiErrorByID", mock.Anything, ediErrorID).Return(expected, nil)
 
 		handler := GetEdiErrorHandler{
-			HandlerConfig:   suite.HandlerConfig(),
+			HandlerConfig:   suite.NewHandlerConfig(),
 			ediErrorFetcher: mockFetcher,
 		}
 
@@ -182,7 +182,7 @@ func (suite *HandlerSuite) TestGetEdiErrorHandler() {
 		})).Return(models.EdiError{}, apperror.NewNotFoundError(missingID, "EDIError not found"))
 
 		handler := GetEdiErrorHandler{
-			HandlerConfig:   suite.HandlerConfig(),
+			HandlerConfig:   suite.NewHandlerConfig(),
 			ediErrorFetcher: mockFetcher,
 		}
 

--- a/pkg/handlers/adminapi/electronic_orders_test.go
+++ b/pkg/handlers/adminapi/electronic_orders_test.go
@@ -28,7 +28,7 @@ func (suite *HandlerSuite) TestGetElectronicOrdersTotalsHandler() {
 			mock.Anything,
 		).Return(map[interface{}]int{models.IssuerArmy: 2}, nil)
 		handler := GetElectronicOrdersTotalsHandler{
-			HandlerConfig:                       suite.HandlerConfig(),
+			HandlerConfig:                       suite.NewHandlerConfig(),
 			ElectronicOrderCategoryCountFetcher: electronicOrderCategoryCountFetcher,
 			NewQueryFilter:                      newQueryFilter,
 		}
@@ -52,7 +52,7 @@ func (suite *HandlerSuite) TestGetElectronicOrdersTotalsHandler() {
 			mock.Anything,
 		).Return(nil, err)
 		handler := GetElectronicOrdersTotalsHandler{
-			HandlerConfig:                       suite.HandlerConfig(),
+			HandlerConfig:                       suite.NewHandlerConfig(),
 			ElectronicOrderCategoryCountFetcher: electronicOrderCategoryCountFetcher,
 			NewQueryFilter:                      newQueryFilter,
 		}

--- a/pkg/handlers/adminapi/moves_test.go
+++ b/pkg/handlers/adminapi/moves_test.go
@@ -33,7 +33,7 @@ func (suite *HandlerSuite) TestIndexMovesHandler() {
 		}
 		queryBuilder := query.NewQueryBuilder()
 		handler := IndexMovesHandler{
-			HandlerConfig:   suite.HandlerConfig(),
+			HandlerConfig:   suite.NewHandlerConfig(),
 			NewQueryFilter:  query.NewQueryFilter,
 			MoveListFetcher: move.NewMoveListFetcher(queryBuilder),
 			NewPagination:   pagination.NewPagination,
@@ -62,7 +62,7 @@ func (suite *HandlerSuite) TestIndexMovesHandler() {
 			mock.Anything,
 		).Return(nil, expectedError).Once()
 		handler := IndexMovesHandler{
-			HandlerConfig:   suite.HandlerConfig(),
+			HandlerConfig:   suite.NewHandlerConfig(),
 			NewQueryFilter:  newQueryFilter,
 			MoveListFetcher: moveListFetcher,
 			NewPagination:   pagination.NewPagination,
@@ -120,7 +120,7 @@ func (suite *HandlerSuite) TestUpdateMoveHandler() {
 			mock.Anything,
 		).Return(400, nil)
 		return UpdateMoveHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			movetaskorder.NewMoveTaskOrderUpdater(
 				builder,
 				mtoserviceitem.NewMTOServiceItemCreator(planner, builder, moveRouter, ghcrateengine.NewDomesticUnpackPricer(), ghcrateengine.NewDomesticPackPricer(), ghcrateengine.NewDomesticLinehaulPricer(), ghcrateengine.NewDomesticShorthaulPricer(), ghcrateengine.NewDomesticOriginPricer(), ghcrateengine.NewDomesticDestinationPricer(), ghcrateengine.NewFuelSurchargePricer()),
@@ -180,7 +180,7 @@ func (suite *HandlerSuite) TestGetMoveHandler() {
 			MoveID:      *handlers.FmtUUID(defaultMove.ID),
 		}
 		handler := GetMoveHandler{
-			HandlerConfig: suite.HandlerConfig(),
+			HandlerConfig: suite.NewHandlerConfig(),
 		}
 
 		response := handler.Handle(params)
@@ -198,7 +198,7 @@ func (suite *HandlerSuite) TestGetMoveHandler() {
 		}
 
 		handler := GetMoveHandler{
-			HandlerConfig: suite.HandlerConfig(),
+			HandlerConfig: suite.NewHandlerConfig(),
 		}
 
 		response := handler.Handle(params)

--- a/pkg/handlers/adminapi/notifications_test.go
+++ b/pkg/handlers/adminapi/notifications_test.go
@@ -26,7 +26,7 @@ func (suite *HandlerSuite) TestIndexNotificationsHandler() {
 
 		queryBuilder := query.NewQueryBuilder()
 		handler := IndexNotificationsHandler{
-			HandlerConfig:  suite.HandlerConfig(),
+			HandlerConfig:  suite.NewHandlerConfig(),
 			NewQueryFilter: query.NewQueryFilter,
 			ListFetcher:    fetch.NewListFetcher(queryBuilder),
 			NewPagination:  pagination.NewPagination,
@@ -63,7 +63,7 @@ func (suite *HandlerSuite) TestIndexNotificationsHandler() {
 			mock.Anything,
 		).Return(0, expectedError).Once()
 		handler := IndexNotificationsHandler{
-			HandlerConfig:  suite.HandlerConfig(),
+			HandlerConfig:  suite.NewHandlerConfig(),
 			NewQueryFilter: newQueryFilter,
 			ListFetcher:    listFetcher,
 			NewPagination:  pagination.NewPagination,

--- a/pkg/handlers/adminapi/office_users_test.go
+++ b/pkg/handlers/adminapi/office_users_test.go
@@ -1079,7 +1079,18 @@ func (suite *HandlerSuite) TestGetRolesPrivilegesHandler() {
 		// Test:				GetOfficeUserHandler, Fetcher - Unauthorized
 		// Set up:				Run request when NOT logged in as admin user
 		// Expected Outcome:	Unauthorized response returned, no data
-		requestUser := factory.BuildOfficeUser(nil, nil, nil)
+		requestUser := factory.BuildOfficeUser(nil, []factory.Customization{
+			{
+				Model: models.User{
+					Roles: roles.Roles{
+						{
+							RoleType: roles.RoleTypeTOO,
+						},
+					},
+				},
+			},
+		}, nil)
+
 		req := httptest.NewRequest("GET", "/office_users/roles-privileges", nil) // We never need to set a body this endpoint
 
 		params := officeuserop.GetRolesPrivilegesParams{

--- a/pkg/handlers/adminapi/office_users_test.go
+++ b/pkg/handlers/adminapi/office_users_test.go
@@ -45,7 +45,7 @@ func (suite *HandlerSuite) TestIndexOfficeUsersHandler() {
 
 		queryBuilder := query.NewQueryBuilder()
 		handler := IndexOfficeUsersHandler{
-			HandlerConfig:         suite.HandlerConfig(),
+			HandlerConfig:         suite.NewHandlerConfig(),
 			NewQueryFilter:        query.NewQueryFilter,
 			OfficeUserListFetcher: officeuser.NewOfficeUsersListFetcher(queryBuilder),
 			NewPagination:         pagination.NewPagination,
@@ -80,7 +80,7 @@ func (suite *HandlerSuite) TestIndexOfficeUsersHandler() {
 
 		queryBuilder := query.NewQueryBuilder()
 		handler := IndexOfficeUsersHandler{
-			HandlerConfig:         suite.HandlerConfig(),
+			HandlerConfig:         suite.NewHandlerConfig(),
 			NewQueryFilter:        query.NewQueryFilter,
 			OfficeUserListFetcher: officeuser.NewOfficeUsersListFetcher(queryBuilder),
 			NewPagination:         pagination.NewPagination,
@@ -121,7 +121,7 @@ func (suite *HandlerSuite) TestIndexOfficeUsersHandler() {
 
 		queryBuilder := query.NewQueryBuilder()
 		handler := IndexOfficeUsersHandler{
-			HandlerConfig:         suite.HandlerConfig(),
+			HandlerConfig:         suite.NewHandlerConfig(),
 			OfficeUserListFetcher: officeuser.NewOfficeUsersListFetcher(queryBuilder),
 			NewQueryFilter:        query.NewQueryFilter,
 			NewPagination:         pagination.NewPagination,
@@ -213,7 +213,7 @@ func (suite *HandlerSuite) TestIndexOfficeUsersHandler() {
 
 		queryBuilder := query.NewQueryBuilder()
 		handler := IndexOfficeUsersHandler{
-			HandlerConfig:         suite.HandlerConfig(),
+			HandlerConfig:         suite.NewHandlerConfig(),
 			NewQueryFilter:        query.NewQueryFilter,
 			OfficeUserListFetcher: officeuser.NewOfficeUsersListFetcher(queryBuilder),
 			NewPagination:         pagination.NewPagination,
@@ -313,7 +313,7 @@ func (suite *HandlerSuite) TestGetOfficeUserHandler() {
 
 		// queryBuilder := query.NewQueryBuilder()
 		handler := GetOfficeUserHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			officeuser.NewOfficeUserFetcherPop(),
 			query.NewQueryFilter,
 		}
@@ -337,7 +337,7 @@ func (suite *HandlerSuite) TestGetOfficeUserHandler() {
 
 		// queryBuilder := query.NewQueryBuilder()
 		handler := GetOfficeUserHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			officeuser.NewOfficeUserFetcherPop(),
 			query.NewQueryFilter,
 		}
@@ -400,7 +400,7 @@ func (suite *HandlerSuite) TestCreateOfficeUserHandler() {
 		}
 		queryBuilder := query.NewQueryBuilder()
 		handler := CreateOfficeUserHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			officeuser.NewOfficeUserCreator(queryBuilder, suite.TestNotificationSender()),
 			query.NewQueryFilter,
 			usersroles.NewUsersRolesCreator(),
@@ -448,7 +448,7 @@ func (suite *HandlerSuite) TestCreateOfficeUserHandler() {
 		}
 		queryBuilder := query.NewQueryBuilder()
 		handler := CreateOfficeUserHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			officeuser.NewOfficeUserCreator(queryBuilder, suite.TestNotificationSender()),
 			query.NewQueryFilter,
 			usersroles.NewUsersRolesCreator(),
@@ -504,7 +504,7 @@ func (suite *HandlerSuite) TestCreateOfficeUserHandler() {
 
 		queryBuilder := query.NewQueryBuilder()
 		handler := CreateOfficeUserHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			officeuser.NewOfficeUserCreator(queryBuilder, suite.TestNotificationSender()),
 			query.NewQueryFilter,
 			usersroles.NewUsersRolesCreator(),
@@ -539,7 +539,7 @@ func (suite *HandlerSuite) TestCreateOfficeUserHandler() {
 
 		queryBuilder := query.NewQueryBuilder()
 		handler := CreateOfficeUserHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			officeuser.NewOfficeUserCreator(queryBuilder, suite.TestNotificationSender()),
 			query.NewQueryFilter,
 			usersroles.NewUsersRolesCreator(),
@@ -586,7 +586,7 @@ func (suite *HandlerSuite) TestCreateOfficeUserHandler() {
 		}
 		queryBuilder := query.NewQueryBuilder()
 		handler := CreateOfficeUserHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			officeuser.NewOfficeUserCreator(queryBuilder, suite.TestNotificationSender()),
 			query.NewQueryFilter,
 			usersroles.NewUsersRolesCreator(),
@@ -623,7 +623,7 @@ func (suite *HandlerSuite) TestCreateOfficeUserHandler() {
 
 		queryBuilder := query.NewQueryBuilder()
 		handler := CreateOfficeUserHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			officeuser.NewOfficeUserCreator(queryBuilder, suite.TestNotificationSender()),
 			query.NewQueryFilter,
 			usersroles.NewUsersRolesCreator(),
@@ -672,7 +672,7 @@ func (suite *HandlerSuite) TestCreateOfficeUserHandler() {
 			mock.Anything,
 		).Return(nil, expectedError, nil).Once()
 		handler := CreateOfficeUserHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			officeUserCreator,
 			query.NewQueryFilter,
 			usersroles.NewUsersRolesCreator(),
@@ -724,7 +724,7 @@ func (suite *HandlerSuite) TestCreateOfficeUserHandler() {
 		).Return(nil, expectedError, nil).Once()
 		queryBuilder := query.NewQueryBuilder()
 		handler := CreateOfficeUserHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			officeuser.NewOfficeUserCreator(queryBuilder, suite.TestNotificationSender()),
 			query.NewQueryFilter,
 			userRoleAssociator,
@@ -740,7 +740,7 @@ func (suite *HandlerSuite) TestCreateOfficeUserHandler() {
 
 func (suite *HandlerSuite) TestUpdateOfficeUserHandler() {
 	setupHandler := func(updater services.OfficeUserUpdater, revoker services.UserSessionRevocation) UpdateOfficeUserHandler {
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 		return UpdateOfficeUserHandler{
 			handlerConfig,
 			updater,
@@ -948,7 +948,7 @@ func (suite *HandlerSuite) TestDeleteOfficeUsersHandler() {
 
 		queryBuilder := query.NewQueryBuilder()
 		handler := DeleteOfficeUserHandler{
-			HandlerConfig:     suite.HandlerConfig(),
+			HandlerConfig:     suite.NewHandlerConfig(),
 			OfficeUserDeleter: officeuser.NewOfficeUserDeleter(queryBuilder),
 		}
 
@@ -988,7 +988,7 @@ func (suite *HandlerSuite) TestDeleteOfficeUsersHandler() {
 
 		queryBuilder := query.NewQueryBuilder()
 		handler := DeleteOfficeUserHandler{
-			HandlerConfig:     suite.HandlerConfig(),
+			HandlerConfig:     suite.NewHandlerConfig(),
 			OfficeUserDeleter: officeuser.NewOfficeUserDeleter(queryBuilder),
 		}
 
@@ -1015,7 +1015,7 @@ func (suite *HandlerSuite) TestDeleteOfficeUsersHandler() {
 
 		queryBuilder := query.NewQueryBuilder()
 		handler := DeleteOfficeUserHandler{
-			HandlerConfig:     suite.HandlerConfig(),
+			HandlerConfig:     suite.NewHandlerConfig(),
 			OfficeUserDeleter: officeuser.NewOfficeUserDeleter(queryBuilder),
 		}
 
@@ -1035,7 +1035,7 @@ func (suite *HandlerSuite) TestGetRolesPrivilegesHandler() {
 		}
 
 		handler := GetRolesPrivilegesHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			rolesservice.NewRolesFetcher(),
 		}
 
@@ -1087,7 +1087,7 @@ func (suite *HandlerSuite) TestGetRolesPrivilegesHandler() {
 		}
 
 		handler := GetRolesPrivilegesHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			rolesservice.NewRolesFetcher(),
 		}
 
@@ -1108,7 +1108,7 @@ func (suite *HandlerSuite) TestGetRolesPrivilegesHandler() {
 		mockFetcher.On("FetchRolesPrivileges", mock.AnythingOfType("*appcontext.appContext")).Return(nil, sql.ErrNoRows)
 
 		handler := GetRolesPrivilegesHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			&mockFetcher,
 		}
 
@@ -1129,7 +1129,7 @@ func (suite *HandlerSuite) TestGetRolesPrivilegesHandler() {
 		mockFetcher.On("FetchRolesPrivileges", mock.AnythingOfType("*appcontext.appContext")).Return(nil, apperror.InternalServerError{})
 
 		handler := GetRolesPrivilegesHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			&mockFetcher,
 		}
 

--- a/pkg/handlers/adminapi/offices_test.go
+++ b/pkg/handlers/adminapi/offices_test.go
@@ -30,7 +30,7 @@ func (suite *HandlerSuite) TestIndexOfficesHandler() {
 		}
 		queryBuilder := query.NewQueryBuilder()
 		handler := IndexOfficesHandler{
-			HandlerConfig:     suite.HandlerConfig(),
+			HandlerConfig:     suite.NewHandlerConfig(),
 			NewQueryFilter:    query.NewQueryFilter,
 			OfficeListFetcher: office.NewOfficeListFetcher(queryBuilder),
 			NewPagination:     pagination.NewPagination,
@@ -62,7 +62,7 @@ func (suite *HandlerSuite) TestIndexOfficesHandler() {
 			mock.AnythingOfType("*appcontext.appContext"),
 		).Return(0, expectedError).Once()
 		handler := IndexOfficesHandler{
-			HandlerConfig:     suite.HandlerConfig(),
+			HandlerConfig:     suite.NewHandlerConfig(),
 			NewQueryFilter:    newQueryFilter,
 			OfficeListFetcher: officeListFetcher,
 			NewPagination:     pagination.NewPagination,
@@ -87,7 +87,7 @@ func (suite *HandlerSuite) TestGetOfficeByIdHandler() {
 		}
 
 		handler := GetOfficeByIdHandler{
-			HandlerConfig:                suite.HandlerConfig(),
+			HandlerConfig:                suite.NewHandlerConfig(),
 			NewQueryFilter:               query.NewQueryFilter,
 			TransportationOfficesFetcher: transportationoffice.NewTransportationOfficesFetcher(),
 		}
@@ -114,7 +114,7 @@ func (suite *HandlerSuite) TestGetOfficeByIdHandler() {
 		).Return(nil, expectedError).Once()
 
 		handler := GetOfficeByIdHandler{
-			HandlerConfig:                suite.HandlerConfig(),
+			HandlerConfig:                suite.NewHandlerConfig(),
 			NewQueryFilter:               query.NewQueryFilter,
 			TransportationOfficesFetcher: officeFetcher,
 		}

--- a/pkg/handlers/adminapi/organizations_test.go
+++ b/pkg/handlers/adminapi/organizations_test.go
@@ -24,7 +24,7 @@ func (suite *HandlerSuite) TestIndexOrganizationsHandler() {
 		}
 		queryBuilder := query.NewQueryBuilder()
 		handler := IndexOrganizationsHandler{
-			HandlerConfig:           suite.HandlerConfig(),
+			HandlerConfig:           suite.NewHandlerConfig(),
 			NewQueryFilter:          query.NewQueryFilter,
 			OrganizationListFetcher: organization2.NewOrganizationListFetcher(queryBuilder),
 			NewPagination:           pagination.NewPagination,
@@ -57,7 +57,7 @@ func (suite *HandlerSuite) TestIndexOrganizationsHandler() {
 			mock.Anything,
 		).Return(0, expectedError).Once()
 		handler := IndexOrganizationsHandler{
-			HandlerConfig:           suite.HandlerConfig(),
+			HandlerConfig:           suite.NewHandlerConfig(),
 			NewQueryFilter:          newMockQueryFilterBuilder(&mocks.QueryFilter{}),
 			OrganizationListFetcher: organizationListFetcher,
 			NewPagination:           pagination.NewPagination,

--- a/pkg/handlers/adminapi/payment_request_syncada_files_test.go
+++ b/pkg/handlers/adminapi/payment_request_syncada_files_test.go
@@ -50,7 +50,7 @@ func (suite *HandlerSuite) TestIndexPaymentRequestSyncadaFilesHandler() {
 		}
 		queryBuilder := query.NewQueryBuilder()
 		handler := IndexPaymentRequestSyncadaFilesHandler{
-			HandlerConfig:  suite.HandlerConfig(),
+			HandlerConfig:  suite.NewHandlerConfig(),
 			NewQueryFilter: query.NewQueryFilter,
 			ListFetcher:    fetch.NewListFetcher(queryBuilder),
 			NewPagination:  pagination.NewPagination,

--- a/pkg/handlers/adminapi/rejected_office_users_test.go
+++ b/pkg/handlers/adminapi/rejected_office_users_test.go
@@ -35,7 +35,7 @@ func (suite *HandlerSuite) TestIndexRejectedOfficeUsersHandler() {
 
 		queryBuilder := query.NewQueryBuilder()
 		handler := IndexRejectedOfficeUsersHandler{
-			HandlerConfig:                 suite.HandlerConfig(),
+			HandlerConfig:                 suite.NewHandlerConfig(),
 			NewQueryFilter:                query.NewQueryFilter,
 			RejectedOfficeUserListFetcher: rejectedofficeusers.NewRejectedOfficeUsersListFetcher(queryBuilder),
 			NewPagination:                 pagination.NewPagination,
@@ -142,7 +142,7 @@ func (suite *HandlerSuite) TestIndexRejectedOfficeUsersHandler() {
 
 		queryBuilder := query.NewQueryBuilder()
 		handler := IndexRejectedOfficeUsersHandler{
-			HandlerConfig:                 suite.HandlerConfig(),
+			HandlerConfig:                 suite.NewHandlerConfig(),
 			NewQueryFilter:                query.NewQueryFilter,
 			RejectedOfficeUserListFetcher: rejectedofficeusers.NewRejectedOfficeUsersListFetcher(queryBuilder),
 			NewPagination:                 pagination.NewPagination,
@@ -283,7 +283,7 @@ func (suite *HandlerSuite) TestGetRejectedOfficeUserHandler() {
 
 		queryBuilder := query.NewQueryBuilder()
 		handler := GetRejectedOfficeUserHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			rejectedofficeusers.NewRejectedOfficeUserFetcher(queryBuilder),
 			mockRoleAssociator,
 			query.NewQueryFilter,
@@ -326,7 +326,7 @@ func (suite *HandlerSuite) TestGetRejectedOfficeUserHandler() {
 		).Return(mockRoles, nil)
 
 		handler := GetRejectedOfficeUserHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			rejectedOfficeUserFetcher,
 			mockRoleAssociator,
 			newMockQueryFilterBuilder(&mocks.QueryFilter{}),
@@ -370,7 +370,7 @@ func (suite *HandlerSuite) TestGetRejectedOfficeUserHandler() {
 		).Return(mockRoles, nil)
 
 		handler := GetRejectedOfficeUserHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			rejectedOfficeUserFetcher,
 			mockRoleAssociator,
 			newMockQueryFilterBuilder(&mocks.QueryFilter{}),

--- a/pkg/handlers/adminapi/requested_office_users_test.go
+++ b/pkg/handlers/adminapi/requested_office_users_test.go
@@ -36,7 +36,7 @@ func (suite *HandlerSuite) TestIndexRequestedOfficeUsersHandler() {
 
 		queryBuilder := query.NewQueryBuilder()
 		handler := IndexRequestedOfficeUsersHandler{
-			HandlerConfig:                  suite.HandlerConfig(),
+			HandlerConfig:                  suite.NewHandlerConfig(),
 			NewQueryFilter:                 query.NewQueryFilter,
 			RequestedOfficeUserListFetcher: requestedofficeusers.NewRequestedOfficeUsersListFetcher(queryBuilder),
 			NewPagination:                  pagination.NewPagination,
@@ -141,7 +141,7 @@ func (suite *HandlerSuite) TestIndexRequestedOfficeUsersHandler() {
 
 		queryBuilder := query.NewQueryBuilder()
 		handler := IndexRequestedOfficeUsersHandler{
-			HandlerConfig:                  suite.HandlerConfig(),
+			HandlerConfig:                  suite.NewHandlerConfig(),
 			NewQueryFilter:                 query.NewQueryFilter,
 			RequestedOfficeUserListFetcher: requestedofficeusers.NewRequestedOfficeUsersListFetcher(queryBuilder),
 			NewPagination:                  pagination.NewPagination,
@@ -298,7 +298,7 @@ func (suite *HandlerSuite) TestIndexRequestedOfficeUsersHandler() {
 
 		queryBuilder := query.NewQueryBuilder()
 		handler := IndexRequestedOfficeUsersHandler{
-			HandlerConfig:                  suite.HandlerConfig(),
+			HandlerConfig:                  suite.NewHandlerConfig(),
 			NewQueryFilter:                 query.NewQueryFilter,
 			RequestedOfficeUserListFetcher: requestedofficeusers.NewRequestedOfficeUsersListFetcher(queryBuilder),
 			NewPagination:                  pagination.NewPagination,
@@ -323,7 +323,7 @@ func (suite *HandlerSuite) TestIndexRequestedOfficeUsersHandler() {
 
 		queryBuilder = query.NewQueryBuilder()
 		handler = IndexRequestedOfficeUsersHandler{
-			HandlerConfig:                  suite.HandlerConfig(),
+			HandlerConfig:                  suite.NewHandlerConfig(),
 			NewQueryFilter:                 query.NewQueryFilter,
 			RequestedOfficeUserListFetcher: requestedofficeusers.NewRequestedOfficeUsersListFetcher(queryBuilder),
 			NewPagination:                  pagination.NewPagination,
@@ -348,7 +348,7 @@ func (suite *HandlerSuite) TestIndexRequestedOfficeUsersHandler() {
 
 		queryBuilder = query.NewQueryBuilder()
 		handler = IndexRequestedOfficeUsersHandler{
-			HandlerConfig:                  suite.HandlerConfig(),
+			HandlerConfig:                  suite.NewHandlerConfig(),
 			NewQueryFilter:                 query.NewQueryFilter,
 			RequestedOfficeUserListFetcher: requestedofficeusers.NewRequestedOfficeUsersListFetcher(queryBuilder),
 			NewPagination:                  pagination.NewPagination,
@@ -397,7 +397,7 @@ func (suite *HandlerSuite) TestIndexRequestedOfficeUsersHandler() {
 
 		queryBuilder := query.NewQueryBuilder()
 		handler := IndexRequestedOfficeUsersHandler{
-			HandlerConfig:                  suite.HandlerConfig(),
+			HandlerConfig:                  suite.NewHandlerConfig(),
 			NewQueryFilter:                 query.NewQueryFilter,
 			RequestedOfficeUserListFetcher: requestedofficeusers.NewRequestedOfficeUsersListFetcher(queryBuilder),
 			NewPagination:                  pagination.NewPagination,
@@ -429,7 +429,7 @@ func (suite *HandlerSuite) TestIndexRequestedOfficeUsersHandler() {
 
 		queryBuilder := query.NewQueryBuilder()
 		handler := IndexRequestedOfficeUsersHandler{
-			HandlerConfig:                  suite.HandlerConfig(),
+			HandlerConfig:                  suite.NewHandlerConfig(),
 			NewQueryFilter:                 query.NewQueryFilter,
 			RequestedOfficeUserListFetcher: requestedofficeusers.NewRequestedOfficeUsersListFetcher(queryBuilder),
 			NewPagination:                  pagination.NewPagination,
@@ -462,7 +462,7 @@ func (suite *HandlerSuite) TestIndexRequestedOfficeUsersHandler() {
 
 		queryBuilder := query.NewQueryBuilder()
 		handler := IndexRequestedOfficeUsersHandler{
-			HandlerConfig:                  suite.HandlerConfig(),
+			HandlerConfig:                  suite.NewHandlerConfig(),
 			NewQueryFilter:                 query.NewQueryFilter,
 			RequestedOfficeUserListFetcher: requestedofficeusers.NewRequestedOfficeUsersListFetcher(queryBuilder),
 			NewPagination:                  pagination.NewPagination,
@@ -496,7 +496,7 @@ func (suite *HandlerSuite) TestIndexRequestedOfficeUsersHandler() {
 
 		queryBuilder := query.NewQueryBuilder()
 		handler := IndexRequestedOfficeUsersHandler{
-			HandlerConfig:                  suite.HandlerConfig(),
+			HandlerConfig:                  suite.NewHandlerConfig(),
 			NewQueryFilter:                 query.NewQueryFilter,
 			RequestedOfficeUserListFetcher: requestedofficeusers.NewRequestedOfficeUsersListFetcher(queryBuilder),
 			NewPagination:                  pagination.NewPagination,
@@ -540,7 +540,7 @@ func (suite *HandlerSuite) TestGetRequestedOfficeUserHandler() {
 
 		queryBuilder := query.NewQueryBuilder()
 		handler := GetRequestedOfficeUserHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			requestedofficeusers.NewRequestedOfficeUserFetcher(queryBuilder),
 			mockRoleAssociator,
 			query.NewQueryFilter,
@@ -583,7 +583,7 @@ func (suite *HandlerSuite) TestGetRequestedOfficeUserHandler() {
 		).Return(mockRoles, nil)
 
 		handler := GetRequestedOfficeUserHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			requestedOfficeUserFetcher,
 			mockRoleAssociator,
 			newMockQueryFilterBuilder(&mocks.QueryFilter{}),
@@ -627,7 +627,7 @@ func (suite *HandlerSuite) TestGetRequestedOfficeUserHandler() {
 		).Return(mockRoles, nil)
 
 		handler := GetRequestedOfficeUserHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			requestedOfficeUserFetcher,
 			mockRoleAssociator,
 			newMockQueryFilterBuilder(&mocks.QueryFilter{}),
@@ -721,7 +721,7 @@ func (suite *HandlerSuite) TestUpdateRequestedOfficeUserHandlerWithoutOktaAccoun
 		).Return(mockRoles, nil)
 
 		handler := UpdateRequestedOfficeUserHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			requestedOfficeUserUpdater,
 			mockUserRoleAssociator,
 			mockRoleAssociator,
@@ -836,7 +836,7 @@ func (suite *HandlerSuite) TestUpdateRequestedOfficeUserHandlerWithOktaAccountCr
 		).Return(mockRoles, nil)
 
 		handler := UpdateRequestedOfficeUserHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			requestedOfficeUserUpdater,
 			mockUserRoleAssociator,
 			mockRoleAssociator,
@@ -944,7 +944,7 @@ func (suite *HandlerSuite) TestUpdateRequestedOfficeUserHandlerWithOktaAccountCr
 		).Return(mockRoles, nil)
 
 		handler := UpdateRequestedOfficeUserHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			requestedOfficeUserUpdater,
 			mockUserRoleAssociator,
 			mockRoleAssociator,

--- a/pkg/handlers/adminapi/upload_information_test.go
+++ b/pkg/handlers/adminapi/upload_information_test.go
@@ -46,7 +46,7 @@ func (suite *HandlerSuite) TestGetUploadHandler() {
 
 		uploadInformationFetcher := upload.NewUploadInformationFetcher()
 		handler := GetUploadHandler{
-			HandlerConfig:            suite.HandlerConfig(),
+			HandlerConfig:            suite.NewHandlerConfig(),
 			UploadInformationFetcher: uploadInformationFetcher,
 		}
 
@@ -71,7 +71,7 @@ func (suite *HandlerSuite) TestGetUploadHandler() {
 			mock.Anything,
 		).Return(services.UploadInformation{}, expectedError).Once()
 		handler := GetUploadHandler{
-			HandlerConfig:            suite.HandlerConfig(),
+			HandlerConfig:            suite.NewHandlerConfig(),
 			UploadInformationFetcher: uploadInformationFetcher,
 		}
 

--- a/pkg/handlers/adminapi/user_test.go
+++ b/pkg/handlers/adminapi/user_test.go
@@ -28,7 +28,7 @@ func (suite *HandlerSuite) TestGetLoggedInUserHandler() {
 
 		queryBuilder := query.NewQueryBuilder()
 		handler := GetLoggedInUserHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			adminuser.NewAdminUserFetcher(queryBuilder),
 			query.NewQueryFilter,
 		}
@@ -55,7 +55,7 @@ func (suite *HandlerSuite) TestGetLoggedInUserHandler() {
 
 		queryBuilder := query.NewQueryBuilder()
 		handler := GetLoggedInUserHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			adminuser.NewAdminUserFetcher(queryBuilder),
 			query.NewQueryFilter,
 		}

--- a/pkg/handlers/adminapi/users_test.go
+++ b/pkg/handlers/adminapi/users_test.go
@@ -42,7 +42,7 @@ func (suite *HandlerSuite) TestGetUserHandler() {
 
 		queryBuilder := query.NewQueryBuilder()
 		handler := GetUserHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			userservice.NewUserFetcher(queryBuilder),
 			query.NewQueryFilter,
 		}
@@ -67,7 +67,7 @@ func (suite *HandlerSuite) TestGetUserHandler() {
 			mock.Anything,
 		).Return(models.User{}, expectedError).Once()
 		handler := GetUserHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			userFetcher,
 			newMockQueryFilterBuilder(&mocks.QueryFilter{}),
 		}
@@ -95,7 +95,7 @@ func (suite *HandlerSuite) TestIndexUsersHandler() {
 
 		queryBuilder := query.NewQueryBuilder()
 		handler := IndexUsersHandler{
-			HandlerConfig:  suite.HandlerConfig(),
+			HandlerConfig:  suite.NewHandlerConfig(),
 			NewQueryFilter: query.NewQueryFilter,
 			ListFetcher:    fetch.NewListFetcher(queryBuilder),
 			NewPagination:  pagination.NewPagination,
@@ -132,7 +132,7 @@ func (suite *HandlerSuite) TestIndexUsersHandler() {
 			mock.Anything,
 		).Return(0, expectedError).Once()
 		handler := IndexUsersHandler{
-			HandlerConfig:  suite.HandlerConfig(),
+			HandlerConfig:  suite.NewHandlerConfig(),
 			NewQueryFilter: newQueryFilter,
 			ListFetcher:    userListFetcher,
 			NewPagination:  pagination.NewPagination,
@@ -175,7 +175,7 @@ func (suite *HandlerSuite) TestUpdateUserHandler() {
 	adminUpdater := adminuser.NewAdminUserUpdater(queryBuilder)
 
 	setupHandler := func() UpdateUserHandler {
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 
 		return UpdateUserHandler{
 			handlerConfig,

--- a/pkg/handlers/adminapi/webhook_subscriptions_test.go
+++ b/pkg/handlers/adminapi/webhook_subscriptions_test.go
@@ -34,7 +34,7 @@ func (suite *HandlerSuite) TestIndexWebhookSubscriptionsHandler() {
 		}
 		queryBuilder := query.NewQueryBuilder()
 		handler := IndexWebhookSubscriptionsHandler{
-			HandlerConfig:  suite.HandlerConfig(),
+			HandlerConfig:  suite.NewHandlerConfig(),
 			NewQueryFilter: query.NewQueryFilter,
 			ListFetcher:    fetch.NewListFetcher(queryBuilder),
 			NewPagination:  pagination.NewPagination,
@@ -78,7 +78,7 @@ func (suite *HandlerSuite) TestIndexWebhookSubscriptionsHandler() {
 		).Return(0, expectedError).Once()
 
 		handler := IndexWebhookSubscriptionsHandler{
-			HandlerConfig:  suite.HandlerConfig(),
+			HandlerConfig:  suite.NewHandlerConfig(),
 			NewQueryFilter: newQueryFilter,
 			ListFetcher:    webhookSubscriptionListFetcher,
 			NewPagination:  pagination.NewPagination,
@@ -104,7 +104,7 @@ func (suite *HandlerSuite) TestGetWebhookSubscriptionHandler() {
 
 		queryBuilder := query.NewQueryBuilder()
 		handler := GetWebhookSubscriptionHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			webhooksubscription.NewWebhookSubscriptionFetcher(queryBuilder),
 			query.NewQueryFilter,
 		}
@@ -139,7 +139,7 @@ func (suite *HandlerSuite) TestGetWebhookSubscriptionHandler() {
 		).Return(models.WebhookSubscription{}, expectedError).Once()
 
 		handler := GetWebhookSubscriptionHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			webhookSubscriptionFetcher,
 			query.NewQueryFilter,
 		}
@@ -157,7 +157,7 @@ func (suite *HandlerSuite) TestGetWebhookSubscriptionHandler() {
 func (suite *HandlerSuite) TestCreateWebhookSubscriptionHandler() {
 	setupHandler := func() CreateWebhookSubscriptionHandler {
 		return CreateWebhookSubscriptionHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			webhooksubscription.NewWebhookSubscriptionCreator(query.NewQueryBuilder()),
 			query.NewQueryFilter,
 		}
@@ -234,7 +234,7 @@ func (suite *HandlerSuite) TestUpdateWebhookSubscriptionHandler() {
 
 		queryBuilder := query.NewQueryBuilder()
 		handler := UpdateWebhookSubscriptionHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			webhooksubscription.NewWebhookSubscriptionUpdater(queryBuilder),
 			query.NewQueryFilter,
 		}
@@ -271,7 +271,7 @@ func (suite *HandlerSuite) TestUpdateWebhookSubscriptionHandler() {
 
 		queryBuilder := query.NewQueryBuilder()
 		handler := UpdateWebhookSubscriptionHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			webhooksubscription.NewWebhookSubscriptionUpdater(queryBuilder),
 			query.NewQueryFilter,
 		}
@@ -315,7 +315,7 @@ func (suite *HandlerSuite) TestUpdateWebhookSubscriptionHandler() {
 
 		queryBuilder := query.NewQueryBuilder()
 		handler := UpdateWebhookSubscriptionHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			webhooksubscription.NewWebhookSubscriptionUpdater(queryBuilder),
 			query.NewQueryFilter,
 		}
@@ -342,7 +342,7 @@ func (suite *HandlerSuite) TestUpdateWebhookSubscriptionHandler() {
 
 		queryBuilder := query.NewQueryBuilder()
 		handler := UpdateWebhookSubscriptionHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			webhooksubscription.NewWebhookSubscriptionUpdater(queryBuilder),
 			query.NewQueryFilter,
 		}

--- a/pkg/handlers/apitests.go
+++ b/pkg/handlers/apitests.go
@@ -236,7 +236,9 @@ func (suite *BaseHandlerTestSuite) AuthenticateRequest(req *http.Request, servic
 		ServiceMemberID: serviceMember.ID,
 		Email:           serviceMember.User.OktaEmail,
 	}
-	session.Roles = append(session.Roles, serviceMember.User.Roles...)
+	defaultRole, err := serviceMember.User.Roles.Default()
+	suite.FatalNoError(err)
+	session.CurrentRole = *defaultRole
 	ctx := auth.SetSessionInRequestContext(req, &session)
 	return req.WithContext(ctx)
 }
@@ -260,7 +262,9 @@ func (suite *BaseHandlerTestSuite) AuthenticateOfficeRequest(req *http.Request, 
 		IDToken:         "fake token",
 		OfficeUserID:    user.ID,
 	}
-	session.Roles = append(session.Roles, user.User.Roles...)
+	defaultRole, err := user.User.Roles.Default()
+	suite.FatalNoError(err)
+	session.CurrentRole = *defaultRole
 	ctx := auth.SetSessionInRequestContext(req, &session)
 	return req.WithContext(ctx)
 }

--- a/pkg/handlers/apitests.go
+++ b/pkg/handlers/apitests.go
@@ -68,11 +68,11 @@ func NewBaseHandlerTestSuite(sender notifications.NotificationSender, packageNam
 	}
 }
 
-// HandlerConfig returns a mostly empty handler config for
+// NewHandlerConfig returns a mostly empty handler config for
 // testing.
 // NOTE: it returns the Config implementation, not the
-// HandlerConfig interface, so overrides can be made to the config
-func (suite *BaseHandlerTestSuite) HandlerConfig() *Config {
+// NewHandlerConfig interface, so overrides can be made to the config
+func (suite *BaseHandlerTestSuite) NewHandlerConfig() *Config {
 	// create a mock feature flag fetcher that always returns enabled
 	mockFeatureFlagFetcher := &mocks.FeatureFlagFetcher{}
 	mockGetFlagFunc := func(_ context.Context, _ *zap.Logger, entityID string, key string, _ map[string]string, mockVariant string) (services.FeatureFlag, error) {

--- a/pkg/handlers/apitests.go
+++ b/pkg/handlers/apitests.go
@@ -238,7 +238,7 @@ func (suite *BaseHandlerTestSuite) AuthenticateRequest(req *http.Request, servic
 	}
 	defaultRole, err := serviceMember.User.Roles.Default()
 	suite.FatalNoError(err)
-	session.CurrentRole = *defaultRole
+	session.ActiveRole = *defaultRole
 	ctx := auth.SetSessionInRequestContext(req, &session)
 	return req.WithContext(ctx)
 }
@@ -264,7 +264,7 @@ func (suite *BaseHandlerTestSuite) AuthenticateOfficeRequest(req *http.Request, 
 	}
 	defaultRole, err := user.User.Roles.Default()
 	suite.FatalNoError(err)
-	session.CurrentRole = *defaultRole
+	session.ActiveRole = *defaultRole
 	ctx := auth.SetSessionInRequestContext(req, &session)
 	return req.WithContext(ctx)
 }

--- a/pkg/handlers/authentication/auth.go
+++ b/pkg/handlers/authentication/auth.go
@@ -444,7 +444,7 @@ func PrimeSimulatorAuthorizationMiddleware(_ *zap.Logger) func(next http.Handler
 		mw := func(w http.ResponseWriter, r *http.Request) {
 			logger := logging.FromContext(r.Context())
 			session := auth.SessionFromRequestContext(r)
-			if session == nil || !(session.CurrentRole.RoleType == roles.RoleTypePrimeSimulator) {
+			if session == nil || !(session.ActiveRole.RoleType == roles.RoleTypePrimeSimulator) {
 				logger.Error("forbidden user for prime simulator")
 				http.Error(w, http.StatusText(403), http.StatusForbidden)
 				return
@@ -1087,7 +1087,7 @@ func AuthorizeKnownUser(ctx context.Context, appCtx appcontext.AppContext, userI
 			zap.String("hostname", appCtx.Session().Hostname),
 			zap.String("user_id", appCtx.Session().UserID.String()))
 	} else {
-		appCtx.Session().CurrentRole = *defaultRole
+		appCtx.Session().ActiveRole = *defaultRole
 	}
 
 	appCtx.Session().Permissions = getPermissionsForUser(appCtx, userIdentity.ID)
@@ -1358,7 +1358,7 @@ func authorizeUnknownUser(ctx context.Context, appCtx appcontext.AppContext, okt
 		// Customers will be created without a role
 		appCtx.Logger().Warn("Authenticating unknown user, cannot get default role from session manager, proceeding without a role")
 	} else {
-		appCtx.Session().CurrentRole = *defaultRole
+		appCtx.Session().ActiveRole = *defaultRole
 	}
 	appCtx.Session().Permissions = getPermissionsForUser(appCtx, user.ID)
 

--- a/pkg/handlers/authentication/auth_test.go
+++ b/pkg/handlers/authentication/auth_test.go
@@ -186,7 +186,7 @@ func (suite *AuthSuite) TestAuthorizationLogoutHandler() {
 	fakeToken := "some_token"
 	fakeAccessToken := "some_access_token"
 
-	handlerConfig := suite.HandlerConfig()
+	handlerConfig := suite.NewHandlerConfig()
 	appnames := handlerConfig.AppNames()
 
 	baseReq := httptest.NewRequest("POST", fmt.Sprintf("http://%s/auth/logout", appnames.OfficeServername), nil)
@@ -248,7 +248,7 @@ func (suite *AuthSuite) TestLogoutOktaRedirectHandler() {
 	fakeToken := "some_token"
 	fakeAccessToken := "some_access_token"
 
-	handlerConfig := suite.HandlerConfig()
+	handlerConfig := suite.NewHandlerConfig()
 	appnames := handlerConfig.AppNames()
 
 	baseReq := httptest.NewRequest("POST", fmt.Sprintf("http://%s/auth/logoutOktaRedirect", appnames.MilServername), nil)
@@ -354,7 +354,7 @@ func (suite *AuthSuite) TestCustomerAPIAuthMiddleware() {
 	}
 
 	setUpHandlerAndMiddleware := func() http.Handler {
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 
 		api := internalapi.NewInternalAPI(handlerConfig)
 
@@ -472,7 +472,7 @@ func (suite *AuthSuite) TestRequirePermissionsMiddlewareAuthorized() {
 	ctx := auth.SetSessionInRequestContext(req, &handlerSession)
 	req = req.WithContext(ctx)
 
-	handlerConfig := suite.HandlerConfig()
+	handlerConfig := suite.NewHandlerConfig()
 	api := ghcapi.NewGhcAPIHandler(handlerConfig)
 
 	handler := http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {})
@@ -516,7 +516,7 @@ func (suite *AuthSuite) TestRequirePermissionsMiddlewareUnauthorized() {
 	ctx := auth.SetSessionInRequestContext(req, &handlerSession)
 	req = req.WithContext(ctx)
 
-	handlerConfig := suite.HandlerConfig()
+	handlerConfig := suite.NewHandlerConfig()
 	api := ghcapi.NewGhcAPIHandler(handlerConfig)
 
 	handler := http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {})
@@ -670,7 +670,7 @@ func (suite *AuthSuite) TestAuthorizeDeactivateUser() {
 		Active: false,
 	}
 
-	handlerConfig := suite.HandlerConfig()
+	handlerConfig := suite.NewHandlerConfig()
 	appnames := handlerConfig.AppNames()
 
 	fakeToken := "some_token"
@@ -696,7 +696,7 @@ func (suite *AuthSuite) TestAuthKnownSingleRoleOffice() {
 	userIdentity, err := models.FetchUserIdentity(suite.DB(), officeUser.User.OktaID)
 	suite.Assert().NoError(err)
 
-	handlerConfig := suite.HandlerConfig()
+	handlerConfig := suite.NewHandlerConfig()
 	appnames := handlerConfig.AppNames()
 
 	fakeToken := "some_token"
@@ -752,7 +752,7 @@ func (suite *AuthSuite) TestAuthSameKnownUserForAllApps() {
 	userIdentity, err := models.FetchUserIdentity(suite.DB(), officeUser.User.OktaID)
 	suite.Assert().NoError(err)
 
-	handlerConfig := suite.HandlerConfig()
+	handlerConfig := suite.NewHandlerConfig()
 	appnames := handlerConfig.AppNames()
 
 	fakeToken := "some_token"
@@ -811,7 +811,7 @@ func (suite *AuthSuite) TestAuthorizeDeactivateOfficeUser() {
 		OfficeActive: &officeActive,
 	}
 
-	handlerConfig := suite.HandlerConfig()
+	handlerConfig := suite.NewHandlerConfig()
 	appnames := handlerConfig.AppNames()
 
 	fakeToken := "some_token"
@@ -848,7 +848,7 @@ func (suite *AuthSuite) TestRedirectOktaErrorMsg() {
 		OfficeUserID: &officeUserID,
 	}
 
-	handlerConfig := suite.HandlerConfig()
+	handlerConfig := suite.NewHandlerConfig()
 	appnames := handlerConfig.AppNames()
 	req := httptest.NewRequest("GET", fmt.Sprintf("http://%s/okta/callback", appnames.OfficeServername), nil)
 
@@ -925,7 +925,7 @@ func (suite *AuthSuite) TestRedirectFromOktaForValidUser() {
 	// Mock the necessary Okta endpoints
 	mockAndActivateOktaEndpoints(tioOfficeUser, provider)
 
-	handlerConfig := suite.HandlerConfig()
+	handlerConfig := suite.NewHandlerConfig()
 	appnames := handlerConfig.AppNames()
 
 	fakeToken := "some_token"
@@ -993,7 +993,7 @@ func (suite *AuthSuite) TestCallbackThatRequiresOktaParamsRedirect() {
 	// Mock the necessary Okta endpoints
 	mockAndActivateOktaEndpoints(tioOfficeUser, provider)
 
-	handlerConfig := suite.HandlerConfig()
+	handlerConfig := suite.NewHandlerConfig()
 	appnames := handlerConfig.AppNames()
 
 	session := auth.Session{
@@ -1060,7 +1060,7 @@ func (suite *AuthSuite) TestCallbackThatLogsUserOutOfOkta() {
 	// Mock the necessary Okta endpoints
 	mockAndActivateOktaEndpoints(tioOfficeUser, provider)
 
-	handlerConfig := suite.HandlerConfig()
+	handlerConfig := suite.NewHandlerConfig()
 	appnames := handlerConfig.AppNames()
 
 	session := auth.Session{
@@ -1189,7 +1189,7 @@ func (suite *AuthSuite) TestRedirectFromOktaForInvalidUser() {
 	// Mock the necessary Okta endpoints
 	mockAndActivateOktaEndpoints(tioOfficeUser, provider)
 
-	handlerConfig := suite.HandlerConfig()
+	handlerConfig := suite.NewHandlerConfig()
 	appnames := handlerConfig.AppNames()
 
 	fakeToken := "some_token"
@@ -1272,7 +1272,7 @@ func (suite *AuthSuite) TestAuthKnownSingleRoleAdmin() {
 		Roles:         roles.Roles{roles.Role{RoleType: roles.RoleTypeServicesCounselor}},
 	}
 
-	handlerConfig := suite.HandlerConfig()
+	handlerConfig := suite.NewHandlerConfig()
 	appnames := handlerConfig.AppNames()
 
 	fakeToken := "some_token"
@@ -1308,7 +1308,7 @@ func (suite *AuthSuite) TestAuthKnownServiceMember() {
 		Roles:           roles.Roles{roles.Role{RoleType: roles.RoleTypeServicesCounselor}},
 	}
 
-	handlerConfig := suite.HandlerConfig()
+	handlerConfig := suite.NewHandlerConfig()
 	appnames := handlerConfig.AppNames()
 
 	fakeToken := "some_token"
@@ -1359,7 +1359,7 @@ func (suite *AuthSuite) TestAuthUnknownServiceMember() {
 	// Set up: Prepare the session, goth.User, callback handler, http response
 	//         and request, landing URL, and pass them into authorizeUnknownUser
 
-	handlerConfig := suite.HandlerConfig()
+	handlerConfig := suite.NewHandlerConfig()
 	appnames := handlerConfig.AppNames()
 
 	// Prepare the session and session manager
@@ -1424,7 +1424,7 @@ func (suite *AuthSuite) TestAuthorizeDeactivateAdmin() {
 		AdminUserActive: &adminUserActive,
 	}
 
-	handlerConfig := suite.HandlerConfig()
+	handlerConfig := suite.NewHandlerConfig()
 	appnames := handlerConfig.AppNames()
 
 	fakeToken := "some_token"
@@ -1462,7 +1462,7 @@ func (suite *AuthSuite) TestAuthorizeUnknownUserOfficeDeactivated() {
 	suite.NoError(err)
 	suite.False(verrs.HasAny())
 
-	handlerConfig := suite.HandlerConfig()
+	handlerConfig := suite.NewHandlerConfig()
 	appnames := handlerConfig.AppNames()
 	session := auth.Session{
 		ApplicationName: auth.OfficeApp,
@@ -1488,7 +1488,7 @@ func (suite *AuthSuite) TestAuthorizeUnknownUserOfficeDeactivated() {
 
 func (suite *AuthSuite) TestAuthorizeUnknownUserOfficeNotFound() {
 
-	handlerConfig := suite.HandlerConfig()
+	handlerConfig := suite.NewHandlerConfig()
 	appnames := handlerConfig.AppNames()
 
 	fakeToken := "some_token"
@@ -1535,7 +1535,7 @@ func (suite *AuthSuite) TestAuthorizeUnknownUserOfficeLogsIn() {
 		},
 	}, nil)
 
-	handlerConfig := suite.HandlerConfig()
+	handlerConfig := suite.NewHandlerConfig()
 	appnames := handlerConfig.AppNames()
 	fakeToken := "some_token"
 
@@ -1589,7 +1589,7 @@ func (suite *AuthSuite) TestAuthorizeUnknownUserOfficeLogsInWithPermissions() {
 		},
 	}, []roles.RoleType{roles.RoleTypeQae})
 
-	handlerConfig := suite.HandlerConfig()
+	handlerConfig := suite.NewHandlerConfig()
 	appnames := handlerConfig.AppNames()
 
 	fakeToken := "some_token"
@@ -1644,7 +1644,7 @@ func (suite *AuthSuite) TestAuthorizeUnknownUserAdminDeactivated() {
 	suite.NoError(err)
 	suite.False(verrs.HasAny())
 
-	handlerConfig := suite.HandlerConfig()
+	handlerConfig := suite.NewHandlerConfig()
 	appnames := handlerConfig.AppNames()
 	session := auth.Session{
 		ApplicationName: auth.AdminApp,
@@ -1669,7 +1669,7 @@ func (suite *AuthSuite) TestAuthorizeUnknownUserAdminDeactivated() {
 }
 
 func (suite *AuthSuite) TestAuthorizeUnknownUserAdminNotFound() {
-	handlerConfig := suite.HandlerConfig()
+	handlerConfig := suite.NewHandlerConfig()
 	appnames := handlerConfig.AppNames()
 	// user not admin_users and has never logged into the app
 	fakeToken := "some_token"
@@ -1699,7 +1699,7 @@ func (suite *AuthSuite) TestAuthorizeUnknownUserAdminNotFound() {
 }
 
 func (suite *AuthSuite) TestAuthorizeKnownUserAdminNotFound() {
-	handlerConfig := suite.HandlerConfig()
+	handlerConfig := suite.NewHandlerConfig()
 	appnames := handlerConfig.AppNames()
 	// user exists in the DB, but not as an admin user
 	fakeToken := "some_token"
@@ -1750,7 +1750,7 @@ func (suite *AuthSuite) TestAuthorizeUnknownUserAdminLogsIn() {
 	})
 	user := adminUser.User
 
-	handlerConfig := suite.HandlerConfig()
+	handlerConfig := suite.NewHandlerConfig()
 	appnames := handlerConfig.AppNames()
 	fakeToken := "some_token"
 	fakeUUID, _ := uuid.FromString("39b28c92-0506-4bef-8b57-e39519f42dc2")
@@ -1802,7 +1802,7 @@ func (suite *AuthSuite) TestoktaAuthenticatedRedirect() {
 
 	fakeToken := "some_token"
 
-	handlerConfig := suite.HandlerConfig()
+	handlerConfig := suite.NewHandlerConfig()
 	appnames := handlerConfig.AppNames()
 	session := auth.Session{
 		ApplicationName: auth.OfficeApp,
@@ -1835,7 +1835,7 @@ func (suite *AuthSuite) TestoktaAuthenticatedRedirect() {
 func (suite *AuthSuite) TestAuthorizePrime() {
 	clientCert := factory.FetchOrBuildDevlocalClientCert(suite.DB())
 
-	handlerConfig := suite.HandlerConfig()
+	handlerConfig := suite.NewHandlerConfig()
 	appnames := handlerConfig.AppNames()
 	req := httptest.NewRequest("GET", fmt.Sprintf("http://%s/prime/v1", appnames.PrimeServername), nil)
 
@@ -1860,7 +1860,7 @@ func (suite *AuthSuite) TestAuthorizePrime() {
 func (suite *AuthSuite) TestAuthorizePPTAS() {
 	clientCert := factory.FetchOrBuildDevlocalClientCert(suite.DB())
 
-	handlerConfig := suite.HandlerConfig()
+	handlerConfig := suite.NewHandlerConfig()
 	appnames := handlerConfig.AppNames()
 	req := httptest.NewRequest("GET", fmt.Sprintf("http://%s/pptas/v1", appnames.PrimeServername), nil)
 

--- a/pkg/handlers/authentication/auth_test.go
+++ b/pkg/handlers/authentication/auth_test.go
@@ -467,7 +467,7 @@ func (suite *AuthSuite) TestRequirePermissionsMiddlewareAuthorized() {
 
 	defaultRole, err := identity.Roles.Default()
 	suite.FatalNoError(err)
-	handlerSession.CurrentRole = *defaultRole
+	handlerSession.ActiveRole = *defaultRole
 
 	ctx := auth.SetSessionInRequestContext(req, &handlerSession)
 	req = req.WithContext(ctx)
@@ -511,7 +511,7 @@ func (suite *AuthSuite) TestRequirePermissionsMiddlewareUnauthorized() {
 
 	defaultRole, err := identity.Roles.Default()
 	suite.FatalNoError(err)
-	handlerSession.CurrentRole = *defaultRole
+	handlerSession.ActiveRole = *defaultRole
 
 	ctx := auth.SetSessionInRequestContext(req, &handlerSession)
 	req = req.WithContext(ctx)
@@ -715,10 +715,10 @@ func (suite *AuthSuite) TestAuthKnownSingleRoleOffice() {
 	// Office app, so should only have office ID information
 	suite.Equal(officeUser.ID, session.OfficeUserID)
 	// Make sure session contains roles and permissions
-	suite.NotEmpty(session.CurrentRole)
+	suite.NotEmpty(session.ActiveRole)
 	userRole, hasRole := officeUser.User.Roles.GetRole(roles.RoleTypeTIO)
 	suite.True(hasRole)
-	sessionRole := session.CurrentRole
+	sessionRole := session.ActiveRole
 	suite.True(hasRole)
 	suite.Equal(userRole.ID, sessionRole.ID)
 	suite.NotEmpty(session.Permissions)
@@ -1568,7 +1568,7 @@ func (suite *AuthSuite) TestAuthorizeUnknownUserOfficeLogsIn() {
 	suite.Equal(uuid.Nil, session.AdminUserID)
 	suite.NotEqual("", foundUser.CurrentOfficeSessionID)
 	// this user was created without roles or permissions
-	suite.Empty(session.CurrentRole)
+	suite.Empty(session.ActiveRole)
 	suite.Empty(session.Permissions)
 }
 
@@ -1622,10 +1622,10 @@ func (suite *AuthSuite) TestAuthorizeUnknownUserOfficeLogsInWithPermissions() {
 	suite.Equal(uuid.Nil, session.AdminUserID)
 	suite.NotEqual("", foundUser.CurrentOfficeSessionID)
 	// Make sure session contains roles and permissions
-	suite.NotEmpty(session.CurrentRole)
+	suite.NotEmpty(session.ActiveRole)
 	userRole, hasRole := officeUser.User.Roles.GetRole(roles.RoleTypeQae)
 	suite.True(hasRole)
-	sessionRole := session.CurrentRole
+	sessionRole := session.ActiveRole
 	suite.True(hasRole)
 	suite.Equal(userRole.ID, sessionRole.ID)
 	suite.NotEmpty(session.Permissions)

--- a/pkg/handlers/authentication/devlocal.go
+++ b/pkg/handlers/authentication/devlocal.go
@@ -1231,7 +1231,7 @@ func createSession(h devlocalAuthHandler, user *models.User, userType string, _ 
 			zap.String("user_id", session.UserID.String()),
 			zap.String("email", session.Email))
 	} else {
-		session.CurrentRole = *defaultRole
+		session.ActiveRole = *defaultRole
 	}
 
 	session.Permissions = getPermissionsForUser(appCtx, userIdentity.ID)

--- a/pkg/handlers/authentication/devlocal.go
+++ b/pkg/handlers/authentication/devlocal.go
@@ -1223,7 +1223,17 @@ func createSession(h devlocalAuthHandler, user *models.User, userType string, _ 
 		return nil, errors.Wrapf(err, "Unable to fetch user identity from OktaID %s", lgUUID)
 	}
 
-	session.Roles = append(session.Roles, userIdentity.Roles...)
+	defaultRole, err := userIdentity.Roles.Default()
+	if err != nil {
+		appCtx.Logger().Warn("User session creation requesting authentication but could not find default role, proceeding without a role",
+			zap.String("application_name", string(session.ApplicationName)),
+			zap.String("hostname", session.Hostname),
+			zap.String("user_id", session.UserID.String()),
+			zap.String("email", session.Email))
+	} else {
+		session.CurrentRole = *defaultRole
+	}
+
 	session.Permissions = getPermissionsForUser(appCtx, userIdentity.ID)
 
 	// Assign user identity to session

--- a/pkg/handlers/authentication/devlocal_test.go
+++ b/pkg/handlers/authentication/devlocal_test.go
@@ -30,7 +30,7 @@ func getCookie(name string, cookies []*http.Cookie) (*http.Cookie, error) {
 func (suite *AuthSuite) TestCreateUserHandlerMilMove() {
 	t := suite.T()
 
-	handlerConfig := suite.HandlerConfig()
+	handlerConfig := suite.NewHandlerConfig()
 	appnames := handlerConfig.AppNames()
 	callbackPort := 1234
 
@@ -66,7 +66,7 @@ func (suite *AuthSuite) TestCreateUserHandlerMilMove() {
 
 func (suite *AuthSuite) TestCreateUserHandlerOffice() {
 
-	handlerConfig := suite.HandlerConfig()
+	handlerConfig := suite.NewHandlerConfig()
 	appnames := handlerConfig.AppNames()
 	callbackPort := 1234
 
@@ -175,7 +175,7 @@ func (suite *AuthSuite) TestCreateUserHandlerOffice() {
 func (suite *AuthSuite) TestCreateUserHandlerAdmin() {
 	t := suite.T()
 
-	handlerConfig := suite.HandlerConfig()
+	handlerConfig := suite.NewHandlerConfig()
 	appnames := handlerConfig.AppNames()
 	callbackPort := 1234
 
@@ -227,7 +227,7 @@ func (suite *AuthSuite) TestCreateUserHandlerAdmin() {
 func (suite *AuthSuite) TestCreateAndLoginUserHandlerFromMilMoveToMilMove() {
 	t := suite.T()
 
-	handlerConfig := suite.HandlerConfig()
+	handlerConfig := suite.NewHandlerConfig()
 	appnames := handlerConfig.AppNames()
 	callbackPort := 1234
 
@@ -271,7 +271,7 @@ func (suite *AuthSuite) TestCreateAndLoginUserHandlerFromMilMoveToMilMove() {
 func (suite *AuthSuite) TestCreateAndLoginUserHandlerFromMilMoveToOffice() {
 	t := suite.T()
 
-	handlerConfig := suite.HandlerConfig()
+	handlerConfig := suite.NewHandlerConfig()
 	appnames := handlerConfig.AppNames()
 	callbackPort := 1234
 
@@ -305,7 +305,7 @@ func (suite *AuthSuite) TestCreateAndLoginUserHandlerFromMilMoveToOffice() {
 func (suite *AuthSuite) TestCreateAndLoginUserHandlerFromMilMoveToAdmin() {
 	t := suite.T()
 
-	handlerConfig := suite.HandlerConfig()
+	handlerConfig := suite.NewHandlerConfig()
 	appnames := handlerConfig.AppNames()
 	callbackPort := 1234
 
@@ -339,7 +339,7 @@ func (suite *AuthSuite) TestCreateAndLoginUserHandlerFromMilMoveToAdmin() {
 func (suite *AuthSuite) TestCreateAndLoginUserHandlerFromOfficeToMilMove() {
 	t := suite.T()
 
-	handlerConfig := suite.HandlerConfig()
+	handlerConfig := suite.NewHandlerConfig()
 	appnames := handlerConfig.AppNames()
 	callbackPort := 1234
 
@@ -378,7 +378,7 @@ func (suite *AuthSuite) TestCreateAndLoginUserHandlerFromOfficeToAdmin() {
 	form := url.Values{}
 	form.Add("userType", "admin")
 
-	handlerConfig := suite.HandlerConfig()
+	handlerConfig := suite.NewHandlerConfig()
 	appnames := handlerConfig.AppNames()
 	req := httptest.NewRequest("POST", fmt.Sprintf("http://%s/devlocal-auth/new", appnames.OfficeServername), strings.NewReader(form.Encode()))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded; param=value")
@@ -405,7 +405,7 @@ func (suite *AuthSuite) TestCreateAndLoginUserHandlerFromOfficeToAdmin() {
 }
 
 func (suite *AuthSuite) TestCreateAndLoginUserHandlerFromAdminToMilMove() {
-	handlerConfig := suite.HandlerConfig()
+	handlerConfig := suite.NewHandlerConfig()
 	appnames := handlerConfig.AppNames()
 	callbackPort := 1234
 
@@ -436,7 +436,7 @@ func (suite *AuthSuite) TestCreateAndLoginUserHandlerFromAdminToMilMove() {
 func (suite *AuthSuite) TestCreateAndLoginUserHandlerFromAdminToOffice() {
 	t := suite.T()
 
-	handlerConfig := suite.HandlerConfig()
+	handlerConfig := suite.NewHandlerConfig()
 	appnames := handlerConfig.AppNames()
 	callbackPort := 1234
 

--- a/pkg/handlers/authentication/permissions.go
+++ b/pkg/handlers/authentication/permissions.go
@@ -162,7 +162,7 @@ func getPermissionsForUser(appCtx appcontext.AppContext, userID uuid.UUID) []str
 	session := appCtx.Session()
 	if session != nil {
 		for _, rp := range AllRolesPermissions {
-			if appCtx.Session().CurrentRole.RoleType == rp.RoleType {
+			if appCtx.Session().ActiveRole.RoleType == rp.RoleType {
 				userPermissions = append(userPermissions, rp.Permissions...)
 			}
 		}

--- a/pkg/handlers/authentication/permissions.go
+++ b/pkg/handlers/authentication/permissions.go
@@ -161,12 +161,17 @@ func getPermissionsForUser(appCtx appcontext.AppContext, userID uuid.UUID) []str
 
 	session := appCtx.Session()
 	if session != nil {
-		for _, rp := range AllRolesPermissions {
-			if appCtx.Session().ActiveRole.RoleType == rp.RoleType {
-				userPermissions = append(userPermissions, rp.Permissions...)
-			}
-		}
+		return GetPermissionsForRole(session.ActiveRole.RoleType)
 	}
 
 	return userPermissions
+}
+
+func GetPermissionsForRole(roleType roles.RoleType) []string {
+	for _, rp := range AllRolesPermissions {
+		if rp.RoleType == roleType {
+			return rp.Permissions
+		}
+	}
+	return []string{}
 }

--- a/pkg/handlers/authentication/permissions.go
+++ b/pkg/handlers/authentication/permissions.go
@@ -2,7 +2,6 @@ package authentication
 
 import (
 	"github.com/gofrs/uuid"
-	"go.uber.org/zap"
 
 	"github.com/transcom/mymove/pkg/appcontext"
 	"github.com/transcom/mymove/pkg/auth"
@@ -139,20 +138,14 @@ var GSR = RolePermissions{
 var AllRolesPermissions = []RolePermissions{TOO, TIO, ServicesCounselor, QAE, CustomerServiceRepresentative, HQ, GSR, ContractingOfficer}
 
 // check if a [user.role] has permissions on a given object
-func checkUserPermission(appCtx appcontext.AppContext, session *auth.Session, permission string) (bool, error) {
-
-	logger := appCtx.Logger()
-	userPermissions := getPermissionsForUser(appCtx, session.UserID)
-
-	for _, perm := range userPermissions {
+func checkUserPermission(session auth.Session, permission string) bool {
+	for _, perm := range session.Permissions {
 		if permission == perm {
-			logger.Info("PERMISSION GRANTED: ", zap.String("permission", permission))
-			return true, nil
+			return true
 		}
 	}
 
-	logger.Warn("Permission not granted for user, ", zap.String("permission denied to user with session IDToken: ", session.IDToken))
-	return false, nil
+	return false
 }
 
 // for a given user return the permissions associated with their roles given the current session role

--- a/pkg/handlers/authentication/permissions_test.go
+++ b/pkg/handlers/authentication/permissions_test.go
@@ -1,0 +1,192 @@
+package authentication
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+
+	"github.com/transcom/mymove/pkg/auth"
+	"github.com/transcom/mymove/pkg/factory"
+	"github.com/transcom/mymove/pkg/models"
+	"github.com/transcom/mymove/pkg/models/roles"
+	roleService "github.com/transcom/mymove/pkg/services/roles"
+)
+
+func (suite *AuthSuite) TestSwitchRolesSuccess() {
+	tooPerms := GetPermissionsForRole(roles.RoleTypeTOO)
+
+	setupOfficeUserAndIdentity := func(userRoles []roles.RoleType) (models.OfficeUser, roles.Role) {
+		officeUser := factory.BuildOfficeUserWithRoles(
+			suite.DB(),
+			factory.GetTraitActiveOfficeUser(),
+			userRoles,
+		)
+
+		// default role is HQ because of alphabetical sorting
+		identity, err := models.FetchUserIdentity(suite.DB(), officeUser.User.OktaID)
+		suite.FatalNoError(err)
+		defaultRole, err := identity.Roles.Default()
+		suite.FatalNoError(err)
+		return officeUser, *defaultRole
+	}
+
+	suite.Run("Can successfully switch roles from HQ to TOO - 200", func() {
+		officeUser, defaultRole := setupOfficeUserAndIdentity([]roles.RoleType{roles.RoleTypeTOO, roles.RoleTypeHQ})
+
+		// Handler session starts with HQ
+		handlerSession := auth.Session{
+			ApplicationName: auth.OfficeApp,
+			UserID:          *officeUser.UserID,
+			IDToken:         "fake token",
+			ActiveRole:      defaultRole,
+		}
+
+		// Patch it to be TOO
+		hc := suite.NewHandlerConfig()
+		sessionMgr := hc.SessionManagers().Office
+		req := httptest.NewRequest("PATCH", "/auth/activeRole", nil)
+		req = suite.SetupSessionRequest(req, &handlerSession, sessionMgr)
+		handler := sessionMgr.LoadAndSave(NewActiveRoleUpdateHandler(
+			suite.AuthContext(),
+			hc,
+			roleService.NewRolesFetcher(),
+		))
+		payload, _ := json.Marshal(map[string]string{"roleType": string(roles.RoleTypeTOO)})
+		req.Body = io.NopCloser(bytes.NewReader(payload))
+		req.Host = "office.example.com"
+
+		rr := httptest.NewRecorder()
+
+		// Submit
+		handler.ServeHTTP(rr, req)
+
+		// Expect 200 OK
+		suite.Equal(http.StatusOK, rr.Code, "handler returned the wrong status code")
+
+		// Expect our session active role to now be TOO
+		// memory
+		suite.Equal(roles.RoleTypeTOO, handlerSession.ActiveRole.RoleType, "Handler memory session did not switch roles")
+		// session store
+		storeCtx, err := sessionMgr.Load(req.Context(), handlerSession.IDToken)
+		suite.FatalNoError(err)
+		suite.NotEmpty(storeCtx)
+
+		unCastedServerSession := sessionMgr.Get(storeCtx, "session")
+		castedServerSession, ok := unCastedServerSession.(*auth.Session)
+		suite.FatalTrue(ok)
+		suite.Equal(handlerSession.IDToken, castedServerSession.IDToken)
+		suite.Equal(roles.RoleTypeTOO, castedServerSession.ActiveRole.RoleType)
+		// Perms went from HQ -> TOO
+		suite.Equal(tooPerms, handlerSession.Permissions)
+		suite.Equal(tooPerms, castedServerSession.Permissions)
+	})
+
+	suite.Run("Error if context can't find session key - 500", func() {
+		// In the scenario the session manager and handler context differ
+		// in session keys, something bad has gone wrong, almost as if
+		// two session managers were created by the backend
+		officeUser, defaultRole := setupOfficeUserAndIdentity([]roles.RoleType{roles.RoleTypeTOO, roles.RoleTypeHQ})
+
+		// Handler session starts with HQ
+		handlerSession := auth.Session{
+			ApplicationName: auth.OfficeApp,
+			UserID:          *officeUser.UserID,
+			IDToken:         "fake token",
+			ActiveRole:      defaultRole,
+		}
+
+		// Patch it to be TOO
+
+		sessionMgr := suite.NewHandlerConfig().SessionManagers().Office
+		req := httptest.NewRequest("PATCH", "/auth/activeRole", nil)
+		req = suite.SetupSessionRequest(req, &handlerSession, sessionMgr)
+		handler := sessionMgr.LoadAndSave(NewActiveRoleUpdateHandler(
+			suite.AuthContext(),
+			suite.NewHandlerConfig(), // Creates a second, conflicting session manager causing the failure
+			roleService.NewRolesFetcher(),
+		))
+		payload, _ := json.Marshal(map[string]string{"roleType": string(roles.RoleTypeTOO)})
+		req.Body = io.NopCloser(bytes.NewReader(payload))
+		req.Host = "office.example.com"
+
+		rr := httptest.NewRecorder()
+
+		// Submit
+		handler.ServeHTTP(rr, req)
+
+		// Expect 500
+		suite.Equal(http.StatusInternalServerError, rr.Code, "handler returned the wrong status code")
+
+		// Expect our session active role to not be TOO
+		// memory
+		suite.NotEqual(roles.RoleTypeTOO, handlerSession.ActiveRole.RoleType, "Handler memory session switched roles when it shouldn't have")
+		// session store
+		storeCtx, err := sessionMgr.Load(req.Context(), handlerSession.IDToken)
+		suite.FatalNoError(err)
+		suite.NotEmpty(storeCtx)
+
+		unCastedServerSession := sessionMgr.Get(storeCtx, "session")
+		castedServerSession, ok := unCastedServerSession.(*auth.Session)
+		suite.FatalTrue(ok)
+		suite.Equal(handlerSession.IDToken, castedServerSession.IDToken)
+		suite.NotEqual(roles.RoleTypeTOO, castedServerSession.ActiveRole.RoleType, "Handler memory session switched roles when it shouldn't have")
+		// Perms should not be TOO
+		suite.NotEqual(tooPerms, handlerSession.Permissions)
+		suite.NotEqual(tooPerms, castedServerSession.Permissions)
+	})
+
+	suite.Run("Error if requested a role not assigned to the user - 403", func() {
+		// In the scenario the session manager and handler context differ
+		// in session keys, something bad has gone wrong, almost as if
+		// two session managers were created by the backend
+		officeUser, defaultRole := setupOfficeUserAndIdentity([]roles.RoleType{roles.RoleTypeHQ})
+
+		// Handler session starts with HQ
+		handlerSession := auth.Session{
+			ApplicationName: auth.OfficeApp,
+			UserID:          *officeUser.UserID,
+			IDToken:         "fake token",
+			ActiveRole:      defaultRole,
+		}
+
+		// Patch it to be TOO
+		sessionMgr := suite.NewHandlerConfig().SessionManagers().Office
+		req := httptest.NewRequest("PATCH", "/auth/activeRole", nil)
+		req = suite.SetupSessionRequest(req, &handlerSession, sessionMgr)
+		handler := sessionMgr.LoadAndSave(NewActiveRoleUpdateHandler(
+			suite.AuthContext(),
+			suite.NewHandlerConfig(), // Creates a second, conflicting session manager causing the failure
+			roleService.NewRolesFetcher(),
+		))
+		payload, _ := json.Marshal(map[string]string{"roleType": string(roles.RoleTypeTOO)})
+		req.Body = io.NopCloser(bytes.NewReader(payload))
+		req.Host = "office.example.com"
+
+		rr := httptest.NewRecorder()
+
+		// Submit
+		handler.ServeHTTP(rr, req)
+
+		// Expect 500
+		suite.Equal(http.StatusForbidden, rr.Code, "handler returned the wrong status code")
+
+		// Expect our session active role to not be TOO
+		// memory
+		suite.NotEqual(roles.RoleTypeTOO, handlerSession.ActiveRole.RoleType, "Handler memory session switched roles when it shouldn't have")
+		// session store
+		storeCtx, err := sessionMgr.Load(req.Context(), handlerSession.IDToken)
+		suite.FatalNoError(err)
+		suite.NotEmpty(storeCtx)
+
+		unCastedServerSession := sessionMgr.Get(storeCtx, "session")
+		castedServerSession, ok := unCastedServerSession.(*auth.Session)
+		suite.FatalTrue(ok)
+		suite.Equal(handlerSession.IDToken, castedServerSession.IDToken)
+		suite.NotEqual(roles.RoleTypeTOO, castedServerSession.ActiveRole.RoleType, "Handler memory session switched roles when it shouldn't have")
+		// Perms should not be TOO
+		suite.NotEqual(tooPerms, handlerSession.Permissions)
+		suite.NotEqual(tooPerms, castedServerSession.Permissions)
+	})
+}

--- a/pkg/handlers/ghcapi/addresses_test.go
+++ b/pkg/handlers/ghcapi/addresses_test.go
@@ -30,7 +30,7 @@ func (suite *HandlerSuite) TestGetLocationByZipCityHandler() {
 		}
 
 		handler := GetLocationByZipCityStateHandler{
-			HandlerConfig: suite.HandlerConfig(),
+			HandlerConfig: suite.NewHandlerConfig(),
 			VLocation:     vLocationService}
 
 		response := handler.Handle(params)

--- a/pkg/handlers/ghcapi/api_test.go
+++ b/pkg/handlers/ghcapi/api_test.go
@@ -32,7 +32,7 @@ func (suite *HandlerSuite) AfterTest() {
 }
 
 func (suite *HandlerSuite) createS3HandlerConfig() handlers.HandlerConfig {
-	handlerConfig := suite.HandlerConfig()
+	handlerConfig := suite.NewHandlerConfig()
 	fakeS3 := storageTest.NewFakeS3Storage(true)
 	handlerConfig.SetFileStorer(fakeS3)
 

--- a/pkg/handlers/ghcapi/application_parameters_test.go
+++ b/pkg/handlers/ghcapi/application_parameters_test.go
@@ -13,7 +13,7 @@ func (suite *HandlerSuite) TestApplicationParametersValidateHandler() {
 	req := httptest.NewRequest("GET", "/application_parameters", nil)
 	req = suite.AuthenticateUserRequest(req, user)
 
-	handlerConfig := suite.HandlerConfig()
+	handlerConfig := suite.NewHandlerConfig()
 	handler := ApplicationParametersParamHandler{
 		HandlerConfig: handlerConfig,
 	}

--- a/pkg/handlers/ghcapi/calendar_test.go
+++ b/pkg/handlers/ghcapi/calendar_test.go
@@ -38,7 +38,7 @@ func (suite *HandlerSuite) TestIsDateSelectionWeekendHolidayHandler() {
 		mock.AnythingOfType("time.Time"),
 	).Return(&info, nil)
 
-	showHandler := IsDateWeekendHolidayHandler{suite.HandlerConfig(), &mockDateSelectionChecker}
+	showHandler := IsDateWeekendHolidayHandler{suite.NewHandlerConfig(), &mockDateSelectionChecker}
 	response := showHandler.Handle(params)
 
 	suite.IsType(&calendarop.IsDateWeekendHolidayOK{}, response)

--- a/pkg/handlers/ghcapi/customer_support_remarks_test.go
+++ b/pkg/handlers/ghcapi/customer_support_remarks_test.go
@@ -54,7 +54,7 @@ func (suite *HandlerSuite) TestListCustomerRemarksForMoveHandler() {
 			HTTPRequest: request,
 			Locator:     remark.Move.Locator,
 		}
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 		handler := ListCustomerSupportRemarksHandler{
 			HandlerConfig:                 handlerConfig,
 			CustomerSupportRemarksFetcher: fetcher,
@@ -80,7 +80,7 @@ func (suite *HandlerSuite) TestListCustomerRemarksForMoveHandler() {
 			HTTPRequest: request,
 			Locator:     "ZZZZZZZZ",
 		}
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 		handler := ListCustomerSupportRemarksHandler{
 			HandlerConfig:                 handlerConfig,
 			CustomerSupportRemarksFetcher: fetcher,
@@ -101,7 +101,7 @@ func (suite *HandlerSuite) TestCreateCustomerSupportRemarksHandler() {
 	suite.Run("Successful POST", func() {
 		move := factory.BuildMove(suite.DB(), nil, nil)
 		officeUser := factory.BuildOfficeUserWithRoles(suite.DB(), nil, []roles.RoleType{roles.RoleTypeTOO})
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 
 		creator := &mocks.CustomerSupportRemarksCreator{}
 		handler := CreateCustomerSupportRemarksHandler{handlerConfig, creator}
@@ -154,7 +154,7 @@ func (suite *HandlerSuite) TestCreateCustomerSupportRemarksHandler() {
 	suite.Run("unsuccessful POST", func() {
 		move := factory.BuildMove(suite.DB(), nil, nil)
 
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 
 		creator := &mocks.CustomerSupportRemarksCreator{}
 		handler := CreateCustomerSupportRemarksHandler{handlerConfig, creator}
@@ -238,7 +238,7 @@ func (suite *HandlerSuite) TestUpdateCustomerSupportRemarksHandler() {
 			CustomerSupportRemarkID: strfmt.UUID(ogRemark.ID.String()),
 		}
 
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 		handler := UpdateCustomerSupportRemarkHandler{handlerConfig, updater}
 
 		updater.On("UpdateCustomerSupportRemark",
@@ -267,7 +267,7 @@ func (suite *HandlerSuite) TestUpdateCustomerSupportRemarksHandler() {
 			Content: &updatedRemark.Content,
 		}
 
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 		handler := UpdateCustomerSupportRemarkHandler{handlerConfig, updater}
 
 		params := customersupportremarksop.UpdateCustomerSupportRemarkForMoveParams{
@@ -299,7 +299,7 @@ func (suite *HandlerSuite) TestDeleteCustomerSupportRemarksHandler() {
 		remarkID := uuid.Must(uuid.NewV4())
 
 		deleter := &mocks.CustomerSupportRemarkDeleter{}
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 		handler := DeleteCustomerSupportRemarkHandler{handlerConfig, deleter}
 
 		request := httptest.NewRequest("DELETE", fmt.Sprintf("/customer-support-remarks/%s/", remarkID.String()), nil)
@@ -327,7 +327,7 @@ func (suite *HandlerSuite) TestDeleteCustomerSupportRemarksHandler() {
 		remarkID := uuid.Must(uuid.NewV4())
 
 		deleter := &mocks.CustomerSupportRemarkDeleter{}
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 		handler := DeleteCustomerSupportRemarkHandler{handlerConfig, deleter}
 
 		request := httptest.NewRequest("DELETE", fmt.Sprintf("/customer-support-remarks/%s/", remarkID.String()), nil)

--- a/pkg/handlers/ghcapi/customer_test.go
+++ b/pkg/handlers/ghcapi/customer_test.go
@@ -34,7 +34,7 @@ func (suite *HandlerSuite) TestGetCustomerHandlerIntegration() {
 		HTTPRequest: request,
 		CustomerID:  strfmt.UUID(customer.ID.String()),
 	}
-	handlerConfig := suite.HandlerConfig()
+	handlerConfig := suite.NewHandlerConfig()
 	handler := GetCustomerHandler{
 		handlerConfig,
 		customerservice.NewCustomerFetcher(),
@@ -94,7 +94,7 @@ func (suite *HandlerSuite) TestUpdateCustomerHandler() {
 		IfMatch:     etag.GenerateEtag(customer.UpdatedAt),
 		Body:        body,
 	}
-	handlerConfig := suite.HandlerConfig()
+	handlerConfig := suite.NewHandlerConfig()
 	handler := UpdateCustomerHandler{
 		handlerConfig,
 		customerservice.NewCustomerUpdater(),
@@ -194,7 +194,7 @@ func (suite *HandlerSuite) TestCreateCustomerWithOktaOptionHandler() {
 			HTTPRequest: request,
 			Body:        body,
 		}
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 		handler := CreateCustomerWithOktaOptionHandler{
 			handlerConfig,
 		}
@@ -286,7 +286,7 @@ func (suite *HandlerSuite) TestCreateCustomerWithOktaOptionHandler() {
 			HTTPRequest: request,
 			Body:        body,
 		}
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 		handler := CreateCustomerWithOktaOptionHandler{
 			handlerConfig,
 		}
@@ -371,7 +371,7 @@ func (suite *HandlerSuite) TestCreateCustomerWithOktaOptionHandler() {
 			HTTPRequest: request,
 			Body:        body,
 		}
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 		handler := CreateCustomerWithOktaOptionHandler{
 			handlerConfig,
 		}
@@ -444,7 +444,7 @@ func (suite *HandlerSuite) TestCreateCustomerWithOktaOptionHandler() {
 			HTTPRequest: request,
 			Body:        body,
 		}
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 		handler := CreateCustomerWithOktaOptionHandler{
 			handlerConfig,
 		}
@@ -472,7 +472,7 @@ func (suite *HandlerSuite) TestSearchCustomersHandler() {
 		mockSearcher := mocks.CustomerSearcher{}
 
 		handler := SearchCustomersHandler{
-			HandlerConfig:    suite.HandlerConfig(),
+			HandlerConfig:    suite.NewHandlerConfig(),
 			CustomerSearcher: &mockSearcher,
 		}
 		mockSearcher.On("SearchCustomers",
@@ -507,7 +507,7 @@ func (suite *HandlerSuite) TestSearchCustomersHandler() {
 		mockSearcher := mocks.CustomerSearcher{}
 
 		handler := SearchCustomersHandler{
-			HandlerConfig:    suite.HandlerConfig(),
+			HandlerConfig:    suite.NewHandlerConfig(),
 			CustomerSearcher: &mockSearcher,
 		}
 		mockSearcher.On("SearchCustomers",

--- a/pkg/handlers/ghcapi/documents_test.go
+++ b/pkg/handlers/ghcapi/documents_test.go
@@ -38,7 +38,7 @@ func (suite *HandlerSuite) TestGetDocumentHandler() {
 	req = suite.AuthenticateRequest(req, document.ServiceMember)
 	params.HTTPRequest = req
 
-	handlerConfig := suite.HandlerConfig()
+	handlerConfig := suite.NewHandlerConfig()
 	fakeS3 := storageTest.NewFakeS3Storage(true)
 	handlerConfig.SetFileStorer(fakeS3)
 	handler := GetDocumentHandler{handlerConfig}
@@ -105,7 +105,7 @@ func (suite *HandlerSuite) TestGetDocumentHandlerForFilenamesWithCommas() {
 	req = suite.AuthenticateRequest(req, document.ServiceMember)
 	params.HTTPRequest = req
 
-	handlerConfig := suite.HandlerConfig()
+	handlerConfig := suite.NewHandlerConfig()
 	fakeS3 := storageTest.NewFakeS3Storage(true)
 	handlerConfig.SetFileStorer(fakeS3)
 	handler := GetDocumentHandler{handlerConfig}
@@ -161,7 +161,7 @@ func (suite *HandlerSuite) TestCreateDocumentsHandler() {
 	req = suite.AuthenticateOfficeRequest(req, officeUser)
 	params.HTTPRequest = req
 
-	handler := CreateDocumentHandler{HandlerConfig: suite.HandlerConfig()}
+	handler := CreateDocumentHandler{HandlerConfig: suite.NewHandlerConfig()}
 	response := handler.Handle(params)
 
 	createdResponse, ok := response.(*documentop.CreateDocumentCreated)

--- a/pkg/handlers/ghcapi/evaluation_report_test.go
+++ b/pkg/handlers/ghcapi/evaluation_report_test.go
@@ -108,7 +108,7 @@ func (suite *HandlerSuite) TestGetCounselingEvaluationReportsHandler() {
 	setupTestData := func() (models.OfficeUser, models.Move, handlers.HandlerConfig) {
 		move := factory.BuildMove(suite.DB(), nil, nil)
 		officeUser := factory.BuildOfficeUserWithRoles(suite.DB(), nil, []roles.RoleType{roles.RoleTypeTOO})
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 		return officeUser, move, handlerConfig
 	}
 
@@ -183,7 +183,7 @@ func (suite *HandlerSuite) TestGetCounselingEvaluationReportsHandler() {
 func (suite *HandlerSuite) TestGetEvaluationReportByIDHandler() {
 	// 200 response
 	suite.Run("Successful fetch (integration) test", func() {
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 		move := factory.BuildMove(suite.DB(), nil, nil)
 		officeUser := factory.BuildOfficeUserWithRoles(suite.DB(), nil, []roles.RoleType{roles.RoleTypeTOO})
 		fetcher := evaluationreportservice.NewEvaluationReportFetcher()
@@ -227,7 +227,7 @@ func (suite *HandlerSuite) TestGetEvaluationReportByIDHandler() {
 		officeUser := factory.BuildOfficeUser(nil, nil, nil)
 
 		uuidForReport, _ := uuid.NewV4()
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 		mockFetcher := mocks.EvaluationReportFetcher{}
 		request := httptest.NewRequest("GET", fmt.Sprintf("/evaluation-reports/%s", uuidForReport.String()), nil)
 		request = suite.AuthenticateOfficeRequest(request, officeUser)
@@ -261,7 +261,7 @@ func (suite *HandlerSuite) TestGetEvaluationReportByIDHandler() {
 	suite.Run("403 response when service returns forbidden", func() {
 		officeUser := factory.BuildOfficeUser(nil, nil, nil)
 		uuidForReport, _ := uuid.NewV4()
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 		mockFetcher := mocks.EvaluationReportFetcher{}
 		request := httptest.NewRequest("GET", fmt.Sprintf("/evaluation-reports/%s", uuidForReport.String()), nil)
 		request = suite.AuthenticateOfficeRequest(request, officeUser)
@@ -298,7 +298,7 @@ func (suite *HandlerSuite) TestCreateEvaluationReportHandler() {
 
 	suite.Run("Successful POST", func() {
 
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 
 		creator := &mocks.EvaluationReportCreator{}
 		move := factory.BuildMove(suite.DB(), nil, nil)
@@ -356,7 +356,7 @@ func (suite *HandlerSuite) TestCreateEvaluationReportHandler() {
 
 	suite.Run("Unsuccessful POST", func() {
 
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 
 		creator := &mocks.EvaluationReportCreator{}
 		handler := CreateEvaluationReportHandler{handlerConfig, creator}
@@ -400,7 +400,7 @@ func (suite *HandlerSuite) TestDeleteEvaluationReportHandler() {
 		reportID := uuid.Must(uuid.NewV4())
 
 		deleter := &mocks.EvaluationReportDeleter{}
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 		handler := DeleteEvaluationReportHandler{handlerConfig, deleter}
 
 		request := httptest.NewRequest("DELETE", fmt.Sprintf("/evaluation-reports/%s", reportID), nil)
@@ -430,7 +430,7 @@ func (suite *HandlerSuite) TestSubmitEvaluationReportHandler() {
 		updater := &mocks.EvaluationReportUpdater{}
 
 		reportID := uuid.Must(uuid.NewV4())
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 		handler := SubmitEvaluationReportHandler{handlerConfig, updater}
 		requestUser := factory.BuildOfficeUser(nil, nil, []factory.Trait{
 			factory.GetTraitOfficeUserWithID,
@@ -464,7 +464,7 @@ func (suite *HandlerSuite) TestSubmitEvaluationReportHandler() {
 		updater := &mocks.EvaluationReportUpdater{}
 
 		reportID := uuid.Must(uuid.NewV4())
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 		handler := SubmitEvaluationReportHandler{handlerConfig, updater}
 		requestUser := factory.BuildOfficeUser(nil, nil, []factory.Trait{
 			factory.GetTraitOfficeUserWithID,
@@ -500,7 +500,7 @@ func (suite *HandlerSuite) TestSubmitEvaluationReportHandler() {
 		updater := &mocks.EvaluationReportUpdater{}
 
 		reportID := uuid.Must(uuid.NewV4())
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 		handler := SubmitEvaluationReportHandler{handlerConfig, updater}
 		requestUser := factory.BuildOfficeUser(nil, nil, []factory.Trait{
 			factory.GetTraitOfficeUserWithID,
@@ -536,7 +536,7 @@ func (suite *HandlerSuite) TestSubmitEvaluationReportHandler() {
 		updater := &mocks.EvaluationReportUpdater{}
 
 		reportID := uuid.Must(uuid.NewV4())
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 		handler := SubmitEvaluationReportHandler{handlerConfig, updater}
 		requestUser := factory.BuildOfficeUser(nil, nil, []factory.Trait{
 			factory.GetTraitOfficeUserWithID,
@@ -572,7 +572,7 @@ func (suite *HandlerSuite) TestSubmitEvaluationReportHandler() {
 		updater := &mocks.EvaluationReportUpdater{}
 
 		reportID := uuid.Must(uuid.NewV4())
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 		handler := SubmitEvaluationReportHandler{handlerConfig, updater}
 		requestUser := factory.BuildOfficeUser(nil, nil, []factory.Trait{
 			factory.GetTraitOfficeUserWithID,
@@ -608,7 +608,7 @@ func (suite *HandlerSuite) TestSubmitEvaluationReportHandler() {
 		updater := &mocks.EvaluationReportUpdater{}
 
 		reportID := uuid.Must(uuid.NewV4())
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 		handler := SubmitEvaluationReportHandler{handlerConfig, updater}
 		requestUser := factory.BuildOfficeUser(nil, nil, []factory.Trait{
 			factory.GetTraitOfficeUserWithID,
@@ -648,7 +648,7 @@ func (suite *HandlerSuite) TestSaveEvaluationReportHandler() {
 		reportID := report.ID
 
 		updater := &mocks.EvaluationReportUpdater{}
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 		handler := SaveEvaluationReportHandler{handlerConfig, updater}
 		requestUser := factory.BuildUser(nil, nil, nil) //Build stubbed user
 
@@ -693,7 +693,7 @@ func (suite *HandlerSuite) TestSaveEvaluationReportHandler() {
 		reportID := uuid.Must(uuid.NewV4())
 
 		updater := &mocks.EvaluationReportUpdater{}
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 		handler := SaveEvaluationReportHandler{handlerConfig, updater}
 		requestUser := factory.BuildUser(nil, nil, nil)
 
@@ -731,7 +731,7 @@ func (suite *HandlerSuite) TestSaveEvaluationReportHandler() {
 		reportID := uuid.Must(uuid.NewV4())
 
 		updater := &mocks.EvaluationReportUpdater{}
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 		handler := SaveEvaluationReportHandler{handlerConfig, updater}
 		requestUser := factory.BuildUser(nil, nil, nil)
 
@@ -769,7 +769,7 @@ func (suite *HandlerSuite) TestSaveEvaluationReportHandler() {
 		reportID := uuid.Must(uuid.NewV4())
 
 		updater := &mocks.EvaluationReportUpdater{}
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 		handler := SaveEvaluationReportHandler{handlerConfig, updater}
 		requestUser := factory.BuildUser(nil, nil, nil)
 
@@ -807,7 +807,7 @@ func (suite *HandlerSuite) TestSaveEvaluationReportHandler() {
 		reportID := uuid.Must(uuid.NewV4())
 
 		updater := &mocks.EvaluationReportUpdater{}
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 		handler := SaveEvaluationReportHandler{handlerConfig, updater}
 		requestUser := factory.BuildUser(nil, nil, nil)
 
@@ -845,7 +845,7 @@ func (suite *HandlerSuite) TestSaveEvaluationReportHandler() {
 		reportID := uuid.Must(uuid.NewV4())
 
 		updater := &mocks.EvaluationReportUpdater{}
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 		handler := SaveEvaluationReportHandler{handlerConfig, updater}
 		requestUser := factory.BuildUser(nil, nil, nil)
 
@@ -883,7 +883,7 @@ func (suite *HandlerSuite) TestSaveEvaluationReportHandler() {
 		reportID := uuid.Must(uuid.NewV4())
 
 		updater := &mocks.EvaluationReportUpdater{}
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 		handler := SaveEvaluationReportHandler{handlerConfig, updater}
 		requestUser := factory.BuildUser(nil, nil, nil)
 
@@ -928,7 +928,7 @@ func (suite *HandlerSuite) TestDownloadEvaluationReportHandler() {
 		shipmentFetcher := &mocks.MTOShipmentFetcher{}
 		orderFetcher := &mocks.OrderFetcher{}
 		violationsFetcher := &mocks.ReportViolationFetcher{}
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 		handler := DownloadEvaluationReportHandler{
 			HandlerConfig:           handlerConfig,
 			EvaluationReportFetcher: reportFetcher,
@@ -981,7 +981,7 @@ func (suite *HandlerSuite) TestDownloadEvaluationReportHandler() {
 		reportID := uuid.Must(uuid.NewV4())
 
 		reportFetcher := &mocks.EvaluationReportFetcher{}
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 		handler := DownloadEvaluationReportHandler{
 			HandlerConfig:           handlerConfig,
 			EvaluationReportFetcher: reportFetcher,
@@ -1016,7 +1016,7 @@ func (suite *HandlerSuite) TestDownloadEvaluationReportHandler() {
 		reportID := uuid.Must(uuid.NewV4())
 
 		reportFetcher := &mocks.EvaluationReportFetcher{}
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 		handler := DownloadEvaluationReportHandler{
 			HandlerConfig:           handlerConfig,
 			EvaluationReportFetcher: reportFetcher,
@@ -1051,7 +1051,7 @@ func (suite *HandlerSuite) TestDownloadEvaluationReportHandler() {
 		reportID := uuid.Must(uuid.NewV4())
 
 		reportFetcher := &mocks.EvaluationReportFetcher{}
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 		handler := DownloadEvaluationReportHandler{
 			HandlerConfig:           handlerConfig,
 			EvaluationReportFetcher: reportFetcher,
@@ -1085,7 +1085,7 @@ func (suite *HandlerSuite) TestDownloadEvaluationReportHandler() {
 
 func (suite *HandlerSuite) TestAddAppealToViolationHandler() {
 	suite.Run("Successful Add Appeal to Violation", func() {
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 		mockService := &mocks.ReportViolationsAddAppeal{}
 		handler := AddAppealToViolationHandler{
 			HandlerConfig:             handlerConfig,
@@ -1111,7 +1111,7 @@ func (suite *HandlerSuite) TestAddAppealToViolationHandler() {
 	})
 
 	suite.Run("Unsuccessful Add Appeal to Violation - Missing Data", func() {
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 		mockService := &mocks.ReportViolationsAddAppeal{}
 		handler := AddAppealToViolationHandler{
 			HandlerConfig:             handlerConfig,
@@ -1133,7 +1133,7 @@ func (suite *HandlerSuite) TestAddAppealToViolationHandler() {
 	})
 
 	suite.Run("Unsuccessful Add Appeal to Violation - Service Error", func() {
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 		mockService := &mocks.ReportViolationsAddAppeal{}
 		handler := AddAppealToViolationHandler{
 			HandlerConfig:             handlerConfig,
@@ -1161,7 +1161,7 @@ func (suite *HandlerSuite) TestAddAppealToViolationHandler() {
 
 func (suite *HandlerSuite) TestAddAppealToSeriousIncidentHandler() {
 	suite.Run("Successful Add Appeal to Serious Incident", func() {
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 		mockService := &mocks.SeriousIncidentAddAppeal{}
 		handler := AddAppealToSeriousIncidentHandler{
 			HandlerConfig:            handlerConfig,
@@ -1185,7 +1185,7 @@ func (suite *HandlerSuite) TestAddAppealToSeriousIncidentHandler() {
 	})
 
 	suite.Run("Unsuccessful Add Appeal to Serious Incident - Missing Data", func() {
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 		mockService := &mocks.SeriousIncidentAddAppeal{}
 		handler := AddAppealToSeriousIncidentHandler{
 			HandlerConfig:            handlerConfig,
@@ -1205,7 +1205,7 @@ func (suite *HandlerSuite) TestAddAppealToSeriousIncidentHandler() {
 	})
 
 	suite.Run("Unsuccessful Add Appeal to Serious Incident - Service Error", func() {
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 		mockService := &mocks.SeriousIncidentAddAppeal{}
 		handler := AddAppealToSeriousIncidentHandler{
 			HandlerConfig:            handlerConfig,

--- a/pkg/handlers/ghcapi/lines_of_accounting_test.go
+++ b/pkg/handlers/ghcapi/lines_of_accounting_test.go
@@ -115,7 +115,7 @@ func (suite *HandlerSuite) TestLinesOfAccountingRequestLineOfAccountingHandler()
 
 			loaFetcher := createLoaFetcher()
 			handler := LinesOfAccountingRequestLineOfAccountingHandler{
-				HandlerConfig:           suite.HandlerConfig(),
+				HandlerConfig:           suite.NewHandlerConfig(),
 				LineOfAccountingFetcher: loaFetcher,
 			}
 
@@ -160,7 +160,7 @@ func (suite *HandlerSuite) TestLinesOfAccountingRequestLineOfAccountingHandler()
 	suite.Run("Returns 200 on LOA fetcher giving sql err rows not found", func() {
 		mockLoaFetcher := &mocks.LineOfAccountingFetcher{}
 		handler := LinesOfAccountingRequestLineOfAccountingHandler{
-			HandlerConfig:           suite.HandlerConfig(),
+			HandlerConfig:           suite.NewHandlerConfig(),
 			LineOfAccountingFetcher: mockLoaFetcher,
 		}
 		req := httptest.NewRequest("POST", "/lines-of-accounting", nil)
@@ -184,7 +184,7 @@ func (suite *HandlerSuite) TestLinesOfAccountingRequestLineOfAccountingHandler()
 	suite.Run("Returns 500 on LOA fetcher erroring without sql no rows", func() {
 		mockLoaFetcher := &mocks.LineOfAccountingFetcher{}
 		handler := LinesOfAccountingRequestLineOfAccountingHandler{
-			HandlerConfig:           suite.HandlerConfig(),
+			HandlerConfig:           suite.NewHandlerConfig(),
 			LineOfAccountingFetcher: mockLoaFetcher,
 		}
 		req := httptest.NewRequest("POST", "/lines-of-accounting", nil)

--- a/pkg/handlers/ghcapi/move_history_test.go
+++ b/pkg/handlers/ghcapi/move_history_test.go
@@ -68,7 +68,7 @@ func (suite *HandlerSuite) TestMockGetMoveHistoryHandler() {
 		}
 
 		handler := GetMoveHistoryHandler{
-			HandlerConfig:      suite.HandlerConfig(),
+			HandlerConfig:      suite.NewHandlerConfig(),
 			MoveHistoryFetcher: &mockHistoryFetcher,
 		}
 
@@ -119,7 +119,7 @@ func (suite *HandlerSuite) TestMockGetMoveHistoryHandler() {
 		req = suite.AuthenticateUserRequest(req, requestUser)
 
 		handler := GetMoveHistoryHandler{
-			HandlerConfig:      suite.HandlerConfig(),
+			HandlerConfig:      suite.NewHandlerConfig(),
 			MoveHistoryFetcher: &mockHistoryFetcher,
 		}
 
@@ -153,7 +153,7 @@ func (suite *HandlerSuite) TestMockGetMoveHistoryHandler() {
 		}
 
 		handler := GetMoveHistoryHandler{
-			HandlerConfig:      suite.HandlerConfig(),
+			HandlerConfig:      suite.NewHandlerConfig(),
 			MoveHistoryFetcher: &mockHistoryFetcher,
 		}
 
@@ -186,7 +186,7 @@ func (suite *HandlerSuite) TestMockGetMoveHistoryHandler() {
 		}
 
 		handler := GetMoveHistoryHandler{
-			HandlerConfig:      suite.HandlerConfig(),
+			HandlerConfig:      suite.NewHandlerConfig(),
 			MoveHistoryFetcher: &mockHistoryFetcher,
 		}
 
@@ -234,7 +234,7 @@ func (suite *HandlerSuite) TestMockGetMoveHistoryHandler() {
 			PerPage:     models.Int64Pointer(2), // This should limit results to only the first 2 records of the possible 4
 		}
 
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 		handler := GetMoveHistoryHandler{
 			handlerConfig,
 			movehistory.NewMoveHistoryFetcher(),

--- a/pkg/handlers/ghcapi/move_task_order.go
+++ b/pkg/handlers/ghcapi/move_task_order.go
@@ -158,7 +158,7 @@ func (h UpdateMTOStatusServiceCounselingCompletedHandlerFunc) Handle(params move
 			}
 
 			if !appCtx.Session().IsOfficeUser() ||
-				!(appCtx.Session().CurrentRole.RoleType == roles.RoleTypeServicesCounselor) {
+				!(appCtx.Session().ActiveRole.RoleType == roles.RoleTypeServicesCounselor) {
 				return handleError(apperror.NewForbiddenError("is not a Services Counselor"))
 			}
 

--- a/pkg/handlers/ghcapi/move_task_order.go
+++ b/pkg/handlers/ghcapi/move_task_order.go
@@ -158,7 +158,7 @@ func (h UpdateMTOStatusServiceCounselingCompletedHandlerFunc) Handle(params move
 			}
 
 			if !appCtx.Session().IsOfficeUser() ||
-				!appCtx.Session().Roles.HasRole(roles.RoleTypeServicesCounselor) {
+				!(appCtx.Session().CurrentRole.RoleType == roles.RoleTypeServicesCounselor) {
 				return handleError(apperror.NewForbiddenError("is not a Services Counselor"))
 			}
 

--- a/pkg/handlers/ghcapi/move_task_order_test.go
+++ b/pkg/handlers/ghcapi/move_task_order_test.go
@@ -52,7 +52,7 @@ func (suite *HandlerSuite) TestGetMoveTaskOrderHandlerIntegration() {
 		HTTPRequest:     request,
 		MoveTaskOrderID: moveTaskOrder.ID.String(),
 	}
-	handlerConfig := suite.HandlerConfig()
+	handlerConfig := suite.NewHandlerConfig()
 	handler := GetMoveTaskOrderHandler{
 		handlerConfig,
 		movetaskorder.NewMoveTaskOrderFetcher(waf),
@@ -182,7 +182,7 @@ func (suite *HandlerSuite) TestUpdateMoveTaskOrderHandlerIntegrationSuccess() {
 			IfMatch:          etag.GenerateEtag(move.UpdatedAt),
 			ServiceItemCodes: &serviceItemCodes,
 		}
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 		handlerConfig.SetNotificationSender(notifications.NewStubNotificationSender("milmovelocal"))
 		queryBuilder := query.NewQueryBuilder()
 		moveRouter := moverouter.NewMoveRouter(transportationoffice.NewTransportationOfficesFetcher())
@@ -256,7 +256,7 @@ func (suite *HandlerSuite) TestUpdateMoveTaskOrderHandlerIntegrationWithStaleEta
 		MoveTaskOrderID: move.ID.String(),
 		IfMatch:         etag.GenerateEtag(time.Now()),
 	}
-	handlerConfig := suite.HandlerConfig()
+	handlerConfig := suite.NewHandlerConfig()
 
 	// Stale ETags are already unit tested in the move_task_order_updater_test,
 	// so we can mock this here to speed up the test and avoid hitting the DB
@@ -304,7 +304,7 @@ func (suite *HandlerSuite) TestUpdateMoveTaskOrderHandlerIntegrationWithIncomple
 		MoveTaskOrderID: move.ID.String(),
 		IfMatch:         etag.GenerateEtag(move.UpdatedAt),
 	}
-	handlerConfig := suite.HandlerConfig()
+	handlerConfig := suite.NewHandlerConfig()
 	queryBuilder := query.NewQueryBuilder()
 	moveRouter := moverouter.NewMoveRouter(transportationoffice.NewTransportationOfficesFetcher())
 	ppmEstimator := &mocks.PPMEstimator{}
@@ -393,7 +393,7 @@ func (suite *HandlerSuite) TestUpdateMTOStatusServiceCounselingCompletedHandler(
 	}
 
 	setupTestData := func() UpdateMTOStatusServiceCounselingCompletedHandlerFunc {
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 		queryBuilder := query.NewQueryBuilder()
 		moveRouter := moverouter.NewMoveRouter(transportationoffice.NewTransportationOfficesFetcher())
 		planner := &routemocks.Planner{}
@@ -612,7 +612,7 @@ func (suite *HandlerSuite) TestUpdateMoveTIORemarksHandler() {
 			},
 		}, nil)
 		requestUser := factory.BuildUser(nil, nil, nil)
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 		queryBuilder := query.NewQueryBuilder()
 		moveRouter := moverouter.NewMoveRouter(transportationoffice.NewTransportationOfficesFetcher())
 		planner := &routemocks.Planner{}

--- a/pkg/handlers/ghcapi/move_test.go
+++ b/pkg/handlers/ghcapi/move_test.go
@@ -57,7 +57,7 @@ func (suite *HandlerSuite) TestGetMoveHandler() {
 		mockLocker := movelocker.NewMoveLocker()
 
 		handler := GetMoveHandler{
-			HandlerConfig: suite.HandlerConfig(),
+			HandlerConfig: suite.NewHandlerConfig(),
 			MoveFetcher:   &mockFetcher,
 			MoveLocker:    mockLocker,
 		}
@@ -134,7 +134,7 @@ func (suite *HandlerSuite) TestGetMoveHandler() {
 		// Validate incoming payload: no body to validate
 
 		handler := GetMoveHandler{
-			HandlerConfig: suite.HandlerConfig(),
+			HandlerConfig: suite.NewHandlerConfig(),
 			MoveFetcher:   &mockFetcher,
 			MoveLocker:    mockLocker,
 		}
@@ -163,7 +163,7 @@ func (suite *HandlerSuite) TestGetMoveHandler() {
 		mockFetcher := mocks.MoveFetcher{}
 
 		handler := GetMoveHandler{
-			HandlerConfig: suite.HandlerConfig(),
+			HandlerConfig: suite.NewHandlerConfig(),
 			MoveFetcher:   &mockFetcher,
 		}
 		req := httptest.NewRequest("GET", "/move/#{move.locator}", nil)
@@ -185,7 +185,7 @@ func (suite *HandlerSuite) TestGetMoveHandler() {
 		mockLocker := movelocker.NewMoveLocker()
 
 		handler := GetMoveHandler{
-			HandlerConfig: suite.HandlerConfig(),
+			HandlerConfig: suite.NewHandlerConfig(),
 			MoveFetcher:   &mockFetcher,
 			MoveLocker:    mockLocker,
 		}
@@ -216,7 +216,7 @@ func (suite *HandlerSuite) TestGetMoveHandler() {
 		mockLocker := movelocker.NewMoveLocker()
 
 		handler := GetMoveHandler{
-			HandlerConfig: suite.HandlerConfig(),
+			HandlerConfig: suite.NewHandlerConfig(),
 			MoveFetcher:   &mockFetcher,
 			MoveLocker:    mockLocker,
 		}
@@ -250,7 +250,7 @@ func (suite *HandlerSuite) TestGetMoveHandler() {
 		mockLocker := movelocker.NewMoveLocker()
 
 		handler := GetMoveHandler{
-			HandlerConfig: suite.HandlerConfig(),
+			HandlerConfig: suite.NewHandlerConfig(),
 			MoveFetcher:   &mockFetcher,
 			MoveLocker:    mockLocker,
 		}
@@ -467,7 +467,7 @@ func (suite *HandlerSuite) TestSearchMovesHandler() {
 
 		mockUnlocker := movelocker.NewMoveUnlocker()
 		handler := SearchMovesHandler{
-			HandlerConfig: suite.HandlerConfig(),
+			HandlerConfig: suite.NewHandlerConfig(),
 			MoveSearcher:  &mockSearcher,
 			MoveUnlocker:  mockUnlocker,
 		}
@@ -519,7 +519,7 @@ func (suite *HandlerSuite) TestSearchMovesHandler() {
 		mockSearcher := mocks.MoveSearcher{}
 
 		handler := SearchMovesHandler{
-			HandlerConfig: suite.HandlerConfig(),
+			HandlerConfig: suite.NewHandlerConfig(),
 			MoveSearcher:  &mockSearcher,
 		}
 		mockSearcher.On("SearchMoves",
@@ -564,7 +564,7 @@ func (suite *HandlerSuite) TestSearchMovesHandler() {
 		mockSearcher := mocks.MoveSearcher{}
 		mockUnlocker := movelocker.NewMoveUnlocker()
 		handler := SearchMovesHandler{
-			HandlerConfig: suite.HandlerConfig(),
+			HandlerConfig: suite.NewHandlerConfig(),
 			MoveSearcher:  &mockSearcher,
 			MoveUnlocker:  mockUnlocker,
 		}
@@ -703,7 +703,7 @@ func (suite *HandlerSuite) TestSetFinancialReviewFlagHandler() {
 		req, move := setupTestData()
 		mockFlagSetter := mocks.MoveFinancialReviewFlagSetter{}
 		handler := SetFinancialReviewFlagHandler{
-			HandlerConfig:                 suite.HandlerConfig(),
+			HandlerConfig:                 suite.NewHandlerConfig(),
 			MoveFinancialReviewFlagSetter: &mockFlagSetter,
 		}
 		mockFlagSetter.On("SetFinancialReviewFlag",
@@ -748,7 +748,7 @@ func (suite *HandlerSuite) TestSetFinancialReviewFlagHandler() {
 		}
 		mockFlagSetter := mocks.MoveFinancialReviewFlagSetter{}
 		handler := SetFinancialReviewFlagHandler{
-			HandlerConfig:                 suite.HandlerConfig(),
+			HandlerConfig:                 suite.NewHandlerConfig(),
 			MoveFinancialReviewFlagSetter: &mockFlagSetter,
 		}
 
@@ -767,7 +767,7 @@ func (suite *HandlerSuite) TestSetFinancialReviewFlagHandler() {
 		req, move := setupTestData()
 		mockFlagSetter := mocks.MoveFinancialReviewFlagSetter{}
 		handler := SetFinancialReviewFlagHandler{
-			HandlerConfig:                 suite.HandlerConfig(),
+			HandlerConfig:                 suite.NewHandlerConfig(),
 			MoveFinancialReviewFlagSetter: &mockFlagSetter,
 		}
 		mockFlagSetter.On("SetFinancialReviewFlag",
@@ -803,7 +803,7 @@ func (suite *HandlerSuite) TestSetFinancialReviewFlagHandler() {
 		req, move := setupTestData()
 		mockFlagSetter := mocks.MoveFinancialReviewFlagSetter{}
 		handler := SetFinancialReviewFlagHandler{
-			HandlerConfig:                 suite.HandlerConfig(),
+			HandlerConfig:                 suite.NewHandlerConfig(),
 			MoveFinancialReviewFlagSetter: &mockFlagSetter,
 		}
 		mockFlagSetter.On("SetFinancialReviewFlag",
@@ -839,7 +839,7 @@ func (suite *HandlerSuite) TestSetFinancialReviewFlagHandler() {
 		req, move := setupTestData()
 		mockFlagSetter := mocks.MoveFinancialReviewFlagSetter{}
 		handler := SetFinancialReviewFlagHandler{
-			HandlerConfig:                 suite.HandlerConfig(),
+			HandlerConfig:                 suite.NewHandlerConfig(),
 			MoveFinancialReviewFlagSetter: &mockFlagSetter,
 		}
 		mockFlagSetter.On("SetFinancialReviewFlag",
@@ -898,7 +898,7 @@ func (suite *HandlerSuite) TestUpdateMoveCloseoutOfficeHandler() {
 	suite.Run("Successful update of closeout office", func() {
 		req, move, transportationOffice := setupTestData()
 		handler := UpdateMoveCloseoutOfficeHandler{
-			HandlerConfig:             suite.HandlerConfig(),
+			HandlerConfig:             suite.NewHandlerConfig(),
 			MoveCloseoutOfficeUpdater: closeoutOfficeUpdater,
 		}
 
@@ -930,7 +930,7 @@ func (suite *HandlerSuite) TestUpdateMoveCloseoutOfficeHandler() {
 	suite.Run("Unsuccessful move not found", func() {
 		req, move, transportationOffice := setupTestData()
 		handler := UpdateMoveCloseoutOfficeHandler{
-			HandlerConfig:             suite.HandlerConfig(),
+			HandlerConfig:             suite.NewHandlerConfig(),
 			MoveCloseoutOfficeUpdater: closeoutOfficeUpdater,
 		}
 
@@ -962,7 +962,7 @@ func (suite *HandlerSuite) TestUpdateMoveCloseoutOfficeHandler() {
 
 		req, move, _ := setupTestData()
 		handler := UpdateMoveCloseoutOfficeHandler{
-			HandlerConfig:             suite.HandlerConfig(),
+			HandlerConfig:             suite.NewHandlerConfig(),
 			MoveCloseoutOfficeUpdater: closeoutOfficeUpdater,
 		}
 
@@ -986,7 +986,7 @@ func (suite *HandlerSuite) TestUpdateMoveCloseoutOfficeHandler() {
 	suite.Run("Unsuccessful eTag does not match", func() {
 		req, move, transportationOffice := setupTestData()
 		handler := UpdateMoveCloseoutOfficeHandler{
-			HandlerConfig:             suite.HandlerConfig(),
+			HandlerConfig:             suite.NewHandlerConfig(),
 			MoveCloseoutOfficeUpdater: closeoutOfficeUpdater,
 		}
 
@@ -1081,7 +1081,7 @@ func (suite *HandlerSuite) TestUpdateAssignedOfficeUserHandler() {
 		req = suite.AuthenticateOfficeRequest(req, assignedUser)
 
 		handler := UpdateAssignedOfficeUserHandler{
-			HandlerConfig:                 suite.HandlerConfig(),
+			HandlerConfig:                 suite.NewHandlerConfig(),
 			MoveAssignedOfficeUserUpdater: assignedOfficeUserUpdater,
 			officeUserFetcherPop:          officeUserFetcher,
 		}
@@ -1186,7 +1186,7 @@ func (suite *HandlerSuite) TestUpdateAssignedOfficeUserHandler() {
 		req = suite.AuthenticateOfficeRequest(req, assignedUser)
 
 		handler := DeleteAssignedOfficeUserHandler{
-			HandlerConfig:                 suite.HandlerConfig(),
+			HandlerConfig:                 suite.NewHandlerConfig(),
 			MoveAssignedOfficeUserUpdater: assignedOfficeUserUpdater,
 		}
 
@@ -1244,7 +1244,7 @@ func (suite *HandlerSuite) TestCheckForLockedMovesAndUnlockHandler() {
 		req := httptest.NewRequest("GET", "/moves/{officeUserID}/CheckForLockedMovesAndUnlock", nil)
 
 		handler := CheckForLockedMovesAndUnlockHandler{
-			HandlerConfig: suite.HandlerConfig(),
+			HandlerConfig: suite.NewHandlerConfig(),
 			MoveUnlocker:  movelocker.NewMoveUnlocker(),
 		}
 

--- a/pkg/handlers/ghcapi/move_test.go
+++ b/pkg/handlers/ghcapi/move_test.go
@@ -1218,7 +1218,7 @@ func (suite *HandlerSuite) TestCheckForLockedMovesAndUnlockHandler() {
 	setupLockedMove := func() {
 		appCtx := suite.AppContextWithSessionForTest(&auth.Session{
 			ApplicationName: auth.OfficeApp,
-			Roles:           validOfficeUser.User.Roles,
+			CurrentRole:     roles.Role{},
 			OfficeUserID:    validOfficeUser.ID,
 			IDToken:         "fake_token",
 			AccessToken:     "fakeAccessToken",

--- a/pkg/handlers/ghcapi/move_test.go
+++ b/pkg/handlers/ghcapi/move_test.go
@@ -1218,7 +1218,7 @@ func (suite *HandlerSuite) TestCheckForLockedMovesAndUnlockHandler() {
 	setupLockedMove := func() {
 		appCtx := suite.AppContextWithSessionForTest(&auth.Session{
 			ApplicationName: auth.OfficeApp,
-			CurrentRole:     roles.Role{},
+			ActiveRole:      roles.Role{},
 			OfficeUserID:    validOfficeUser.ID,
 			IDToken:         "fake_token",
 			AccessToken:     "fakeAccessToken",

--- a/pkg/handlers/ghcapi/mto_agent_test.go
+++ b/pkg/handlers/ghcapi/mto_agent_test.go
@@ -43,7 +43,7 @@ func (suite *HandlerSuite) TestListMTOAgentsHandler() {
 		).Return(nil).Once()
 
 		handler := ListMTOAgentsHandler{
-			HandlerConfig: suite.HandlerConfig(),
+			HandlerConfig: suite.NewHandlerConfig(),
 			ListFetcher:   listFetcher,
 		}
 
@@ -74,7 +74,7 @@ func (suite *HandlerSuite) TestListMTOAgentsHandler() {
 		).Return(errors.New("an error happened")).Once()
 
 		handler := ListMTOAgentsHandler{
-			HandlerConfig: suite.HandlerConfig(),
+			HandlerConfig: suite.NewHandlerConfig(),
 			ListFetcher:   listFetcher,
 		}
 
@@ -106,7 +106,7 @@ func (suite *HandlerSuite) TestListMTOAgentsHandler() {
 		).Return(models.ErrFetchNotFound).Once()
 
 		handler := ListMTOAgentsHandler{
-			HandlerConfig: suite.HandlerConfig(),
+			HandlerConfig: suite.NewHandlerConfig(),
 			ListFetcher:   listFetcher,
 		}
 

--- a/pkg/handlers/ghcapi/mto_service_items_test.go
+++ b/pkg/handlers/ghcapi/mto_service_items_test.go
@@ -311,7 +311,7 @@ func (suite *HandlerSuite) TestListMTOServiceItemHandler() {
 		mockCounselingPricer := mocks.CounselingServicesPricer{}
 		mockMoveManagementPricer := mocks.ManagementServicesPricer{}
 		handler := ListMTOServiceItemsHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			&mockListFetcher,
 			&mockFetcher,
 			&mockCounselingPricer,
@@ -360,7 +360,7 @@ func (suite *HandlerSuite) TestListMTOServiceItemHandler() {
 		mockCounselingPricer := mocks.CounselingServicesPricer{}
 		mockMoveManagementPricer := mocks.ManagementServicesPricer{}
 		handler := ListMTOServiceItemsHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			&mockListFetcher,
 			&mockFetcher,
 			&mockCounselingPricer,
@@ -462,7 +462,7 @@ func (suite *HandlerSuite) TestUpdateMTOServiceItemStatusHandler() {
 		).Return(errors.New("Not found error")).Once()
 
 		handler := UpdateMTOServiceItemStatusHandler{
-			HandlerConfig:         suite.HandlerConfig(),
+			HandlerConfig:         suite.NewHandlerConfig(),
 			MTOServiceItemUpdater: &serviceItemStatusUpdater,
 			Fetcher:               &fetcher,
 			ShipmentSITStatus:     sitstatus.NewShipmentSITStatus(),
@@ -500,7 +500,7 @@ func (suite *HandlerSuite) TestUpdateMTOServiceItemStatusHandler() {
 		).Return(&models.MTOServiceItem{ID: serviceItemID}, nil).Once()
 
 		handler := UpdateMTOServiceItemStatusHandler{
-			HandlerConfig:         suite.HandlerConfig(),
+			HandlerConfig:         suite.NewHandlerConfig(),
 			MTOServiceItemUpdater: &serviceItemStatusUpdater,
 			Fetcher:               &fetcher,
 			ShipmentSITStatus:     sitstatus.NewShipmentSITStatus(),
@@ -539,7 +539,7 @@ func (suite *HandlerSuite) TestUpdateMTOServiceItemStatusHandler() {
 		).Return(nil, apperror.NewPreconditionFailedError(serviceItemID, errors.New("oh no"))).Once()
 
 		handler := UpdateMTOServiceItemStatusHandler{
-			HandlerConfig:         suite.HandlerConfig(),
+			HandlerConfig:         suite.NewHandlerConfig(),
 			MTOServiceItemUpdater: &serviceItemStatusUpdater,
 			Fetcher:               &fetcher,
 			ShipmentSITStatus:     sitstatus.NewShipmentSITStatus(),
@@ -578,7 +578,7 @@ func (suite *HandlerSuite) TestUpdateMTOServiceItemStatusHandler() {
 		).Return(nil, errors.New("oh no")).Once()
 
 		handler := UpdateMTOServiceItemStatusHandler{
-			HandlerConfig:         suite.HandlerConfig(),
+			HandlerConfig:         suite.NewHandlerConfig(),
 			MTOServiceItemUpdater: &serviceItemStatusUpdater,
 			Fetcher:               &fetcher,
 			ShipmentSITStatus:     sitstatus.NewShipmentSITStatus(),
@@ -610,7 +610,7 @@ func (suite *HandlerSuite) TestUpdateMTOServiceItemStatusHandler() {
 		).Return(nil).Once()
 
 		handler := UpdateMTOServiceItemStatusHandler{
-			HandlerConfig:         suite.HandlerConfig(),
+			HandlerConfig:         suite.NewHandlerConfig(),
 			MTOServiceItemUpdater: &serviceItemStatusUpdater,
 			Fetcher:               &fetcher,
 			ShipmentSITStatus:     sitstatus.NewShipmentSITStatus(),
@@ -664,7 +664,7 @@ func (suite *HandlerSuite) TestUpdateMTOServiceItemStatusHandler() {
 		mtoServiceItemStatusUpdater := mtoserviceitem.NewMTOServiceItemUpdater(planner, queryBuilder, moveRouter, shipmentFetcher, addressCreator, portLocationFetcher, ghcrateengine.NewDomesticUnpackPricer(), ghcrateengine.NewDomesticLinehaulPricer(), ghcrateengine.NewDomesticDestinationPricer(), ghcrateengine.NewFuelSurchargePricer())
 
 		handler := UpdateMTOServiceItemStatusHandler{
-			HandlerConfig:         suite.HandlerConfig(),
+			HandlerConfig:         suite.NewHandlerConfig(),
 			MTOServiceItemUpdater: mtoServiceItemStatusUpdater,
 			Fetcher:               fetcher,
 			ShipmentSITStatus:     sitstatus.NewShipmentSITStatus(),
@@ -725,7 +725,7 @@ func (suite *HandlerSuite) TestUpdateMTOServiceItemStatusHandler() {
 		mtoServiceItemStatusUpdater := mtoserviceitem.NewMTOServiceItemUpdater(planner, queryBuilder, moveRouter, shipmentFetcher, addressCreator, portLocationFetcher, ghcrateengine.NewDomesticUnpackPricer(), ghcrateengine.NewDomesticLinehaulPricer(), ghcrateengine.NewDomesticDestinationPricer(), ghcrateengine.NewFuelSurchargePricer())
 
 		handler := UpdateMTOServiceItemStatusHandler{
-			HandlerConfig:         suite.HandlerConfig(),
+			HandlerConfig:         suite.NewHandlerConfig(),
 			MTOServiceItemUpdater: mtoServiceItemStatusUpdater,
 			Fetcher:               fetcher,
 			ShipmentSITStatus:     sitstatus.NewShipmentSITStatus(),
@@ -788,7 +788,7 @@ func (suite *HandlerSuite) TestGetMTOServiceItemHandler() {
 		).Return(&mtoServiceItem, nil).Once()
 
 		handler := GetMTOServiceItemHandler{
-			HandlerConfig:         suite.HandlerConfig(),
+			HandlerConfig:         suite.NewHandlerConfig(),
 			mtoServiceItemFetcher: &serviceItemFetcher,
 		}
 
@@ -811,7 +811,7 @@ func (suite *HandlerSuite) TestGetMTOServiceItemHandler() {
 		).Return(nil, errors.New("Not found error")).Once()
 
 		handler := GetMTOServiceItemHandler{
-			HandlerConfig:         suite.HandlerConfig(),
+			HandlerConfig:         suite.NewHandlerConfig(),
 			mtoServiceItemFetcher: &serviceItemFetcher,
 		}
 
@@ -902,7 +902,7 @@ func (suite *HandlerSuite) TestUpdateServiceItemSitEntryDateHandler() {
 		).Return(&mtoServiceItem, nil).Once()
 
 		handler := UpdateServiceItemSitEntryDateHandler{
-			HandlerConfig:       suite.HandlerConfig(),
+			HandlerConfig:       suite.NewHandlerConfig(),
 			sitEntryDateUpdater: &sitEntryDateUpdater,
 			ShipmentSITStatus:   sitstatus.NewShipmentSITStatus(),
 			MTOShipmentFetcher:  shipmentFetcher,
@@ -928,7 +928,7 @@ func (suite *HandlerSuite) TestUpdateServiceItemSitEntryDateHandler() {
 		).Return(nil, errors.New("Not found error")).Once()
 
 		handler := UpdateServiceItemSitEntryDateHandler{
-			HandlerConfig:       suite.HandlerConfig(),
+			HandlerConfig:       suite.NewHandlerConfig(),
 			sitEntryDateUpdater: &sitEntryDateUpdater,
 			ShipmentSITStatus:   sitstatus.NewShipmentSITStatus(),
 			MTOShipmentFetcher:  shipmentFetcher,

--- a/pkg/handlers/ghcapi/mto_shipment.go
+++ b/pkg/handlers/ghcapi/mto_shipment.go
@@ -474,7 +474,7 @@ func (h DeleteShipmentHandler) Handle(params shipmentops.DeleteShipmentParams) m
 	return h.AuditableAppContextFromRequestWithErrors(params.HTTPRequest,
 		func(appCtx appcontext.AppContext) (middleware.Responder, error) {
 
-			if !(appCtx.Session().CurrentRole.RoleType == roles.RoleTypeTOO) && !(appCtx.Session().CurrentRole.RoleType == roles.RoleTypeServicesCounselor) {
+			if !(appCtx.Session().ActiveRole.RoleType == roles.RoleTypeTOO) && !(appCtx.Session().ActiveRole.RoleType == roles.RoleTypeServicesCounselor) {
 				forbiddenError := apperror.NewForbiddenError("user is not authenticated with an office role")
 				appCtx.Logger().Error(forbiddenError.Error())
 				return shipmentops.NewDeleteShipmentForbidden(), forbiddenError
@@ -545,7 +545,7 @@ func (h ApproveShipmentHandler) Handle(params shipmentops.ApproveShipmentParams)
 	return h.AuditableAppContextFromRequestWithErrors(params.HTTPRequest,
 		func(appCtx appcontext.AppContext) (middleware.Responder, error) {
 
-			if !appCtx.Session().IsOfficeUser() || !(appCtx.Session().CurrentRole.RoleType == roles.RoleTypeTOO) {
+			if !appCtx.Session().IsOfficeUser() || !(appCtx.Session().ActiveRole.RoleType == roles.RoleTypeTOO) {
 				forbiddenError := apperror.NewForbiddenError("Only TOO role can approve shipments")
 				appCtx.Logger().Error(forbiddenError.Error())
 				return shipmentops.NewApproveShipmentForbidden(), forbiddenError
@@ -697,7 +697,7 @@ func (h ApproveShipmentsHandler) Handle(params shipmentops.ApproveShipmentsParam
 		func(appCtx appcontext.AppContext) (middleware.Responder, error) {
 
 			// Check user permissions (TOO role required)
-			if !appCtx.Session().IsOfficeUser() || !(appCtx.Session().CurrentRole.RoleType == roles.RoleTypeTOO) {
+			if !appCtx.Session().IsOfficeUser() || !(appCtx.Session().ActiveRole.RoleType == roles.RoleTypeTOO) {
 				forbiddenError := apperror.NewForbiddenError("Only TOO role can approve shipments")
 				appCtx.Logger().Error(forbiddenError.Error())
 				return shipmentops.NewApproveShipmentsForbidden(), forbiddenError
@@ -883,7 +883,7 @@ func (h RequestShipmentDiversionHandler) Handle(params shipmentops.RequestShipme
 	return h.AuditableAppContextFromRequestWithErrors(params.HTTPRequest,
 		func(appCtx appcontext.AppContext) (middleware.Responder, error) {
 
-			if !appCtx.Session().IsOfficeUser() || !(appCtx.Session().CurrentRole.RoleType == roles.RoleTypeTOO) {
+			if !appCtx.Session().IsOfficeUser() || !(appCtx.Session().ActiveRole.RoleType == roles.RoleTypeTOO) {
 				forbiddenError := apperror.NewForbiddenError("Only TOO role can Request shipment diversions")
 				appCtx.Logger().Error(forbiddenError.Error())
 				return shipmentops.NewRequestShipmentDiversionForbidden(), forbiddenError
@@ -965,7 +965,7 @@ func (h ApproveShipmentDiversionHandler) Handle(params shipmentops.ApproveShipme
 	return h.AuditableAppContextFromRequestWithErrors(params.HTTPRequest,
 		func(appCtx appcontext.AppContext) (middleware.Responder, error) {
 
-			if !appCtx.Session().IsOfficeUser() || !(appCtx.Session().CurrentRole.RoleType == roles.RoleTypeTOO) {
+			if !appCtx.Session().IsOfficeUser() || !(appCtx.Session().ActiveRole.RoleType == roles.RoleTypeTOO) {
 				forbiddenError := apperror.NewForbiddenError("Only TOO role can approve shipment diversions")
 				appCtx.Logger().Error(forbiddenError.Error())
 				return shipmentops.NewApproveShipmentDiversionForbidden(), forbiddenError
@@ -1045,7 +1045,7 @@ func (h RejectShipmentHandler) Handle(params shipmentops.RejectShipmentParams) m
 	return h.AuditableAppContextFromRequestWithErrors(params.HTTPRequest,
 		func(appCtx appcontext.AppContext) (middleware.Responder, error) {
 
-			if !appCtx.Session().IsOfficeUser() || !(appCtx.Session().CurrentRole.RoleType == roles.RoleTypeTOO) {
+			if !appCtx.Session().IsOfficeUser() || !(appCtx.Session().ActiveRole.RoleType == roles.RoleTypeTOO) {
 				forbiddenError := apperror.NewForbiddenError("Only TOO role can reject shipments")
 				appCtx.Logger().Error(forbiddenError.Error())
 				return shipmentops.NewRejectShipmentForbidden(), forbiddenError
@@ -1118,7 +1118,7 @@ func (h RequestShipmentCancellationHandler) Handle(params shipmentops.RequestShi
 	return h.AuditableAppContextFromRequestWithErrors(params.HTTPRequest,
 		func(appCtx appcontext.AppContext) (middleware.Responder, error) {
 
-			if !appCtx.Session().IsOfficeUser() || !(appCtx.Session().CurrentRole.RoleType == roles.RoleTypeTOO) {
+			if !appCtx.Session().IsOfficeUser() || !(appCtx.Session().ActiveRole.RoleType == roles.RoleTypeTOO) {
 				forbiddenError := apperror.NewForbiddenError("Only TOO role can Request shipment diversions")
 				appCtx.Logger().Error(forbiddenError.Error())
 				return shipmentops.NewRequestShipmentCancellationForbidden(), forbiddenError
@@ -1203,7 +1203,7 @@ func (h RequestShipmentReweighHandler) Handle(params shipmentops.RequestShipment
 	return h.AuditableAppContextFromRequestWithErrors(params.HTTPRequest,
 		func(appCtx appcontext.AppContext) (middleware.Responder, error) {
 
-			if !appCtx.Session().IsOfficeUser() || !(appCtx.Session().CurrentRole.RoleType == roles.RoleTypeTOO) {
+			if !appCtx.Session().IsOfficeUser() || !(appCtx.Session().ActiveRole.RoleType == roles.RoleTypeTOO) {
 				forbiddenError := apperror.NewForbiddenError("Only TOO role can Request a shipment reweigh")
 				appCtx.Logger().Error(forbiddenError.Error())
 				return shipmentops.NewRequestShipmentReweighForbidden(), forbiddenError
@@ -1391,7 +1391,7 @@ func (h ApproveSITExtensionHandler) Handle(params shipmentops.ApproveSITExtensio
 				}
 			}
 
-			if !appCtx.Session().IsOfficeUser() || !(appCtx.Session().CurrentRole.RoleType == roles.RoleTypeTOO) {
+			if !appCtx.Session().IsOfficeUser() || !(appCtx.Session().ActiveRole.RoleType == roles.RoleTypeTOO) {
 				forbiddenError := apperror.NewForbiddenError("is not a TOO")
 				return handleError(forbiddenError)
 			}
@@ -1480,7 +1480,7 @@ func (h DenySITExtensionHandler) Handle(params shipmentops.DenySITExtensionParam
 				}
 			}
 
-			if !appCtx.Session().IsOfficeUser() || !(appCtx.Session().CurrentRole.RoleType == roles.RoleTypeTOO) {
+			if !appCtx.Session().IsOfficeUser() || !(appCtx.Session().ActiveRole.RoleType == roles.RoleTypeTOO) {
 				forbiddenError := apperror.NewForbiddenError("is not a TOO")
 				return handleError(forbiddenError)
 			}
@@ -1562,7 +1562,7 @@ func (h UpdateSITServiceItemCustomerExpenseHandler) Handle(params shipmentops.Up
 				}
 			}
 
-			if !appCtx.Session().IsOfficeUser() || !(appCtx.Session().CurrentRole.RoleType == roles.RoleTypeTOO) {
+			if !appCtx.Session().IsOfficeUser() || !(appCtx.Session().ActiveRole.RoleType == roles.RoleTypeTOO) {
 				forbiddenError := apperror.NewForbiddenError("is not a TOO")
 				return handleError(forbiddenError)
 			}
@@ -1649,7 +1649,7 @@ func (h CreateApprovedSITDurationUpdateHandler) Handle(params shipmentops.Create
 				return handleError(err)
 			}
 
-			if !appCtx.Session().IsOfficeUser() || !(appCtx.Session().CurrentRole.RoleType == roles.RoleTypeTOO) {
+			if !appCtx.Session().IsOfficeUser() || !(appCtx.Session().ActiveRole.RoleType == roles.RoleTypeTOO) {
 				return handleError(apperror.NewForbiddenError("is not a TOO"))
 			}
 
@@ -1683,7 +1683,7 @@ func (h TerminateShipmentHandler) Handle(params shipmentops.CreateTerminationPar
 	return h.AuditableAppContextFromRequestWithErrors(params.HTTPRequest,
 		func(appCtx appcontext.AppContext) (middleware.Responder, error) {
 
-			if !(appCtx.Session().CurrentRole.RoleType == roles.RoleTypeContractingOfficer) {
+			if !(appCtx.Session().ActiveRole.RoleType == roles.RoleTypeContractingOfficer) {
 				forbiddenError := apperror.NewForbiddenError("user is not authenticated with the authorized office role to terminate shipments")
 				appCtx.Logger().Error(forbiddenError.Error())
 				return shipmentops.NewCreateTerminationForbidden(), forbiddenError

--- a/pkg/handlers/ghcapi/mto_shipment.go
+++ b/pkg/handlers/ghcapi/mto_shipment.go
@@ -474,7 +474,7 @@ func (h DeleteShipmentHandler) Handle(params shipmentops.DeleteShipmentParams) m
 	return h.AuditableAppContextFromRequestWithErrors(params.HTTPRequest,
 		func(appCtx appcontext.AppContext) (middleware.Responder, error) {
 
-			if !appCtx.Session().Roles.HasRole(roles.RoleTypeTOO) && !appCtx.Session().Roles.HasRole(roles.RoleTypeServicesCounselor) {
+			if !(appCtx.Session().CurrentRole.RoleType == roles.RoleTypeTOO) && !(appCtx.Session().CurrentRole.RoleType == roles.RoleTypeServicesCounselor) {
 				forbiddenError := apperror.NewForbiddenError("user is not authenticated with an office role")
 				appCtx.Logger().Error(forbiddenError.Error())
 				return shipmentops.NewDeleteShipmentForbidden(), forbiddenError
@@ -545,7 +545,7 @@ func (h ApproveShipmentHandler) Handle(params shipmentops.ApproveShipmentParams)
 	return h.AuditableAppContextFromRequestWithErrors(params.HTTPRequest,
 		func(appCtx appcontext.AppContext) (middleware.Responder, error) {
 
-			if !appCtx.Session().IsOfficeUser() || !appCtx.Session().Roles.HasRole(roles.RoleTypeTOO) {
+			if !appCtx.Session().IsOfficeUser() || !(appCtx.Session().CurrentRole.RoleType == roles.RoleTypeTOO) {
 				forbiddenError := apperror.NewForbiddenError("Only TOO role can approve shipments")
 				appCtx.Logger().Error(forbiddenError.Error())
 				return shipmentops.NewApproveShipmentForbidden(), forbiddenError
@@ -697,7 +697,7 @@ func (h ApproveShipmentsHandler) Handle(params shipmentops.ApproveShipmentsParam
 		func(appCtx appcontext.AppContext) (middleware.Responder, error) {
 
 			// Check user permissions (TOO role required)
-			if !appCtx.Session().IsOfficeUser() || !appCtx.Session().Roles.HasRole(roles.RoleTypeTOO) {
+			if !appCtx.Session().IsOfficeUser() || !(appCtx.Session().CurrentRole.RoleType == roles.RoleTypeTOO) {
 				forbiddenError := apperror.NewForbiddenError("Only TOO role can approve shipments")
 				appCtx.Logger().Error(forbiddenError.Error())
 				return shipmentops.NewApproveShipmentsForbidden(), forbiddenError
@@ -883,7 +883,7 @@ func (h RequestShipmentDiversionHandler) Handle(params shipmentops.RequestShipme
 	return h.AuditableAppContextFromRequestWithErrors(params.HTTPRequest,
 		func(appCtx appcontext.AppContext) (middleware.Responder, error) {
 
-			if !appCtx.Session().IsOfficeUser() || !appCtx.Session().Roles.HasRole(roles.RoleTypeTOO) {
+			if !appCtx.Session().IsOfficeUser() || !(appCtx.Session().CurrentRole.RoleType == roles.RoleTypeTOO) {
 				forbiddenError := apperror.NewForbiddenError("Only TOO role can Request shipment diversions")
 				appCtx.Logger().Error(forbiddenError.Error())
 				return shipmentops.NewRequestShipmentDiversionForbidden(), forbiddenError
@@ -965,7 +965,7 @@ func (h ApproveShipmentDiversionHandler) Handle(params shipmentops.ApproveShipme
 	return h.AuditableAppContextFromRequestWithErrors(params.HTTPRequest,
 		func(appCtx appcontext.AppContext) (middleware.Responder, error) {
 
-			if !appCtx.Session().IsOfficeUser() || !appCtx.Session().Roles.HasRole(roles.RoleTypeTOO) {
+			if !appCtx.Session().IsOfficeUser() || !(appCtx.Session().CurrentRole.RoleType == roles.RoleTypeTOO) {
 				forbiddenError := apperror.NewForbiddenError("Only TOO role can approve shipment diversions")
 				appCtx.Logger().Error(forbiddenError.Error())
 				return shipmentops.NewApproveShipmentDiversionForbidden(), forbiddenError
@@ -1045,7 +1045,7 @@ func (h RejectShipmentHandler) Handle(params shipmentops.RejectShipmentParams) m
 	return h.AuditableAppContextFromRequestWithErrors(params.HTTPRequest,
 		func(appCtx appcontext.AppContext) (middleware.Responder, error) {
 
-			if !appCtx.Session().IsOfficeUser() || !appCtx.Session().Roles.HasRole(roles.RoleTypeTOO) {
+			if !appCtx.Session().IsOfficeUser() || !(appCtx.Session().CurrentRole.RoleType == roles.RoleTypeTOO) {
 				forbiddenError := apperror.NewForbiddenError("Only TOO role can reject shipments")
 				appCtx.Logger().Error(forbiddenError.Error())
 				return shipmentops.NewRejectShipmentForbidden(), forbiddenError
@@ -1118,7 +1118,7 @@ func (h RequestShipmentCancellationHandler) Handle(params shipmentops.RequestShi
 	return h.AuditableAppContextFromRequestWithErrors(params.HTTPRequest,
 		func(appCtx appcontext.AppContext) (middleware.Responder, error) {
 
-			if !appCtx.Session().IsOfficeUser() || !appCtx.Session().Roles.HasRole(roles.RoleTypeTOO) {
+			if !appCtx.Session().IsOfficeUser() || !(appCtx.Session().CurrentRole.RoleType == roles.RoleTypeTOO) {
 				forbiddenError := apperror.NewForbiddenError("Only TOO role can Request shipment diversions")
 				appCtx.Logger().Error(forbiddenError.Error())
 				return shipmentops.NewRequestShipmentCancellationForbidden(), forbiddenError
@@ -1203,7 +1203,7 @@ func (h RequestShipmentReweighHandler) Handle(params shipmentops.RequestShipment
 	return h.AuditableAppContextFromRequestWithErrors(params.HTTPRequest,
 		func(appCtx appcontext.AppContext) (middleware.Responder, error) {
 
-			if !appCtx.Session().IsOfficeUser() || !appCtx.Session().Roles.HasRole(roles.RoleTypeTOO) {
+			if !appCtx.Session().IsOfficeUser() || !(appCtx.Session().CurrentRole.RoleType == roles.RoleTypeTOO) {
 				forbiddenError := apperror.NewForbiddenError("Only TOO role can Request a shipment reweigh")
 				appCtx.Logger().Error(forbiddenError.Error())
 				return shipmentops.NewRequestShipmentReweighForbidden(), forbiddenError
@@ -1391,7 +1391,7 @@ func (h ApproveSITExtensionHandler) Handle(params shipmentops.ApproveSITExtensio
 				}
 			}
 
-			if !appCtx.Session().IsOfficeUser() || !appCtx.Session().Roles.HasRole(roles.RoleTypeTOO) {
+			if !appCtx.Session().IsOfficeUser() || !(appCtx.Session().CurrentRole.RoleType == roles.RoleTypeTOO) {
 				forbiddenError := apperror.NewForbiddenError("is not a TOO")
 				return handleError(forbiddenError)
 			}
@@ -1480,7 +1480,7 @@ func (h DenySITExtensionHandler) Handle(params shipmentops.DenySITExtensionParam
 				}
 			}
 
-			if !appCtx.Session().IsOfficeUser() || !appCtx.Session().Roles.HasRole(roles.RoleTypeTOO) {
+			if !appCtx.Session().IsOfficeUser() || !(appCtx.Session().CurrentRole.RoleType == roles.RoleTypeTOO) {
 				forbiddenError := apperror.NewForbiddenError("is not a TOO")
 				return handleError(forbiddenError)
 			}
@@ -1562,7 +1562,7 @@ func (h UpdateSITServiceItemCustomerExpenseHandler) Handle(params shipmentops.Up
 				}
 			}
 
-			if !appCtx.Session().IsOfficeUser() || !appCtx.Session().Roles.HasRole(roles.RoleTypeTOO) {
+			if !appCtx.Session().IsOfficeUser() || !(appCtx.Session().CurrentRole.RoleType == roles.RoleTypeTOO) {
 				forbiddenError := apperror.NewForbiddenError("is not a TOO")
 				return handleError(forbiddenError)
 			}
@@ -1649,7 +1649,7 @@ func (h CreateApprovedSITDurationUpdateHandler) Handle(params shipmentops.Create
 				return handleError(err)
 			}
 
-			if !appCtx.Session().IsOfficeUser() || !appCtx.Session().Roles.HasRole(roles.RoleTypeTOO) {
+			if !appCtx.Session().IsOfficeUser() || !(appCtx.Session().CurrentRole.RoleType == roles.RoleTypeTOO) {
 				return handleError(apperror.NewForbiddenError("is not a TOO"))
 			}
 
@@ -1683,7 +1683,7 @@ func (h TerminateShipmentHandler) Handle(params shipmentops.CreateTerminationPar
 	return h.AuditableAppContextFromRequestWithErrors(params.HTTPRequest,
 		func(appCtx appcontext.AppContext) (middleware.Responder, error) {
 
-			if !appCtx.Session().Roles.HasRole(roles.RoleTypeContractingOfficer) {
+			if !(appCtx.Session().CurrentRole.RoleType == roles.RoleTypeContractingOfficer) {
 				forbiddenError := apperror.NewForbiddenError("user is not authenticated with the authorized office role to terminate shipments")
 				appCtx.Logger().Error(forbiddenError.Error())
 				return shipmentops.NewCreateTerminationForbidden(), forbiddenError

--- a/pkg/handlers/ghcapi/mto_shipment_test.go
+++ b/pkg/handlers/ghcapi/mto_shipment_test.go
@@ -4812,7 +4812,7 @@ func (suite *HandlerSuite) TestCreateMTOShipmentHandlerUsingPPM() {
 			ApplicationName: auth.OfficeApp,
 			UserID:          user.ID,
 			IDToken:         "fake token",
-			CurrentRole:     roles.Role{},
+			ActiveRole:      roles.Role{},
 		}
 		ctx := auth.SetSessionInRequestContext(req, session)
 
@@ -5003,7 +5003,7 @@ func (suite *HandlerSuite) TestCreateMTOShipmentHandlerUsingPPM() {
 			ApplicationName: auth.OfficeApp,
 			UserID:          user.ID,
 			IDToken:         "fake token",
-			CurrentRole:     roles.Role{},
+			ActiveRole:      roles.Role{},
 		}
 		ctx := auth.SetSessionInRequestContext(req, session)
 
@@ -5174,7 +5174,7 @@ func (suite *HandlerSuite) TestCreateMTOShipmentHandlerUsingPPM() {
 			ApplicationName: auth.OfficeApp,
 			UserID:          user.ID,
 			IDToken:         "fake token",
-			CurrentRole:     roles.Role{},
+			ActiveRole:      roles.Role{},
 		}
 		ctx := auth.SetSessionInRequestContext(req, session)
 

--- a/pkg/handlers/ghcapi/mto_shipment_test.go
+++ b/pkg/handlers/ghcapi/mto_shipment_test.go
@@ -217,7 +217,7 @@ func (suite *HandlerSuite) TestListMTOShipmentsHandler() {
 		sitExtension := subtestData.sitExtension
 
 		handler := ListMTOShipmentsHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			mtoshipment.NewMTOShipmentFetcher(),
 			sitstatus.NewShipmentSITStatus(),
 		}
@@ -276,7 +276,7 @@ func (suite *HandlerSuite) TestListMTOShipmentsHandler() {
 		mockMTOShipmentFetcher := &mocks.MTOShipmentFetcher{}
 
 		handler := ListMTOShipmentsHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			mockMTOShipmentFetcher,
 			sitstatus.NewShipmentSITStatus(),
 		}
@@ -300,7 +300,7 @@ func (suite *HandlerSuite) TestListMTOShipmentsHandler() {
 		mockMTOShipmentFetcher := &mocks.MTOShipmentFetcher{}
 
 		handler := ListMTOShipmentsHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			mockMTOShipmentFetcher,
 			sitstatus.NewShipmentSITStatus(),
 		}
@@ -328,7 +328,7 @@ func (suite *HandlerSuite) TestDeleteShipmentHandler() {
 
 		req := httptest.NewRequest("DELETE", fmt.Sprintf("/shipments/%s", uuid.String()), nil)
 		req = suite.AuthenticateOfficeRequest(req, officeUser)
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 
 		handler := DeleteShipmentHandler{
 			handlerConfig,
@@ -358,7 +358,7 @@ func (suite *HandlerSuite) TestDeleteShipmentHandler() {
 
 		req := httptest.NewRequest("DELETE", fmt.Sprintf("/shipments/%s", shipment.ID.String()), nil)
 		req = suite.AuthenticateOfficeRequest(req, officeUser)
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 
 		handler := DeleteShipmentHandler{
 			handlerConfig,
@@ -392,7 +392,7 @@ func (suite *HandlerSuite) TestDeleteShipmentHandler() {
 
 		req := httptest.NewRequest("DELETE", fmt.Sprintf("/shipments/%s", shipment.ID.String()), nil)
 		req = suite.AuthenticateOfficeRequest(req, officeUser)
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 
 		handler := DeleteShipmentHandler{
 			handlerConfig,
@@ -428,7 +428,7 @@ func (suite *HandlerSuite) TestDeleteShipmentHandler() {
 
 		req := httptest.NewRequest("DELETE", fmt.Sprintf("/shipments/%s", shipment.ID.String()), nil)
 		req = suite.AuthenticateOfficeRequest(req, officeUser)
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 
 		handler := DeleteShipmentHandler{
 			handlerConfig,
@@ -464,7 +464,7 @@ func (suite *HandlerSuite) TestDeleteShipmentHandler() {
 
 		req := httptest.NewRequest("DELETE", fmt.Sprintf("/shipments/%s", shipment.ID.String()), nil)
 		req = suite.AuthenticateOfficeRequest(req, officeUser)
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 
 		handler := DeleteShipmentHandler{
 			handlerConfig,
@@ -500,7 +500,7 @@ func (suite *HandlerSuite) TestDeleteShipmentHandler() {
 
 		req := httptest.NewRequest("DELETE", fmt.Sprintf("/shipments/%s", shipment.ID.String()), nil)
 		req = suite.AuthenticateOfficeRequest(req, officeUser)
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 
 		handler := DeleteShipmentHandler{
 			handlerConfig,
@@ -527,7 +527,7 @@ func (suite *HandlerSuite) TestGetShipmentHandler() {
 	suite.Run("Successful fetch (integration) test", func() {
 		shipment := factory.BuildMTOShipmentMinimal(suite.DB(), nil, nil)
 		officeUser := factory.BuildOfficeUser(nil, nil, nil)
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 		fetcher := mtoshipment.NewMTOShipmentFetcher()
 		request := httptest.NewRequest("GET", fmt.Sprintf("/shipments/%s", shipment.ID.String()), nil)
 		request = suite.AuthenticateOfficeRequest(request, officeUser)
@@ -556,7 +556,7 @@ func (suite *HandlerSuite) TestGetShipmentHandler() {
 	suite.Run("404 response when the service returns not found", func() {
 		uuidForShipment, _ := uuid.NewV4()
 		officeUser := factory.BuildOfficeUser(nil, nil, nil)
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 		fetcher := mtoshipment.NewMTOShipmentFetcher()
 		request := httptest.NewRequest("GET", fmt.Sprintf("/shipments/%s", uuidForShipment.String()), nil)
 		request = suite.AuthenticateOfficeRequest(request, officeUser)
@@ -678,7 +678,7 @@ func (suite *HandlerSuite) TestApproveShipmentHandler() {
 		suite.FatalNoError(err, "Error creating a new trace ID.")
 		req = req.WithContext(trace.NewContext(req.Context(), traceID))
 
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 
 		reweighRequester := &mocks.ShipmentReweighRequester{}
 
@@ -780,7 +780,7 @@ func (suite *HandlerSuite) TestApproveShipmentHandler() {
 		suite.FatalNoError(err, "Error creating a new trace ID.")
 		req = req.WithContext(trace.NewContext(req.Context(), traceID))
 
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 
 		handler := ApproveShipmentHandler{
 			handlerConfig,
@@ -884,7 +884,7 @@ func (suite *HandlerSuite) TestApproveShipmentHandler() {
 		suite.FatalNoError(err, "Error creating a new trace ID.")
 		req = req.WithContext(trace.NewContext(req.Context(), traceID))
 
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 
 		handler := ApproveShipmentHandler{
 			handlerConfig,
@@ -958,7 +958,7 @@ func (suite *HandlerSuite) TestApproveShipmentHandler() {
 		suite.FatalNoError(err, "Error creating a new trace ID.")
 		req = req.WithContext(trace.NewContext(req.Context(), traceID))
 
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 		mockMoveWeights := &mocks.MoveWeights{}
 
 		handler := ApproveShipmentHandler{
@@ -995,7 +995,7 @@ func (suite *HandlerSuite) TestApproveShipmentHandler() {
 
 		req := httptest.NewRequest("POST", fmt.Sprintf("/shipments/%s/approve", uuid.String()), nil)
 		req = suite.AuthenticateOfficeRequest(req, officeUser)
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 
 		handler := ApproveShipmentHandler{
 			handlerConfig,
@@ -1039,7 +1039,7 @@ func (suite *HandlerSuite) TestApproveShipmentHandler() {
 
 		req := httptest.NewRequest("POST", fmt.Sprintf("/shipments/%s/approve", shipment.ID.String()), nil)
 		req = suite.AuthenticateOfficeRequest(req, officeUser)
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 		reweighRequester := &mocks.ShipmentReweighRequester{}
 
 		handler := ApproveShipmentHandler{
@@ -1084,7 +1084,7 @@ func (suite *HandlerSuite) TestApproveShipmentHandler() {
 
 		req := httptest.NewRequest("POST", fmt.Sprintf("/shipments/%s/approve", shipment.ID.String()), nil)
 		req = suite.AuthenticateOfficeRequest(req, officeUser)
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 		reweighRequester := &mocks.ShipmentReweighRequester{}
 
 		handler := ApproveShipmentHandler{
@@ -1129,7 +1129,7 @@ func (suite *HandlerSuite) TestApproveShipmentHandler() {
 
 		req := httptest.NewRequest("POST", fmt.Sprintf("/shipments/%s/approve", shipment.ID.String()), nil)
 		req = suite.AuthenticateOfficeRequest(req, officeUser)
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 		reweighRequester := &mocks.ShipmentReweighRequester{}
 
 		handler := ApproveShipmentHandler{
@@ -1174,7 +1174,7 @@ func (suite *HandlerSuite) TestApproveShipmentHandler() {
 
 		req := httptest.NewRequest("POST", fmt.Sprintf("/shipments/%s/approve", shipment.ID.String()), nil)
 		req = suite.AuthenticateOfficeRequest(req, officeUser)
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 		reweighRequester := &mocks.ShipmentReweighRequester{}
 
 		handler := ApproveShipmentHandler{
@@ -1219,7 +1219,7 @@ func (suite *HandlerSuite) TestApproveShipmentHandler() {
 
 		req := httptest.NewRequest("POST", fmt.Sprintf("/shipments/%s/approve", shipment.ID.String()), nil)
 		req = suite.AuthenticateOfficeRequest(req, officeUser)
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 		reweighRequester := &mocks.ShipmentReweighRequester{}
 
 		handler := ApproveShipmentHandler{
@@ -1351,7 +1351,7 @@ func (suite *HandlerSuite) TestApproveShipmentsHandler() {
 		suite.FatalNoError(err, "Error creating a new trace ID.")
 		req = req.WithContext(trace.NewContext(req.Context(), traceID))
 
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 		reweighRequester := &mocks.ShipmentReweighRequester{}
 
 		handler := ApproveShipmentsHandler{
@@ -1417,7 +1417,7 @@ func (suite *HandlerSuite) TestApproveShipmentsHandler() {
 
 		req := httptest.NewRequest("POST", "/shipments/approve", nil)
 		req = suite.AuthenticateOfficeRequest(req, officeUser)
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 		reweighRequester := &mocks.ShipmentReweighRequester{}
 
 		handler := ApproveShipmentsHandler{
@@ -1465,7 +1465,7 @@ func (suite *HandlerSuite) TestApproveShipmentsHandler() {
 
 		req := httptest.NewRequest("POST", "/shipments/approve", nil)
 		req = suite.AuthenticateOfficeRequest(req, officeUser)
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 		reweighRequester := &mocks.ShipmentReweighRequester{}
 
 		handler := ApproveShipmentsHandler{
@@ -1513,7 +1513,7 @@ func (suite *HandlerSuite) TestApproveShipmentsHandler() {
 
 		req := httptest.NewRequest("POST", "/shipments/approve", nil)
 		req = suite.AuthenticateOfficeRequest(req, officeUser)
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 		reweighRequester := &mocks.ShipmentReweighRequester{}
 
 		handler := ApproveShipmentsHandler{
@@ -1561,7 +1561,7 @@ func (suite *HandlerSuite) TestApproveShipmentsHandler() {
 
 		req := httptest.NewRequest("POST", "/shipments/approve", nil)
 		req = suite.AuthenticateOfficeRequest(req, officeUser)
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 		reweighRequester := &mocks.ShipmentReweighRequester{}
 
 		handler := ApproveShipmentsHandler{
@@ -1609,7 +1609,7 @@ func (suite *HandlerSuite) TestApproveShipmentsHandler() {
 
 		req := httptest.NewRequest("POST", "/shipments/approve", nil)
 		req = suite.AuthenticateOfficeRequest(req, officeUser)
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 		reweighRequester := &mocks.ShipmentReweighRequester{}
 
 		handler := ApproveShipmentsHandler{
@@ -1649,7 +1649,7 @@ func (suite *HandlerSuite) TestApproveShipmentsHandler() {
 
 		req := httptest.NewRequest("POST", "/shipments/approve", nil)
 		req = suite.AuthenticateOfficeRequest(req, officeUser)
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 		reweighRequester := &mocks.ShipmentReweighRequester{}
 
 		handler := ApproveShipmentsHandler{
@@ -1692,7 +1692,7 @@ func (suite *HandlerSuite) TestApproveShipmentsHandler() {
 
 		req := httptest.NewRequest("POST", "/shipments/approve", nil)
 		req = suite.AuthenticateOfficeRequest(req, officeUser)
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 		reweighRequester := &mocks.ShipmentReweighRequester{}
 
 		handler := ApproveShipmentsHandler{
@@ -1798,7 +1798,7 @@ func (suite *HandlerSuite) TestApproveShipmentsHandler() {
 		suite.FatalNoError(err, "Error creating a new trace ID.")
 		req = req.WithContext(trace.NewContext(req.Context(), traceID))
 
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 		reweighRequester := &mocks.ShipmentReweighRequester{}
 		reweighRequester.On("RequestShipmentReweigh", mock.AnythingOfType("*appcontext.appContext"), mock.AnythingOfType("uuid.UUID"), models.ReweighRequesterSystem).Return(nil, nil)
 
@@ -1913,7 +1913,7 @@ func (suite *HandlerSuite) TestApproveShipmentsHandler() {
 		suite.FatalNoError(err, "Error creating a new trace ID.")
 		req = req.WithContext(trace.NewContext(req.Context(), traceID))
 
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 		reweighRequester := &mocks.ShipmentReweighRequester{}
 		mockMoveWeights.On("CheckAutoReweigh", mock.AnythingOfType("*appcontext.appContext"), mock.AnythingOfType("uuid.UUID"), mock.AnythingOfType("*models.MTOShipment")).Return(apperror.SessionError{})
 
@@ -2026,7 +2026,7 @@ func (suite *HandlerSuite) TestApproveShipmentsHandler() {
 		suite.FatalNoError(err, "Error creating a new trace ID.")
 		req = req.WithContext(trace.NewContext(req.Context(), traceID))
 
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 		reweighRequester := &mocks.ShipmentReweighRequester{}
 		reweighRequester.On("RequestShipmentReweigh", mock.AnythingOfType("*appcontext.appContext"), mock.AnythingOfType("uuid.UUID"), models.ReweighRequesterSystem).Return(nil, apperror.NotFoundError{})
 
@@ -2095,7 +2095,7 @@ func (suite *HandlerSuite) TestRequestShipmentDiversionHandler() {
 		suite.FatalNoError(err, "Error creating a new trace ID.")
 		req = req.WithContext(trace.NewContext(req.Context(), traceID))
 
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 
 		handler := RequestShipmentDiversionHandler{
 			handlerConfig,
@@ -2133,7 +2133,7 @@ func (suite *HandlerSuite) TestRequestShipmentDiversionHandler() {
 
 		req := httptest.NewRequest("POST", fmt.Sprintf("/shipments/%s/request-diversion", uuid.String()), nil)
 		req = suite.AuthenticateOfficeRequest(req, officeUser)
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 
 		handler := RequestShipmentDiversionHandler{
 			handlerConfig,
@@ -2175,7 +2175,7 @@ func (suite *HandlerSuite) TestRequestShipmentDiversionHandler() {
 
 		req := httptest.NewRequest("POST", fmt.Sprintf("/shipments/%s/request-diversion", shipment.ID.String()), nil)
 		req = suite.AuthenticateOfficeRequest(req, officeUser)
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 
 		handler := RequestShipmentDiversionHandler{
 			handlerConfig,
@@ -2217,7 +2217,7 @@ func (suite *HandlerSuite) TestRequestShipmentDiversionHandler() {
 
 		req := httptest.NewRequest("POST", fmt.Sprintf("/shipments/%s/request-diversion", shipment.ID.String()), nil)
 		req = suite.AuthenticateOfficeRequest(req, officeUser)
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 
 		handler := RequestShipmentDiversionHandler{
 			handlerConfig,
@@ -2259,7 +2259,7 @@ func (suite *HandlerSuite) TestRequestShipmentDiversionHandler() {
 
 		req := httptest.NewRequest("POST", fmt.Sprintf("/shipments/%s/request-diversion", shipment.ID.String()), nil)
 		req = suite.AuthenticateOfficeRequest(req, officeUser)
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 
 		handler := RequestShipmentDiversionHandler{
 			handlerConfig,
@@ -2301,7 +2301,7 @@ func (suite *HandlerSuite) TestRequestShipmentDiversionHandler() {
 
 		req := httptest.NewRequest("POST", fmt.Sprintf("/shipments/%s/request-diversion", shipment.ID.String()), nil)
 		req = suite.AuthenticateOfficeRequest(req, officeUser)
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 
 		handler := RequestShipmentDiversionHandler{
 			handlerConfig,
@@ -2343,7 +2343,7 @@ func (suite *HandlerSuite) TestRequestShipmentDiversionHandler() {
 
 		req := httptest.NewRequest("POST", fmt.Sprintf("/shipments/%s/request-diversion", shipment.ID.String()), nil)
 		req = suite.AuthenticateOfficeRequest(req, officeUser)
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 
 		handler := RequestShipmentDiversionHandler{
 			handlerConfig,
@@ -2400,7 +2400,7 @@ func (suite *HandlerSuite) TestApproveShipmentDiversionHandler() {
 		suite.FatalNoError(err, "Error creating a new trace ID.")
 		req = req.WithContext(trace.NewContext(req.Context(), traceID))
 
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 
 		handler := ApproveShipmentDiversionHandler{
 			handlerConfig,
@@ -2435,7 +2435,7 @@ func (suite *HandlerSuite) TestApproveShipmentDiversionHandler() {
 
 		req := httptest.NewRequest("POST", fmt.Sprintf("/shipments/%s/approve-diversion", uuid.String()), nil)
 		req = suite.AuthenticateOfficeRequest(req, officeUser)
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 
 		handler := ApproveShipmentDiversionHandler{
 			handlerConfig,
@@ -2474,7 +2474,7 @@ func (suite *HandlerSuite) TestApproveShipmentDiversionHandler() {
 
 		req := httptest.NewRequest("POST", fmt.Sprintf("/shipments/%s/approve-diversion", shipment.ID.String()), nil)
 		req = suite.AuthenticateOfficeRequest(req, officeUser)
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 
 		handler := ApproveShipmentDiversionHandler{
 			handlerConfig,
@@ -2513,7 +2513,7 @@ func (suite *HandlerSuite) TestApproveShipmentDiversionHandler() {
 
 		req := httptest.NewRequest("POST", fmt.Sprintf("/shipments/%s/approve-diversion", shipment.ID.String()), nil)
 		req = suite.AuthenticateOfficeRequest(req, officeUser)
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 
 		handler := ApproveShipmentDiversionHandler{
 			handlerConfig,
@@ -2552,7 +2552,7 @@ func (suite *HandlerSuite) TestApproveShipmentDiversionHandler() {
 
 		req := httptest.NewRequest("POST", fmt.Sprintf("/shipments/%s/approve-diversion", shipment.ID.String()), nil)
 		req = suite.AuthenticateOfficeRequest(req, officeUser)
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 
 		handler := ApproveShipmentDiversionHandler{
 			handlerConfig,
@@ -2591,7 +2591,7 @@ func (suite *HandlerSuite) TestApproveShipmentDiversionHandler() {
 
 		req := httptest.NewRequest("POST", fmt.Sprintf("/shipments/%s/approve-diversion", shipment.ID.String()), nil)
 		req = suite.AuthenticateOfficeRequest(req, officeUser)
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 
 		handler := ApproveShipmentDiversionHandler{
 			handlerConfig,
@@ -2630,7 +2630,7 @@ func (suite *HandlerSuite) TestApproveShipmentDiversionHandler() {
 
 		req := httptest.NewRequest("POST", fmt.Sprintf("/shipments/%s/approve-diversion", shipment.ID.String()), nil)
 		req = suite.AuthenticateOfficeRequest(req, officeUser)
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 
 		handler := ApproveShipmentDiversionHandler{
 			handlerConfig,
@@ -2679,7 +2679,7 @@ func (suite *HandlerSuite) TestRejectShipmentHandler() {
 		suite.FatalNoError(err, "Error creating a new trace ID.")
 		req = req.WithContext(trace.NewContext(req.Context(), traceID))
 
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 
 		handler := RejectShipmentHandler{
 			handlerConfig,
@@ -2717,7 +2717,7 @@ func (suite *HandlerSuite) TestRejectShipmentHandler() {
 
 		req := httptest.NewRequest("POST", fmt.Sprintf("/shipments/%s/reject", uuid.String()), nil)
 		req = suite.AuthenticateOfficeRequest(req, officeUser)
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 
 		handler := RejectShipmentHandler{
 			handlerConfig,
@@ -2759,7 +2759,7 @@ func (suite *HandlerSuite) TestRejectShipmentHandler() {
 
 		req := httptest.NewRequest("POST", fmt.Sprintf("/shipments/%s/reject", shipment.ID.String()), nil)
 		req = suite.AuthenticateOfficeRequest(req, officeUser)
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 
 		handler := RejectShipmentHandler{
 			handlerConfig,
@@ -2801,7 +2801,7 @@ func (suite *HandlerSuite) TestRejectShipmentHandler() {
 
 		req := httptest.NewRequest("POST", fmt.Sprintf("/shipments/%s/reject", shipment.ID.String()), nil)
 		req = suite.AuthenticateOfficeRequest(req, officeUser)
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 
 		handler := RejectShipmentHandler{
 			handlerConfig,
@@ -2843,7 +2843,7 @@ func (suite *HandlerSuite) TestRejectShipmentHandler() {
 
 		req := httptest.NewRequest("POST", fmt.Sprintf("/shipments/%s/reject", shipment.ID.String()), nil)
 		req = suite.AuthenticateOfficeRequest(req, officeUser)
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 
 		handler := RejectShipmentHandler{
 			handlerConfig,
@@ -2885,7 +2885,7 @@ func (suite *HandlerSuite) TestRejectShipmentHandler() {
 
 		req := httptest.NewRequest("POST", fmt.Sprintf("/shipments/%s/reject", shipment.ID.String()), nil)
 		req = suite.AuthenticateOfficeRequest(req, officeUser)
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 
 		handler := RejectShipmentHandler{
 			handlerConfig,
@@ -2927,7 +2927,7 @@ func (suite *HandlerSuite) TestRejectShipmentHandler() {
 
 		req := httptest.NewRequest("POST", fmt.Sprintf("/shipments/%s/reject", shipment.ID.String()), nil)
 		req = suite.AuthenticateOfficeRequest(req, officeUser)
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 
 		handler := RejectShipmentHandler{
 			handlerConfig,
@@ -2969,7 +2969,7 @@ func (suite *HandlerSuite) TestRejectShipmentHandler() {
 
 		req := httptest.NewRequest("POST", fmt.Sprintf("/shipments/%s/reject", shipment.ID.String()), nil)
 		req = suite.AuthenticateOfficeRequest(req, officeUser)
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 
 		handler := RejectShipmentHandler{
 			handlerConfig,
@@ -3026,7 +3026,7 @@ func (suite *HandlerSuite) TestRequestShipmentCancellationHandler() {
 		suite.FatalNoError(err, "Error creating a new trace ID.")
 		req = req.WithContext(trace.NewContext(req.Context(), traceID))
 
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 
 		handler := RequestShipmentCancellationHandler{
 			handlerConfig,
@@ -3061,7 +3061,7 @@ func (suite *HandlerSuite) TestRequestShipmentCancellationHandler() {
 
 		req := httptest.NewRequest("POST", fmt.Sprintf("/shipments/%s/request-cancellation", uuid.String()), nil)
 		req = suite.AuthenticateOfficeRequest(req, officeUser)
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 
 		handler := RequestShipmentCancellationHandler{
 			handlerConfig,
@@ -3100,7 +3100,7 @@ func (suite *HandlerSuite) TestRequestShipmentCancellationHandler() {
 
 		req := httptest.NewRequest("POST", fmt.Sprintf("/shipments/%s/request-cancellation", shipment.ID.String()), nil)
 		req = suite.AuthenticateOfficeRequest(req, officeUser)
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 
 		handler := RequestShipmentCancellationHandler{
 			handlerConfig,
@@ -3141,7 +3141,7 @@ func (suite *HandlerSuite) TestRequestShipmentCancellationHandler() {
 
 		req := httptest.NewRequest("POST", fmt.Sprintf("/shipments/%s/request-cancellation", shipment.ID.String()), nil)
 		req = suite.AuthenticateOfficeRequest(req, officeUser)
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 
 		handler := RequestShipmentCancellationHandler{
 			handlerConfig,
@@ -3180,7 +3180,7 @@ func (suite *HandlerSuite) TestRequestShipmentCancellationHandler() {
 
 		req := httptest.NewRequest("POST", fmt.Sprintf("/shipments/%s/request-cancellation", shipment.ID.String()), nil)
 		req = suite.AuthenticateOfficeRequest(req, officeUser)
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 
 		handler := RequestShipmentCancellationHandler{
 			handlerConfig,
@@ -3219,7 +3219,7 @@ func (suite *HandlerSuite) TestRequestShipmentCancellationHandler() {
 
 		req := httptest.NewRequest("POST", fmt.Sprintf("/shipments/%s/request-cancellation", shipment.ID.String()), nil)
 		req = suite.AuthenticateOfficeRequest(req, officeUser)
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 
 		handler := RequestShipmentCancellationHandler{
 			handlerConfig,
@@ -3258,7 +3258,7 @@ func (suite *HandlerSuite) TestRequestShipmentCancellationHandler() {
 
 		req := httptest.NewRequest("POST", fmt.Sprintf("/shipments/%s/request-cancellation", shipment.ID.String()), nil)
 		req = suite.AuthenticateOfficeRequest(req, officeUser)
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 
 		handler := RequestShipmentCancellationHandler{
 			handlerConfig,
@@ -3311,7 +3311,7 @@ func (suite *HandlerSuite) TestRequestShipmentReweighHandler() {
 		suite.FatalNoError(err, "Error creating a new trace ID.")
 		req = req.WithContext(trace.NewContext(req.Context(), traceID))
 
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 		handlerConfig.SetNotificationSender(suite.TestNotificationSender())
 		planner := &routemocks.Planner{}
 		planner.On("ZipTransitDistance",
@@ -3370,7 +3370,7 @@ func (suite *HandlerSuite) TestRequestShipmentReweighHandler() {
 
 		req := httptest.NewRequest("POST", fmt.Sprintf("/shipments/%s/request-reweigh", uuid.String()), nil)
 		req = suite.AuthenticateOfficeRequest(req, officeUser)
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 		planner := &routemocks.Planner{}
 		planner.On("ZipTransitDistance",
 			mock.AnythingOfType("*appcontext.appContext"),
@@ -3425,7 +3425,7 @@ func (suite *HandlerSuite) TestRequestShipmentReweighHandler() {
 
 		req := httptest.NewRequest("POST", fmt.Sprintf("/shipments/%s/request-reweigh", shipment.ID.String()), nil)
 		req = suite.AuthenticateOfficeRequest(req, officeUser)
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 		planner := &routemocks.Planner{}
 		planner.On("ZipTransitDistance",
 			mock.AnythingOfType("*appcontext.appContext"),
@@ -3481,7 +3481,7 @@ func (suite *HandlerSuite) TestRequestShipmentReweighHandler() {
 
 		req := httptest.NewRequest("POST", fmt.Sprintf("/shipments/%s/request-reweigh", shipment.ID.String()), nil)
 		req = suite.AuthenticateOfficeRequest(req, officeUser)
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 		planner := &routemocks.Planner{}
 		planner.On("ZipTransitDistance",
 			mock.AnythingOfType("*appcontext.appContext"),
@@ -3538,7 +3538,7 @@ func (suite *HandlerSuite) TestRequestShipmentReweighHandler() {
 
 		req := httptest.NewRequest("POST", fmt.Sprintf("/shipments/%s/request-reweigh", shipment.ID.String()), nil)
 		req = suite.AuthenticateOfficeRequest(req, officeUser)
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 		planner := &routemocks.Planner{}
 		planner.On("ZipTransitDistance",
 			mock.AnythingOfType("*appcontext.appContext"),
@@ -3594,7 +3594,7 @@ func (suite *HandlerSuite) TestRequestShipmentReweighHandler() {
 
 		req := httptest.NewRequest("POST", fmt.Sprintf("/shipments/%s/request-reweigh", shipment.ID.String()), nil)
 		req = suite.AuthenticateOfficeRequest(req, officeUser)
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 		planner := &routemocks.Planner{}
 		planner.On("ZipTransitDistance",
 			mock.AnythingOfType("*appcontext.appContext"),
@@ -3667,7 +3667,7 @@ func (suite *HandlerSuite) TestReviewShipmentAddressUpdateHandler() {
 			ShipmentID:  *handlers.FmtUUID(addressChange.ShipmentID),
 		}
 
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 
 		mockCreator := mocks.ShipmentAddressUpdateRequester{}
 
@@ -3699,7 +3699,7 @@ func (suite *HandlerSuite) TestReviewShipmentAddressUpdateHandler() {
 
 		mockCreator := mocks.ShipmentAddressUpdateRequester{}
 
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 
 		handler := ReviewShipmentAddressUpdateHandler{
 			handlerConfig,
@@ -3744,7 +3744,7 @@ func (suite *HandlerSuite) TestReviewShipmentAddressUpdateHandler() {
 
 		mockCreator := mocks.ShipmentAddressUpdateRequester{}
 
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 
 		handler := ReviewShipmentAddressUpdateHandler{
 			handlerConfig,
@@ -3789,7 +3789,7 @@ func (suite *HandlerSuite) TestReviewShipmentAddressUpdateHandler() {
 
 		mockCreator := mocks.ShipmentAddressUpdateRequester{}
 
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 
 		handler := ReviewShipmentAddressUpdateHandler{
 			handlerConfig,
@@ -3832,7 +3832,7 @@ func (suite *HandlerSuite) TestReviewShipmentAddressUpdateHandler() {
 
 		mockCreator := mocks.ShipmentAddressUpdateRequester{}
 
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 
 		handler := ReviewShipmentAddressUpdateHandler{
 			handlerConfig,
@@ -3931,7 +3931,7 @@ func (suite *HandlerSuite) TestApproveSITExtensionHandler() {
 		sitExtensionApprover := sitextension.NewSITExtensionApprover(moveRouter)
 		req := httptest.NewRequest("PATCH", fmt.Sprintf("/shipments/%s/sit-extension/%s/approve", mtoShipment.ID.String(), sitExtension.ID.String()), nil)
 		req = suite.AuthenticateOfficeRequest(req, officeUser)
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 
 		builder := query.NewQueryBuilder()
 		fetcher := fetch.NewFetcher(builder)
@@ -4028,7 +4028,7 @@ func (suite *HandlerSuite) TestDenySITExtensionHandler() {
 		sitExtensionDenier := sitextension.NewSITExtensionDenier(moveRouter)
 		req := httptest.NewRequest("PATCH", fmt.Sprintf("/shipments/%s/sit-extension/%s/deny", mtoShipment.ID.String(), sitExtension.ID.String()), nil)
 		req = suite.AuthenticateOfficeRequest(req, officeUser)
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 
 		handler := DenySITExtensionHandler{
 			handlerConfig,
@@ -4073,7 +4073,7 @@ func (suite *HandlerSuite) CreateApprovedSITDurationUpdate() {
 		approvedSITDurationUpdateCreator := sitextension.NewApprovedSITDurationUpdateCreator()
 		req := httptest.NewRequest("POST", fmt.Sprintf("/shipments/%s/sit-extension/", mtoShipment.ID.String()), nil)
 		req = suite.AuthenticateOfficeRequest(req, officeUser)
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 
 		builder := query.NewQueryBuilder()
 		fetcher := fetch.NewFetcher(builder)
@@ -4156,7 +4156,7 @@ func (suite *HandlerSuite) CreateApprovedSITDurationUpdate() {
 		approvedSITDurationUpdateCreator := sitextension.NewApprovedSITDurationUpdateCreator()
 		req := httptest.NewRequest("POST", fmt.Sprintf("/shipments/%s/sit-extension/", mtoShipment.ID.String()), nil)
 		req = suite.AuthenticateOfficeRequest(req, officeUser)
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 
 		builder := query.NewQueryBuilder()
 		fetcher := fetch.NewFetcher(builder)
@@ -4320,7 +4320,7 @@ func (suite *HandlerSuite) TestCreateMTOShipmentHandler() {
 	}
 
 	suite.Run("Successful POST - Integration Test", func() {
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 
 		subtestData := suite.makeCreateMTOShipmentSubtestData()
 		builder := subtestData.builder
@@ -4376,7 +4376,7 @@ func (suite *HandlerSuite) TestCreateMTOShipmentHandler() {
 	})
 
 	suite.Run("POST failure - 500", func() {
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 
 		subtestData := suite.makeCreateMTOShipmentSubtestData()
 		params := subtestData.params
@@ -4411,7 +4411,7 @@ func (suite *HandlerSuite) TestCreateMTOShipmentHandler() {
 	})
 
 	suite.Run("POST failure - 422 -- Bad agent IDs set on shipment", func() {
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 
 		subtestData := suite.makeCreateMTOShipmentSubtestData()
 		builder := subtestData.builder
@@ -4473,7 +4473,7 @@ func (suite *HandlerSuite) TestCreateMTOShipmentHandler() {
 	})
 
 	suite.Run("POST failure - 422 - invalid input, missing pickup address", func() {
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 
 		subtestData := suite.makeCreateMTOShipmentSubtestData()
 		builder := subtestData.builder
@@ -4530,7 +4530,7 @@ func (suite *HandlerSuite) TestCreateMTOShipmentHandler() {
 	})
 
 	suite.Run("POST failure - 404 -- not found", func() {
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 
 		subtestData := suite.makeCreateMTOShipmentSubtestData()
 		builder := subtestData.builder
@@ -4583,7 +4583,7 @@ func (suite *HandlerSuite) TestCreateMTOShipmentHandler() {
 	})
 
 	suite.Run("POST failure - 400 -- nil body", func() {
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 
 		subtestData := suite.makeCreateMTOShipmentSubtestData()
 		builder := subtestData.builder
@@ -4675,7 +4675,7 @@ func (suite *HandlerSuite) TestCreateMTOShipmentHandlerUsingPPM() {
 			},
 		}, nil)
 
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 		builder := query.NewQueryBuilder()
 		fetcher := fetch.NewFetcher(builder)
 		creator := mtoshipment.NewMTOShipmentCreatorV1(builder, fetcher, moveservices.NewMoveRouter(transportationoffice.NewTransportationOfficesFetcher()), addressCreator)
@@ -4917,7 +4917,7 @@ func (suite *HandlerSuite) TestCreateMTOShipmentHandlerUsingPPM() {
 			},
 		}, nil)
 
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 		builder := query.NewQueryBuilder()
 		fetcher := fetch.NewFetcher(builder)
 		creator := mtoshipment.NewMTOShipmentCreatorV1(builder, fetcher, moveservices.NewMoveRouter(transportationoffice.NewTransportationOfficesFetcher()), addressCreator)
@@ -5087,7 +5087,7 @@ func (suite *HandlerSuite) TestCreateMTOShipmentHandlerUsingPPM() {
 			},
 		}, nil)
 
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 		builder := query.NewQueryBuilder()
 		fetcher := fetch.NewFetcher(builder)
 		creator := mtoshipment.NewMTOShipmentCreatorV1(builder, fetcher, moveservices.NewMoveRouter(transportationoffice.NewTransportationOfficesFetcher()), addressCreator)
@@ -5350,7 +5350,7 @@ func (suite *HandlerSuite) TestUpdateShipmentHandler() {
 		mobileHomeShipmentUpdater := mobilehomeshipment.NewMobileHomeShipmentUpdater()
 		shipmentUpdater := shipmentorchestrator.NewShipmentUpdater(mtoShipmentUpdater, ppmShipmentUpdater, boatShipmentUpdater, mobileHomeShipmentUpdater, nil)
 		handler := UpdateShipmentHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			shipmentUpdater,
 			sitstatus.NewShipmentSITStatus(),
 		}
@@ -5418,7 +5418,7 @@ func (suite *HandlerSuite) TestUpdateShipmentHandler() {
 		mobileHomeShipmentUpdater := mobilehomeshipment.NewMobileHomeShipmentUpdater()
 		shipmentUpdater := shipmentorchestrator.NewShipmentUpdater(mtoShipmentUpdater, ppmShipmentUpdater, boatShipmentUpdater, mobileHomeShipmentUpdater, nil)
 		handler := UpdateShipmentHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			shipmentUpdater,
 			sitstatus.NewShipmentSITStatus(),
 		}
@@ -5604,7 +5604,7 @@ func (suite *HandlerSuite) TestUpdateShipmentHandler() {
 		mobileHomeShipmentUpdater := mobilehomeshipment.NewMobileHomeShipmentUpdater()
 		shipmentUpdater := shipmentorchestrator.NewShipmentUpdater(mtoShipmentUpdater, ppmShipmentUpdater, boatShipmentUpdater, mobileHomeShipmentUpdater, nil)
 		handler := UpdateShipmentHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			shipmentUpdater,
 			sitstatus.NewShipmentSITStatus(),
 		}
@@ -5684,7 +5684,7 @@ func (suite *HandlerSuite) TestUpdateShipmentHandler() {
 		mobileHomeShipmentUpdater := mobilehomeshipment.NewMobileHomeShipmentUpdater()
 		shipmentUpdater := shipmentorchestrator.NewShipmentUpdater(mtoShipmentUpdater, ppmShipmentUpdater, boatShipmentUpdater, mobileHomeShipmentUpdater, nil)
 		handler := UpdateShipmentHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			shipmentUpdater,
 			sitstatus.NewShipmentSITStatus(),
 		}
@@ -5764,7 +5764,7 @@ func (suite *HandlerSuite) TestUpdateShipmentHandler() {
 		mobileHomeShipmentUpdater := mobilehomeshipment.NewMobileHomeShipmentUpdater()
 		shipmentUpdater := shipmentorchestrator.NewShipmentUpdater(mtoShipmentUpdater, ppmShipmentUpdater, boatShipmentUpdater, mobileHomeShipmentUpdater, nil)
 		handler := UpdateShipmentHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			shipmentUpdater,
 			sitstatus.NewShipmentSITStatus(),
 		}
@@ -5802,7 +5802,7 @@ func (suite *HandlerSuite) TestUpdateShipmentHandler() {
 		mobileHomeShipmentUpdater := mobilehomeshipment.NewMobileHomeShipmentUpdater()
 		shipmentUpdater := shipmentorchestrator.NewShipmentUpdater(mtoShipmentUpdater, ppmShipmentUpdater, boatShipmentUpdater, mobileHomeShipmentUpdater, nil)
 		handler := UpdateShipmentHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			shipmentUpdater,
 			sitstatus.NewShipmentSITStatus(),
 		}
@@ -5842,7 +5842,7 @@ func (suite *HandlerSuite) TestUpdateShipmentHandler() {
 		mobileHomeShipmentUpdater := mobilehomeshipment.NewMobileHomeShipmentUpdater()
 		shipmentUpdater := shipmentorchestrator.NewShipmentUpdater(mtoShipmentUpdater, ppmShipmentUpdater, boatShipmentUpdater, mobileHomeShipmentUpdater, nil)
 		handler := UpdateShipmentHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			shipmentUpdater,
 			sitstatus.NewShipmentSITStatus(),
 		}
@@ -5883,7 +5883,7 @@ func (suite *HandlerSuite) TestUpdateShipmentHandler() {
 		mobileHomeShipmentUpdater := mobilehomeshipment.NewMobileHomeShipmentUpdater()
 		shipmentUpdater := shipmentorchestrator.NewShipmentUpdater(mtoShipmentUpdater, ppmShipmentUpdater, boatShipmentUpdater, mobileHomeShipmentUpdater, nil)
 		handler := UpdateShipmentHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			shipmentUpdater,
 			sitstatus.NewShipmentSITStatus(),
 		}
@@ -5913,7 +5913,7 @@ func (suite *HandlerSuite) TestUpdateShipmentHandler() {
 	suite.Run("PATCH failure - 500", func() {
 		mockUpdater := mocks.ShipmentUpdater{}
 		handler := UpdateShipmentHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			&mockUpdater,
 			sitstatus.NewShipmentSITStatus(),
 		}
@@ -6000,7 +6000,7 @@ func (suite *HandlerSuite) TestUpdateSITServiceItemCustomerExpenseHandler() {
 		updater := mtoserviceitem.NewMTOServiceItemUpdater(planner, builder, moveRouter, shipmentFetcher, addressCreator, portLocationFetcher, ghcrateengine.NewDomesticUnpackPricer(), ghcrateengine.NewDomesticLinehaulPricer(), ghcrateengine.NewDomesticDestinationPricer(), ghcrateengine.NewFuelSurchargePricer())
 		req := httptest.NewRequest("PATCH", fmt.Sprintf("/shipments/%s/sit-service-item/convert-to-customer-expense", approvedShipment.ID.String()), nil)
 		req = suite.AuthenticateOfficeRequest(req, officeUser)
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 
 		handler := UpdateSITServiceItemCustomerExpenseHandler{
 			handlerConfig,
@@ -6076,7 +6076,7 @@ func (suite *HandlerSuite) TestUpdateSITServiceItemCustomerExpenseHandler() {
 		updater := mtoserviceitem.NewMTOServiceItemUpdater(planner, builder, moveRouter, shipmentFetcher, addressCreator, portLocationFetcher, ghcrateengine.NewDomesticUnpackPricer(), ghcrateengine.NewDomesticLinehaulPricer(), ghcrateengine.NewDomesticDestinationPricer(), ghcrateengine.NewFuelSurchargePricer())
 		req := httptest.NewRequest("PATCH", fmt.Sprintf("/shipments/%s/sit-service-item/convert-to-customer-expense", approvedShipment.ID.String()), nil)
 		req = suite.AuthenticateOfficeRequest(req, officeUser)
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 
 		handler := UpdateSITServiceItemCustomerExpenseHandler{
 			handlerConfig,
@@ -6134,7 +6134,7 @@ func (suite *HandlerSuite) TestUpdateSITServiceItemCustomerExpenseHandler() {
 
 		req := httptest.NewRequest("PATCH", fmt.Sprintf("/shipments/%s/sit-service-item/convert-to-customer-expense", approvedShipment.ID.String()), nil)
 		req = suite.AuthenticateOfficeRequest(req, officeUser)
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 
 		handler := UpdateSITServiceItemCustomerExpenseHandler{
 			handlerConfig,
@@ -6170,7 +6170,7 @@ func (suite *HandlerSuite) TestTerminateShipmentHandler() {
 		req = suite.AuthenticateOfficeRequest(req, user)
 
 		handler := TerminateShipmentHandler{
-			HandlerConfig:       suite.HandlerConfig(),
+			HandlerConfig:       suite.NewHandlerConfig(),
 			ShipmentTermination: &mocks.ShipmentTermination{},
 		}
 
@@ -6201,7 +6201,7 @@ func (suite *HandlerSuite) TestTerminateShipmentHandler() {
 		req = suite.AuthenticateOfficeRequest(req, contractingOfficer)
 
 		handler := TerminateShipmentHandler{
-			HandlerConfig:       suite.HandlerConfig(),
+			HandlerConfig:       suite.NewHandlerConfig(),
 			ShipmentTermination: terminator,
 		}
 
@@ -6237,7 +6237,7 @@ func (suite *HandlerSuite) TestTerminateShipmentHandler() {
 		req = suite.AuthenticateOfficeRequest(req, contractingOfficer)
 
 		handler := TerminateShipmentHandler{
-			HandlerConfig:       suite.HandlerConfig(),
+			HandlerConfig:       suite.NewHandlerConfig(),
 			ShipmentTermination: mockTerminator,
 		}
 
@@ -6264,7 +6264,7 @@ func (suite *HandlerSuite) TestTerminateShipmentHandler() {
 		req = suite.AuthenticateOfficeRequest(req, contractingOfficer)
 
 		handler := TerminateShipmentHandler{
-			HandlerConfig:       suite.HandlerConfig(),
+			HandlerConfig:       suite.NewHandlerConfig(),
 			ShipmentTermination: mockTerminator,
 		}
 

--- a/pkg/handlers/ghcapi/mto_shipment_test.go
+++ b/pkg/handlers/ghcapi/mto_shipment_test.go
@@ -4812,7 +4812,7 @@ func (suite *HandlerSuite) TestCreateMTOShipmentHandlerUsingPPM() {
 			ApplicationName: auth.OfficeApp,
 			UserID:          user.ID,
 			IDToken:         "fake token",
-			Roles:           roles.Roles{},
+			CurrentRole:     roles.Role{},
 		}
 		ctx := auth.SetSessionInRequestContext(req, session)
 
@@ -5003,7 +5003,7 @@ func (suite *HandlerSuite) TestCreateMTOShipmentHandlerUsingPPM() {
 			ApplicationName: auth.OfficeApp,
 			UserID:          user.ID,
 			IDToken:         "fake token",
-			Roles:           roles.Roles{},
+			CurrentRole:     roles.Role{},
 		}
 		ctx := auth.SetSessionInRequestContext(req, session)
 
@@ -5174,7 +5174,7 @@ func (suite *HandlerSuite) TestCreateMTOShipmentHandlerUsingPPM() {
 			ApplicationName: auth.OfficeApp,
 			UserID:          user.ID,
 			IDToken:         "fake token",
-			Roles:           roles.Roles{},
+			CurrentRole:     roles.Role{},
 		}
 		ctx := auth.SetSessionInRequestContext(req, session)
 

--- a/pkg/handlers/ghcapi/office_users_test.go
+++ b/pkg/handlers/ghcapi/office_users_test.go
@@ -25,7 +25,7 @@ func (suite *HandlerSuite) setupOfficeUserCreatorTestScenario() (*mocks.OfficeUs
 	mockRoleAssociator := &mocks.RoleAssociater{}
 	mockTransportaionOfficeAssignmentUpdater := &mocks.TransportaionOfficeAssignmentUpdater{}
 	handler := &RequestOfficeUserHandler{
-		HandlerConfig:                        suite.HandlerConfig(),
+		HandlerConfig:                        suite.NewHandlerConfig(),
 		OfficeUserCreator:                    mockCreator,
 		NewQueryFilter:                       query.NewQueryFilter,
 		UserRoleAssociator:                   mockUserRoleAssociator,

--- a/pkg/handlers/ghcapi/orders.go
+++ b/pkg/handlers/ghcapi/orders.go
@@ -138,7 +138,7 @@ func (h CounselingUpdateOrderHandler) Handle(
 			}
 
 			if !appCtx.Session().IsOfficeUser() ||
-				!appCtx.Session().Roles.HasRole(roles.RoleTypeServicesCounselor) {
+				!(appCtx.Session().CurrentRole.RoleType == roles.RoleTypeServicesCounselor) {
 				return handleError(apperror.NewForbiddenError("is not a Services Counselor"))
 			}
 
@@ -485,7 +485,7 @@ func (h CounselingUpdateAllowanceHandler) Handle(
 			}
 
 			if !appCtx.Session().IsOfficeUser() ||
-				!appCtx.Session().Roles.HasRole(roles.RoleTypeServicesCounselor) {
+				!(appCtx.Session().CurrentRole.RoleType == roles.RoleTypeServicesCounselor) {
 				return handleError(apperror.NewForbiddenError("is not a Services Counselor"))
 			}
 

--- a/pkg/handlers/ghcapi/orders.go
+++ b/pkg/handlers/ghcapi/orders.go
@@ -138,7 +138,7 @@ func (h CounselingUpdateOrderHandler) Handle(
 			}
 
 			if !appCtx.Session().IsOfficeUser() ||
-				!(appCtx.Session().CurrentRole.RoleType == roles.RoleTypeServicesCounselor) {
+				!(appCtx.Session().ActiveRole.RoleType == roles.RoleTypeServicesCounselor) {
 				return handleError(apperror.NewForbiddenError("is not a Services Counselor"))
 			}
 
@@ -485,7 +485,7 @@ func (h CounselingUpdateAllowanceHandler) Handle(
 			}
 
 			if !appCtx.Session().IsOfficeUser() ||
-				!(appCtx.Session().CurrentRole.RoleType == roles.RoleTypeServicesCounselor) {
+				!(appCtx.Session().ActiveRole.RoleType == roles.RoleTypeServicesCounselor) {
 				return handleError(apperror.NewForbiddenError("is not a Services Counselor"))
 			}
 

--- a/pkg/handlers/ghcapi/orders_test.go
+++ b/pkg/handlers/ghcapi/orders_test.go
@@ -1191,7 +1191,7 @@ func (suite *HandlerSuite) TestCounselingUpdateOrderHandler() {
 		order := subtestData.order
 		body := subtestData.body
 
-		requestUser := factory.BuildOfficeUserWithRoles(nil, nil, []roles.RoleType{roles.RoleTypeTOO, roles.RoleTypeTIO, roles.RoleTypeServicesCounselor})
+		requestUser := factory.BuildOfficeUserWithRoles(suite.DB(), nil, []roles.RoleType{roles.RoleTypeTOO, roles.RoleTypeTIO, roles.RoleTypeServicesCounselor})
 		request = suite.AuthenticateOfficeRequest(request, requestUser)
 
 		params := orderop.CounselingUpdateOrderParams{
@@ -1666,7 +1666,7 @@ func (suite *HandlerSuite) TestCounselingUpdateAllowanceHandler() {
 		move := factory.BuildNeedsServiceCounselingMove(suite.DB(), nil, nil)
 		order := move.Orders
 
-		requestUser := factory.BuildOfficeUserWithRoles(nil, nil, []roles.RoleType{roles.RoleTypeTOO, roles.RoleTypeTIO, roles.RoleTypeServicesCounselor})
+		requestUser := factory.BuildOfficeUserWithRoles(nil, nil, []roles.RoleType{roles.RoleTypeServicesCounselor})
 		request = suite.AuthenticateOfficeRequest(request, requestUser)
 
 		params := orderop.CounselingUpdateAllowanceParams{

--- a/pkg/handlers/ghcapi/orders_test.go
+++ b/pkg/handlers/ghcapi/orders_test.go
@@ -86,7 +86,7 @@ func (suite *HandlerSuite) TestCreateOrder() {
 	}
 
 	fakeS3 := storageTest.NewFakeS3Storage(true)
-	handlerConfig := suite.HandlerConfig()
+	handlerConfig := suite.NewHandlerConfig()
 	handlerConfig.SetFileStorer(fakeS3)
 	createHandler := CreateOrderHandler{handlerConfig, waf}
 
@@ -214,7 +214,7 @@ func (suite *HandlerSuite) TestCreateOrderWithOCONUSValues() {
 	}
 
 	fakeS3 := storageTest.NewFakeS3Storage(true)
-	handlerConfig := suite.HandlerConfig()
+	handlerConfig := suite.NewHandlerConfig()
 	handlerConfig.SetFileStorer(fakeS3)
 	createHandler := CreateOrderHandler{handlerConfig, waf}
 
@@ -348,7 +348,7 @@ func (suite *HandlerSuite) TestCreateOrderWithCivilianTDYUBAllowanceValues() {
 	}
 
 	fakeS3 := storageTest.NewFakeS3Storage(true)
-	handlerConfig := suite.HandlerConfig()
+	handlerConfig := suite.NewHandlerConfig()
 	handlerConfig.SetFileStorer(fakeS3)
 	createHandler := CreateOrderHandler{handlerConfig, waf}
 
@@ -377,7 +377,7 @@ func (suite *HandlerSuite) TestGetOrderHandlerIntegration() {
 		HTTPRequest: request,
 		OrderID:     strfmt.UUID(order.ID.String()),
 	}
-	handlerConfig := suite.HandlerConfig()
+	handlerConfig := suite.NewHandlerConfig()
 	handler := GetOrdersHandler{
 		handlerConfig,
 		orderservice.NewOrderFetcher(waf),
@@ -440,7 +440,7 @@ func (suite *HandlerSuite) TestWeightAllowances() {
 		orderFetcher.On("FetchOrder", mock.AnythingOfType("*appcontext.appContext"),
 			order.ID).Return(&order, nil)
 
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 		handler := GetOrdersHandler{
 			handlerConfig,
 			&orderFetcher,
@@ -488,7 +488,7 @@ func (suite *HandlerSuite) TestWeightAllowances() {
 		orderFetcher.On("FetchOrder", mock.AnythingOfType("*appcontext.appContext"),
 			order.ID).Return(&order, nil)
 
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 		handler := GetOrdersHandler{
 			handlerConfig,
 			&orderFetcher,
@@ -790,7 +790,7 @@ func (suite *HandlerSuite) TestUpdateOrderHandlerWithAmendedUploads() {
 	})
 
 	suite.Run("Does not update move status if move status is not APPROVALS_REQUESTED", func() {
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 		subtestData := suite.makeUpdateOrderHandlerSubtestData()
 		move := subtestData.move
 		order := subtestData.move.Orders
@@ -891,7 +891,7 @@ func (suite *HandlerSuite) TestUpdateOrderHandler() {
 	request := httptest.NewRequest("PATCH", "/orders/{orderID}", nil)
 
 	suite.Run("Returns 200 when all validations pass", func() {
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 		subtestData := suite.makeUpdateOrderHandlerSubtestData()
 		order := subtestData.order
 		body := subtestData.body
@@ -947,7 +947,7 @@ func (suite *HandlerSuite) TestUpdateOrderHandler() {
 	// be authorized to update orders. If not, we also need to prevent them from
 	// clicking the Edit Orders button in the frontend.
 	suite.Run("Allows a TIO to update orders", func() {
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 		subtestData := suite.makeUpdateOrderHandlerSubtestData()
 		move := subtestData.move
 		order := subtestData.order
@@ -986,7 +986,7 @@ func (suite *HandlerSuite) TestUpdateOrderHandler() {
 	})
 
 	suite.Run("Returns 404 when updater returns NotFoundError", func() {
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 		subtestData := suite.makeUpdateOrderHandlerSubtestData()
 		order := subtestData.order
 		body := subtestData.body
@@ -1024,7 +1024,7 @@ func (suite *HandlerSuite) TestUpdateOrderHandler() {
 	})
 
 	suite.Run("Returns 412 when eTag does not match", func() {
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 		subtestData := suite.makeUpdateOrderHandlerSubtestData()
 		order := subtestData.order
 		body := subtestData.body
@@ -1062,7 +1062,7 @@ func (suite *HandlerSuite) TestUpdateOrderHandler() {
 	})
 
 	suite.Run("Returns 422 when updater service returns validation errors", func() {
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 		subtestData := suite.makeUpdateOrderHandlerSubtestData()
 		order := subtestData.order
 		body := subtestData.body
@@ -1126,7 +1126,7 @@ func (suite *HandlerSuite) TestUpdateOrderEventTrigger() {
 	updater.On("UpdateOrderAsTOO", mock.AnythingOfType("*appcontext.appContext"),
 		order.ID, *params.Body, params.IfMatch).Return(&order, move.ID, nil)
 
-	handlerConfig := suite.HandlerConfig()
+	handlerConfig := suite.NewHandlerConfig()
 	handler := UpdateOrderHandler{
 		handlerConfig,
 		updater,
@@ -1186,7 +1186,7 @@ func (suite *HandlerSuite) TestCounselingUpdateOrderHandler() {
 	request := httptest.NewRequest("PATCH", "/counseling/orders/{orderID}", nil)
 
 	suite.Run("Returns 200 when all validations pass", func() {
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 		subtestData := suite.makeCounselingUpdateOrderHandlerSubtestData()
 		order := subtestData.order
 		body := subtestData.body
@@ -1234,7 +1234,7 @@ func (suite *HandlerSuite) TestCounselingUpdateOrderHandler() {
 	})
 
 	suite.Run("Returns 404 when updater returns NotFoundError", func() {
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 		subtestData := suite.makeCounselingUpdateOrderHandlerSubtestData()
 		order := subtestData.order
 		body := subtestData.body
@@ -1271,7 +1271,7 @@ func (suite *HandlerSuite) TestCounselingUpdateOrderHandler() {
 	})
 
 	suite.Run("Returns 412 when eTag does not match", func() {
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 		subtestData := suite.makeCounselingUpdateOrderHandlerSubtestData()
 		order := subtestData.order
 		body := subtestData.body
@@ -1308,7 +1308,7 @@ func (suite *HandlerSuite) TestCounselingUpdateOrderHandler() {
 	})
 
 	suite.Run("Returns 422 when updater service returns validation errors", func() {
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 		subtestData := suite.makeCounselingUpdateOrderHandlerSubtestData()
 		order := subtestData.order
 		body := subtestData.body
@@ -1434,7 +1434,7 @@ func (suite *HandlerSuite) TestUpdateAllowanceHandler() {
 	request := httptest.NewRequest("PATCH", "/orders/{orderID}/allowances", nil)
 
 	suite.Run("Returns 200 when all validations pass", func() {
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 		subtestData := suite.makeUpdateAllowanceHandlerSubtestData()
 		order := subtestData.order
 		body := subtestData.body
@@ -1479,7 +1479,7 @@ func (suite *HandlerSuite) TestUpdateAllowanceHandler() {
 	})
 
 	suite.Run("Returns 404 when updater returns NotFoundError", func() {
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 		subtestData := suite.makeUpdateAllowanceHandlerSubtestData()
 		order := subtestData.order
 		body := subtestData.body
@@ -1516,7 +1516,7 @@ func (suite *HandlerSuite) TestUpdateAllowanceHandler() {
 	})
 
 	suite.Run("Returns 412 when eTag does not match", func() {
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 		subtestData := suite.makeUpdateAllowanceHandlerSubtestData()
 		order := subtestData.order
 		body := subtestData.body
@@ -1553,7 +1553,7 @@ func (suite *HandlerSuite) TestUpdateAllowanceHandler() {
 	})
 
 	suite.Run("Returns 422 when updater service returns validation errors", func() {
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 		subtestData := suite.makeUpdateAllowanceHandlerSubtestData()
 		order := subtestData.order
 		body := subtestData.body
@@ -1616,7 +1616,7 @@ func (suite *HandlerSuite) TestUpdateAllowanceEventTrigger() {
 	updater.On("UpdateAllowanceAsTOO", mock.AnythingOfType("*appcontext.appContext"),
 		order.ID, *params.Body, params.IfMatch).Return(&order, move.ID, nil)
 
-	handlerConfig := suite.HandlerConfig()
+	handlerConfig := suite.NewHandlerConfig()
 	handler := UpdateAllowanceHandler{
 		handlerConfig,
 		updater,
@@ -1662,7 +1662,7 @@ func (suite *HandlerSuite) TestCounselingUpdateAllowanceHandler() {
 	request := httptest.NewRequest("PATCH", "/counseling/orders/{orderID}/allowances", nil)
 
 	suite.Run("Returns 200 when all validations pass", func() {
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 		move := factory.BuildNeedsServiceCounselingMove(suite.DB(), nil, nil)
 		order := move.Orders
 
@@ -1706,7 +1706,7 @@ func (suite *HandlerSuite) TestCounselingUpdateAllowanceHandler() {
 	})
 
 	suite.Run("Returns 404 when updater returns NotFoundError", func() {
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 		move := factory.BuildNeedsServiceCounselingMove(suite.DB(), nil, nil)
 		order := move.Orders
 
@@ -1742,7 +1742,7 @@ func (suite *HandlerSuite) TestCounselingUpdateAllowanceHandler() {
 	})
 
 	suite.Run("Returns 412 when eTag does not match", func() {
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 		move := factory.BuildNeedsServiceCounselingMove(suite.DB(), nil, nil)
 		order := move.Orders
 
@@ -1778,7 +1778,7 @@ func (suite *HandlerSuite) TestCounselingUpdateAllowanceHandler() {
 	})
 
 	suite.Run("Returns 422 when updater service returns validation errors", func() {
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 		move := factory.BuildNeedsServiceCounselingMove(suite.DB(), nil, nil)
 		order := move.Orders
 
@@ -1818,7 +1818,7 @@ func (suite *HandlerSuite) TestUpdateMaxBillableWeightAsTIOHandler() {
 	request := httptest.NewRequest("PATCH", "/orders/{orderID}/update-max-billable-weight/tio", nil)
 
 	suite.Run("Returns 200 when all validations pass", func() {
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 		subtestData := suite.makeUpdateMaxBillableWeightAsTIOHandlerSubtestData()
 		order := subtestData.order
 		body := subtestData.body
@@ -1857,7 +1857,7 @@ func (suite *HandlerSuite) TestUpdateMaxBillableWeightAsTIOHandler() {
 	})
 
 	suite.Run("Returns 404 when updater returns NotFoundError", func() {
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 		subtestData := suite.makeUpdateMaxBillableWeightAsTIOHandlerSubtestData()
 		order := subtestData.order
 		body := subtestData.body
@@ -1896,7 +1896,7 @@ func (suite *HandlerSuite) TestUpdateMaxBillableWeightAsTIOHandler() {
 	})
 
 	suite.Run("Returns 412 when eTag does not match", func() {
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 		subtestData := suite.makeUpdateMaxBillableWeightAsTIOHandlerSubtestData()
 		order := subtestData.order
 		body := subtestData.body
@@ -1935,7 +1935,7 @@ func (suite *HandlerSuite) TestUpdateMaxBillableWeightAsTIOHandler() {
 	})
 
 	suite.Run("Returns 422 when updater service returns validation errors", func() {
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 		subtestData := suite.makeUpdateMaxBillableWeightAsTIOHandlerSubtestData()
 		order := subtestData.order
 		body := subtestData.body
@@ -1981,7 +1981,7 @@ func (suite *HandlerSuite) TestUpdateBillableWeightHandler() {
 	request := httptest.NewRequest("PATCH", "/orders/{orderID}/update-billable-weight", nil)
 
 	suite.Run("Returns 200 when all validations pass", func() {
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 		subtestData := suite.makeUpdateBillableWeightHandlerSubtestData()
 		order := subtestData.order
 		body := subtestData.body
@@ -2020,7 +2020,7 @@ func (suite *HandlerSuite) TestUpdateBillableWeightHandler() {
 	})
 
 	suite.Run("Returns 404 when updater returns NotFoundError", func() {
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 		subtestData := suite.makeUpdateBillableWeightHandlerSubtestData()
 		order := subtestData.order
 		body := subtestData.body
@@ -2058,7 +2058,7 @@ func (suite *HandlerSuite) TestUpdateBillableWeightHandler() {
 	})
 
 	suite.Run("Returns 412 when eTag does not match", func() {
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 		subtestData := suite.makeUpdateBillableWeightHandlerSubtestData()
 		order := subtestData.order
 		body := subtestData.body
@@ -2096,7 +2096,7 @@ func (suite *HandlerSuite) TestUpdateBillableWeightHandler() {
 	})
 
 	suite.Run("Returns 422 when updater service returns validation errors", func() {
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 		subtestData := suite.makeUpdateBillableWeightHandlerSubtestData()
 		order := subtestData.order
 		body := subtestData.body
@@ -2164,7 +2164,7 @@ func (suite *HandlerSuite) TestUpdateBillableWeightEventTrigger() {
 	updater.On("UpdateBillableWeightAsTOO", mock.AnythingOfType("*appcontext.appContext"),
 		order.ID, dbAuthorizedWeight, params.IfMatch).Return(&order, move.ID, nil)
 
-	handlerConfig := suite.HandlerConfig()
+	handlerConfig := suite.NewHandlerConfig()
 	handler := UpdateBillableWeightHandler{
 		handlerConfig,
 		updater,
@@ -2192,7 +2192,7 @@ func (suite *HandlerSuite) TestAcknowledgeExcessWeightRiskHandler() {
 	request := httptest.NewRequest("POST", "/orders/{orderID}/acknowledge-excess-weight-risk", nil)
 
 	suite.Run("Returns 200 when all validations pass", func() {
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 		now := time.Now()
 		move := factory.BuildApprovalsRequestedMove(suite.DB(), []factory.Customization{
 			{
@@ -2235,7 +2235,7 @@ func (suite *HandlerSuite) TestAcknowledgeExcessWeightRiskHandler() {
 	})
 
 	suite.Run("Returns 404 when updater returns NotFoundError", func() {
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 		now := time.Now()
 		move := factory.BuildApprovalsRequestedMove(suite.DB(), []factory.Customization{
 			{
@@ -2276,7 +2276,7 @@ func (suite *HandlerSuite) TestAcknowledgeExcessWeightRiskHandler() {
 	})
 
 	suite.Run("Returns 412 when eTag does not match", func() {
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 		now := time.Now()
 		move := factory.BuildApprovalsRequestedMove(suite.DB(), []factory.Customization{
 			{
@@ -2317,7 +2317,7 @@ func (suite *HandlerSuite) TestAcknowledgeExcessWeightRiskHandler() {
 	})
 
 	suite.Run("Returns 422 when updater service returns validation errors", func() {
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 		now := time.Now()
 		move := factory.BuildApprovalsRequestedMove(suite.DB(), []factory.Customization{
 			{
@@ -2365,7 +2365,7 @@ func (suite *HandlerSuite) TestacknowledgeExcessUnaccompaniedBaggageWeightRiskHa
 	request := httptest.NewRequest("POST", "/orders/{orderID}/acknowledge-excess-unaccompanied-baggage-weight-risk", nil)
 
 	suite.Run("Returns 200 when all validations pass", func() {
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 		now := time.Now()
 		move := factory.BuildApprovalsRequestedMove(suite.DB(), []factory.Customization{
 			{
@@ -2408,7 +2408,7 @@ func (suite *HandlerSuite) TestacknowledgeExcessUnaccompaniedBaggageWeightRiskHa
 	})
 
 	suite.Run("Returns 404 when updater returns NotFoundError", func() {
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 		now := time.Now()
 		move := factory.BuildApprovalsRequestedMove(suite.DB(), []factory.Customization{
 			{
@@ -2449,7 +2449,7 @@ func (suite *HandlerSuite) TestacknowledgeExcessUnaccompaniedBaggageWeightRiskHa
 	})
 
 	suite.Run("Returns 412 when eTag does not match", func() {
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 		now := time.Now()
 		move := factory.BuildApprovalsRequestedMove(suite.DB(), []factory.Customization{
 			{
@@ -2490,7 +2490,7 @@ func (suite *HandlerSuite) TestacknowledgeExcessUnaccompaniedBaggageWeightRiskHa
 	})
 
 	suite.Run("Returns 422 when updater service returns validation errors", func() {
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 		now := time.Now()
 		move := factory.BuildApprovalsRequestedMove(suite.DB(), []factory.Customization{
 			{
@@ -2564,7 +2564,7 @@ func (suite *HandlerSuite) TestAcknowledgeExcessWeightRiskEventTrigger() {
 	updater.On("AcknowledgeExcessWeightRisk", mock.AnythingOfType("*appcontext.appContext"),
 		order.ID, params.IfMatch).Return(&move, nil)
 
-	handlerConfig := suite.HandlerConfig()
+	handlerConfig := suite.NewHandlerConfig()
 	handler := AcknowledgeExcessWeightRiskHandler{
 		handlerConfig,
 		updater,

--- a/pkg/handlers/ghcapi/payment_request_test.go
+++ b/pkg/handlers/ghcapi/payment_request_test.go
@@ -63,7 +63,7 @@ func (suite *HandlerSuite) TestFetchPaymentRequestHandler() {
 		}
 
 		handler := GetPaymentRequestHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			paymentrequest.NewPaymentRequestFetcher(),
 		}
 
@@ -108,7 +108,7 @@ func (suite *HandlerSuite) TestFetchPaymentRequestHandler() {
 		}
 
 		handler := GetPaymentRequestHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			paymentRequestFetcher,
 		}
 
@@ -165,7 +165,7 @@ func (suite *HandlerSuite) TestGetPaymentRequestsForMoveHandler() {
 			HTTPRequest: request,
 			Locator:     moveLocator,
 		}
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 		handler := GetPaymentRequestForMoveHandler{
 			HandlerConfig:             handlerConfig,
 			PaymentRequestListFetcher: paymentrequest.NewPaymentRequestListFetcher(),
@@ -209,7 +209,7 @@ func (suite *HandlerSuite) TestGetPaymentRequestsForMoveHandler() {
 			HTTPRequest: request,
 			Locator:     "ABC123",
 		}
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 		handler := GetPaymentRequestForMoveHandler{
 			HandlerConfig:             handlerConfig,
 			PaymentRequestListFetcher: paymentRequestListFetcher,
@@ -276,7 +276,7 @@ func (suite *HandlerSuite) TestUpdatePaymentRequestStatusHandler() {
 		}
 
 		handler := UpdatePaymentRequestStatusHandler{
-			HandlerConfig:               suite.HandlerConfig(),
+			HandlerConfig:               suite.NewHandlerConfig(),
 			PaymentRequestStatusUpdater: statusUpdater,
 			PaymentRequestFetcher:       paymentRequestFetcher,
 		}
@@ -314,7 +314,7 @@ func (suite *HandlerSuite) TestUpdatePaymentRequestStatusHandler() {
 		}
 
 		handler := UpdatePaymentRequestStatusHandler{
-			HandlerConfig:               suite.HandlerConfig(),
+			HandlerConfig:               suite.NewHandlerConfig(),
 			PaymentRequestStatusUpdater: statusUpdater,
 			PaymentRequestFetcher:       paymentRequestFetcher,
 		}
@@ -361,7 +361,7 @@ func (suite *HandlerSuite) TestUpdatePaymentRequestStatusHandler() {
 			}
 
 			handler := UpdatePaymentRequestStatusHandler{
-				HandlerConfig:               suite.HandlerConfig(),
+				HandlerConfig:               suite.NewHandlerConfig(),
 				PaymentRequestStatusUpdater: statusUpdater,
 				PaymentRequestFetcher:       paymentRequestFetcher,
 			}
@@ -411,7 +411,7 @@ func (suite *HandlerSuite) TestUpdatePaymentRequestStatusHandler() {
 		}
 
 		handler := UpdatePaymentRequestStatusHandler{
-			HandlerConfig:               suite.HandlerConfig(),
+			HandlerConfig:               suite.NewHandlerConfig(),
 			PaymentRequestStatusUpdater: paymentRequestStatusUpdater,
 			PaymentRequestFetcher:       paymentRequestFetcher,
 		}
@@ -450,7 +450,7 @@ func (suite *HandlerSuite) TestUpdatePaymentRequestStatusHandler() {
 		}
 
 		handler := UpdatePaymentRequestStatusHandler{
-			HandlerConfig:               suite.HandlerConfig(),
+			HandlerConfig:               suite.NewHandlerConfig(),
 			PaymentRequestStatusUpdater: paymentRequestStatusUpdater,
 			PaymentRequestFetcher:       paymentRequestFetcher,
 		}
@@ -487,7 +487,7 @@ func (suite *HandlerSuite) TestUpdatePaymentRequestStatusHandler() {
 		}
 
 		handler := UpdatePaymentRequestStatusHandler{
-			HandlerConfig:               suite.HandlerConfig(),
+			HandlerConfig:               suite.NewHandlerConfig(),
 			PaymentRequestStatusUpdater: paymentRequestStatusUpdater,
 			PaymentRequestFetcher:       paymentRequestFetcher,
 		}
@@ -524,7 +524,7 @@ func (suite *HandlerSuite) TestUpdatePaymentRequestStatusHandler() {
 		}
 
 		handler := UpdatePaymentRequestStatusHandler{
-			HandlerConfig:               suite.HandlerConfig(),
+			HandlerConfig:               suite.NewHandlerConfig(),
 			PaymentRequestStatusUpdater: paymentRequestStatusUpdater,
 			PaymentRequestFetcher:       paymentRequestFetcher,
 		}
@@ -561,7 +561,7 @@ func (suite *HandlerSuite) TestUpdatePaymentRequestStatusHandler() {
 		}
 
 		handler := UpdatePaymentRequestStatusHandler{
-			HandlerConfig:               suite.HandlerConfig(),
+			HandlerConfig:               suite.NewHandlerConfig(),
 			PaymentRequestStatusUpdater: paymentRequestStatusUpdater,
 			PaymentRequestFetcher:       paymentRequestFetcher,
 		}
@@ -905,7 +905,7 @@ func (suite *HandlerSuite) TestShipmentsSITBalanceHandler() {
 		}
 
 		handler := ShipmentsSITBalanceHandler{
-			HandlerConfig:              suite.HandlerConfig(),
+			HandlerConfig:              suite.NewHandlerConfig(),
 			ShipmentsPaymentSITBalance: paymentrequest.NewPaymentRequestShipmentsSITBalance(),
 		}
 
@@ -951,7 +951,7 @@ func (suite *HandlerSuite) TestShipmentsSITBalanceHandler() {
 		}
 
 		handler := ShipmentsSITBalanceHandler{
-			HandlerConfig:              suite.HandlerConfig(),
+			HandlerConfig:              suite.NewHandlerConfig(),
 			ShipmentsPaymentSITBalance: paymentrequest.NewPaymentRequestShipmentsSITBalance(),
 		}
 

--- a/pkg/handlers/ghcapi/payment_service_items_test.go
+++ b/pkg/handlers/ghcapi/payment_service_items_test.go
@@ -57,7 +57,7 @@ func (suite *HandlerSuite) TestUpdatePaymentServiceItemHandler() {
 		subtestData := suite.makeUpdatePaymentSubtestData()
 
 		handler := UpdatePaymentServiceItemStatusHandler{
-			HandlerConfig:                   suite.HandlerConfig(),
+			HandlerConfig:                   suite.NewHandlerConfig(),
 			PaymentServiceItemStatusUpdater: paymentServiceItemService.NewPaymentServiceItemStatusUpdater(),
 		}
 
@@ -79,7 +79,7 @@ func (suite *HandlerSuite) TestUpdatePaymentServiceItemHandler() {
 		subtestData := suite.makeUpdatePaymentSubtestData()
 
 		handler := UpdatePaymentServiceItemStatusHandler{
-			HandlerConfig:                   suite.HandlerConfig(),
+			HandlerConfig:                   suite.NewHandlerConfig(),
 			PaymentServiceItemStatusUpdater: paymentServiceItemService.NewPaymentServiceItemStatusUpdater(),
 		}
 		subtestData.params.PaymentServiceItemID = uuid.Nil.String()
@@ -99,7 +99,7 @@ func (suite *HandlerSuite) TestUpdatePaymentServiceItemHandler() {
 		subtestData := suite.makeUpdatePaymentSubtestData()
 
 		handler := UpdatePaymentServiceItemStatusHandler{
-			HandlerConfig:                   suite.HandlerConfig(),
+			HandlerConfig:                   suite.NewHandlerConfig(),
 			PaymentServiceItemStatusUpdater: paymentServiceItemService.NewPaymentServiceItemStatusUpdater(),
 		}
 
@@ -122,7 +122,7 @@ func (suite *HandlerSuite) TestUpdatePaymentServiceItemHandler() {
 		paymentServiceItem := factory.BuildPaymentServiceItem(suite.DB(), nil, nil)
 
 		handler := UpdatePaymentServiceItemStatusHandler{
-			HandlerConfig:                   suite.HandlerConfig(),
+			HandlerConfig:                   suite.NewHandlerConfig(),
 			PaymentServiceItemStatusUpdater: paymentServiceItemService.NewPaymentServiceItemStatusUpdater(),
 		}
 		subtestData.params.IfMatch = etag.GenerateEtag(paymentServiceItem.UpdatedAt)
@@ -156,7 +156,7 @@ func (suite *HandlerSuite) TestUpdatePaymentServiceItemHandler() {
 		}, nil)
 
 		handler := UpdatePaymentServiceItemStatusHandler{
-			HandlerConfig:                   suite.HandlerConfig(),
+			HandlerConfig:                   suite.NewHandlerConfig(),
 			PaymentServiceItemStatusUpdater: paymentServiceItemService.NewPaymentServiceItemStatusUpdater(),
 		}
 		subtestData.params.IfMatch = etag.GenerateEtag(deniedPaymentServiceItem.UpdatedAt)
@@ -207,7 +207,7 @@ func (suite *HandlerSuite) TestUpdatePaymentServiceItemHandler() {
 		}
 
 		handler := UpdatePaymentServiceItemStatusHandler{
-			HandlerConfig:                   suite.HandlerConfig(),
+			HandlerConfig:                   suite.NewHandlerConfig(),
 			PaymentServiceItemStatusUpdater: paymentServiceItemService.NewPaymentServiceItemStatusUpdater(),
 		}
 

--- a/pkg/handlers/ghcapi/ppm_closeout_test.go
+++ b/pkg/handlers/ghcapi/ppm_closeout_test.go
@@ -34,7 +34,7 @@ func (suite *HandlerSuite) TestGetPPMCloseoutHandler() {
 
 	setUpHandler := func(ppmCloseoutFetcher services.PPMCloseoutFetcher) GetPPMCloseoutHandler {
 		return GetPPMCloseoutHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			ppmCloseoutFetcher,
 		}
 	}
@@ -106,8 +106,8 @@ func (suite *HandlerSuite) TestGetPPMCloseoutHandler() {
 	suite.Run("404 response when the service returns not found", func() {
 		uuidForShipment, _ := uuid.NewV4()
 		officeUser := factory.BuildOfficeUser(nil, nil, nil)
-		handlerConfig := suite.HandlerConfig()
-		fetcher := ppmcloseout.NewPPMCloseoutFetcher(suite.HandlerConfig().DTODPlanner(), &paymentrequest.RequestPaymentHelper{}, &mocks.PPMEstimator{})
+		handlerConfig := suite.NewHandlerConfig()
+		fetcher := ppmcloseout.NewPPMCloseoutFetcher(suite.NewHandlerConfig().DTODPlanner(), &paymentrequest.RequestPaymentHelper{}, &mocks.PPMEstimator{})
 		request := httptest.NewRequest("GET", fmt.Sprintf("/ppm-shipments/%s/closeout", uuidForShipment.String()), nil)
 		request = suite.AuthenticateOfficeRequest(request, officeUser)
 

--- a/pkg/handlers/ghcapi/ppm_document_test.go
+++ b/pkg/handlers/ghcapi/ppm_document_test.go
@@ -698,7 +698,7 @@ func (suite *HandlerSuite) TestShowAOAPacketHandler() {
 
 		ppmshipment := factory.BuildPPMShipmentReadyForFinalCustomerCloseOutWithAllDocTypes(suite.DB(), userUploader)
 
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 		handler := showAOAPacketHandler{
 			HandlerConfig:    handlerConfig,
 			SSWPPMComputer:   &mockSSWPPMComputer,
@@ -734,7 +734,7 @@ func (suite *HandlerSuite) TestShowAOAPacketHandler() {
 
 		ppmshipment := factory.BuildPPMShipmentReadyForFinalCustomerCloseOutWithAllDocTypes(suite.DB(), userUploader)
 
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 		handler := showAOAPacketHandler{
 			HandlerConfig:    handlerConfig,
 			SSWPPMComputer:   &mockSSWPPMComputer,
@@ -765,7 +765,7 @@ func (suite *HandlerSuite) TestShowAOAPacketHandler() {
 		mockSSWPPMGenerator := mocks.SSWPPMGenerator{}
 		mockAOAPacketCreator := mocks.AOAPacketCreator{}
 
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 		handler := showAOAPacketHandler{
 			HandlerConfig:    handlerConfig,
 			SSWPPMComputer:   &mockSSWPPMComputer,

--- a/pkg/handlers/ghcapi/progear_weight_ticket_test.go
+++ b/pkg/handlers/ghcapi/progear_weight_ticket_test.go
@@ -44,7 +44,7 @@ func (suite *HandlerSuite) TestCreateProGearWeightTicketHandler() {
 		}
 
 		subtestData.handler = CreateProGearWeightTicketHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			progearCreator,
 		}
 
@@ -110,7 +110,7 @@ func (suite *HandlerSuite) TestCreateProGearWeightTicketHandler() {
 		).Return(nil, serverErr)
 
 		handler := CreateProGearWeightTicketHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			&mockCreator,
 		}
 
@@ -246,7 +246,7 @@ func (suite *HandlerSuite) TestUpdateProGearWeightTicketHandler() {
 		).Return(nil, err)
 
 		handler := UpdateProgearWeightTicketHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			&mockUpdater,
 		}
 

--- a/pkg/handlers/ghcapi/pws_violations_test.go
+++ b/pkg/handlers/ghcapi/pws_violations_test.go
@@ -17,7 +17,7 @@ func (suite *HandlerSuite) TestGetPWSViolationsHandler() {
 		params := pwsviolationsop.GetPWSViolationsParams{
 			HTTPRequest: request,
 		}
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 		handler := GetPWSViolationsHandler{
 			HandlerConfig:        handlerConfig,
 			PWSViolationsFetcher: fetcher,

--- a/pkg/handlers/ghcapi/queues.go
+++ b/pkg/handlers/ghcapi/queues.go
@@ -36,7 +36,7 @@ func (h GetMovesQueueHandler) Handle(params queues.GetMovesQueueParams) middlewa
 	return h.AuditableAppContextFromRequestWithErrors(params.HTTPRequest,
 		func(appCtx appcontext.AppContext) (middleware.Responder, error) {
 			if !appCtx.Session().IsOfficeUser() ||
-				(!(appCtx.Session().CurrentRole.RoleType == roles.RoleTypeTOO) && !(appCtx.Session().CurrentRole.RoleType == roles.RoleTypeHQ)) {
+				(!(appCtx.Session().ActiveRole.RoleType == roles.RoleTypeTOO) && !(appCtx.Session().ActiveRole.RoleType == roles.RoleTypeHQ)) {
 				forbiddenErr := apperror.NewForbiddenError(
 					"user is not authenticated with TOO or HQ office role",
 				)
@@ -96,7 +96,7 @@ func (h GetMovesQueueHandler) Handle(params queues.GetMovesQueueParams) middlewa
 				assignedGblocs = models.GetAssignedGBLOCs(officeUser)
 			}
 
-			if params.ViewAsGBLOC != nil && ((appCtx.Session().CurrentRole.RoleType == roles.RoleTypeHQ) || slices.Contains(assignedGblocs, *params.ViewAsGBLOC)) {
+			if params.ViewAsGBLOC != nil && ((appCtx.Session().ActiveRole.RoleType == roles.RoleTypeHQ) || slices.Contains(assignedGblocs, *params.ViewAsGBLOC)) {
 				ListOrderParams.ViewAsGBLOC = params.ViewAsGBLOC
 			}
 
@@ -195,7 +195,7 @@ func (h GetDestinationRequestsQueueHandler) Handle(params queues.GetDestinationR
 	return h.AuditableAppContextFromRequestWithErrors(params.HTTPRequest,
 		func(appCtx appcontext.AppContext) (middleware.Responder, error) {
 			if !appCtx.Session().IsOfficeUser() ||
-				(!(appCtx.Session().CurrentRole.RoleType == roles.RoleTypeTOO)) {
+				(!(appCtx.Session().ActiveRole.RoleType == roles.RoleTypeTOO)) {
 				forbiddenErr := apperror.NewForbiddenError(
 					"user is not authenticated with TOO role",
 				)
@@ -253,7 +253,7 @@ func (h GetDestinationRequestsQueueHandler) Handle(params queues.GetDestinationR
 				assignedGblocs = models.GetAssignedGBLOCs(officeUser)
 			}
 
-			if params.ViewAsGBLOC != nil && ((appCtx.Session().CurrentRole.RoleType == roles.RoleTypeHQ) || slices.Contains(assignedGblocs, *params.ViewAsGBLOC)) {
+			if params.ViewAsGBLOC != nil && ((appCtx.Session().ActiveRole.RoleType == roles.RoleTypeHQ) || slices.Contains(assignedGblocs, *params.ViewAsGBLOC)) {
 				ListOrderParams.ViewAsGBLOC = params.ViewAsGBLOC
 			}
 
@@ -402,7 +402,7 @@ func (h GetPaymentRequestsQueueHandler) Handle(
 	return h.AuditableAppContextFromRequestWithErrors(params.HTTPRequest,
 		func(appCtx appcontext.AppContext) (middleware.Responder, error) {
 			if !appCtx.Session().IsOfficeUser() ||
-				(!(appCtx.Session().CurrentRole.RoleType == roles.RoleTypeTIO) && !(appCtx.Session().CurrentRole.RoleType == roles.RoleTypeHQ)) {
+				(!(appCtx.Session().ActiveRole.RoleType == roles.RoleTypeTIO) && !(appCtx.Session().ActiveRole.RoleType == roles.RoleTypeHQ)) {
 				forbiddenErr := apperror.NewForbiddenError(
 					"user is not authenticated with TIO or HQ office role",
 				)
@@ -459,7 +459,7 @@ func (h GetPaymentRequestsQueueHandler) Handle(
 				assignedGblocs = models.GetAssignedGBLOCs(officeUser)
 			}
 
-			if params.ViewAsGBLOC != nil && ((appCtx.Session().CurrentRole.RoleType == roles.RoleTypeHQ) || slices.Contains(assignedGblocs, *params.ViewAsGBLOC)) {
+			if params.ViewAsGBLOC != nil && ((appCtx.Session().ActiveRole.RoleType == roles.RoleTypeHQ) || slices.Contains(assignedGblocs, *params.ViewAsGBLOC)) {
 				listPaymentRequestParams.ViewAsGBLOC = params.ViewAsGBLOC
 			}
 
@@ -558,7 +558,7 @@ func (h GetServicesCounselingQueueHandler) Handle(
 	return h.AuditableAppContextFromRequestWithErrors(params.HTTPRequest,
 		func(appCtx appcontext.AppContext) (middleware.Responder, error) {
 			if !appCtx.Session().IsOfficeUser() ||
-				(!(appCtx.Session().CurrentRole.RoleType == roles.RoleTypeServicesCounselor) && !(appCtx.Session().CurrentRole.RoleType == roles.RoleTypeHQ)) {
+				(!(appCtx.Session().ActiveRole.RoleType == roles.RoleTypeServicesCounselor) && !(appCtx.Session().ActiveRole.RoleType == roles.RoleTypeHQ)) {
 				forbiddenErr := apperror.NewForbiddenError(
 					"user is not authenticated with Services Counselor or HQ office role",
 				)
@@ -629,7 +629,7 @@ func (h GetServicesCounselingQueueHandler) Handle(
 				assignedGblocs = models.GetAssignedGBLOCs(officeUser)
 			}
 
-			if params.ViewAsGBLOC != nil && ((appCtx.Session().CurrentRole.RoleType == roles.RoleTypeHQ) || slices.Contains(assignedGblocs, *params.ViewAsGBLOC)) {
+			if params.ViewAsGBLOC != nil && ((appCtx.Session().ActiveRole.RoleType == roles.RoleTypeHQ) || slices.Contains(assignedGblocs, *params.ViewAsGBLOC)) {
 				ListOrderParams.ViewAsGBLOC = params.ViewAsGBLOC
 			}
 
@@ -997,7 +997,7 @@ func (h GetServicesCounselingOriginListHandler) Handle(
 	return h.AuditableAppContextFromRequestWithErrors(params.HTTPRequest,
 		func(appCtx appcontext.AppContext) (middleware.Responder, error) {
 			if !appCtx.Session().IsOfficeUser() ||
-				!(appCtx.Session().CurrentRole.RoleType == roles.RoleTypeServicesCounselor) {
+				!(appCtx.Session().ActiveRole.RoleType == roles.RoleTypeServicesCounselor) {
 				forbiddenErr := apperror.NewForbiddenError(
 					"user is not authenticated with an office role",
 				)
@@ -1027,7 +1027,7 @@ func (h GetServicesCounselingOriginListHandler) Handle(
 				assignedGblocs = models.GetAssignedGBLOCs(officeUser)
 			}
 
-			if params.ViewAsGBLOC != nil && ((appCtx.Session().CurrentRole.RoleType == roles.RoleTypeHQ) || slices.Contains(assignedGblocs, *params.ViewAsGBLOC)) {
+			if params.ViewAsGBLOC != nil && ((appCtx.Session().ActiveRole.RoleType == roles.RoleTypeHQ) || slices.Contains(assignedGblocs, *params.ViewAsGBLOC)) {
 				ListOrderParams.ViewAsGBLOC = params.ViewAsGBLOC
 			}
 

--- a/pkg/handlers/ghcapi/queues.go
+++ b/pkg/handlers/ghcapi/queues.go
@@ -36,7 +36,7 @@ func (h GetMovesQueueHandler) Handle(params queues.GetMovesQueueParams) middlewa
 	return h.AuditableAppContextFromRequestWithErrors(params.HTTPRequest,
 		func(appCtx appcontext.AppContext) (middleware.Responder, error) {
 			if !appCtx.Session().IsOfficeUser() ||
-				(!appCtx.Session().Roles.HasRole(roles.RoleTypeTOO) && !appCtx.Session().Roles.HasRole(roles.RoleTypeHQ)) {
+				(!(appCtx.Session().CurrentRole.RoleType == roles.RoleTypeTOO) && !(appCtx.Session().CurrentRole.RoleType == roles.RoleTypeHQ)) {
 				forbiddenErr := apperror.NewForbiddenError(
 					"user is not authenticated with TOO or HQ office role",
 				)
@@ -96,7 +96,7 @@ func (h GetMovesQueueHandler) Handle(params queues.GetMovesQueueParams) middlewa
 				assignedGblocs = models.GetAssignedGBLOCs(officeUser)
 			}
 
-			if params.ViewAsGBLOC != nil && (appCtx.Session().Roles.HasRole(roles.RoleTypeHQ) || slices.Contains(assignedGblocs, *params.ViewAsGBLOC)) {
+			if params.ViewAsGBLOC != nil && ((appCtx.Session().CurrentRole.RoleType == roles.RoleTypeHQ) || slices.Contains(assignedGblocs, *params.ViewAsGBLOC)) {
 				ListOrderParams.ViewAsGBLOC = params.ViewAsGBLOC
 			}
 
@@ -105,7 +105,6 @@ func (h GetMovesQueueHandler) Handle(params queues.GetMovesQueueParams) middlewa
 				appCtx.Logger().Error("Error retreiving user privileges", zap.Error(err))
 			}
 			officeUser.User.Privileges = privileges
-			officeUser.User.Roles = appCtx.Session().Roles
 
 			var officeUsers models.OfficeUsers
 			var officeUsersSafety models.OfficeUsers
@@ -196,7 +195,7 @@ func (h GetDestinationRequestsQueueHandler) Handle(params queues.GetDestinationR
 	return h.AuditableAppContextFromRequestWithErrors(params.HTTPRequest,
 		func(appCtx appcontext.AppContext) (middleware.Responder, error) {
 			if !appCtx.Session().IsOfficeUser() ||
-				(!appCtx.Session().Roles.HasRole(roles.RoleTypeTOO)) {
+				(!(appCtx.Session().CurrentRole.RoleType == roles.RoleTypeTOO)) {
 				forbiddenErr := apperror.NewForbiddenError(
 					"user is not authenticated with TOO role",
 				)
@@ -254,7 +253,7 @@ func (h GetDestinationRequestsQueueHandler) Handle(params queues.GetDestinationR
 				assignedGblocs = models.GetAssignedGBLOCs(officeUser)
 			}
 
-			if params.ViewAsGBLOC != nil && (appCtx.Session().Roles.HasRole(roles.RoleTypeHQ) || slices.Contains(assignedGblocs, *params.ViewAsGBLOC)) {
+			if params.ViewAsGBLOC != nil && ((appCtx.Session().CurrentRole.RoleType == roles.RoleTypeHQ) || slices.Contains(assignedGblocs, *params.ViewAsGBLOC)) {
 				ListOrderParams.ViewAsGBLOC = params.ViewAsGBLOC
 			}
 
@@ -275,7 +274,6 @@ func (h GetDestinationRequestsQueueHandler) Handle(params queues.GetDestinationR
 				appCtx.Logger().Error("Error retreiving user privileges", zap.Error(err))
 			}
 			officeUser.User.Privileges = privileges
-			officeUser.User.Roles = appCtx.Session().Roles
 			var officeUsers models.OfficeUsers
 			var officeUsersSafety models.OfficeUsers
 			if privileges.HasPrivilege(models.PrivilegeTypeSupervisor) {
@@ -404,7 +402,7 @@ func (h GetPaymentRequestsQueueHandler) Handle(
 	return h.AuditableAppContextFromRequestWithErrors(params.HTTPRequest,
 		func(appCtx appcontext.AppContext) (middleware.Responder, error) {
 			if !appCtx.Session().IsOfficeUser() ||
-				(!appCtx.Session().Roles.HasRole(roles.RoleTypeTIO) && !appCtx.Session().Roles.HasRole(roles.RoleTypeHQ)) {
+				(!(appCtx.Session().CurrentRole.RoleType == roles.RoleTypeTIO) && !(appCtx.Session().CurrentRole.RoleType == roles.RoleTypeHQ)) {
 				forbiddenErr := apperror.NewForbiddenError(
 					"user is not authenticated with TIO or HQ office role",
 				)
@@ -461,7 +459,7 @@ func (h GetPaymentRequestsQueueHandler) Handle(
 				assignedGblocs = models.GetAssignedGBLOCs(officeUser)
 			}
 
-			if params.ViewAsGBLOC != nil && (appCtx.Session().Roles.HasRole(roles.RoleTypeHQ) || slices.Contains(assignedGblocs, *params.ViewAsGBLOC)) {
+			if params.ViewAsGBLOC != nil && ((appCtx.Session().CurrentRole.RoleType == roles.RoleTypeHQ) || slices.Contains(assignedGblocs, *params.ViewAsGBLOC)) {
 				listPaymentRequestParams.ViewAsGBLOC = params.ViewAsGBLOC
 			}
 
@@ -470,7 +468,6 @@ func (h GetPaymentRequestsQueueHandler) Handle(
 				appCtx.Logger().Error("Error retreiving user privileges", zap.Error(err))
 			}
 			officeUser.User.Privileges = privileges
-			officeUser.User.Roles = appCtx.Session().Roles
 
 			var officeUsers models.OfficeUsers
 			var officeUsersSafety models.OfficeUsers
@@ -561,7 +558,7 @@ func (h GetServicesCounselingQueueHandler) Handle(
 	return h.AuditableAppContextFromRequestWithErrors(params.HTTPRequest,
 		func(appCtx appcontext.AppContext) (middleware.Responder, error) {
 			if !appCtx.Session().IsOfficeUser() ||
-				(!appCtx.Session().Roles.HasRole(roles.RoleTypeServicesCounselor) && !appCtx.Session().Roles.HasRole(roles.RoleTypeHQ)) {
+				(!(appCtx.Session().CurrentRole.RoleType == roles.RoleTypeServicesCounselor) && !(appCtx.Session().CurrentRole.RoleType == roles.RoleTypeHQ)) {
 				forbiddenErr := apperror.NewForbiddenError(
 					"user is not authenticated with Services Counselor or HQ office role",
 				)
@@ -632,7 +629,7 @@ func (h GetServicesCounselingQueueHandler) Handle(
 				assignedGblocs = models.GetAssignedGBLOCs(officeUser)
 			}
 
-			if params.ViewAsGBLOC != nil && (appCtx.Session().Roles.HasRole(roles.RoleTypeHQ) || slices.Contains(assignedGblocs, *params.ViewAsGBLOC)) {
+			if params.ViewAsGBLOC != nil && ((appCtx.Session().CurrentRole.RoleType == roles.RoleTypeHQ) || slices.Contains(assignedGblocs, *params.ViewAsGBLOC)) {
 				ListOrderParams.ViewAsGBLOC = params.ViewAsGBLOC
 			}
 
@@ -641,7 +638,6 @@ func (h GetServicesCounselingQueueHandler) Handle(
 				appCtx.Logger().Error("Error retreiving user privileges", zap.Error(err))
 			}
 			officeUser.User.Privileges = privileges
-			officeUser.User.Roles = appCtx.Session().Roles
 
 			var officeUsers models.OfficeUsers
 			var officeUsersSafety models.OfficeUsers
@@ -1001,7 +997,7 @@ func (h GetServicesCounselingOriginListHandler) Handle(
 	return h.AuditableAppContextFromRequestWithErrors(params.HTTPRequest,
 		func(appCtx appcontext.AppContext) (middleware.Responder, error) {
 			if !appCtx.Session().IsOfficeUser() ||
-				!appCtx.Session().Roles.HasRole(roles.RoleTypeServicesCounselor) {
+				!(appCtx.Session().CurrentRole.RoleType == roles.RoleTypeServicesCounselor) {
 				forbiddenErr := apperror.NewForbiddenError(
 					"user is not authenticated with an office role",
 				)
@@ -1031,7 +1027,7 @@ func (h GetServicesCounselingOriginListHandler) Handle(
 				assignedGblocs = models.GetAssignedGBLOCs(officeUser)
 			}
 
-			if params.ViewAsGBLOC != nil && (appCtx.Session().Roles.HasRole(roles.RoleTypeHQ) || slices.Contains(assignedGblocs, *params.ViewAsGBLOC)) {
+			if params.ViewAsGBLOC != nil && ((appCtx.Session().CurrentRole.RoleType == roles.RoleTypeHQ) || slices.Contains(assignedGblocs, *params.ViewAsGBLOC)) {
 				ListOrderParams.ViewAsGBLOC = params.ViewAsGBLOC
 			}
 

--- a/pkg/handlers/ghcapi/queues_test.go
+++ b/pkg/handlers/ghcapi/queues_test.go
@@ -77,7 +77,7 @@ func (suite *HandlerSuite) TestGetMoveQueuesHandler() {
 	params := queues.GetMovesQueueParams{
 		HTTPRequest: request,
 	}
-	handlerConfig := suite.HandlerConfig()
+	handlerConfig := suite.NewHandlerConfig()
 	mockUnlocker := movelocker.NewMoveUnlocker()
 	handler := GetMovesQueueHandler{
 		handlerConfig,
@@ -121,7 +121,7 @@ func (suite *HandlerSuite) TestListPrimeMovesHandler() {
 	params := queues.ListPrimeMovesParams{
 		HTTPRequest: request,
 	}
-	handlerConfig := suite.HandlerConfig()
+	handlerConfig := suite.NewHandlerConfig()
 	handler := ListPrimeMovesHandler{
 		handlerConfig,
 		movetaskorder.NewMoveTaskOrderFetcher(waf),
@@ -206,7 +206,7 @@ func (suite *HandlerSuite) TestGetMoveQueuesHandlerMoveInfo() {
 		params := queues.GetMovesQueueParams{
 			HTTPRequest: request,
 		}
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 		mockUnlocker := movelocker.NewMoveUnlocker()
 		handler := GetMovesQueueHandler{
 			handlerConfig,
@@ -281,7 +281,7 @@ func (suite *HandlerSuite) TestGetMoveQueuesBranchFilter() {
 		HTTPRequest: request,
 		Branch:      models.StringPointer("AIR_FORCE"),
 	}
-	handlerConfig := suite.HandlerConfig()
+	handlerConfig := suite.NewHandlerConfig()
 	mockUnlocker := movelocker.NewMoveUnlocker()
 	handler := GetMovesQueueHandler{
 		handlerConfig,
@@ -370,7 +370,7 @@ func (suite *HandlerSuite) TestGetMoveQueuesHandlerStatuses() {
 	params := queues.GetMovesQueueParams{
 		HTTPRequest: request,
 	}
-	handlerConfig := suite.HandlerConfig()
+	handlerConfig := suite.NewHandlerConfig()
 	mockUnlocker := movelocker.NewMoveUnlocker()
 	handler := GetMovesQueueHandler{
 		handlerConfig,
@@ -525,7 +525,7 @@ func (suite *HandlerSuite) TestGetMoveQueuesHandlerFilters() {
 	request := httptest.NewRequest("GET", "/queues/moves", nil)
 	request = suite.AuthenticateOfficeRequest(request, officeUser)
 
-	handlerConfig := suite.HandlerConfig()
+	handlerConfig := suite.NewHandlerConfig()
 	mockUnlocker := movelocker.NewMoveUnlocker()
 	handler := GetMovesQueueHandler{
 		handlerConfig,
@@ -783,7 +783,7 @@ func (suite *HandlerSuite) TestGetMoveQueuesHandlerCustomerInfoFilters() {
 	request := httptest.NewRequest("GET", "/queues/moves", nil)
 	request = suite.AuthenticateOfficeRequest(request, officeUser)
 
-	handlerConfig := suite.HandlerConfig()
+	handlerConfig := suite.NewHandlerConfig()
 	mockUnlocker := movelocker.NewMoveUnlocker()
 	handler := GetMovesQueueHandler{
 		handlerConfig,
@@ -930,7 +930,7 @@ func (suite *HandlerSuite) TestGetMoveQueuesHandlerUnauthorizedRole() {
 	params := queues.GetMovesQueueParams{
 		HTTPRequest: request,
 	}
-	handlerConfig := suite.HandlerConfig()
+	handlerConfig := suite.NewHandlerConfig()
 	mockUnlocker := movelocker.NewMoveUnlocker()
 	handler := GetMovesQueueHandler{
 		handlerConfig,
@@ -962,7 +962,7 @@ func (suite *HandlerSuite) TestGetMoveQueuesHandlerUnauthorizedUser() {
 	params := queues.GetMovesQueueParams{
 		HTTPRequest: request,
 	}
-	handlerConfig := suite.HandlerConfig()
+	handlerConfig := suite.NewHandlerConfig()
 	mockUnlocker := movelocker.NewMoveUnlocker()
 	handler := GetMovesQueueHandler{
 		handlerConfig,
@@ -1015,7 +1015,7 @@ func (suite *HandlerSuite) TestGetMoveQueuesHandlerEmptyResults() {
 	params := queues.GetMovesQueueParams{
 		HTTPRequest: request,
 	}
-	handlerConfig := suite.HandlerConfig()
+	handlerConfig := suite.NewHandlerConfig()
 	mockUnlocker := movelocker.NewMoveUnlocker()
 	handler := GetMovesQueueHandler{
 		handlerConfig,
@@ -1065,7 +1065,7 @@ func (suite *HandlerSuite) TestGetPaymentRequestsQueueHandler() {
 	params := queues.GetPaymentRequestsQueueParams{
 		HTTPRequest: request,
 	}
-	handlerConfig := suite.HandlerConfig()
+	handlerConfig := suite.NewHandlerConfig()
 	mockUnlocker := movelocker.NewMoveUnlocker()
 	handler := GetPaymentRequestsQueueHandler{
 		handlerConfig,
@@ -1143,7 +1143,7 @@ func (suite *HandlerSuite) TestGetPaymentRequestsQueueSubmittedAtFilter() {
 	request := httptest.NewRequest("GET", "/queues/payment-requests", nil)
 	request = suite.AuthenticateOfficeRequest(request, officeUser)
 
-	handlerConfig := suite.HandlerConfig()
+	handlerConfig := suite.NewHandlerConfig()
 	mockUnlocker := movelocker.NewMoveUnlocker()
 	handler := GetPaymentRequestsQueueHandler{
 		handlerConfig,
@@ -1223,7 +1223,7 @@ func (suite *HandlerSuite) TestGetPaymentRequestsQueueHandlerUnauthorizedRole() 
 		Page:        models.Int64Pointer(1),
 		PerPage:     models.Int64Pointer(1),
 	}
-	handlerConfig := suite.HandlerConfig()
+	handlerConfig := suite.NewHandlerConfig()
 	mockUnlocker := movelocker.NewMoveUnlocker()
 	handler := GetPaymentRequestsQueueHandler{
 		handlerConfig,
@@ -1259,7 +1259,7 @@ func (suite *HandlerSuite) TestGetPaymentRequestsQueueHandlerServerError() {
 		Page:        models.Int64Pointer(1),
 		PerPage:     models.Int64Pointer(1),
 	}
-	handlerConfig := suite.HandlerConfig()
+	handlerConfig := suite.NewHandlerConfig()
 	mockUnlocker := movelocker.NewMoveUnlocker()
 	handler := GetPaymentRequestsQueueHandler{
 		handlerConfig,
@@ -1296,7 +1296,7 @@ func (suite *HandlerSuite) TestGetPaymentRequestsQueueHandlerEmptyResults() {
 		Page:        models.Int64Pointer(1),
 		PerPage:     models.Int64Pointer(1),
 	}
-	handlerConfig := suite.HandlerConfig()
+	handlerConfig := suite.NewHandlerConfig()
 	mockUnlocker := movelocker.NewMoveUnlocker()
 	handler := GetPaymentRequestsQueueHandler{
 		handlerConfig,
@@ -1526,7 +1526,7 @@ func (suite *HandlerSuite) makeServicesCounselingSubtestData() (subtestData *ser
 
 	request := httptest.NewRequest("GET", "/queues/counseling", nil)
 	subtestData.request = suite.AuthenticateOfficeRequest(request, subtestData.officeUser)
-	handlerConfig := suite.HandlerConfig()
+	handlerConfig := suite.NewHandlerConfig()
 	mockUnlocker := movelocker.NewMoveUnlocker()
 	subtestData.handler = GetServicesCounselingQueueHandler{
 		handlerConfig,
@@ -1685,7 +1685,7 @@ func (suite *HandlerSuite) TestGetBulkAssignmentDataHandler() {
 			HTTPRequest: request,
 			QueueType:   models.StringPointer("COUNSELING"),
 		}
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 		handler := GetBulkAssignmentDataHandler{
 			handlerConfig,
 			officeusercreator.NewOfficeUserFetcherPop(),
@@ -1747,7 +1747,7 @@ func (suite *HandlerSuite) TestGetBulkAssignmentDataHandler() {
 			HTTPRequest: request,
 			QueueType:   models.StringPointer("COUNSELING"),
 		}
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 		handler := GetBulkAssignmentDataHandler{
 			handlerConfig,
 			officeusercreator.NewOfficeUserFetcherPop(),
@@ -1873,7 +1873,7 @@ func (suite *HandlerSuite) TestGetBulkAssignmentDataHandler() {
 			HTTPRequest: request,
 			QueueType:   models.StringPointer("DESTINATION_REQUESTS"),
 		}
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 		handler := GetBulkAssignmentDataHandler{
 			handlerConfig,
 			officeusercreator.NewOfficeUserFetcherPop(),
@@ -1950,7 +1950,7 @@ func (suite *HandlerSuite) TestGetBulkAssignmentDataHandler() {
 			HTTPRequest: request,
 			QueueType:   models.StringPointer("TASK_ORDER"),
 		}
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 		handler := GetBulkAssignmentDataHandler{
 			handlerConfig,
 			officeusercreator.NewOfficeUserFetcherPop(),
@@ -2034,7 +2034,7 @@ func (suite *HandlerSuite) TestGetBulkAssignmentDataHandler() {
 			HTTPRequest: request,
 			QueueType:   models.StringPointer("CLOSEOUT"),
 		}
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 		handler := GetBulkAssignmentDataHandler{
 			handlerConfig,
 			officeusercreator.NewOfficeUserFetcherPop(),
@@ -2084,7 +2084,7 @@ func (suite *HandlerSuite) TestGetBulkAssignmentDataHandler() {
 			HTTPRequest: request,
 			QueueType:   models.StringPointer("PAYMENT_REQUEST"),
 		}
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 		handler := GetBulkAssignmentDataHandler{
 			handlerConfig,
 			officeusercreator.NewOfficeUserFetcherPop(),
@@ -2160,7 +2160,7 @@ func (suite *HandlerSuite) TestGetBulkAssignmentDataHandler() {
 			HTTPRequest: request,
 			QueueType:   models.StringPointer("PAYMENT_REQUEST"),
 		}
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 		handler := GetBulkAssignmentDataHandler{
 			handlerConfig,
 			officeusercreator.NewOfficeUserFetcherPop(),
@@ -2325,7 +2325,7 @@ func (suite *HandlerSuite) TestAvailableOfficeUsers() {
 		params := queues.GetMovesQueueParams{
 			HTTPRequest: request,
 		}
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 		mockUnlocker := movelocker.NewMoveUnlocker()
 		handler := GetMovesQueueHandler{
 			handlerConfig,
@@ -2369,7 +2369,7 @@ func (suite *HandlerSuite) TestAvailableOfficeUsers() {
 		params := queues.GetServicesCounselingQueueParams{
 			HTTPRequest: request,
 		}
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 		mockUnlocker := movelocker.NewMoveUnlocker()
 		handler := GetServicesCounselingQueueHandler{
 			handlerConfig,
@@ -2406,7 +2406,7 @@ func (suite *HandlerSuite) TestAvailableOfficeUsers() {
 		params := queues.GetPaymentRequestsQueueParams{
 			HTTPRequest: request,
 		}
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 		mockUnlocker := movelocker.NewMoveUnlocker()
 		handler := GetPaymentRequestsQueueHandler{
 			handlerConfig,
@@ -2476,7 +2476,7 @@ func (suite *HandlerSuite) TestSaveBulkAssignmentDataHandler() {
 				UserData:  userData,
 			},
 		}
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 		handler := SaveBulkAssignmentDataHandler{
 			handlerConfig,
 			officeusercreator.NewOfficeUserFetcherPop(),
@@ -2548,7 +2548,7 @@ func (suite *HandlerSuite) TestSaveBulkAssignmentDataHandler() {
 				UserData:  userData,
 			},
 		}
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 		handler := SaveBulkAssignmentDataHandler{
 			handlerConfig,
 			officeusercreator.NewOfficeUserFetcherPop(),
@@ -2625,7 +2625,7 @@ func (suite *HandlerSuite) TestLockAndUnlockBulkAssignmentMoves() {
 			HTTPRequest: getRequest,
 			QueueType:   models.StringPointer("COUNSELING"),
 		}
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 		getHandler := GetBulkAssignmentDataHandler{
 			handlerConfig,
 			officeusercreator.NewOfficeUserFetcherPop(),
@@ -2810,7 +2810,7 @@ func (suite *HandlerSuite) TestGetDestinationRequestsQueuesHandler() {
 	params := queues.GetDestinationRequestsQueueParams{
 		HTTPRequest: request,
 	}
-	handlerConfig := suite.HandlerConfig()
+	handlerConfig := suite.NewHandlerConfig()
 	mockUnlocker := movelocker.NewMoveUnlocker()
 	handler := GetDestinationRequestsQueueHandler{
 		handlerConfig,
@@ -2945,7 +2945,7 @@ func (suite *HandlerSuite) TestGetDestinationRequestsQueueAssignedUser() {
 		params := queues.GetDestinationRequestsQueueParams{
 			HTTPRequest: request,
 		}
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 		mockUnlocker := movelocker.NewMoveUnlocker()
 		handler := GetDestinationRequestsQueueHandler{
 			handlerConfig,
@@ -3077,7 +3077,7 @@ func (suite *HandlerSuite) TestGetDestinationRequestsQueueAssignedUser() {
 		params := queues.GetDestinationRequestsQueueParams{
 			HTTPRequest: request,
 		}
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 		mockUnlocker := movelocker.NewMoveUnlocker()
 		handler := GetDestinationRequestsQueueHandler{
 			handlerConfig,

--- a/pkg/handlers/ghcapi/report_violations_test.go
+++ b/pkg/handlers/ghcapi/report_violations_test.go
@@ -21,7 +21,7 @@ func (suite *HandlerSuite) TestGetReportViolationByIDHandler() {
 	// 200 response
 	suite.Run("Successful fetch (integration) test", func() {
 
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 		fetcher := reportviolationservice.NewReportViolationFetcher()
 		handler := GetReportViolationsHandler{
 			HandlerConfig:          handlerConfig,
@@ -52,7 +52,7 @@ func (suite *HandlerSuite) TestGetReportViolationByIDHandler() {
 	suite.Run("404 response when service returns not found", func() {
 		badID, _ := uuid.NewV4()
 
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 		mockFetcher := mocks.ReportViolationFetcher{}
 		handler := GetReportViolationsHandler{
 			HandlerConfig:          handlerConfig,
@@ -86,7 +86,7 @@ func (suite *HandlerSuite) TestGetReportViolationByIDHandler() {
 func (suite *HandlerSuite) TestAssociateReportViolationsHandler() {
 	suite.Run("Successful POST", func() {
 
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 		creator := &mocks.ReportViolationsCreator{}
 		handler := AssociateReportViolationsHandler{
 			HandlerConfig:           handlerConfig,
@@ -123,7 +123,7 @@ func (suite *HandlerSuite) TestAssociateReportViolationsHandler() {
 
 	suite.Run("Unsuccessful POST", func() {
 
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 		creator := &mocks.ReportViolationsCreator{}
 		handler := AssociateReportViolationsHandler{
 			HandlerConfig:           handlerConfig,

--- a/pkg/handlers/ghcapi/tac_test.go
+++ b/pkg/handlers/ghcapi/tac_test.go
@@ -32,7 +32,7 @@ func (suite *HandlerSuite) TestTacValidation() {
 				HTTPRequest: request,
 				Tac:         tc.tacCode,
 			}
-			handlerConfig := suite.HandlerConfig()
+			handlerConfig := suite.NewHandlerConfig()
 			handler := TacValidationHandler{handlerConfig}
 
 			// Validate incoming payload: no body to validate
@@ -58,7 +58,7 @@ func (suite *HandlerSuite) TestTacValidation() {
 			HTTPRequest: request,
 			Tac:         tac,
 		}
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 		handler := TacValidationHandler{handlerConfig}
 
 		// Validate incoming payload: no body to validate
@@ -82,7 +82,7 @@ func (suite *HandlerSuite) TestTacValidation() {
 			HTTPRequest: request,
 			Tac:         tac,
 		}
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 		handler := TacValidationHandler{handlerConfig}
 
 		// Validate incoming payload: no body to validate

--- a/pkg/handlers/ghcapi/transportation_offices_test.go
+++ b/pkg/handlers/ghcapi/transportation_offices_test.go
@@ -32,7 +32,7 @@ func (suite *HandlerSuite) TestGetTransportationOfficesHandler() {
 	}
 
 	handler := GetTransportationOfficesHandler{
-		HandlerConfig:                suite.HandlerConfig(),
+		HandlerConfig:                suite.NewHandlerConfig(),
 		TransportationOfficesFetcher: fetcher}
 
 	response := handler.Handle(params)
@@ -57,7 +57,7 @@ func (suite *HandlerSuite) TestNoTransportationOfficesHandler() {
 	}
 
 	handler := GetTransportationOfficesHandler{
-		HandlerConfig:                suite.HandlerConfig(),
+		HandlerConfig:                suite.NewHandlerConfig(),
 		TransportationOfficesFetcher: fetcher}
 
 	response := handler.Handle(params)
@@ -97,7 +97,7 @@ func (suite *HandlerSuite) TestGetTransportationOfficesOpenHandler() {
 	}
 
 	handler := GetTransportationOfficesOpenHandler{
-		HandlerConfig:                suite.HandlerConfig(),
+		HandlerConfig:                suite.NewHandlerConfig(),
 		TransportationOfficesFetcher: fetcher}
 
 	response := handler.Handle(params)
@@ -136,7 +136,7 @@ func (suite *HandlerSuite) TestGetTransportationOfficesGBLOCsHandler() {
 	}
 
 	handler := GetTransportationOfficesGBLOCsHandler{
-		HandlerConfig:                suite.HandlerConfig(),
+		HandlerConfig:                suite.NewHandlerConfig(),
 		TransportationOfficesFetcher: fetcher,
 	}
 
@@ -191,7 +191,7 @@ func (suite *HandlerSuite) TestShowCounselingOfficesHandler() {
 	}
 
 	handler := ShowCounselingOfficesHandler{
-		HandlerConfig:                suite.HandlerConfig(),
+		HandlerConfig:                suite.NewHandlerConfig(),
 		TransportationOfficesFetcher: fetcher}
 
 	response := handler.Handle(params)

--- a/pkg/handlers/ghcapi/uploads_test.go
+++ b/pkg/handlers/ghcapi/uploads_test.go
@@ -107,7 +107,7 @@ func makeRequest(suite *HandlerSuite, params uploadop.CreateUploadParams, servic
 
 	params.HTTPRequest = req
 
-	handlerConfig := suite.HandlerConfig()
+	handlerConfig := suite.NewHandlerConfig()
 	handlerConfig.SetFileStorer(fakeS3)
 
 	handler := CreateUploadHandler{handlerConfig}
@@ -122,7 +122,7 @@ func makePPMRequest(suite *HandlerSuite, params ppmop.CreatePPMUploadParams, off
 
 	params.HTTPRequest = req
 
-	handlerConfig := suite.HandlerConfig()
+	handlerConfig := suite.NewHandlerConfig()
 	handlerConfig.SetFileStorer(fakeS3)
 	userUploader, err := uploader.NewUserUploader(handlerConfig.FileStorer(), uploader.MaxCustomerUserUploadFileSizeLimit)
 	suite.FatalNoError(err)
@@ -288,7 +288,7 @@ func (suite *HandlerSuite) TestGetUploadStatusHandlerSuccess() {
 	req = suite.AuthenticateRequest(req, uploadUser1.Document.ServiceMember)
 	params.HTTPRequest = req
 
-	handlerConfig := suite.HandlerConfig()
+	handlerConfig := suite.NewHandlerConfig()
 	handlerConfig.SetFileStorer(fakeS3)
 	handlerConfig.SetNotificationReceiver(localReceiver)
 	uploadInformationFetcher := upload.NewUploadInformationFetcher()
@@ -319,7 +319,7 @@ func (suite *HandlerSuite) TestGetUploadStatusHandlerFailure() {
 		fakeS3 := storageTest.NewFakeS3Storage(true)
 		localReceiver := notifications.StubNotificationReceiver{}
 
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 		handlerConfig.SetFileStorer(fakeS3)
 		handlerConfig.SetNotificationReceiver(localReceiver)
 		uploadInformationFetcher := upload.NewUploadInformationFetcher()
@@ -366,7 +366,7 @@ func (suite *HandlerSuite) TestGetUploadStatusHandlerFailure() {
 		req = suite.AuthenticateRequest(req, otherServiceMember)
 		params.HTTPRequest = req
 
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 		handlerConfig.SetFileStorer(fakeS3)
 		handlerConfig.SetNotificationReceiver(localReceiver)
 		uploadInformationFetcher := upload.NewUploadInformationFetcher()

--- a/pkg/handlers/ghcapi/weight_ticket_test.go
+++ b/pkg/handlers/ghcapi/weight_ticket_test.go
@@ -44,7 +44,7 @@ func (suite *HandlerSuite) TestCreateWeightTicketHandler() {
 		}
 
 		subtestData.handler = CreateWeightTicketHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			weightTicketCreator,
 		}
 
@@ -99,7 +99,7 @@ func (suite *HandlerSuite) TestCreateWeightTicketHandler() {
 		).Return(nil, serverErr)
 
 		handler := CreateWeightTicketHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			&mockCreator,
 		}
 
@@ -231,7 +231,7 @@ func (suite *HandlerSuite) TestUpdateWeightTicketHandler() {
 		).Return(nil, err)
 
 		handler := UpdateWeightTicketHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			&mockUpdater,
 		}
 

--- a/pkg/handlers/internalapi/addresses_test.go
+++ b/pkg/handlers/internalapi/addresses_test.go
@@ -62,7 +62,7 @@ func (suite *HandlerSuite) TestShowAddressHandler() {
 				AddressID:   *handlers.FmtUUID(ts.ID),
 			}
 
-			handler := ShowAddressHandler{suite.HandlerConfig()}
+			handler := ShowAddressHandler{suite.NewHandlerConfig()}
 			res := handler.Handle(params)
 
 			response := res.(*addressop.ShowAddressOK)
@@ -98,7 +98,7 @@ func (suite *HandlerSuite) TestGetLocationByZipCityHandler() {
 		}
 
 		handler := GetLocationByZipCityStateHandler{
-			HandlerConfig: suite.HandlerConfig(),
+			HandlerConfig: suite.NewHandlerConfig(),
 			VLocation:     vLocationServices}
 
 		response := handler.Handle(params)

--- a/pkg/handlers/internalapi/api_test.go
+++ b/pkg/handlers/internalapi/api_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func (suite *HandlerSuite) createS3HandlerConfig() handlers.HandlerConfig {
-	handlerConfig := suite.HandlerConfig()
+	handlerConfig := suite.NewHandlerConfig()
 	fakeS3 := storageTest.NewFakeS3Storage(true)
 	handlerConfig.SetFileStorer(fakeS3)
 	handlerConfig.SetNotificationSender(suite.TestNotificationSender())

--- a/pkg/handlers/internalapi/application_parameters_test.go
+++ b/pkg/handlers/internalapi/application_parameters_test.go
@@ -27,7 +27,7 @@ func (suite *HandlerSuite) TestApplicationParametersValidateHandler() {
 			HTTPRequest: req,
 			Body:        &body,
 		}
-		handler := ApplicationParametersValidateHandler{suite.HandlerConfig()}
+		handler := ApplicationParametersValidateHandler{suite.NewHandlerConfig()}
 		response := handler.Handle(params)
 
 		suite.Assertions.IsType(&application_parameters.ValidateOK{}, response)
@@ -52,7 +52,7 @@ func (suite *HandlerSuite) TestApplicationParametersValidateHandler() {
 			Body:        &body,
 		}
 
-		handler := ApplicationParametersValidateHandler{suite.HandlerConfig()}
+		handler := ApplicationParametersValidateHandler{suite.NewHandlerConfig()}
 		response := handler.Handle(params)
 
 		suite.Assertions.IsType(&application_parameters.ValidateUnauthorized{}, response)

--- a/pkg/handlers/internalapi/backup_contacts_test.go
+++ b/pkg/handlers/internalapi/backup_contacts_test.go
@@ -32,7 +32,7 @@ func (suite *HandlerSuite) TestCreateBackupContactHandler() {
 
 	params.HTTPRequest = suite.AuthenticateRequest(req, serviceMember)
 
-	handler := CreateBackupContactHandler{suite.HandlerConfig()}
+	handler := CreateBackupContactHandler{suite.NewHandlerConfig()}
 	response := handler.Handle(params)
 
 	_, ok := response.(*contactop.CreateServiceMemberBackupContactCreated)
@@ -74,7 +74,7 @@ func (suite *HandlerSuite) TestIndexBackupContactsHandler() {
 	}
 	params.HTTPRequest = suite.AuthenticateRequest(req, contact.ServiceMember)
 
-	handler := IndexBackupContactsHandler{suite.HandlerConfig()}
+	handler := IndexBackupContactsHandler{suite.NewHandlerConfig()}
 	response := handler.Handle(params)
 
 	okResponse := response.(*contactop.IndexServiceMemberBackupContactsOK)
@@ -104,7 +104,7 @@ func (suite *HandlerSuite) TestIndexBackupContactsHandlerWrongUser() {
 	// Logged in as other user
 	params.HTTPRequest = suite.AuthenticateRequest(req, otherServiceMember)
 
-	handler := IndexBackupContactsHandler{suite.HandlerConfig()}
+	handler := IndexBackupContactsHandler{suite.NewHandlerConfig()}
 	response := handler.Handle(params)
 
 	errResponse := response.(*handlers.ErrResponse)
@@ -128,7 +128,7 @@ func (suite *HandlerSuite) TestShowBackupContactsHandler() {
 	}
 	params.HTTPRequest = suite.AuthenticateRequest(req, contact.ServiceMember)
 
-	handler := ShowBackupContactHandler{suite.HandlerConfig()}
+	handler := ShowBackupContactHandler{suite.NewHandlerConfig()}
 	response := handler.Handle(params)
 
 	okResponse := response.(*contactop.ShowServiceMemberBackupContactOK)
@@ -154,7 +154,7 @@ func (suite *HandlerSuite) TestShowBackupContactsHandlerWrongUser() {
 	// Logged in as other user
 	params.HTTPRequest = suite.AuthenticateRequest(req, otherServiceMember)
 
-	handler := ShowBackupContactHandler{suite.HandlerConfig()}
+	handler := ShowBackupContactHandler{suite.NewHandlerConfig()}
 	response := handler.Handle(params)
 
 	errResponse := response.(*handlers.ErrResponse)
@@ -186,7 +186,7 @@ func (suite *HandlerSuite) TestUpdateBackupContactsHandler() {
 	}
 	params.HTTPRequest = suite.AuthenticateRequest(req, contact.ServiceMember)
 
-	handler := UpdateBackupContactHandler{suite.HandlerConfig()}
+	handler := UpdateBackupContactHandler{suite.NewHandlerConfig()}
 	response := handler.Handle(params)
 
 	okResponse := response.(*contactop.UpdateServiceMemberBackupContactCreated)
@@ -220,7 +220,7 @@ func (suite *HandlerSuite) TestUpdateBackupContactsHandlerWrongUser() {
 	// Logged in as other user
 	params.HTTPRequest = suite.AuthenticateRequest(req, otherServiceMember)
 
-	handler := UpdateBackupContactHandler{suite.HandlerConfig()}
+	handler := UpdateBackupContactHandler{suite.NewHandlerConfig()}
 	response := handler.Handle(params)
 
 	errResponse := response.(*handlers.ErrResponse)

--- a/pkg/handlers/internalapi/calendar_test.go
+++ b/pkg/handlers/internalapi/calendar_test.go
@@ -80,7 +80,7 @@ func (suite *HandlerSuite) TestShowAvailableMoveDatesHandler() {
 		strfmt.Date(time.Date(2018, 12, 26, 0, 0, 0, 0, time.UTC)),
 	}
 
-	showHandler := ShowAvailableMoveDatesHandler{suite.HandlerConfig()}
+	showHandler := ShowAvailableMoveDatesHandler{suite.NewHandlerConfig()}
 	response := showHandler.Handle(params)
 
 	suite.IsType(&calendarop.ShowAvailableMoveDatesOK{}, response)
@@ -115,7 +115,7 @@ func (suite *HandlerSuite) TestIsDateSelectionWeekendHolidayHandler() {
 		mock.AnythingOfType("time.Time"),
 	).Return(&info, nil)
 
-	showHandler := IsDateWeekendHolidayHandler{suite.HandlerConfig(), &mockDateSelectionChecker}
+	showHandler := IsDateWeekendHolidayHandler{suite.NewHandlerConfig(), &mockDateSelectionChecker}
 	response := showHandler.Handle(params)
 
 	suite.IsType(&calendarop.IsDateWeekendHolidayOK{}, response)

--- a/pkg/handlers/internalapi/documents_test.go
+++ b/pkg/handlers/internalapi/documents_test.go
@@ -32,7 +32,7 @@ func (suite *HandlerSuite) TestCreateDocumentsHandler() {
 	req = suite.AuthenticateRequest(req, serviceMember)
 	params.HTTPRequest = req
 
-	handler := CreateDocumentHandler{suite.HandlerConfig()}
+	handler := CreateDocumentHandler{suite.NewHandlerConfig()}
 	response := handler.Handle(params)
 
 	createdResponse, ok := response.(*documentop.CreateDocumentCreated)
@@ -80,7 +80,7 @@ func (suite *HandlerSuite) TestShowDocumentHandler() {
 	req = suite.AuthenticateRequest(req, document.ServiceMember)
 	params.HTTPRequest = req
 
-	handlerConfig := suite.HandlerConfig()
+	handlerConfig := suite.NewHandlerConfig()
 	fakeS3 := storageTest.NewFakeS3Storage(true)
 	handlerConfig.SetFileStorer(fakeS3)
 	handler := ShowDocumentHandler{handlerConfig}

--- a/pkg/handlers/internalapi/duty_locations_test.go
+++ b/pkg/handlers/internalapi/duty_locations_test.go
@@ -70,7 +70,7 @@ func (suite *HandlerSuite) TestSearchDutyLocationHandler() {
 	suite.MustSave(&dutylocationHI)
 
 	setupTestHandler := func(isAlaskaEnabled bool, isSimulateFeatureFlagError bool) SearchDutyLocationsHandler {
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 		mockFeatureFlagFetcher := &mocks.FeatureFlagFetcher{}
 
 		mockGetFlagFunc := func(_ context.Context, _ *zap.Logger, entityID string, key string, _ map[string]string, mockVariant string) (services.FeatureFlag, error) {

--- a/pkg/handlers/internalapi/entitlements_test.go
+++ b/pkg/handlers/internalapi/entitlements_test.go
@@ -26,7 +26,7 @@ func (suite *HandlerSuite) TestIndexEntitlementsHandlerReturns200() {
 	}
 
 	// And: index entitlements endpoint is hit
-	handler := IndexEntitlementsHandler{suite.HandlerConfig(), waf}
+	handler := IndexEntitlementsHandler{suite.NewHandlerConfig(), waf}
 	response := handler.Handle(params)
 
 	// Then: expect a 200 status code

--- a/pkg/handlers/internalapi/feature_flag_test.go
+++ b/pkg/handlers/internalapi/feature_flag_test.go
@@ -27,7 +27,7 @@ func (suite *HandlerSuite) TestBooleanFeatureFlagUnauthenticatedHandler() {
 			},
 		}
 
-		handler := BooleanFeatureFlagsUnauthenticatedHandler{suite.HandlerConfig()}
+		handler := BooleanFeatureFlagsUnauthenticatedHandler{suite.NewHandlerConfig()}
 
 		response := handler.Handle(params)
 
@@ -60,7 +60,7 @@ func (suite *HandlerSuite) TestBooleanFeatureFlagUnauthenticatedHandler() {
 			},
 		}
 
-		handler := BooleanFeatureFlagsUnauthenticatedHandler{suite.HandlerConfig()}
+		handler := BooleanFeatureFlagsUnauthenticatedHandler{suite.NewHandlerConfig()}
 		response := handler.Handle(params)
 		res, ok := response.(*ffop.BooleanFeatureFlagUnauthenticatedUnauthorized)
 		suite.True(ok)
@@ -82,7 +82,7 @@ func (suite *HandlerSuite) TestBooleanFeatureFlagForUserHandler() {
 		},
 	}
 
-	handler := BooleanFeatureFlagsForUserHandler{suite.HandlerConfig()}
+	handler := BooleanFeatureFlagsForUserHandler{suite.NewHandlerConfig()}
 
 	response := handler.Handle(params)
 
@@ -115,7 +115,7 @@ func (suite *HandlerSuite) TestVariantFeatureFlagForUserHandler() {
 		},
 	}
 
-	handler := VariantFeatureFlagsForUserHandler{suite.HandlerConfig()}
+	handler := VariantFeatureFlagsForUserHandler{suite.NewHandlerConfig()}
 
 	response := handler.Handle(params)
 

--- a/pkg/handlers/internalapi/moves_test.go
+++ b/pkg/handlers/internalapi/moves_test.go
@@ -61,7 +61,7 @@ func (suite *HandlerSuite) TestPatchMoveHandler() {
 
 	closeoutOfficeUpdater := moverouter.NewCloseoutOfficeUpdater(moverouter.NewMoveFetcher(), transportationoffice.NewTransportationOfficesFetcher())
 	// And: a move is patched
-	handler := PatchMoveHandler{suite.HandlerConfig(), closeoutOfficeUpdater}
+	handler := PatchMoveHandler{suite.NewHandlerConfig(), closeoutOfficeUpdater}
 	response := handler.Handle(params)
 
 	// Then: expect a 200 status code
@@ -98,7 +98,7 @@ func (suite *HandlerSuite) TestPatchMoveHandlerWrongUser() {
 	}
 
 	closeoutOfficeUpdater := moverouter.NewCloseoutOfficeUpdater(moverouter.NewMoveFetcher(), transportationoffice.NewTransportationOfficesFetcher())
-	handler := PatchMoveHandler{suite.HandlerConfig(), closeoutOfficeUpdater}
+	handler := PatchMoveHandler{suite.NewHandlerConfig(), closeoutOfficeUpdater}
 	response := handler.Handle(params)
 
 	suite.IsType(&moveop.PatchMoveForbidden{}, response)
@@ -127,7 +127,7 @@ func (suite *HandlerSuite) TestPatchMoveHandlerNoMove() {
 	}
 
 	closeoutOfficeUpdater := moverouter.NewCloseoutOfficeUpdater(moverouter.NewMoveFetcher(), transportationoffice.NewTransportationOfficesFetcher())
-	handler := PatchMoveHandler{suite.HandlerConfig(), closeoutOfficeUpdater}
+	handler := PatchMoveHandler{suite.NewHandlerConfig(), closeoutOfficeUpdater}
 	response := handler.Handle(params)
 
 	suite.IsType(&moveop.PatchMoveNotFound{}, response)
@@ -156,7 +156,7 @@ func (suite *HandlerSuite) TestPatchMoveHandlerCloseoutOfficeNotFound() {
 
 	closeoutOfficeUpdater := moverouter.NewCloseoutOfficeUpdater(moverouter.NewMoveFetcher(), transportationoffice.NewTransportationOfficesFetcher())
 	// And: a move is patched
-	handler := PatchMoveHandler{suite.HandlerConfig(), closeoutOfficeUpdater}
+	handler := PatchMoveHandler{suite.NewHandlerConfig(), closeoutOfficeUpdater}
 	response := handler.Handle(params)
 
 	// Then: expect a 404 status code
@@ -191,7 +191,7 @@ func (suite *HandlerSuite) TestPatchMoveHandlerETagPreconditionFailure() {
 
 	closeoutOfficeUpdater := moverouter.NewCloseoutOfficeUpdater(moverouter.NewMoveFetcher(), transportationoffice.NewTransportationOfficesFetcher())
 	// And: a move is patched
-	handler := PatchMoveHandler{suite.HandlerConfig(), closeoutOfficeUpdater}
+	handler := PatchMoveHandler{suite.NewHandlerConfig(), closeoutOfficeUpdater}
 	response := handler.Handle(params)
 
 	suite.Assertions.IsType(&moveop.PatchMovePreconditionFailed{}, response)
@@ -211,7 +211,7 @@ func (suite *HandlerSuite) TestShowMoveHandler() {
 		MoveID:      strfmt.UUID(move.ID.String()),
 	}
 	// And: show Move is queried
-	showHandler := ShowMoveHandler{suite.HandlerConfig()}
+	showHandler := ShowMoveHandler{suite.NewHandlerConfig()}
 	showResponse := showHandler.Handle(params)
 
 	// Then: Expect a 200 status code
@@ -238,7 +238,7 @@ func (suite *HandlerSuite) TestShowMoveWrongUser() {
 		MoveID:      strfmt.UUID(move.ID.String()),
 	}
 	// And: Show move is queried
-	showHandler := ShowMoveHandler{suite.HandlerConfig()}
+	showHandler := ShowMoveHandler{suite.NewHandlerConfig()}
 	showResponse := showHandler.Handle(showMoveParams)
 	// Then: expect a forbidden response
 	suite.CheckResponseForbidden(showResponse)
@@ -300,7 +300,7 @@ func (suite *HandlerSuite) TestSubmitMoveForApprovalHandler() {
 			SubmitMoveForApprovalPayload: &newSubmitMoveForApprovalPayload,
 		}
 		// When: a move is submitted
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 		handlerConfig.SetNotificationSender(notifications.NewStubNotificationSender("milmovelocal"))
 		handler := SubmitMoveHandler{handlerConfig, moverouter.NewMoveRouter(transportationoffice.NewTransportationOfficesFetcher())}
 		response := handler.Handle(params)
@@ -382,7 +382,7 @@ func (suite *HandlerSuite) TestSubmitMoveForApprovalHandler() {
 			SubmitMoveForApprovalPayload: &newSubmitMoveForApprovalPayload,
 		}
 		// When: a move is submitted
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 		handlerConfig.SetNotificationSender(notifications.NewStubNotificationSender("milmovelocal"))
 		handler := SubmitMoveHandler{handlerConfig, moverouter.NewMoveRouter(transportationoffice.NewTransportationOfficesFetcher())}
 		response := handler.Handle(params)
@@ -422,7 +422,7 @@ func (suite *HandlerSuite) TestSubmitMoveForApprovalHandler() {
 			SubmitMoveForApprovalPayload: &newSubmitMoveForApprovalPayload,
 		}
 		// And: a move is submitted
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 		handlerConfig.SetNotificationSender(notifications.NewStubNotificationSender("milmovelocal"))
 		handler := SubmitMoveHandler{handlerConfig, moverouter.NewMoveRouter(transportationoffice.NewTransportationOfficesFetcher())}
 		response := handler.Handle(params)
@@ -475,7 +475,7 @@ func (suite *HandlerSuite) TestSubmitMoveForServiceCounselingHandler() {
 			SubmitMoveForApprovalPayload: &newSubmitMoveForApprovalPayload,
 		}
 		// When: a move is submitted
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 		handlerConfig.SetNotificationSender(notifications.NewStubNotificationSender("milmovelocal"))
 		handler := SubmitMoveHandler{handlerConfig, moverouter.NewMoveRouter(transportationoffice.NewTransportationOfficesFetcher())}
 		response := handler.Handle(params)
@@ -525,7 +525,7 @@ func (suite *HandlerSuite) TestSubmitAmendedOrdersHandler() {
 			MoveID:      strfmt.UUID(move.ID.String()),
 		}
 		// And: a move is submitted
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 
 		handler := SubmitAmendedOrdersHandler{handlerConfig, moverouter.NewMoveRouter(transportationoffice.NewTransportationOfficesFetcher())}
 		response := handler.Handle(params)
@@ -614,7 +614,7 @@ func (suite *HandlerSuite) TestSubmitGetAllMovesHandler() {
 
 		// And: a move is submitted
 		fakeS3 := storageTest.NewFakeS3Storage(true)
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 		handlerConfig.SetFileStorer(fakeS3)
 
 		handler := GetAllMovesHandler{handlerConfig}

--- a/pkg/handlers/internalapi/moving_expense_test.go
+++ b/pkg/handlers/internalapi/moving_expense_test.go
@@ -46,7 +46,7 @@ func (suite *HandlerSuite) TestCreateMovingExpenseHandler() {
 		}
 
 		subtestData.handler = CreateMovingExpenseHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			movingExpenseCreator,
 		}
 
@@ -114,7 +114,7 @@ func (suite *HandlerSuite) TestCreateMovingExpenseHandler() {
 		).Return(nil, serverErr)
 
 		handler := CreateMovingExpenseHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			&mockCreator,
 		}
 

--- a/pkg/handlers/internalapi/mto_shipment_test.go
+++ b/pkg/handlers/internalapi/mto_shipment_test.go
@@ -216,7 +216,7 @@ func (suite *HandlerSuite) TestCreateMTOShipmentHandlerV1() {
 				Match: false,
 			}
 
-			handlerConfig := suite.HandlerConfig()
+			handlerConfig := suite.NewHandlerConfig()
 			if !ubFeatureFlag {
 				mockFeatureFlagFetcher := &mocks.FeatureFlagFetcher{}
 				mockFeatureFlagFetcher.On("GetBooleanFlagForUser",
@@ -234,7 +234,7 @@ func (suite *HandlerSuite) TestCreateMTOShipmentHandlerV1() {
 			}
 		} else {
 			subtestData.handler = CreateMTOShipmentHandler{
-				suite.HandlerConfig(),
+				suite.NewHandlerConfig(),
 				shipmentCreator,
 			}
 		}
@@ -730,7 +730,7 @@ func (suite *HandlerSuite) TestCreateMTOShipmentHandlerV1() {
 		).Return(nil, err)
 
 		handler := CreateMTOShipmentHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			&mockShipmentCreator,
 		}
 
@@ -806,7 +806,7 @@ func (suite *HandlerSuite) TestUpdateMTOShipmentHandler() {
 		}
 
 		handler := UpdateMTOShipmentHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			shipmentUpdaterSO,
 		}
 
@@ -1649,7 +1649,7 @@ func (suite *HandlerSuite) TestListMTOShipmentsHandler() {
 	suite.Run("Successful list fetch - 200 - Integration Test", func() {
 		subtestData := suite.makeListSubtestData()
 		handler := ListMTOShipmentsHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			mtoshipment.NewMTOShipmentFetcher(),
 		}
 
@@ -1755,7 +1755,7 @@ func (suite *HandlerSuite) TestListMTOShipmentsHandler() {
 		}
 		mockMTOShipmentFetcher := &mocks.MTOShipmentFetcher{}
 		handler := ListMTOShipmentsHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			mockMTOShipmentFetcher,
 		}
 
@@ -1774,7 +1774,7 @@ func (suite *HandlerSuite) TestListMTOShipmentsHandler() {
 		}
 		mockMTOShipmentFetcher := &mocks.MTOShipmentFetcher{}
 		handler := ListMTOShipmentsHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			mockMTOShipmentFetcher,
 		}
 
@@ -1793,7 +1793,7 @@ func (suite *HandlerSuite) TestListMTOShipmentsHandler() {
 		}
 
 		handler := ListMTOShipmentsHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			mtoshipment.NewMTOShipmentFetcher(),
 		}
 
@@ -1806,7 +1806,7 @@ func (suite *HandlerSuite) TestListMTOShipmentsHandler() {
 		subtestData := suite.makeListSubtestData()
 		mockMTOShipmentFetcher := &mocks.MTOShipmentFetcher{}
 		handler := ListMTOShipmentsHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			mockMTOShipmentFetcher,
 		}
 
@@ -1847,7 +1847,7 @@ func (suite *HandlerSuite) TestDeleteShipmentHandler() {
 
 		req := httptest.NewRequest("DELETE", fmt.Sprintf("/mto-shipments/%s", shipment.ID.String()), nil)
 		req = suite.AuthenticateRequest(req, move.Orders.ServiceMember)
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 
 		handler := DeleteShipmentHandler{
 			handlerConfig,
@@ -1883,7 +1883,7 @@ func (suite *HandlerSuite) TestDeleteShipmentHandler() {
 
 		req := httptest.NewRequest("DELETE", fmt.Sprintf("/mto-shipments/%s", shipment.ID.String()), nil)
 		req = suite.AuthenticateRequest(req, move.Orders.ServiceMember)
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 
 		handler := DeleteShipmentHandler{
 			handlerConfig,
@@ -1918,7 +1918,7 @@ func (suite *HandlerSuite) TestDeleteShipmentHandler() {
 
 		req := httptest.NewRequest("DELETE", fmt.Sprintf("/mto-shipments/%s", shipment.ID.String()), nil)
 		req = suite.AuthenticateRequest(req, move.Orders.ServiceMember)
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 
 		handler := DeleteShipmentHandler{
 			handlerConfig,
@@ -1961,7 +1961,7 @@ func (suite *HandlerSuite) TestDeleteShipmentHandler() {
 		req := httptest.NewRequest("DELETE", fmt.Sprintf("/mto-shipments/%s", shipment.ID.String()), nil)
 		req = suite.AuthenticateRequest(req, sm1)
 
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 
 		handler := DeleteShipmentHandler{
 			handlerConfig,
@@ -1996,7 +1996,7 @@ func (suite *HandlerSuite) TestDeleteShipmentHandler() {
 
 		req := httptest.NewRequest("DELETE", fmt.Sprintf("/mto-shipments/%s", shipment.ID.String()), nil)
 		req = suite.AuthenticateRequest(req, move.Orders.ServiceMember)
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 
 		handler := DeleteShipmentHandler{
 			handlerConfig,
@@ -2032,7 +2032,7 @@ func (suite *HandlerSuite) TestDeleteShipmentHandler() {
 		req := httptest.NewRequest("DELETE", fmt.Sprintf("/mto-shipments/%s", shipment.ID.String()), nil)
 		req = suite.AuthenticateRequest(req, move.Orders.ServiceMember)
 
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 
 		handler := DeleteShipmentHandler{
 			handlerConfig,

--- a/pkg/handlers/internalapi/office_test.go
+++ b/pkg/handlers/internalapi/office_test.go
@@ -56,7 +56,7 @@ func (suite *HandlerSuite) TestApproveMoveHandler() {
 	}
 	// And: a move is approved
 	handler := ApproveMoveHandler{
-		suite.HandlerConfig(),
+		suite.NewHandlerConfig(),
 		moveRouter,
 	}
 	response := handler.Handle(params)
@@ -103,7 +103,7 @@ func (suite *HandlerSuite) TestApproveMoveHandlerIncompleteOrders() {
 	}
 	// And: move handler is hit
 	handler := ApproveMoveHandler{
-		suite.HandlerConfig(),
+		suite.NewHandlerConfig(),
 		moveRouter,
 	}
 	response := handler.Handle(params)
@@ -129,7 +129,7 @@ func (suite *HandlerSuite) TestApproveMoveHandlerForbidden() {
 	}
 	// And: a move is approved
 	handler := ApproveMoveHandler{
-		suite.HandlerConfig(),
+		suite.NewHandlerConfig(),
 		moveRouter,
 	}
 	response := handler.Handle(params)
@@ -157,7 +157,7 @@ func (suite *HandlerSuite) TestCancelMoveHandler() {
 		}
 
 		// And: a move is canceled
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 		handler := CancelMoveHandler{handlerConfig, moveRouter}
 		response := handler.Handle(params)
 
@@ -188,7 +188,7 @@ func (suite *HandlerSuite) TestCancelMoveHandler() {
 		}
 
 		// And: a move is canceled
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 		handler := CancelMoveHandler{handlerConfig, moveRouter}
 		response := handler.Handle(params)
 
@@ -220,7 +220,7 @@ func (suite *HandlerSuite) TestCancelMoveHandler() {
 		}
 
 		// And: a move is canceled
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 		handler := CancelMoveHandler{handlerConfig, moveRouter}
 		response := handler.Handle(params)
 
@@ -244,7 +244,7 @@ func (suite *HandlerSuite) TestApproveReimbursementHandler() {
 	}
 
 	// And: a reimbursement is approved
-	handler := ApproveReimbursementHandler{suite.HandlerConfig()}
+	handler := ApproveReimbursementHandler{suite.NewHandlerConfig()}
 	response := handler.Handle(params)
 
 	// Then: expect a 200 status code
@@ -269,7 +269,7 @@ func (suite *HandlerSuite) TestApproveReimbursementHandlerForbidden() {
 	}
 
 	// And: a reimbursement is approved
-	handler := ApproveReimbursementHandler{suite.HandlerConfig()}
+	handler := ApproveReimbursementHandler{suite.NewHandlerConfig()}
 	response := handler.Handle(params)
 
 	// Then: expect Forbidden response

--- a/pkg/handlers/internalapi/okta_profile_test.go
+++ b/pkg/handlers/internalapi/okta_profile_test.go
@@ -65,7 +65,7 @@ func (suite *HandlerSuite) TestGetOktaProfileHandler() {
 		HTTPRequest: req,
 	}
 
-	handler := GetOktaProfileHandler{suite.HandlerConfig()}
+	handler := GetOktaProfileHandler{suite.NewHandlerConfig()}
 	response := handler.Handle(params)
 
 	suite.Assertions.IsType(nil, response)
@@ -126,7 +126,7 @@ func (suite *HandlerSuite) TestUpdateOktaProfileHandler() {
 		UpdateOktaUserProfileData: &reqPayload,
 	}
 
-	handler := UpdateOktaProfileHandler{suite.HandlerConfig()}
+	handler := UpdateOktaProfileHandler{suite.NewHandlerConfig()}
 	response := handler.Handle(params)
 
 	// TODO figure out how to write this test correctly

--- a/pkg/handlers/internalapi/orders_test.go
+++ b/pkg/handlers/internalapi/orders_test.go
@@ -91,7 +91,7 @@ func (suite *HandlerSuite) TestCreateOrder() {
 		}
 
 		fakeS3 := storageTest.NewFakeS3Storage(true)
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 		handlerConfig.SetFileStorer(fakeS3)
 		createHandler := CreateOrdersHandler{handlerConfig}
 
@@ -214,7 +214,7 @@ func (suite *HandlerSuite) TestCreateOrder() {
 		}
 
 		fakeS3 := storageTest.NewFakeS3Storage(true)
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 		handlerConfig.SetFileStorer(fakeS3)
 		createHandler := CreateOrdersHandler{handlerConfig}
 		response := createHandler.Handle(params)
@@ -336,7 +336,7 @@ func (suite *HandlerSuite) TestCreateOrder() {
 		}
 
 		fakeS3 := storageTest.NewFakeS3Storage(true)
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 		handlerConfig.SetFileStorer(fakeS3)
 		createHandler := CreateOrdersHandler{handlerConfig}
 
@@ -372,7 +372,7 @@ func (suite *HandlerSuite) TestShowOrder() {
 	}
 
 	fakeS3 := storageTest.NewFakeS3Storage(true)
-	handlerConfig := suite.HandlerConfig()
+	handlerConfig := suite.NewHandlerConfig()
 	handlerConfig.SetFileStorer(fakeS3)
 	showHandler := ShowOrdersHandler{handlerConfig}
 
@@ -787,7 +787,7 @@ func (suite *HandlerSuite) TestUpdateOrdersHandler() {
 		}
 
 		fakeS3 := storageTest.NewFakeS3Storage(true)
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 		handlerConfig.SetFileStorer(fakeS3)
 
 		handler := UpdateOrdersHandler{handlerConfig}
@@ -939,7 +939,7 @@ func (suite *HandlerSuite) TestUpdateOrdersHandler() {
 		}
 
 		fakeS3 := storageTest.NewFakeS3Storage(true)
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 		handlerConfig.SetFileStorer(fakeS3)
 
 		handler := UpdateOrdersHandler{handlerConfig}
@@ -1040,7 +1040,7 @@ func (suite *HandlerSuite) TestUpdateOrdersHandler() {
 		}
 
 		fakeS3 := storageTest.NewFakeS3Storage(true)
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 		handlerConfig.SetFileStorer(fakeS3)
 
 		handler := UpdateOrdersHandler{handlerConfig}
@@ -1112,7 +1112,7 @@ func (suite *HandlerSuite) TestUpdateOrdersHandler() {
 		}
 
 		fakeS3 := storageTest.NewFakeS3Storage(true)
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 		handlerConfig.SetFileStorer(fakeS3)
 
 		handler := UpdateOrdersHandler{handlerConfig}
@@ -1235,7 +1235,7 @@ func (suite *HandlerSuite) TestUpdateOrdersHandlerOriginPostalCodeAndGBLOC() {
 	}
 
 	fakeS3 := storageTest.NewFakeS3Storage(true)
-	handlerConfig := suite.HandlerConfig()
+	handlerConfig := suite.NewHandlerConfig()
 	handlerConfig.SetFileStorer(fakeS3)
 
 	handler := UpdateOrdersHandler{handlerConfig}
@@ -1375,7 +1375,7 @@ func (suite *HandlerSuite) TestUpdateOrdersHandlerWithCounselingOffice() {
 	}
 
 	fakeS3 := storageTest.NewFakeS3Storage(true)
-	handlerConfig := suite.HandlerConfig()
+	handlerConfig := suite.NewHandlerConfig()
 	handlerConfig.SetFileStorer(fakeS3)
 
 	handler := UpdateOrdersHandler{handlerConfig}

--- a/pkg/handlers/internalapi/postal_codes_test.go
+++ b/pkg/handlers/internalapi/postal_codes_test.go
@@ -30,7 +30,7 @@ func (suite *HandlerSuite) TestValidatePostalCodeWithRateDataHandler() {
 			PostalCodeType: postalCodeTypeString,
 		}
 
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 		postalCodeValidator := &mocks.PostalCodeValidator{}
 		postalCodeValidator.On("ValidatePostalCode",
 			mock.AnythingOfType("*appcontext.appContext"),
@@ -69,7 +69,7 @@ func (suite *HandlerSuite) TestValidatePostalCodeWithRateDataHandler() {
 			PostalCodeType: postalCodeTypeString,
 		}
 
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 		postalCodeValidator := &mocks.PostalCodeValidator{}
 		postalCodeValidator.On("ValidatePostalCode",
 			mock.AnythingOfType("*appcontext.appContext"),
@@ -108,7 +108,7 @@ func (suite *HandlerSuite) TestValidatePostalCodeWithRateDataHandler() {
 			PostalCodeType: postalCodeTypeString,
 		}
 
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 		postalCodeValidator := &mocks.PostalCodeValidator{}
 		postalCodeValidator.On("ValidatePostalCode",
 			mock.AnythingOfType("*appcontext.appContext"),

--- a/pkg/handlers/internalapi/ppm_shipment_test.go
+++ b/pkg/handlers/internalapi/ppm_shipment_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/transcom/mymove/pkg/gen/internalmessages"
 	"github.com/transcom/mymove/pkg/handlers"
 	"github.com/transcom/mymove/pkg/models"
+	"github.com/transcom/mymove/pkg/models/roles"
 	"github.com/transcom/mymove/pkg/services"
 	"github.com/transcom/mymove/pkg/services/mocks"
 	mtoshipment "github.com/transcom/mymove/pkg/services/mto_shipment"
@@ -569,7 +570,15 @@ func (suite *HandlerSuite) TestResubmitPPMShipmentDocumentationHandlerUnit() {
 
 		request, params := setUpRequestAndParams(ppmShipment, false, false)
 
-		officeUser := factory.BuildOfficeUser(nil, nil, nil)
+		officeUser := factory.BuildOfficeUser(nil, []factory.Customization{{
+			Model: models.User{
+				Roles: roles.Roles{
+					{
+						RoleType: roles.RoleTypeTOO,
+					},
+				},
+			},
+		}}, nil)
 		request = suite.AuthenticateOfficeRequest(request, officeUser)
 		params.HTTPRequest = request
 

--- a/pkg/handlers/internalapi/ppm_shipment_test.go
+++ b/pkg/handlers/internalapi/ppm_shipment_test.go
@@ -86,7 +86,7 @@ func (suite *HandlerSuite) TestSubmitPPMShipmentDocumentationHandlerUnit() {
 
 	setUpHandler := func(submitter services.PPMShipmentNewSubmitter) SubmitPPMShipmentDocumentationHandler {
 		return SubmitPPMShipmentDocumentationHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			submitter,
 		}
 	}
@@ -559,7 +559,7 @@ func (suite *HandlerSuite) TestResubmitPPMShipmentDocumentationHandlerUnit() {
 
 	setUpHandler := func(submitter services.PPMShipmentUpdatedSubmitter) ResubmitPPMShipmentDocumentationHandler {
 		return ResubmitPPMShipmentDocumentationHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			submitter,
 		}
 	}
@@ -993,7 +993,7 @@ func (suite *HandlerSuite) TestShowAOAPacketHandler() {
 
 		ppmshipment := factory.BuildPPMShipmentReadyForFinalCustomerCloseOutWithAllDocTypes(suite.DB(), userUploader)
 
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 		handler := showAOAPacketHandler{
 			HandlerConfig:    handlerConfig,
 			SSWPPMComputer:   &mockSSWPPMComputer,
@@ -1030,7 +1030,7 @@ func (suite *HandlerSuite) TestShowAOAPacketHandler() {
 
 		ppmshipment := factory.BuildPPMShipmentReadyForFinalCustomerCloseOutWithAllDocTypes(suite.DB(), userUploader)
 
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 		handler := showAOAPacketHandler{
 			HandlerConfig:    handlerConfig,
 			SSWPPMComputer:   &mockSSWPPMComputer,
@@ -1062,7 +1062,7 @@ func (suite *HandlerSuite) TestShowAOAPacketHandler() {
 		mockSSWPPMGenerator := mocks.SSWPPMGenerator{}
 		mockAOAPacketCreator := mocks.AOAPacketCreator{}
 
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 		handler := showAOAPacketHandler{
 			HandlerConfig:    handlerConfig,
 			SSWPPMComputer:   &mockSSWPPMComputer,
@@ -1092,7 +1092,7 @@ func (suite *HandlerSuite) TestShowAOAPacketHandler() {
 		mockSSWPPMGenerator := mocks.SSWPPMGenerator{}
 		mockAOAPacketCreator := mocks.AOAPacketCreator{}
 
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 		handler := showAOAPacketHandler{
 			HandlerConfig:    handlerConfig,
 			SSWPPMComputer:   &mockSSWPPMComputer,

--- a/pkg/handlers/internalapi/progear_weight_ticket_test.go
+++ b/pkg/handlers/internalapi/progear_weight_ticket_test.go
@@ -42,7 +42,7 @@ func (suite *HandlerSuite) TestCreateProGearWeightTicketHandler() {
 		}
 
 		subtestData.handler = CreateProGearWeightTicketHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			progearCreator,
 		}
 
@@ -101,7 +101,7 @@ func (suite *HandlerSuite) TestCreateProGearWeightTicketHandler() {
 		).Return(nil, serverErr)
 
 		handler := CreateProGearWeightTicketHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			&mockCreator,
 		}
 
@@ -256,7 +256,7 @@ func (suite *HandlerSuite) TestUpdateProGearWeightTicketHandler() {
 		).Return(nil, err)
 
 		handler := UpdateProGearWeightTicketHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			&mockUpdater,
 		}
 

--- a/pkg/handlers/internalapi/registration_test.go
+++ b/pkg/handlers/internalapi/registration_test.go
@@ -60,7 +60,7 @@ func (suite *HandlerSuite) TestCustomerRegistrationHandler() {
 			HTTPRequest:  request.WithContext(ctx),
 			Registration: body,
 		}
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 		handler := CustomerRegistrationHandler{
 			handlerConfig,
 		}
@@ -119,7 +119,7 @@ func (suite *HandlerSuite) TestCustomerRegistrationHandler() {
 			HTTPRequest:  request.WithContext(ctx),
 			Registration: body,
 		}
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 		handler := CustomerRegistrationHandler{
 			handlerConfig,
 		}
@@ -164,7 +164,7 @@ func (suite *HandlerSuite) TestCustomerRegistrationHandler() {
 			HTTPRequest:  request.WithContext(ctx),
 			Registration: body,
 		}
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 		handler := CustomerRegistrationHandler{handlerConfig}
 
 		response := handler.Handle(params)
@@ -201,7 +201,7 @@ func (suite *HandlerSuite) TestCustomerRegistrationHandler() {
 			HTTPRequest:  request.WithContext(ctx),
 			Registration: body,
 		}
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 		handler := CustomerRegistrationHandler{handlerConfig}
 
 		response := handler.Handle(params)
@@ -242,7 +242,7 @@ func (suite *HandlerSuite) TestCustomerRegistrationHandler() {
 			HTTPRequest:  request.WithContext(ctx),
 			Registration: body,
 		}
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 		handler := CustomerRegistrationHandler{handlerConfig}
 
 		response := handler.Handle(params)
@@ -283,7 +283,7 @@ func (suite *HandlerSuite) TestCustomerRegistrationHandler() {
 			HTTPRequest:  request.WithContext(ctx),
 			Registration: body,
 		}
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 		handler := CustomerRegistrationHandler{handlerConfig}
 
 		response := handler.Handle(params)
@@ -324,7 +324,7 @@ func (suite *HandlerSuite) TestCustomerRegistrationHandler() {
 			HTTPRequest:  request.WithContext(ctx),
 			Registration: body,
 		}
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 		handler := CustomerRegistrationHandler{handlerConfig}
 
 		response := handler.Handle(params)
@@ -365,7 +365,7 @@ func (suite *HandlerSuite) TestCustomerRegistrationHandler() {
 			HTTPRequest:  request.WithContext(ctx),
 			Registration: body,
 		}
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 		handler := CustomerRegistrationHandler{handlerConfig}
 
 		response := handler.Handle(params)
@@ -409,7 +409,7 @@ func (suite *HandlerSuite) TestCustomerRegistrationHandler() {
 			HTTPRequest:  request.WithContext(ctx),
 			Registration: body,
 		}
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 		handler := CustomerRegistrationHandler{handlerConfig}
 
 		response := handler.Handle(params)
@@ -427,7 +427,7 @@ func (suite *HandlerSuite) TestCustomerRegistrationHandler() {
 			HTTPRequest: request.WithContext(ctx),
 		}
 
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 		handler := CustomerRegistrationHandler{handlerConfig}
 
 		response := handler.Handle(params)
@@ -462,7 +462,7 @@ func (suite *HandlerSuite) TestCustomerRegistrationHandler() {
 			HTTPRequest:  request.WithContext(ctx),
 			Registration: body,
 		}
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 		handler := CustomerRegistrationHandler{handlerConfig}
 
 		response := handler.Handle(params)

--- a/pkg/handlers/internalapi/service_members_test.go
+++ b/pkg/handlers/internalapi/service_members_test.go
@@ -47,7 +47,7 @@ func (suite *HandlerSuite) TestShowServiceMemberHandler() {
 		ServiceMemberID: strfmt.UUID(newServiceMember.ID.String()),
 	}
 	// And: show ServiceMember is queried
-	showHandler := ShowServiceMemberHandler{suite.HandlerConfig()}
+	showHandler := ShowServiceMemberHandler{suite.NewHandlerConfig()}
 	response := showHandler.Handle(params)
 
 	// Then: Expect a 200 status code
@@ -71,7 +71,7 @@ func (suite *HandlerSuite) TestShowServiceMemberWrongUser() {
 		ServiceMemberID: strfmt.UUID(notLoggedInUser.ID.String()),
 	}
 	// And: Show servicemember is queried
-	showHandler := ShowServiceMemberHandler{suite.HandlerConfig()}
+	showHandler := ShowServiceMemberHandler{suite.NewHandlerConfig()}
 	response := showHandler.Handle(showServiceMemberParams)
 
 	suite.Assertions.IsType(&handlers.ErrResponse{}, response)
@@ -94,7 +94,7 @@ func (suite *HandlerSuite) TestSubmitServiceMemberHandlerNoValues() {
 		CreateServiceMemberPayload: &newServiceMemberPayload,
 		HTTPRequest:                req,
 	}
-	handler := CreateServiceMemberHandler{suite.HandlerConfig()}
+	handler := CreateServiceMemberHandler{suite.NewHandlerConfig()}
 	response := handler.Handle(params)
 
 	suite.Assertions.IsType(&handlers.CookieUpdateResponder{}, response)
@@ -155,7 +155,7 @@ func (suite *HandlerSuite) TestSubmitServiceMemberHandlerAllValues() {
 		HTTPRequest:                req,
 	}
 
-	handler := CreateServiceMemberHandler{suite.HandlerConfig()}
+	handler := CreateServiceMemberHandler{suite.NewHandlerConfig()}
 	response := handler.Handle(params)
 
 	suite.Assertions.IsType(&handlers.CookieUpdateResponder{}, response)
@@ -267,7 +267,7 @@ func (suite *HandlerSuite) TestPatchServiceMemberHandler() {
 	}
 
 	fakeS3 := storageTest.NewFakeS3Storage(true)
-	handlerConfig := suite.HandlerConfig()
+	handlerConfig := suite.NewHandlerConfig()
 	handlerConfig.SetFileStorer(fakeS3)
 	handler := PatchServiceMemberHandler{handlerConfig}
 	response := handler.Handle(params)
@@ -433,7 +433,7 @@ func (suite *HandlerSuite) TestPatchServiceMemberHandlerSubmittedMove() {
 		PatchServiceMemberPayload: &patchPayload,
 	}
 
-	handlerConfig := suite.HandlerConfig()
+	handlerConfig := suite.NewHandlerConfig()
 	fakeS3 := storageTest.NewFakeS3Storage(true)
 	handlerConfig.SetFileStorer(fakeS3)
 	handler := PatchServiceMemberHandler{handlerConfig}
@@ -501,7 +501,7 @@ func (suite *HandlerSuite) TestPatchServiceMemberHandlerWrongUser() {
 		PatchServiceMemberPayload: &patchPayload,
 	}
 
-	handler := PatchServiceMemberHandler{suite.HandlerConfig()}
+	handler := PatchServiceMemberHandler{suite.NewHandlerConfig()}
 	response := handler.Handle(params)
 
 	suite.Assertions.IsType(&handlers.ErrResponse{}, response)
@@ -531,7 +531,7 @@ func (suite *HandlerSuite) TestPatchServiceMemberHandlerNoServiceMember() {
 		PatchServiceMemberPayload: &patchPayload,
 	}
 
-	handler := PatchServiceMemberHandler{suite.HandlerConfig()}
+	handler := PatchServiceMemberHandler{suite.NewHandlerConfig()}
 	response := handler.Handle(params)
 
 	suite.Assertions.IsType(&handlers.ErrResponse{}, response)
@@ -562,7 +562,7 @@ func (suite *HandlerSuite) TestPatchServiceMemberHandlerNoChange() {
 		PatchServiceMemberPayload: &patchPayload,
 	}
 
-	handler := PatchServiceMemberHandler{suite.HandlerConfig()}
+	handler := PatchServiceMemberHandler{suite.NewHandlerConfig()}
 	response := handler.Handle(params)
 
 	suite.Assertions.IsType(&servicememberop.PatchServiceMemberOK{}, response)
@@ -586,7 +586,7 @@ func (suite *HandlerSuite) TestShowServiceMemberOrders() {
 	}
 
 	fakeS3 := storageTest.NewFakeS3Storage(true)
-	handlerConfig := suite.HandlerConfig()
+	handlerConfig := suite.NewHandlerConfig()
 	handlerConfig.SetFileStorer(fakeS3)
 	handler := ShowServiceMemberOrdersHandler{handlerConfig}
 

--- a/pkg/handlers/internalapi/signed_certifications_test.go
+++ b/pkg/handlers/internalapi/signed_certifications_test.go
@@ -43,7 +43,7 @@ func (suite *HandlerSuite) TestCreateSignedCertificationHandler() {
 
 	params.HTTPRequest = req
 
-	handler := CreateSignedCertificationHandler{suite.HandlerConfig()}
+	handler := CreateSignedCertificationHandler{suite.NewHandlerConfig()}
 	response := handler.Handle(params)
 
 	_, ok := response.(*certop.CreateSignedCertificationCreated)
@@ -89,7 +89,7 @@ func (suite *HandlerSuite) TestCreateSignedCertificationHandlerMismatchedUser() 
 
 	params.HTTPRequest = req
 
-	handler := CreateSignedCertificationHandler{suite.HandlerConfig()}
+	handler := CreateSignedCertificationHandler{suite.NewHandlerConfig()}
 	response := handler.Handle(params)
 
 	suite.CheckResponseForbidden(response)
@@ -125,7 +125,7 @@ func (suite *HandlerSuite) TestCreateSignedCertificationHandlerBadMoveID() {
 
 	params.HTTPRequest = req
 
-	handler := CreateSignedCertificationHandler{suite.HandlerConfig()}
+	handler := CreateSignedCertificationHandler{suite.NewHandlerConfig()}
 	response := handler.Handle(params)
 
 	suite.CheckResponseNotFound(response)
@@ -177,7 +177,7 @@ func (suite *HandlerSuite) TestIndexSignedCertificationHandlerBadMoveID() {
 
 	params.HTTPRequest = req
 
-	handler := IndexSignedCertificationsHandler{suite.HandlerConfig()}
+	handler := IndexSignedCertificationsHandler{suite.NewHandlerConfig()}
 	response := handler.Handle(params)
 
 	suite.CheckResponseNotFound(response)
@@ -226,7 +226,7 @@ func (suite *HandlerSuite) TestIndexSignedCertificationHandlerMismatchedUser() {
 
 	params.HTTPRequest = req
 
-	handler := IndexSignedCertificationsHandler{suite.HandlerConfig()}
+	handler := IndexSignedCertificationsHandler{suite.NewHandlerConfig()}
 	response := handler.Handle(params)
 
 	suite.CheckResponseForbidden(response)
@@ -270,7 +270,7 @@ func (suite *HandlerSuite) TestIndexSignedCertificationHandler() {
 
 	params.HTTPRequest = req
 
-	handler := IndexSignedCertificationsHandler{suite.HandlerConfig()}
+	handler := IndexSignedCertificationsHandler{suite.NewHandlerConfig()}
 	response := handler.Handle(params)
 
 	okResponse, ok := response.(*certop.IndexSignedCertificationOK)

--- a/pkg/handlers/internalapi/transportation_offices_test.go
+++ b/pkg/handlers/internalapi/transportation_offices_test.go
@@ -11,6 +11,7 @@ import (
 	transportationofficeop "github.com/transcom/mymove/pkg/gen/internalapi/internaloperations/transportation_offices"
 	"github.com/transcom/mymove/pkg/handlers"
 	"github.com/transcom/mymove/pkg/models"
+	"github.com/transcom/mymove/pkg/models/roles"
 	"github.com/transcom/mymove/pkg/services/address"
 	transportationofficeservice "github.com/transcom/mymove/pkg/services/transportation_office"
 )
@@ -102,7 +103,15 @@ func (suite *HandlerSuite) TestGetTransportationOfficesHandlerUnauthorized() {
 }
 
 func (suite *HandlerSuite) TestGetTransportationOfficesHandlerForbidden() {
-	officeUser := factory.BuildOfficeUser(nil, nil, nil)
+	officeUser := factory.BuildOfficeUser(nil, []factory.Customization{{
+		Model: models.User{
+			Roles: roles.Roles{
+				{
+					RoleType: roles.RoleTypeTOO,
+				},
+			},
+		},
+	}}, nil)
 	fetcher := transportationofficeservice.NewTransportationOfficesFetcher()
 
 	req := httptest.NewRequest("GET", "/transportation_offices", nil)

--- a/pkg/handlers/internalapi/transportation_offices_test.go
+++ b/pkg/handlers/internalapi/transportation_offices_test.go
@@ -25,7 +25,7 @@ func (suite *HandlerSuite) TestShowDutyLocationTransportationOfficeHandler() {
 		HTTPRequest:    req,
 		DutyLocationID: *handlers.FmtUUID(location.ID),
 	}
-	showHandler := ShowDutyLocationTransportationOfficeHandler{suite.HandlerConfig()}
+	showHandler := ShowDutyLocationTransportationOfficeHandler{suite.NewHandlerConfig()}
 	response := showHandler.Handle(params)
 
 	suite.Assertions.IsType(&transportationofficeop.ShowDutyLocationTransportationOfficeOK{}, response)
@@ -49,7 +49,7 @@ func (suite *HandlerSuite) TestShowDutyLocationTransportationOfficeHandlerNoOffi
 		HTTPRequest:    req,
 		DutyLocationID: *handlers.FmtUUID(location.ID),
 	}
-	showHandler := ShowDutyLocationTransportationOfficeHandler{suite.HandlerConfig()}
+	showHandler := ShowDutyLocationTransportationOfficeHandler{suite.NewHandlerConfig()}
 	response := showHandler.Handle(params)
 
 	suite.Assertions.IsType(&handlers.ErrResponse{}, response)
@@ -72,7 +72,7 @@ func (suite *HandlerSuite) TestGetTransportationOfficesHandler() {
 	}
 
 	handler := GetTransportationOfficesHandler{
-		HandlerConfig:                suite.HandlerConfig(),
+		HandlerConfig:                suite.NewHandlerConfig(),
 		TransportationOfficesFetcher: fetcher}
 
 	response := handler.Handle(params)
@@ -93,7 +93,7 @@ func (suite *HandlerSuite) TestGetTransportationOfficesHandlerUnauthorized() {
 	}
 
 	handler := GetTransportationOfficesHandler{
-		HandlerConfig:                suite.HandlerConfig(),
+		HandlerConfig:                suite.NewHandlerConfig(),
 		TransportationOfficesFetcher: fetcher}
 
 	// Request without authentication
@@ -115,7 +115,7 @@ func (suite *HandlerSuite) TestGetTransportationOfficesHandlerForbidden() {
 	}
 
 	handler := GetTransportationOfficesHandler{
-		HandlerConfig:                suite.HandlerConfig(),
+		HandlerConfig:                suite.NewHandlerConfig(),
 		TransportationOfficesFetcher: fetcher}
 
 	response := handler.Handle(params)
@@ -163,7 +163,7 @@ func (suite *HandlerSuite) TestShowCounselingOfficesHandler() {
 	}
 
 	handler := ShowCounselingOfficesHandler{
-		HandlerConfig:                suite.HandlerConfig(),
+		HandlerConfig:                suite.NewHandlerConfig(),
 		TransportationOfficesFetcher: fetcher}
 
 	response := handler.Handle(params)

--- a/pkg/handlers/internalapi/uploads_test.go
+++ b/pkg/handlers/internalapi/uploads_test.go
@@ -114,7 +114,7 @@ func makeRequest(suite *HandlerSuite, params uploadop.CreateUploadParams, servic
 
 	params.HTTPRequest = req
 
-	handlerConfig := suite.HandlerConfig()
+	handlerConfig := suite.NewHandlerConfig()
 	handlerConfig.SetFileStorer(fakeS3)
 	handler := CreateUploadHandler{handlerConfig}
 	response := handler.Handle(params)
@@ -128,7 +128,7 @@ func makePPMRequest(suite *HandlerSuite, params ppmop.CreatePPMUploadParams, ser
 
 	params.HTTPRequest = req
 
-	handlerConfig := suite.HandlerConfig()
+	handlerConfig := suite.NewHandlerConfig()
 	handlerConfig.SetFileStorer(fakeS3)
 	userUploader, err := uploader.NewUserUploader(handlerConfig.FileStorer(), uploader.MaxCustomerUserUploadFileSizeLimit)
 	suite.FatalNoError(err)
@@ -302,7 +302,7 @@ func (suite *HandlerSuite) TestDeleteUploadHandlerSuccess() {
 		req = suite.AuthenticateRequest(req, uploadUser.Document.ServiceMember)
 		params.HTTPRequest = req
 
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 		handlerConfig.SetFileStorer(fakeS3)
 		uploadInformationFetcher := upload.NewUploadInformationFetcher()
 		fmt.Print(uploadInformationFetcher)
@@ -334,7 +334,7 @@ func (suite *HandlerSuite) TestDeleteUploadHandlerSuccess() {
 		req = suite.AuthenticateRequest(req, uploadUser.Document.ServiceMember)
 		params.HTTPRequest = req
 
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 		handlerConfig.SetFileStorer(fakeS3)
 		uploadInformationFetcher := upload.NewUploadInformationFetcher()
 		fmt.Print(uploadInformationFetcher)
@@ -380,7 +380,7 @@ func (suite *HandlerSuite) TestDeleteUploadsHandlerSuccess() {
 	req = suite.AuthenticateRequest(req, uploadUser1.Document.ServiceMember)
 	params.HTTPRequest = req
 
-	handlerConfig := suite.HandlerConfig()
+	handlerConfig := suite.NewHandlerConfig()
 	handlerConfig.SetFileStorer(fakeS3)
 	handler := DeleteUploadsHandler{handlerConfig}
 	response := handler.Handle(params)
@@ -433,7 +433,7 @@ func (suite *HandlerSuite) TestDeleteUploadHandlerSuccessEvenWithS3Failure() {
 
 	fakeS3Failure := storageTest.NewFakeS3Storage(false)
 
-	handlerConfig := suite.HandlerConfig()
+	handlerConfig := suite.NewHandlerConfig()
 	handlerConfig.SetFileStorer(fakeS3Failure)
 	uploadInformationFetcher := upload.NewUploadInformationFetcher()
 	handler := DeleteUploadHandler{handlerConfig, uploadInformationFetcher}

--- a/pkg/handlers/internalapi/users.go
+++ b/pkg/handlers/internalapi/users.go
@@ -14,6 +14,7 @@ import (
 	"github.com/transcom/mymove/pkg/handlers"
 	"github.com/transcom/mymove/pkg/handlers/internalapi/internal/payloads"
 	"github.com/transcom/mymove/pkg/models"
+	"github.com/transcom/mymove/pkg/models/roles"
 	"github.com/transcom/mymove/pkg/services"
 )
 
@@ -23,14 +24,25 @@ type ShowLoggedInUserHandler struct {
 	officeUserFetcherPop services.OfficeUserFetcherPop
 }
 
-// decoratePayloadWithRoles will add session role to the logged in user payload and return it
-func decoratePayloadWithRoles(s *auth.Session, p *internalmessages.LoggedInUserPayload) {
-	p.Roles = append(p.Roles, &internalmessages.Role{
+// decoratePayloadWithCurrentAndInactiveRoles will add session role to the logged in user payload and return it
+func decoratePayloadWithCurrentAndInactiveRoles(s *auth.Session, p *internalmessages.LoggedInUserPayload, allUserRoles roles.Roles) {
+	p.ActiveRole = &internalmessages.Role{
 		ID:        handlers.FmtUUID(s.UserID),
-		RoleType:  handlers.FmtString(string(s.CurrentRole.RoleType)),
-		CreatedAt: handlers.FmtDateTime(s.CurrentRole.CreatedAt),
-		UpdatedAt: handlers.FmtDateTime(s.CurrentRole.UpdatedAt),
-	})
+		RoleType:  handlers.FmtString(string(s.ActiveRole.RoleType)),
+		CreatedAt: handlers.FmtDateTime(s.ActiveRole.CreatedAt),
+		UpdatedAt: handlers.FmtDateTime(s.ActiveRole.UpdatedAt),
+	}
+	for _, role := range allUserRoles {
+		// Make sure we don't accidentally mark the current role as inactive
+		if role != s.ActiveRole {
+			p.InactiveRoles = append(p.InactiveRoles, &internalmessages.Role{
+				ID:        handlers.FmtUUID(s.UserID),
+				RoleType:  handlers.FmtString(string(role.RoleType)),
+				CreatedAt: handlers.FmtDateTime(role.CreatedAt),
+				UpdatedAt: handlers.FmtDateTime(role.UpdatedAt),
+			})
+		}
+	}
 }
 
 // decoratePayloadWithPermissions will add session permissions to the logged in user payload and return it
@@ -72,7 +84,20 @@ func (h ShowLoggedInUserHandler) Handle(params userop.ShowLoggedInUserParams) mi
 					OfficeUser: payloads.OfficeUser(&officeUser),
 				}
 
-				decoratePayloadWithRoles(appCtx.Session(), &userPayload)
+				// Set a current office user role if it isn't set yet
+				if (appCtx.Session().ActiveRole == roles.Role{}) {
+					defaultRole, err := officeUser.User.Roles.Default()
+					if err != nil {
+						appCtx.Logger().Warn("could not find any roles for the logged in user, proceeding without a role",
+							zap.String("officeUserId", officeUser.ID.String()),
+							zap.Error(err),
+						)
+					} else {
+						appCtx.Session().ActiveRole = *defaultRole
+					}
+				}
+
+				decoratePayloadWithCurrentAndInactiveRoles(appCtx.Session(), &userPayload, officeUser.User.Roles)
 				decoratePayloadWithPermissions(appCtx.Session(), &userPayload)
 				decoratePayloadWithPrivileges(appCtx, &userPayload)
 
@@ -125,7 +150,21 @@ func (h ShowLoggedInUserHandler) Handle(params userop.ShowLoggedInUserParams) mi
 				FirstName:     appCtx.Session().FirstName,
 				Email:         appCtx.Session().Email,
 			}
-			decoratePayloadWithRoles(appCtx.Session(), &userPayload)
+
+			// Set a current service member user role if it isn't set yet
+			if (appCtx.Session().ActiveRole == roles.Role{}) {
+				defaultRole, err := serviceMember.User.Roles.Default()
+				if err != nil {
+					appCtx.Logger().Warn("could not find any roles for the logged in user, proceeding without a role",
+						zap.String("serviceMemberUserId", serviceMember.ID.String()),
+						zap.Error(err),
+					)
+				} else {
+					appCtx.Session().ActiveRole = *defaultRole
+				}
+			}
+
+			decoratePayloadWithCurrentAndInactiveRoles(appCtx.Session(), &userPayload, serviceMember.User.Roles)
 			decoratePayloadWithPermissions(appCtx.Session(), &userPayload)
 			decoratePayloadWithPrivileges(appCtx, &userPayload)
 			return userop.NewShowLoggedInUserOK().WithPayload(&userPayload), nil

--- a/pkg/handlers/internalapi/users.go
+++ b/pkg/handlers/internalapi/users.go
@@ -23,16 +23,14 @@ type ShowLoggedInUserHandler struct {
 	officeUserFetcherPop services.OfficeUserFetcherPop
 }
 
-// decoratePayloadWithRoles will add session roles to the logged in user payload and return it
+// decoratePayloadWithRoles will add session role to the logged in user payload and return it
 func decoratePayloadWithRoles(s *auth.Session, p *internalmessages.LoggedInUserPayload) {
-	for _, role := range s.Roles {
-		p.Roles = append(p.Roles, &internalmessages.Role{
-			ID:        handlers.FmtUUID(s.UserID),
-			RoleType:  handlers.FmtString(string(role.RoleType)),
-			CreatedAt: handlers.FmtDateTime(role.CreatedAt),
-			UpdatedAt: handlers.FmtDateTime(role.UpdatedAt),
-		})
-	}
+	p.Roles = append(p.Roles, &internalmessages.Role{
+		ID:        handlers.FmtUUID(s.UserID),
+		RoleType:  handlers.FmtString(string(s.CurrentRole.RoleType)),
+		CreatedAt: handlers.FmtDateTime(s.CurrentRole.CreatedAt),
+		UpdatedAt: handlers.FmtDateTime(s.CurrentRole.UpdatedAt),
+	})
 }
 
 // decoratePayloadWithPermissions will add session permissions to the logged in user payload and return it

--- a/pkg/handlers/internalapi/users_test.go
+++ b/pkg/handlers/internalapi/users_test.go
@@ -21,7 +21,7 @@ func (suite *HandlerSuite) TestUnknownLoggedInUserHandler() {
 	}
 	builder := officeuser.NewOfficeUserFetcherPop()
 
-	handler := ShowLoggedInUserHandler{suite.HandlerConfig(), builder}
+	handler := ShowLoggedInUserHandler{suite.NewHandlerConfig(), builder}
 
 	response := handler.Handle(params)
 
@@ -42,7 +42,7 @@ func (suite *HandlerSuite) TestServiceMemberNoTransportationOfficeLoggedInUserHa
 			HTTPRequest: req,
 		}
 		builder := officeuser.NewOfficeUserFetcherPop()
-		handler := ShowLoggedInUserHandler{suite.HandlerConfig(), builder}
+		handler := ShowLoggedInUserHandler{suite.NewHandlerConfig(), builder}
 
 		response := handler.Handle(params)
 
@@ -72,7 +72,7 @@ func (suite *HandlerSuite) TestServiceMemberNoTransportationOfficeLoggedInUserHa
 		}
 		fakeS3 := storageTest.NewFakeS3Storage(true)
 		builder := officeuser.NewOfficeUserFetcherPop()
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 		handlerConfig.SetFileStorer(fakeS3)
 		handler := ShowLoggedInUserHandler{handlerConfig, builder}
 
@@ -102,7 +102,7 @@ func (suite *HandlerSuite) TestServiceMemberNoMovesLoggedInUserHandler() {
 		HTTPRequest: req,
 	}
 
-	handlerConfig := suite.HandlerConfig()
+	handlerConfig := suite.NewHandlerConfig()
 
 	builder := officeuser.NewOfficeUserFetcherPop()
 
@@ -134,7 +134,7 @@ func (suite *HandlerSuite) TestServiceMemberWithCloseoutOfficeHandler() {
 	}
 	fakeS3 := storageTest.NewFakeS3Storage(true)
 	builder := officeuser.NewOfficeUserFetcherPop()
-	handlerConfig := suite.HandlerConfig()
+	handlerConfig := suite.NewHandlerConfig()
 	handlerConfig.SetFileStorer(fakeS3)
 
 	handler := ShowLoggedInUserHandler{handlerConfig, builder}
@@ -167,7 +167,7 @@ func (suite *HandlerSuite) TestServiceMemberWithNoCloseoutOfficeHandler() {
 	}
 	fakeS3 := storageTest.NewFakeS3Storage(true)
 	builder := officeuser.NewOfficeUserFetcherPop()
-	handlerConfig := suite.HandlerConfig()
+	handlerConfig := suite.NewHandlerConfig()
 	handlerConfig.SetFileStorer(fakeS3)
 
 	handler := ShowLoggedInUserHandler{handlerConfig, builder}

--- a/pkg/handlers/internalapi/validation_code_test.go
+++ b/pkg/handlers/internalapi/validation_code_test.go
@@ -24,7 +24,7 @@ func (suite *HandlerSuite) TestValidationValidateHander() {
 			HTTPRequest: req,
 			Body:        body,
 		}
-		handler := ValidationCodeValidationCodeHandler{suite.HandlerConfig()}
+		handler := ValidationCodeValidationCodeHandler{suite.NewHandlerConfig()}
 		response := handler.Handle(params)
 
 		suite.Assertions.IsType(&vcodeops.ValidateCodeOK{}, response)
@@ -47,7 +47,7 @@ func (suite *HandlerSuite) TestValidationValidateHander() {
 			Body:        body,
 		}
 
-		handler := ValidationCodeValidationCodeHandler{suite.HandlerConfig()}
+		handler := ValidationCodeValidationCodeHandler{suite.NewHandlerConfig()}
 		response := handler.Handle(params)
 
 		suite.Assertions.IsType(&vcodeops.ValidateCodeUnauthorized{}, response)

--- a/pkg/handlers/internalapi/weight_ticket_test.go
+++ b/pkg/handlers/internalapi/weight_ticket_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/transcom/mymove/pkg/gen/internalmessages"
 	"github.com/transcom/mymove/pkg/handlers"
 	"github.com/transcom/mymove/pkg/models"
+	"github.com/transcom/mymove/pkg/models/roles"
 	"github.com/transcom/mymove/pkg/services/mocks"
 	weightticket "github.com/transcom/mymove/pkg/services/weight_ticket"
 	"github.com/transcom/mymove/pkg/testdatagen"
@@ -353,7 +354,15 @@ func (suite *HandlerSuite) TestDeleteWeightTicketHandler() {
 	suite.Run("DELETE failure - 403 - permission denied - wrong application / user", func() {
 		subtestData := makeDeleteSubtestData(false)
 
-		officeUser := factory.BuildOfficeUser(suite.DB(), nil, nil)
+		officeUser := factory.BuildOfficeUser(suite.DB(), []factory.Customization{{
+			Model: models.User{
+				Roles: roles.Roles{
+					{
+						RoleType: roles.RoleTypeTOO,
+					},
+				},
+			},
+		}}, nil)
 
 		req := subtestData.params.HTTPRequest
 		unauthorizedReq := suite.AuthenticateOfficeRequest(req, officeUser)

--- a/pkg/handlers/internalapi/weight_ticket_test.go
+++ b/pkg/handlers/internalapi/weight_ticket_test.go
@@ -43,7 +43,7 @@ func (suite *HandlerSuite) TestCreateWeightTicketHandler() {
 		}
 
 		subtestData.handler = CreateWeightTicketHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			weightTicketCreator,
 		}
 
@@ -113,7 +113,7 @@ func (suite *HandlerSuite) TestCreateWeightTicketHandler() {
 		).Return(nil, serverErr)
 
 		handler := CreateWeightTicketHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			&mockCreator,
 		}
 
@@ -276,7 +276,7 @@ func (suite *HandlerSuite) TestUpdateWeightTicketHandler() {
 		).Return(nil, err)
 
 		handler := UpdateWeightTicketHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			&mockUpdater,
 		}
 

--- a/pkg/handlers/ordersapi/get_orders_by_issuer_and_orders_num_test.go
+++ b/pkg/handlers/ordersapi/get_orders_by_issuer_and_orders_num_test.go
@@ -28,7 +28,7 @@ func (suite *HandlerSuite) TestGetOrdersByIssuerAndOrdersNumSuccess() {
 		OrdersNum:   order.OrdersNumber,
 	}
 
-	handler := GetOrdersByIssuerAndOrdersNumHandler{suite.HandlerConfig()}
+	handler := GetOrdersByIssuerAndOrdersNumHandler{suite.NewHandlerConfig()}
 	response := handler.Handle(params)
 
 	suite.Assertions.IsType(&ordersoperations.GetOrdersByIssuerAndOrdersNumOK{}, response)
@@ -51,7 +51,7 @@ func (suite *HandlerSuite) TestGetOrdersByIssuerAndOrdersNumNoApiPerm() {
 		OrdersNum:   "8675309",
 	}
 
-	handler := GetOrdersByIssuerAndOrdersNumHandler{suite.HandlerConfig()}
+	handler := GetOrdersByIssuerAndOrdersNumHandler{suite.NewHandlerConfig()}
 	response := handler.Handle(params)
 
 	suite.IsType(&handlers.ErrResponse{}, response)
@@ -127,7 +127,7 @@ func (suite *HandlerSuite) TestGetOrdersByIssuerAndOrdersNumReadPerms() {
 				OrdersNum:   order.OrdersNumber,
 			}
 
-			handler := GetOrdersByIssuerAndOrdersNumHandler{suite.HandlerConfig()}
+			handler := GetOrdersByIssuerAndOrdersNumHandler{suite.NewHandlerConfig()}
 			response := handler.Handle(params)
 
 			suite.IsType(&handlers.ErrResponse{}, response)
@@ -156,7 +156,7 @@ func (suite *HandlerSuite) TestGetOrdersByIssuerAndOrdersNumNotFound() {
 		OrdersNum:   ordersNum,
 	}
 
-	handler := GetOrdersByIssuerAndOrdersNumHandler{suite.HandlerConfig()}
+	handler := GetOrdersByIssuerAndOrdersNumHandler{suite.NewHandlerConfig()}
 	response := handler.Handle(params)
 
 	suite.IsType(&handlers.ErrResponse{}, response)

--- a/pkg/handlers/ordersapi/get_orders_test.go
+++ b/pkg/handlers/ordersapi/get_orders_test.go
@@ -29,7 +29,7 @@ func (suite *HandlerSuite) TestGetOrdersSuccess() {
 		UUID:        strfmt.UUID(order.ID.String()),
 	}
 
-	handler := GetOrdersHandler{suite.HandlerConfig()}
+	handler := GetOrdersHandler{suite.NewHandlerConfig()}
 	response := handler.Handle(params)
 
 	suite.IsType(&ordersoperations.GetOrdersOK{}, response)
@@ -51,7 +51,7 @@ func (suite *HandlerSuite) TestGetOrdersNoApiPerm() {
 		UUID:        strfmt.UUID(uuid.String()),
 	}
 
-	handler := GetOrdersHandler{suite.HandlerConfig()}
+	handler := GetOrdersHandler{suite.NewHandlerConfig()}
 	response := handler.Handle(params)
 
 	suite.IsType(&handlers.ErrResponse{}, response)
@@ -126,7 +126,7 @@ func (suite *HandlerSuite) TestGetOrdersReadPerms() {
 				UUID:        strfmt.UUID(order.ID.String()),
 			}
 
-			handler := GetOrdersHandler{suite.HandlerConfig()}
+			handler := GetOrdersHandler{suite.NewHandlerConfig()}
 			response := handler.Handle(params)
 
 			suite.IsType(&handlers.ErrResponse{}, response)
@@ -152,7 +152,7 @@ func (suite *HandlerSuite) TestGetOrdersMissingUUID() {
 		UUID:        strfmt.UUID(uuid.String()),
 	}
 
-	handler := GetOrdersHandler{suite.HandlerConfig()}
+	handler := GetOrdersHandler{suite.NewHandlerConfig()}
 	response := handler.Handle(params)
 
 	suite.IsType(&handlers.ErrResponse{}, response)

--- a/pkg/handlers/ordersapi/index_orders_for_member_test.go
+++ b/pkg/handlers/ordersapi/index_orders_for_member_test.go
@@ -33,7 +33,7 @@ func (suite *HandlerSuite) TestIndexOrdersForMemberNumSuccess() {
 		Edipi:       order.Edipi,
 	}
 
-	handler := IndexOrdersForMemberHandler{suite.HandlerConfig()}
+	handler := IndexOrdersForMemberHandler{suite.NewHandlerConfig()}
 	response := handler.Handle(params)
 
 	suite.IsType(&ordersoperations.IndexOrdersForMemberOK{}, response)
@@ -61,7 +61,7 @@ func (suite *HandlerSuite) TestIndexOrdersForMemberNumNoApiPerm() {
 		Edipi:       "1234567890",
 	}
 
-	handler := IndexOrdersForMemberHandler{suite.HandlerConfig()}
+	handler := IndexOrdersForMemberHandler{suite.NewHandlerConfig()}
 	response := handler.Handle(params)
 
 	suite.IsType(&handlers.ErrResponse{}, response)
@@ -84,7 +84,7 @@ func (suite *HandlerSuite) TestIndexOrdersForMemberNumNoReadPerms() {
 		Edipi:       "1234567890",
 	}
 
-	handler := IndexOrdersForMemberHandler{suite.HandlerConfig()}
+	handler := IndexOrdersForMemberHandler{suite.NewHandlerConfig()}
 	response := handler.Handle(params)
 
 	suite.IsType(&handlers.ErrResponse{}, response)
@@ -159,7 +159,7 @@ func (suite *HandlerSuite) TestIndexOrderForMemberReadPerms() {
 				Edipi:       order.Edipi,
 			}
 
-			handler := IndexOrdersForMemberHandler{suite.HandlerConfig()}
+			handler := IndexOrdersForMemberHandler{suite.NewHandlerConfig()}
 			response := handler.Handle(params)
 
 			suite.Assertions.IsType(&ordersoperations.IndexOrdersForMemberOK{}, response)

--- a/pkg/handlers/ordersapi/post_revision_test.go
+++ b/pkg/handlers/ordersapi/post_revision_test.go
@@ -23,7 +23,7 @@ func (suite *HandlerSuite) TestPostRevisionNoApiPerm() {
 		OrdersNum:   "8675309",
 	}
 
-	handler := PostRevisionHandler{suite.HandlerConfig()}
+	handler := PostRevisionHandler{suite.NewHandlerConfig()}
 	response := handler.Handle(params)
 
 	suite.IsType(&handlers.ErrResponse{}, response)
@@ -78,7 +78,7 @@ func (suite *HandlerSuite) TestPostRevisionWritePerms() {
 				OrdersNum:   "8675309",
 			}
 
-			handler := PostRevisionHandler{suite.HandlerConfig()}
+			handler := PostRevisionHandler{suite.NewHandlerConfig()}
 			response := handler.Handle(params)
 
 			suite.IsType(&handlers.ErrResponse{}, response)

--- a/pkg/handlers/ordersapi/post_revision_to_orders_test.go
+++ b/pkg/handlers/ordersapi/post_revision_to_orders_test.go
@@ -26,7 +26,7 @@ func (suite *HandlerSuite) TestPostRevisionToOrdersNoApiPerm() {
 		UUID:        strfmt.UUID(id.String()),
 	}
 
-	handler := PostRevisionToOrdersHandler{suite.HandlerConfig()}
+	handler := PostRevisionToOrdersHandler{suite.NewHandlerConfig()}
 	response := handler.Handle(params)
 
 	suite.IsType(&handlers.ErrResponse{}, response)
@@ -102,7 +102,7 @@ func (suite *HandlerSuite) TestPostRevisionToOrdersWritePerms() {
 				UUID:        strfmt.UUID(origOrder.ID.String()),
 			}
 
-			handler := PostRevisionToOrdersHandler{suite.HandlerConfig()}
+			handler := PostRevisionToOrdersHandler{suite.NewHandlerConfig()}
 			response := handler.Handle(params)
 
 			suite.IsType(&handlers.ErrResponse{}, response)

--- a/pkg/handlers/primeapi/move_task_order_test.go
+++ b/pkg/handlers/primeapi/move_task_order_test.go
@@ -61,7 +61,7 @@ func (suite *HandlerSuite) TestListMovesHandler() {
 		since := handlers.FmtDateTime(lastFetch)
 		request := httptest.NewRequest("GET", fmt.Sprintf("/moves?since=%s", since.String()), nil)
 		params := movetaskorderops.ListMovesParams{HTTPRequest: request, Since: since}
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 
 		// Validate incoming payload: no body to validate
 
@@ -133,7 +133,7 @@ func (suite *HandlerSuite) TestListMovesHandler() {
 		since := handlers.FmtDateTime(lastFetch)
 		request := httptest.NewRequest("GET", fmt.Sprintf("/moves?since=%s", since.String()), nil)
 		params := movetaskorderops.ListMovesParams{HTTPRequest: request, Since: since}
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 
 		// Validate incoming payload: no body to validate
 
@@ -175,7 +175,7 @@ func (suite *HandlerSuite) TestListMovesHandler() {
 
 		request := httptest.NewRequest("GET", fmt.Sprintf("/moves?acknowledged=%v", true), nil)
 		params := movetaskorderops.ListMovesParams{HTTPRequest: request, Acknowledged: &trueValue}
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 
 		// make the request
 		handler := ListMovesHandler{HandlerConfig: handlerConfig, MoveTaskOrderFetcher: movetaskorder.NewMoveTaskOrderFetcher(waf)}
@@ -213,7 +213,7 @@ func (suite *HandlerSuite) TestListMovesHandler() {
 
 		request := httptest.NewRequest("GET", fmt.Sprintf("/moves?acknowledged=%v", false), nil)
 		params := movetaskorderops.ListMovesParams{HTTPRequest: request, Acknowledged: &falseValue}
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 
 		// make the request
 		handler := ListMovesHandler{HandlerConfig: handlerConfig, MoveTaskOrderFetcher: movetaskorder.NewMoveTaskOrderFetcher(waf)}
@@ -255,7 +255,7 @@ func (suite *HandlerSuite) TestListMovesHandler() {
 		request := httptest.NewRequest("GET", fmt.Sprintf("/moves?acknowledgedBefore=%s", acknowledgedBefore.String()), nil)
 
 		params := movetaskorderops.ListMovesParams{HTTPRequest: request, AcknowledgedBefore: acknowledgedBefore}
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 
 		// make the request
 		handler := ListMovesHandler{HandlerConfig: handlerConfig, MoveTaskOrderFetcher: movetaskorder.NewMoveTaskOrderFetcher(waf)}
@@ -315,7 +315,7 @@ func (suite *HandlerSuite) TestGetMoveTaskOrder() {
 
 	suite.Run("Success with Prime-available move by ID", func() {
 		handler := GetMoveTaskOrderHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			movetaskorder.NewMoveTaskOrderFetcher(waf),
 		}
 
@@ -346,7 +346,7 @@ func (suite *HandlerSuite) TestGetMoveTaskOrder() {
 
 	suite.Run("Success with Prime-available move by Locator", func() {
 		handler := GetMoveTaskOrderHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			movetaskorder.NewMoveTaskOrderFetcher(waf),
 		}
 		successMove := factory.BuildAvailableToPrimeMove(suite.DB(), nil, nil)
@@ -376,7 +376,7 @@ func (suite *HandlerSuite) TestGetMoveTaskOrder() {
 
 	suite.Run("Success returns reweighs on shipments if they exist", func() {
 		handler := GetMoveTaskOrderHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			movetaskorder.NewMoveTaskOrderFetcher(waf),
 		}
 		successMove := factory.BuildAvailableToPrimeMove(suite.DB(), nil, nil)
@@ -430,7 +430,7 @@ func (suite *HandlerSuite) TestGetMoveTaskOrder() {
 
 	suite.Run("Success - returns sit extensions on shipments if they exist", func() {
 		handler := GetMoveTaskOrderHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			movetaskorder.NewMoveTaskOrderFetcher(waf),
 		}
 		successMove := factory.BuildAvailableToPrimeMove(suite.DB(), nil, nil)
@@ -488,7 +488,7 @@ func (suite *HandlerSuite) TestGetMoveTaskOrder() {
 
 	suite.Run("Success - filters shipments handled by an external vendor", func() {
 		handler := GetMoveTaskOrderHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			movetaskorder.NewMoveTaskOrderFetcher(waf),
 		}
 		move := factory.BuildAvailableToPrimeMove(suite.DB(), nil, nil)
@@ -543,7 +543,7 @@ func (suite *HandlerSuite) TestGetMoveTaskOrder() {
 
 	suite.Run("Success - returns shipment with attached PpmShipment", func() {
 		handler := GetMoveTaskOrderHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			movetaskorder.NewMoveTaskOrderFetcher(waf),
 		}
 		move := factory.BuildAvailableToPrimeMove(suite.DB(), nil, nil)
@@ -579,7 +579,7 @@ func (suite *HandlerSuite) TestGetMoveTaskOrder() {
 	suite.Run("Success - returns all the fields at the mtoShipment level", func() {
 		// This tests fields that aren't other structs and Addresses
 		handler := GetMoveTaskOrderHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			movetaskorder.NewMoveTaskOrderFetcher(waf),
 		}
 		successMove := factory.BuildAvailableToPrimeMove(suite.DB(), nil, nil)
@@ -694,7 +694,7 @@ func (suite *HandlerSuite) TestGetMoveTaskOrder() {
 
 	suite.Run("Success - returns all the fields associated with StorageFacility within MtoShipments", func() {
 		handler := GetMoveTaskOrderHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			movetaskorder.NewMoveTaskOrderFetcher(waf),
 		}
 		successMove := factory.BuildAvailableToPrimeMove(suite.DB(), nil, nil)
@@ -750,7 +750,7 @@ func (suite *HandlerSuite) TestGetMoveTaskOrder() {
 
 	suite.Run("Success - returns all the fields associated with Agents within MtoShipments", func() {
 		handler := GetMoveTaskOrderHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			movetaskorder.NewMoveTaskOrderFetcher(waf),
 		}
 		successMove := factory.BuildAvailableToPrimeMove(suite.DB(), nil, nil)
@@ -801,7 +801,7 @@ func (suite *HandlerSuite) TestGetMoveTaskOrder() {
 
 	suite.Run("Success - return all base fields assoicated with the getMoveTaskOrder", func() {
 		handler := GetMoveTaskOrderHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			movetaskorder.NewMoveTaskOrderFetcher(waf),
 		}
 		now := time.Now()
@@ -853,7 +853,7 @@ func (suite *HandlerSuite) TestGetMoveTaskOrder() {
 
 	suite.Run("Success - return all Order fields assoicated with the getMoveTaskOrder", func() {
 		handler := GetMoveTaskOrderHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			movetaskorder.NewMoveTaskOrderFetcher(waf),
 		}
 		currentAddress := factory.BuildAddress(suite.DB(), nil, nil)
@@ -954,7 +954,7 @@ func (suite *HandlerSuite) TestGetMoveTaskOrder() {
 
 	suite.Run("Success - return all PaymentRequests fields associated with the getMoveTaskOrder", func() {
 		handler := GetMoveTaskOrderHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			movetaskorder.NewMoveTaskOrderFetcher(waf),
 		}
 
@@ -1237,7 +1237,7 @@ func (suite *HandlerSuite) TestGetMoveTaskOrder() {
 
 	suite.Run("Success - return all MTOServiceItemBasic fields assoicated with the getMoveTaskOrder", func() {
 		handler := GetMoveTaskOrderHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			movetaskorder.NewMoveTaskOrderFetcher(waf),
 		}
 
@@ -1316,7 +1316,7 @@ func (suite *HandlerSuite) TestGetMoveTaskOrder() {
 
 	suite.Run("Success - return all MTOServiceItemOriginSIT fields assoicated with the getMoveTaskOrder", func() {
 		handler := GetMoveTaskOrderHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			movetaskorder.NewMoveTaskOrderFetcher(waf),
 		}
 
@@ -1430,7 +1430,7 @@ func (suite *HandlerSuite) TestGetMoveTaskOrder() {
 
 	suite.Run("Success - return all MTOServiceItemDestSIT fields assoicated with the getMoveTaskOrder", func() {
 		handler := GetMoveTaskOrderHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			movetaskorder.NewMoveTaskOrderFetcher(waf),
 		}
 
@@ -1555,7 +1555,7 @@ func (suite *HandlerSuite) TestGetMoveTaskOrder() {
 
 	suite.Run("Success - return all MTOServiceItemDomesticShuttle fields assoicated with the getMoveTaskOrder", func() {
 		handler := GetMoveTaskOrderHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			movetaskorder.NewMoveTaskOrderFetcher(waf),
 		}
 
@@ -1641,7 +1641,7 @@ func (suite *HandlerSuite) TestGetMoveTaskOrder() {
 
 	suite.Run("Success - return all MTOServiceItemDomesticCrating fields assoicated with the getMoveTaskOrder", func() {
 		handler := GetMoveTaskOrderHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			movetaskorder.NewMoveTaskOrderFetcher(waf),
 		}
 
@@ -1769,7 +1769,7 @@ func (suite *HandlerSuite) TestGetMoveTaskOrder() {
 
 	suite.Run("Failure 'Not Found' for non-available move", func() {
 		handler := GetMoveTaskOrderHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			movetaskorder.NewMoveTaskOrderFetcher(waf),
 		}
 		failureMove := factory.BuildMove(suite.DB(), nil, nil) // default is not available to Prime
@@ -1799,7 +1799,7 @@ func (suite *HandlerSuite) TestCreateExcessWeightRecord() {
 	fakeS3 := storageTest.NewFakeS3Storage(true)
 
 	suite.Run("Success - Created an excess weight record", func() {
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 		handlerConfig.SetFileStorer(fakeS3)
 		handler := CreateExcessWeightRecordHandler{
 			handlerConfig,
@@ -1839,7 +1839,7 @@ func (suite *HandlerSuite) TestCreateExcessWeightRecord() {
 	})
 
 	suite.Run("Fail - Move not found - 404", func() {
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 		handlerConfig.SetFileStorer(fakeS3)
 		handler := CreateExcessWeightRecordHandler{
 			handlerConfig,
@@ -1867,7 +1867,7 @@ func (suite *HandlerSuite) TestCreateExcessWeightRecord() {
 	})
 
 	suite.Run("Fail - Move not Prime-available - 404", func() {
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 		handlerConfig.SetFileStorer(fakeS3)
 		handler := CreateExcessWeightRecordHandler{
 			handlerConfig,
@@ -1992,7 +1992,7 @@ func (suite *HandlerSuite) TestUpdateMTOPostCounselingInfo() {
 		mtoChecker := movetaskorder.NewMoveTaskOrderChecker()
 
 		handler := UpdateMTOPostCounselingInformationHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			fetcher,
 			updater,
 			mtoChecker,
@@ -2074,7 +2074,7 @@ func (suite *HandlerSuite) TestUpdateMTOPostCounselingInfo() {
 		siCreator := mtoserviceitem.NewMTOServiceItemCreator(planner, queryBuilder, moveRouter, ghcrateengine.NewDomesticUnpackPricer(), ghcrateengine.NewDomesticPackPricer(), ghcrateengine.NewDomesticLinehaulPricer(), ghcrateengine.NewDomesticShorthaulPricer(), ghcrateengine.NewDomesticOriginPricer(), ghcrateengine.NewDomesticDestinationPricer(), ghcrateengine.NewFuelSurchargePricer())
 		updater := movetaskorder.NewMoveTaskOrderUpdater(queryBuilder, siCreator, moveRouter, setUpSignedCertificationCreatorMock(nil, nil), setUpSignedCertificationUpdaterMock(nil, nil), ppmEstimator)
 		handler := UpdateMTOPostCounselingInformationHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			fetcher,
 			updater,
 			mtoChecker,
@@ -2102,7 +2102,7 @@ func (suite *HandlerSuite) TestUpdateMTOPostCounselingInfo() {
 		mtoChecker := movetaskorder.NewMoveTaskOrderChecker()
 
 		handler := UpdateMTOPostCounselingInformationHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			&mockFetcher,
 			&mockUpdater,
 			mtoChecker,
@@ -2143,7 +2143,7 @@ func (suite *HandlerSuite) TestUpdateMTOPostCounselingInfo() {
 		mtoChecker := movetaskorder.NewMoveTaskOrderChecker()
 
 		handler := UpdateMTOPostCounselingInformationHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			&mockFetcher,
 			&mockUpdater,
 			mtoChecker,
@@ -2182,7 +2182,7 @@ func (suite *HandlerSuite) TestUpdateMTOPostCounselingInfo() {
 		mtoChecker := movetaskorder.NewMoveTaskOrderChecker()
 
 		handler := UpdateMTOPostCounselingInformationHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			&mockFetcher,
 			&mockUpdater,
 			mtoChecker,
@@ -2220,7 +2220,7 @@ func (suite *HandlerSuite) TestUpdateMTOPostCounselingInfo() {
 		mtoChecker := movetaskorder.NewMoveTaskOrderChecker()
 
 		handler := UpdateMTOPostCounselingInformationHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			&mockFetcher,
 			&mockUpdater,
 			mtoChecker,
@@ -2265,7 +2265,7 @@ func (suite *HandlerSuite) TestDownloadMoveOrderHandler() {
 
 		moves := models.Moves{move}
 
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 		handler := DownloadMoveOrderHandler{
 			HandlerConfig:                       handlerConfig,
 			MoveSearcher:                        &mockMoveSearcher,
@@ -2322,7 +2322,7 @@ func (suite *HandlerSuite) TestDownloadMoveOrderHandler() {
 
 		moves := models.Moves{move}
 
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 		handler := DownloadMoveOrderHandler{
 			HandlerConfig:                       handlerConfig,
 			MoveSearcher:                        &mockMoveSearcher,
@@ -2372,7 +2372,7 @@ func (suite *HandlerSuite) TestDownloadMoveOrderHandler() {
 		mockOrderFetcher := mocks.OrderFetcher{}
 		mockPrimeDownloadMoveUploadPDFGenerator := mocks.PrimeDownloadMoveUploadPDFGenerator{}
 
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 		handler := DownloadMoveOrderHandler{
 			HandlerConfig:                       handlerConfig,
 			MoveSearcher:                        &mockMoveSearcher,
@@ -2400,7 +2400,7 @@ func (suite *HandlerSuite) TestDownloadMoveOrderHandler() {
 		mockOrderFetcher := mocks.OrderFetcher{}
 		moves := models.Moves{}
 
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 		handler := DownloadMoveOrderHandler{
 			HandlerConfig: handlerConfig,
 			MoveSearcher:  &mockMoveSearcher,
@@ -2441,7 +2441,7 @@ func (suite *HandlerSuite) TestDownloadMoveOrderHandler() {
 
 		moves := models.Moves{move}
 
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 		handler := DownloadMoveOrderHandler{
 			HandlerConfig: handlerConfig,
 			MoveSearcher:  &mockMoveSearcher,
@@ -2474,7 +2474,7 @@ func (suite *HandlerSuite) TestDownloadMoveOrderHandler() {
 		mockMoveSearcher := mocks.MoveSearcher{}
 		mockOrderFetcher := mocks.OrderFetcher{}
 
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 		handler := DownloadMoveOrderHandler{
 			HandlerConfig: handlerConfig,
 			MoveSearcher:  &mockMoveSearcher,
@@ -2514,7 +2514,7 @@ func (suite *HandlerSuite) TestDownloadMoveOrderHandler() {
 
 		moves := models.Moves{move}
 
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 		handler := DownloadMoveOrderHandler{
 			HandlerConfig:                       handlerConfig,
 			MoveSearcher:                        &mockMoveSearcher,
@@ -2567,7 +2567,7 @@ func (suite *HandlerSuite) TestDownloadMoveOrderHandler() {
 
 		moves := models.Moves{move}
 
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 		handler := DownloadMoveOrderHandler{
 			HandlerConfig:                       handlerConfig,
 			MoveSearcher:                        &mockMoveSearcher,
@@ -2621,7 +2621,7 @@ func (suite *HandlerSuite) TestDownloadMoveOrderHandler() {
 
 		moves := models.Moves{move}
 
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 		handler := DownloadMoveOrderHandler{
 			HandlerConfig:                       handlerConfig,
 			MoveSearcher:                        &mockMoveSearcher,
@@ -2675,7 +2675,7 @@ func (suite *HandlerSuite) TestDownloadMoveOrderHandler() {
 
 		moves := models.Moves{move}
 
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 		handler := DownloadMoveOrderHandler{
 			HandlerConfig:                       handlerConfig,
 			MoveSearcher:                        &mockMoveSearcher,
@@ -2730,7 +2730,7 @@ func (suite *HandlerSuite) TestDownloadMoveOrderHandler() {
 
 		moves := models.Moves{move}
 
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 		handler := DownloadMoveOrderHandler{
 			HandlerConfig:                       handlerConfig,
 			MoveSearcher:                        &mockMoveSearcher,
@@ -2781,7 +2781,7 @@ func (suite *HandlerSuite) TestAcknowledgeMovesAndShipmentsHandler() {
 	suite.Run("Successful Acknowledge Moves and Shipments - 200", func() {
 		mockMoveAndShipmentAcknowledgementUpdater := mocks.MoveAndShipmentAcknowledgementUpdater{}
 		move := factory.BuildMoveWithShipment(suite.DB(), nil, nil)
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 		handler := AcknowledgeMovesAndShipmentsHandler{
 			HandlerConfig:                         handlerConfig,
 			MoveAndShipmentAcknowledgementUpdater: &mockMoveAndShipmentAcknowledgementUpdater,
@@ -2823,7 +2823,7 @@ func (suite *HandlerSuite) TestAcknowledgeMovesAndShipmentsHandler() {
 	suite.Run("Unsuccessful Acknowledge Moves and Shipments - 500", func() {
 		mockMoveAndShipmentAcknowledgementUpdater := mocks.MoveAndShipmentAcknowledgementUpdater{}
 		move := factory.BuildMoveWithShipment(suite.DB(), nil, nil)
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 		handler := AcknowledgeMovesAndShipmentsHandler{
 			HandlerConfig:                         handlerConfig,
 			MoveAndShipmentAcknowledgementUpdater: &mockMoveAndShipmentAcknowledgementUpdater,
@@ -2864,7 +2864,7 @@ func (suite *HandlerSuite) TestAcknowledgeMovesAndShipmentsHandler() {
 
 	suite.Run("Unsuccessful Acknowledge Moves and Shipments - 422", func() {
 		mockMoveAndShipmentAcknowledgementUpdater := mocks.MoveAndShipmentAcknowledgementUpdater{}
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 		handler := AcknowledgeMovesAndShipmentsHandler{
 			HandlerConfig:                         handlerConfig,
 			MoveAndShipmentAcknowledgementUpdater: &mockMoveAndShipmentAcknowledgementUpdater,

--- a/pkg/handlers/primeapi/mto_agent_test.go
+++ b/pkg/handlers/primeapi/mto_agent_test.go
@@ -53,7 +53,7 @@ func (suite *HandlerSuite) makeUpdateMTOAgentSubtestData() (subtestData *updateM
 
 	// Create handler and request
 	subtestData.handler = UpdateMTOAgentHandler{
-		suite.HandlerConfig(),
+		suite.NewHandlerConfig(),
 		mtoagent.NewMTOAgentUpdater(movetaskorder.NewMoveTaskOrderChecker()),
 	}
 	subtestData.req = httptest.NewRequest("PUT", fmt.Sprintf("/mto-shipments/%s/agents/%s", subtestData.agent.MTOShipmentID.String(), subtestData.agent.ID.String()), nil)
@@ -301,7 +301,7 @@ func (suite *HandlerSuite) makeCreateMTOAgentSubtestData() (subtestData *createM
 
 	// Create Handler
 	subtestData.handler = CreateMTOAgentHandler{
-		suite.HandlerConfig(),
+		suite.NewHandlerConfig(),
 		mtoagent.NewMTOAgentCreator(movetaskorder.NewMoveTaskOrderChecker()),
 	}
 	subtestData.req = httptest.NewRequest("POST", fmt.Sprintf("/mto-shipments/%s/agents", subtestData.mtoShipment.ID), nil)

--- a/pkg/handlers/primeapi/mto_service_item_test.go
+++ b/pkg/handlers/primeapi/mto_service_item_test.go
@@ -148,7 +148,7 @@ func (suite *HandlerSuite) TestCreateMTOServiceItemHandler() {
 		).Return(400, nil)
 		creator := mtoserviceitem.NewMTOServiceItemCreator(planner, builder, moveRouter, ghcrateengine.NewDomesticUnpackPricer(), ghcrateengine.NewDomesticPackPricer(), ghcrateengine.NewDomesticLinehaulPricer(), ghcrateengine.NewDomesticShorthaulPricer(), ghcrateengine.NewDomesticOriginPricer(), ghcrateengine.NewDomesticDestinationPricer(), ghcrateengine.NewFuelSurchargePricer())
 		handler := CreateMTOServiceItemHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			creator,
 			mtoChecker,
 		}
@@ -183,7 +183,7 @@ func (suite *HandlerSuite) TestCreateMTOServiceItemHandler() {
 		).Return(400, nil)
 		creator := mtoserviceitem.NewMTOServiceItemCreator(planner, builder, moveRouter, ghcrateengine.NewDomesticUnpackPricer(), ghcrateengine.NewDomesticPackPricer(), ghcrateengine.NewDomesticLinehaulPricer(), ghcrateengine.NewDomesticShorthaulPricer(), ghcrateengine.NewDomesticOriginPricer(), ghcrateengine.NewDomesticDestinationPricer(), ghcrateengine.NewFuelSurchargePricer())
 		handler := CreateMTOServiceItemHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			creator,
 			mtoChecker,
 		}
@@ -232,7 +232,7 @@ func (suite *HandlerSuite) TestCreateMTOServiceItemHandler() {
 		).Return(400, nil)
 		creator := mtoserviceitem.NewMTOServiceItemCreator(planner, builder, moveRouter, ghcrateengine.NewDomesticUnpackPricer(), ghcrateengine.NewDomesticPackPricer(), ghcrateengine.NewDomesticLinehaulPricer(), ghcrateengine.NewDomesticShorthaulPricer(), ghcrateengine.NewDomesticOriginPricer(), ghcrateengine.NewDomesticDestinationPricer(), ghcrateengine.NewFuelSurchargePricer())
 		handler := CreateMTOServiceItemHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			creator,
 			mtoChecker,
 		}
@@ -286,7 +286,7 @@ func (suite *HandlerSuite) TestCreateMTOServiceItemHandler() {
 		).Return(400, nil)
 		creator := mtoserviceitem.NewMTOServiceItemCreator(planner, builder, moveRouter, ghcrateengine.NewDomesticUnpackPricer(), ghcrateengine.NewDomesticPackPricer(), ghcrateengine.NewDomesticLinehaulPricer(), ghcrateengine.NewDomesticShorthaulPricer(), ghcrateengine.NewDomesticOriginPricer(), ghcrateengine.NewDomesticDestinationPricer(), ghcrateengine.NewFuelSurchargePricer())
 		handler := CreateMTOServiceItemHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			creator,
 			mtoChecker,
 		}
@@ -305,7 +305,7 @@ func (suite *HandlerSuite) TestCreateMTOServiceItemHandler() {
 		subtestData := makeSubtestData()
 		mockCreator := mocks.MTOServiceItemCreator{}
 		handler := CreateMTOServiceItemHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			&mockCreator,
 			mtoChecker,
 		}
@@ -333,7 +333,7 @@ func (suite *HandlerSuite) TestCreateMTOServiceItemHandler() {
 		subtestData := makeSubtestData()
 		mockCreator := mocks.MTOServiceItemCreator{}
 		handler := CreateMTOServiceItemHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			&mockCreator,
 			mtoChecker,
 		}
@@ -363,7 +363,7 @@ func (suite *HandlerSuite) TestCreateMTOServiceItemHandler() {
 		subtestData := makeSubtestData()
 		mockCreator := mocks.MTOServiceItemCreator{}
 		handler := CreateMTOServiceItemHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			&mockCreator,
 			mtoChecker,
 		}
@@ -390,7 +390,7 @@ func (suite *HandlerSuite) TestCreateMTOServiceItemHandler() {
 		subtestData := makeSubtestData()
 		mockCreator := mocks.MTOServiceItemCreator{}
 		handler := CreateMTOServiceItemHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			&mockCreator,
 			mtoChecker,
 		}
@@ -424,7 +424,7 @@ func (suite *HandlerSuite) TestCreateMTOServiceItemHandler() {
 		).Return(400, nil)
 		creator := mtoserviceitem.NewMTOServiceItemCreator(planner, builder, moveRouter, ghcrateengine.NewDomesticUnpackPricer(), ghcrateengine.NewDomesticPackPricer(), ghcrateengine.NewDomesticLinehaulPricer(), ghcrateengine.NewDomesticShorthaulPricer(), ghcrateengine.NewDomesticOriginPricer(), ghcrateengine.NewDomesticDestinationPricer(), ghcrateengine.NewFuelSurchargePricer())
 		handler := CreateMTOServiceItemHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			creator,
 			mtoChecker,
 		}
@@ -468,7 +468,7 @@ func (suite *HandlerSuite) TestCreateMTOServiceItemHandler() {
 		).Return(400, nil)
 		creator := mtoserviceitem.NewMTOServiceItemCreator(planner, builder, moveRouter, ghcrateengine.NewDomesticUnpackPricer(), ghcrateengine.NewDomesticPackPricer(), ghcrateengine.NewDomesticLinehaulPricer(), ghcrateengine.NewDomesticShorthaulPricer(), ghcrateengine.NewDomesticOriginPricer(), ghcrateengine.NewDomesticDestinationPricer(), ghcrateengine.NewFuelSurchargePricer())
 		handler := CreateMTOServiceItemHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			creator,
 			mtoChecker,
 		}
@@ -497,7 +497,7 @@ func (suite *HandlerSuite) TestCreateMTOServiceItemHandler() {
 		subtestData := makeSubtestData()
 		mockCreator := mocks.MTOServiceItemCreator{}
 		handler := CreateMTOServiceItemHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			&mockCreator,
 			mtoChecker,
 		}
@@ -524,7 +524,7 @@ func (suite *HandlerSuite) TestCreateMTOServiceItemHandler() {
 		subtestData := makeSubtestData()
 		mockCreator := mocks.MTOServiceItemCreator{}
 		handler := CreateMTOServiceItemHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			&mockCreator,
 			mtoChecker,
 		}
@@ -570,7 +570,7 @@ func (suite *HandlerSuite) TestCreateMTOServiceItemHandler() {
 		).Return(400, nil)
 		creator := mtoserviceitem.NewMTOServiceItemCreator(planner, builder, moveRouter, ghcrateengine.NewDomesticUnpackPricer(), ghcrateengine.NewDomesticPackPricer(), ghcrateengine.NewDomesticLinehaulPricer(), ghcrateengine.NewDomesticShorthaulPricer(), ghcrateengine.NewDomesticOriginPricer(), ghcrateengine.NewDomesticDestinationPricer(), ghcrateengine.NewFuelSurchargePricer())
 		handler := CreateMTOServiceItemHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			creator,
 			mtoChecker,
 		}
@@ -602,7 +602,7 @@ func (suite *HandlerSuite) TestCreateMTOServiceItemHandler() {
 		).Return(400, nil)
 		creator := mtoserviceitem.NewMTOServiceItemCreator(planner, builder, moveRouter, ghcrateengine.NewDomesticUnpackPricer(), ghcrateengine.NewDomesticPackPricer(), ghcrateengine.NewDomesticLinehaulPricer(), ghcrateengine.NewDomesticShorthaulPricer(), ghcrateengine.NewDomesticOriginPricer(), ghcrateengine.NewDomesticDestinationPricer(), ghcrateengine.NewFuelSurchargePricer())
 		handler := CreateMTOServiceItemHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			creator,
 			mtoChecker,
 		}
@@ -681,7 +681,7 @@ func (suite *HandlerSuite) TestCreateMTOServiceItemDomesticCratingHandler() {
 		).Return(400, nil)
 		creator := mtoserviceitem.NewMTOServiceItemCreator(planner, builder, moveRouter, ghcrateengine.NewDomesticUnpackPricer(), ghcrateengine.NewDomesticPackPricer(), ghcrateengine.NewDomesticLinehaulPricer(), ghcrateengine.NewDomesticShorthaulPricer(), ghcrateengine.NewDomesticOriginPricer(), ghcrateengine.NewDomesticDestinationPricer(), ghcrateengine.NewFuelSurchargePricer())
 		handler := CreateMTOServiceItemHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			creator,
 			mtoChecker,
 		}
@@ -718,7 +718,7 @@ func (suite *HandlerSuite) TestCreateMTOServiceItemDomesticCratingHandler() {
 		).Return(400, nil)
 		creator := mtoserviceitem.NewMTOServiceItemCreator(planner, builder, moveRouter, ghcrateengine.NewDomesticUnpackPricer(), ghcrateengine.NewDomesticPackPricer(), ghcrateengine.NewDomesticLinehaulPricer(), ghcrateengine.NewDomesticShorthaulPricer(), ghcrateengine.NewDomesticOriginPricer(), ghcrateengine.NewDomesticDestinationPricer(), ghcrateengine.NewFuelSurchargePricer())
 		handler := CreateMTOServiceItemHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			creator,
 			mtoChecker,
 		}
@@ -748,7 +748,7 @@ func (suite *HandlerSuite) TestCreateMTOServiceItemDomesticCratingHandler() {
 		subtestData := makeSubtestData()
 		mockCreator := mocks.MTOServiceItemCreator{}
 		handler := CreateMTOServiceItemHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			&mockCreator,
 			mtoChecker,
 		}
@@ -841,7 +841,7 @@ func (suite *HandlerSuite) TestCreateMTOServiceItemOriginSITHandler() {
 		).Return(400, nil)
 		creator := mtoserviceitem.NewMTOServiceItemCreator(planner, builder, moveRouter, ghcrateengine.NewDomesticUnpackPricer(), ghcrateengine.NewDomesticPackPricer(), ghcrateengine.NewDomesticLinehaulPricer(), ghcrateengine.NewDomesticShorthaulPricer(), ghcrateengine.NewDomesticOriginPricer(), ghcrateengine.NewDomesticDestinationPricer(), ghcrateengine.NewFuelSurchargePricer())
 		handler := CreateMTOServiceItemHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			creator,
 			mtoChecker,
 		}
@@ -887,7 +887,7 @@ func (suite *HandlerSuite) TestCreateMTOServiceItemOriginSITHandler() {
 		).Return(400, nil)
 		creator := mtoserviceitem.NewMTOServiceItemCreator(planner, builder, moveRouter, ghcrateengine.NewDomesticUnpackPricer(), ghcrateengine.NewDomesticPackPricer(), ghcrateengine.NewDomesticLinehaulPricer(), ghcrateengine.NewDomesticShorthaulPricer(), ghcrateengine.NewDomesticOriginPricer(), ghcrateengine.NewDomesticDestinationPricer(), ghcrateengine.NewFuelSurchargePricer())
 		handler := CreateMTOServiceItemHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			creator,
 			mtoChecker,
 		}
@@ -956,7 +956,7 @@ func (suite *HandlerSuite) TestCreateMTOServiceItemOriginSITHandler() {
 		).Return(400, nil)
 		creator := mtoserviceitem.NewMTOServiceItemCreator(planner, builder, moveRouter, ghcrateengine.NewDomesticUnpackPricer(), ghcrateengine.NewDomesticPackPricer(), ghcrateengine.NewDomesticLinehaulPricer(), ghcrateengine.NewDomesticShorthaulPricer(), ghcrateengine.NewDomesticOriginPricer(), ghcrateengine.NewDomesticDestinationPricer(), ghcrateengine.NewFuelSurchargePricer())
 		handler := CreateMTOServiceItemHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			creator,
 			mtoChecker,
 		}
@@ -1040,7 +1040,7 @@ func (suite *HandlerSuite) TestCreateMTOServiceItemOriginSITHandlerWithDOFSITNoA
 		).Return(400, nil)
 		creator := mtoserviceitem.NewMTOServiceItemCreator(planner, builder, moveRouter, ghcrateengine.NewDomesticUnpackPricer(), ghcrateengine.NewDomesticPackPricer(), ghcrateengine.NewDomesticLinehaulPricer(), ghcrateengine.NewDomesticShorthaulPricer(), ghcrateengine.NewDomesticOriginPricer(), ghcrateengine.NewDomesticDestinationPricer(), ghcrateengine.NewFuelSurchargePricer())
 		handler := CreateMTOServiceItemHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			creator,
 			mtoChecker,
 		}
@@ -1150,7 +1150,7 @@ func (suite *HandlerSuite) TestCreateMTOServiceItemOriginSITHandlerWithDOFSITWit
 		).Return(400, nil)
 		creator := mtoserviceitem.NewMTOServiceItemCreator(planner, builder, moveRouter, ghcrateengine.NewDomesticUnpackPricer(), ghcrateengine.NewDomesticPackPricer(), ghcrateengine.NewDomesticLinehaulPricer(), ghcrateengine.NewDomesticShorthaulPricer(), ghcrateengine.NewDomesticOriginPricer(), ghcrateengine.NewDomesticDestinationPricer(), ghcrateengine.NewFuelSurchargePricer())
 		handler := CreateMTOServiceItemHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			creator,
 			mtoChecker,
 		}
@@ -1323,7 +1323,7 @@ func (suite *HandlerSuite) TestCreateMTOServiceItemDestSITHandler() {
 		).Return(400, nil)
 		creator := mtoserviceitem.NewMTOServiceItemCreator(planner, builder, moveRouter, ghcrateengine.NewDomesticUnpackPricer(), ghcrateengine.NewDomesticPackPricer(), ghcrateengine.NewDomesticLinehaulPricer(), ghcrateengine.NewDomesticShorthaulPricer(), ghcrateengine.NewDomesticOriginPricer(), ghcrateengine.NewDomesticDestinationPricer(), ghcrateengine.NewFuelSurchargePricer())
 		handler := CreateMTOServiceItemHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			creator,
 			mtoChecker,
 		}
@@ -1397,7 +1397,7 @@ func (suite *HandlerSuite) TestCreateMTOServiceItemDestSITHandler() {
 		).Return(400, nil)
 		creator := mtoserviceitem.NewMTOServiceItemCreator(planner, builder, moveRouter, ghcrateengine.NewDomesticUnpackPricer(), ghcrateengine.NewDomesticPackPricer(), ghcrateengine.NewDomesticLinehaulPricer(), ghcrateengine.NewDomesticShorthaulPricer(), ghcrateengine.NewDomesticOriginPricer(), ghcrateengine.NewDomesticDestinationPricer(), ghcrateengine.NewFuelSurchargePricer())
 		handler := CreateMTOServiceItemHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			creator,
 			mtoChecker,
 		}
@@ -1430,7 +1430,7 @@ func (suite *HandlerSuite) TestCreateMTOServiceItemDestSITHandler() {
 		).Return(400, nil)
 		creator := mtoserviceitem.NewMTOServiceItemCreator(planner, builder, moveRouter, ghcrateengine.NewDomesticUnpackPricer(), ghcrateengine.NewDomesticPackPricer(), ghcrateengine.NewDomesticLinehaulPricer(), ghcrateengine.NewDomesticShorthaulPricer(), ghcrateengine.NewDomesticOriginPricer(), ghcrateengine.NewDomesticDestinationPricer(), ghcrateengine.NewFuelSurchargePricer())
 		handler := CreateMTOServiceItemHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			creator,
 			mtoChecker,
 		}
@@ -1486,7 +1486,7 @@ func (suite *HandlerSuite) TestCreateMTOServiceItemDestSITHandler() {
 		).Return(400, nil)
 		creator := mtoserviceitem.NewMTOServiceItemCreator(planner, builder, moveRouter, ghcrateengine.NewDomesticUnpackPricer(), ghcrateengine.NewDomesticPackPricer(), ghcrateengine.NewDomesticLinehaulPricer(), ghcrateengine.NewDomesticShorthaulPricer(), ghcrateengine.NewDomesticOriginPricer(), ghcrateengine.NewDomesticDestinationPricer(), ghcrateengine.NewFuelSurchargePricer())
 		handler := CreateMTOServiceItemHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			creator,
 			mtoChecker,
 		}
@@ -1540,7 +1540,7 @@ func (suite *HandlerSuite) TestCreateMTOServiceItemDestSITHandler() {
 		).Return(400, nil)
 		creator := mtoserviceitem.NewMTOServiceItemCreator(planner, builder, moveRouter, ghcrateengine.NewDomesticUnpackPricer(), ghcrateengine.NewDomesticPackPricer(), ghcrateengine.NewDomesticLinehaulPricer(), ghcrateengine.NewDomesticShorthaulPricer(), ghcrateengine.NewDomesticOriginPricer(), ghcrateengine.NewDomesticDestinationPricer(), ghcrateengine.NewFuelSurchargePricer())
 		handler := CreateMTOServiceItemHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			creator,
 			mtoChecker,
 		}
@@ -1571,7 +1571,7 @@ func (suite *HandlerSuite) TestCreateMTOServiceItemDestSITHandler() {
 		planner := &routemocks.Planner{}
 		creator := mtoserviceitem.NewMTOServiceItemCreator(planner, builder, moveRouter, ghcrateengine.NewDomesticUnpackPricer(), ghcrateengine.NewDomesticPackPricer(), ghcrateengine.NewDomesticLinehaulPricer(), ghcrateengine.NewDomesticShorthaulPricer(), ghcrateengine.NewDomesticOriginPricer(), ghcrateengine.NewDomesticDestinationPricer(), ghcrateengine.NewFuelSurchargePricer())
 		handler := CreateMTOServiceItemHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			creator,
 			mtoChecker,
 		}
@@ -1737,7 +1737,7 @@ func (suite *HandlerSuite) TestUpdateMTOServiceItemDDDSIT() {
 			mock.Anything,
 		).Return(400, nil)
 		subtestData.handler = UpdateMTOServiceItemHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			mtoserviceitem.NewMTOServiceItemUpdater(planner, queryBuilder, moveRouter, shipmentFetcher, addressCreator, portLocationFetcher, ghcrateengine.NewDomesticUnpackPricer(), ghcrateengine.NewDomesticLinehaulPricer(), ghcrateengine.NewDomesticDestinationPricer(), ghcrateengine.NewFuelSurchargePricer()),
 		}
 
@@ -2020,7 +2020,7 @@ func (suite *HandlerSuite) TestUpdateMTOServiceItemDOPSIT() {
 			mock.Anything,
 		).Return(400, nil)
 		subtestData.handler = UpdateMTOServiceItemHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			mtoserviceitem.NewMTOServiceItemUpdater(planner, queryBuilder, moveRouter, shipmentFetcher, addressCreator, portLocationFetcher, ghcrateengine.NewDomesticUnpackPricer(), ghcrateengine.NewDomesticLinehaulPricer(), ghcrateengine.NewDomesticDestinationPricer(), ghcrateengine.NewFuelSurchargePricer()),
 		}
 

--- a/pkg/handlers/primeapi/mto_shipment_address_test.go
+++ b/pkg/handlers/primeapi/mto_shipment_address_test.go
@@ -54,7 +54,7 @@ func (suite *HandlerSuite) TestUpdateMTOShipmentAddressHandler() {
 
 		// Create handler
 		handler := UpdateMTOShipmentAddressHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			mtoshipment.NewMTOShipmentAddressUpdater(planner, addressCreator, addressUpdater),
 			vLocationServices,
 		}
@@ -418,7 +418,7 @@ func (suite *HandlerSuite) TestUpdateMTOShipmentAddressHandler() {
 		}
 
 		// setting the AK flag to false and use a valid address
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 
 		expectedFeatureFlag := services.FeatureFlag{
 			Key:   "enable_alaska",
@@ -475,7 +475,7 @@ func (suite *HandlerSuite) TestUpdateMTOShipmentAddressHandler() {
 		}
 
 		// setting the HI flag to false and use a valid address
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 
 		expectedFeatureFlag := services.FeatureFlag{
 			Key:   "enable_alaska",

--- a/pkg/handlers/primeapi/mto_shipment_test.go
+++ b/pkg/handlers/primeapi/mto_shipment_test.go
@@ -75,7 +75,7 @@ func (suite *HandlerSuite) TestUpdateShipmentDestinationAddressHandler() {
 		).Return(nil, expectedError).Once()
 
 		handler := UpdateShipmentDestinationAddressHandler{
-			HandlerConfig:                  suite.HandlerConfig(),
+			HandlerConfig:                  suite.NewHandlerConfig(),
 			ShipmentAddressUpdateRequester: &mockCreator,
 			VLocation:                      vLocationFetcher,
 		}
@@ -89,7 +89,7 @@ func (suite *HandlerSuite) TestUpdateShipmentDestinationAddressHandler() {
 		mockCreator := mocks.ShipmentAddressUpdateRequester{}
 		vLocationServices := address.NewVLocation()
 		handler := UpdateShipmentDestinationAddressHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			&mockCreator,
 			vLocationServices,
 		}
@@ -108,7 +108,7 @@ func (suite *HandlerSuite) TestUpdateShipmentDestinationAddressHandler() {
 		vLocationServices := address.NewVLocation()
 
 		// setting the AK flag to false and use a valid address
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 
 		expectedFeatureFlag := services.FeatureFlag{
 			Key:   "enable_alaska",
@@ -145,7 +145,7 @@ func (suite *HandlerSuite) TestUpdateShipmentDestinationAddressHandler() {
 		vLocationServices := address.NewVLocation()
 
 		// setting the AK flag to false and use a valid address
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 
 		expectedFeatureFlag := services.FeatureFlag{
 			Key:   "enable_hawaii",
@@ -180,7 +180,7 @@ func (suite *HandlerSuite) TestUpdateShipmentDestinationAddressHandler() {
 		subtestData := makeSubtestData()
 		mockCreator := mocks.ShipmentAddressUpdateRequester{}
 		handler := UpdateShipmentDestinationAddressHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			&mockCreator,
 			vLocationServices,
 		}
@@ -213,7 +213,7 @@ func (suite *HandlerSuite) TestUpdateShipmentDestinationAddressHandler() {
 		subtestData := makeSubtestData()
 		mockCreator := mocks.ShipmentAddressUpdateRequester{}
 		handler := UpdateShipmentDestinationAddressHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			&mockCreator,
 			vLocationServices,
 		}
@@ -244,7 +244,7 @@ func (suite *HandlerSuite) TestUpdateShipmentDestinationAddressHandler() {
 		subtestData := makeSubtestData()
 		mockCreator := mocks.ShipmentAddressUpdateRequester{}
 		handler := UpdateShipmentDestinationAddressHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			&mockCreator,
 			vLocationServices,
 		}
@@ -275,7 +275,7 @@ func (suite *HandlerSuite) TestUpdateShipmentDestinationAddressHandler() {
 		subtestData := makeSubtestData()
 		mockCreator := mocks.ShipmentAddressUpdateRequester{}
 		handler := UpdateShipmentDestinationAddressHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			&mockCreator,
 			vLocationServices,
 		}
@@ -343,7 +343,7 @@ func (suite *HandlerSuite) TestUpdateMTOShipmentStatusHandler() {
 	req := httptest.NewRequest("PATCH", fmt.Sprintf("/mto_shipments/%s/status", uuid.Nil.String()), nil)
 
 	setupTestData := func() (UpdateMTOShipmentStatusHandler, models.MTOShipment) {
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 		handlerConfig.SetHHGPlanner(planner)
 		planner := &routemocks.Planner{}
 		planner.On("ZipTransitDistance",
@@ -575,7 +575,7 @@ func (suite *HandlerSuite) TestDeleteMTOShipmentHandler() {
 			moveRouter, setUpSignedCertificationCreatorMock(nil, nil), setUpSignedCertificationUpdaterMock(nil, nil), ppmEstimator,
 		)
 		deleter := mtoshipment.NewPrimeShipmentDeleter(moveTaskOrderUpdater)
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 		handler := DeleteMTOShipmentHandler{
 			handlerConfig,
 			deleter,
@@ -677,7 +677,7 @@ func (suite *HandlerSuite) TestDeleteMTOShipmentHandler() {
 		}, nil)
 		deleter := &mocks.ShipmentDeleter{}
 		deleter.On("DeleteShipment", mock.AnythingOfType("*appcontext.appContext"), shipment.ID).Return(uuid.Nil, apperror.ConflictError{})
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 		handler := DeleteMTOShipmentHandler{
 			handlerConfig,
 			deleter,
@@ -707,7 +707,7 @@ func (suite *HandlerSuite) TestDeleteMTOShipmentHandler() {
 		}, nil)
 		deleter := &mocks.ShipmentDeleter{}
 		deleter.On("DeleteShipment", mock.AnythingOfType("*appcontext.appContext"), shipment.ID).Return(uuid.Nil, apperror.UnprocessableEntityError{})
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 		handler := DeleteMTOShipmentHandler{
 			handlerConfig,
 			deleter,
@@ -737,7 +737,7 @@ func (suite *HandlerSuite) TestDeleteMTOShipmentHandler() {
 		}, nil)
 		deleter := &mocks.ShipmentDeleter{}
 		deleter.On("DeleteShipment", mock.AnythingOfType("*appcontext.appContext"), shipment.ID).Return(uuid.Nil, apperror.EventError{})
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 		handler := DeleteMTOShipmentHandler{
 			handlerConfig,
 			deleter,

--- a/pkg/handlers/primeapi/payment_request_test.go
+++ b/pkg/handlers/primeapi/payment_request_test.go
@@ -117,7 +117,7 @@ func (suite *HandlerSuite) TestCreatePaymentRequestHandler() {
 			})).Return(&returnedPaymentRequest, nil).Once()
 
 		handler := CreatePaymentRequestHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			paymentRequestCreator,
 		}
 
@@ -180,7 +180,7 @@ func (suite *HandlerSuite) TestCreatePaymentRequestHandler() {
 			mock.AnythingOfType("*models.PaymentRequest")).Return(&returnedPaymentRequest, nil).Once()
 
 		handler := CreatePaymentRequestHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			paymentRequestCreator,
 		}
 
@@ -237,7 +237,7 @@ func (suite *HandlerSuite) TestCreatePaymentRequestHandler() {
 			mock.AnythingOfType("*models.PaymentRequest")).Return(&returnedPaymentRequest, nil).Once()
 
 		handler := CreatePaymentRequestHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			paymentRequestCreator,
 		}
 
@@ -284,7 +284,7 @@ func (suite *HandlerSuite) TestCreatePaymentRequestHandler() {
 			mock.AnythingOfType("*models.PaymentRequest")).Return(&models.PaymentRequest{}, nil).Once()
 
 		handler := CreatePaymentRequestHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			paymentRequestCreator,
 		}
 
@@ -314,7 +314,7 @@ func (suite *HandlerSuite) TestCreatePaymentRequestHandler() {
 			mock.AnythingOfType("*models.PaymentRequest")).Return(&models.PaymentRequest{}, errors.New("creator failed")).Once()
 
 		handler := CreatePaymentRequestHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			paymentRequestCreator,
 		}
 
@@ -351,7 +351,7 @@ func (suite *HandlerSuite) TestCreatePaymentRequestHandler() {
 			mock.AnythingOfType("*models.PaymentRequest")).Return(&models.PaymentRequest{}, nil).Once()
 
 		handler := CreatePaymentRequestHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			paymentRequestCreator,
 		}
 
@@ -386,7 +386,7 @@ func (suite *HandlerSuite) TestCreatePaymentRequestHandler() {
 			mock.AnythingOfType("*models.PaymentRequest")).Return(&models.PaymentRequest{}, nil).Once()
 
 		handler := CreatePaymentRequestHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			paymentRequestCreator,
 		}
 
@@ -434,7 +434,7 @@ func (suite *HandlerSuite) TestCreatePaymentRequestHandler() {
 			mock.AnythingOfType("*models.PaymentRequest")).Return(nil, err).Once()
 
 		handler := CreatePaymentRequestHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			paymentRequestCreator,
 		}
 
@@ -481,7 +481,7 @@ func (suite *HandlerSuite) TestCreatePaymentRequestHandler() {
 			mock.AnythingOfType("*models.PaymentRequest")).Return(nil, err).Once()
 
 		handler := CreatePaymentRequestHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			paymentRequestCreator,
 		}
 
@@ -527,7 +527,7 @@ func (suite *HandlerSuite) TestCreatePaymentRequestHandler() {
 			mock.AnythingOfType("*models.PaymentRequest")).Return(nil, err).Once()
 
 		handler := CreatePaymentRequestHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			paymentRequestCreator,
 		}
 
@@ -754,7 +754,7 @@ func (suite *HandlerSuite) TestCreatePaymentRequestHandlerNewPaymentRequestCreat
 		)
 
 		handler := CreatePaymentRequestHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			paymentRequestCreator,
 		}
 
@@ -812,7 +812,7 @@ func (suite *HandlerSuite) TestCreatePaymentRequestHandlerNewPaymentRequestCreat
 		)
 
 		handler := CreatePaymentRequestHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			paymentRequestCreator,
 		}
 
@@ -856,7 +856,7 @@ func (suite *HandlerSuite) TestCreatePaymentRequestHandlerNewPaymentRequestCreat
 		)
 
 		handler := CreatePaymentRequestHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			paymentRequestCreator,
 		}
 
@@ -913,7 +913,7 @@ func (suite *HandlerSuite) TestCreatePaymentRequestHandlerInvalidMTOReferenceID(
 		)
 
 		handler := CreatePaymentRequestHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			paymentRequestCreator,
 		}
 
@@ -971,7 +971,7 @@ func (suite *HandlerSuite) TestCreatePaymentRequestHandlerInvalidMTOReferenceID(
 		)
 
 		handler := CreatePaymentRequestHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			paymentRequestCreator,
 		}
 

--- a/pkg/handlers/primeapi/reweigh_test.go
+++ b/pkg/handlers/primeapi/reweigh_test.go
@@ -48,7 +48,7 @@ func (suite *HandlerSuite) TestUpdateReweighHandler() {
 
 		// Create handler
 		handler := UpdateReweighHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			reweighservice.NewReweighUpdater(movetaskorder.NewMoveTaskOrderChecker(), paymentRequestShipmentRecalculator),
 		}
 		// Make an available MTO

--- a/pkg/handlers/primeapi/service_request_document_upload_test.go
+++ b/pkg/handlers/primeapi/service_request_document_upload_test.go
@@ -18,7 +18,7 @@ func (suite *HandlerSuite) CreateServiceRequestDocumentUploadHandler() {
 	fakeS3 := storageTest.NewFakeS3Storage(true)
 
 	setupTestData := func() (CreateServiceRequestDocumentUploadHandler, models.MTOServiceItem) {
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 		handlerConfig.SetFileStorer(fakeS3)
 		handler := CreateServiceRequestDocumentUploadHandler{
 			handlerConfig,

--- a/pkg/handlers/primeapi/sit_extension_test.go
+++ b/pkg/handlers/primeapi/sit_extension_test.go
@@ -47,7 +47,7 @@ func (suite *HandlerSuite) CreateSITExtensionHandler() {
 
 		// Create handler
 		handler := CreateSITExtensionHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			sitextensionservice.NewSitExtensionCreator(moveRouter),
 		}
 		return handler, shipment

--- a/pkg/handlers/primeapi/upload_test.go
+++ b/pkg/handlers/primeapi/upload_test.go
@@ -19,7 +19,7 @@ func (suite *HandlerSuite) TestCreateUploadHandler() {
 	fakeS3 := storageTest.NewFakeS3Storage(true)
 
 	setupTestData := func() (CreateUploadHandler, models.PaymentRequest) {
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 		handlerConfig.SetFileStorer(fakeS3)
 		handler := CreateUploadHandler{
 			handlerConfig,

--- a/pkg/handlers/primeapiv2/move_task_order_test.go
+++ b/pkg/handlers/primeapiv2/move_task_order_test.go
@@ -40,7 +40,7 @@ func (suite *HandlerSuite) TestGetMoveTaskOrder() {
 
 	suite.Run("Success with Prime-available move by ID", func() {
 		handler := GetMoveTaskOrderHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			movetaskorder.NewMoveTaskOrderFetcher(waf),
 		}
 
@@ -71,7 +71,7 @@ func (suite *HandlerSuite) TestGetMoveTaskOrder() {
 
 	suite.Run("Success with Prime-available move by Locator", func() {
 		handler := GetMoveTaskOrderHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			movetaskorder.NewMoveTaskOrderFetcher(waf),
 		}
 		successMove := factory.BuildAvailableToPrimeMove(suite.DB(), nil, nil)
@@ -101,7 +101,7 @@ func (suite *HandlerSuite) TestGetMoveTaskOrder() {
 
 	suite.Run("Success returns reweighs on shipments if they exist", func() {
 		handler := GetMoveTaskOrderHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			movetaskorder.NewMoveTaskOrderFetcher(waf),
 		}
 		successMove := factory.BuildAvailableToPrimeMove(suite.DB(), nil, nil)
@@ -155,7 +155,7 @@ func (suite *HandlerSuite) TestGetMoveTaskOrder() {
 
 	suite.Run("Success - returns sit extensions on shipments if they exist", func() {
 		handler := GetMoveTaskOrderHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			movetaskorder.NewMoveTaskOrderFetcher(waf),
 		}
 		successMove := factory.BuildAvailableToPrimeMove(suite.DB(), nil, nil)
@@ -213,7 +213,7 @@ func (suite *HandlerSuite) TestGetMoveTaskOrder() {
 
 	suite.Run("Success - filters shipments handled by an external vendor", func() {
 		handler := GetMoveTaskOrderHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			movetaskorder.NewMoveTaskOrderFetcher(waf),
 		}
 		move := factory.BuildAvailableToPrimeMove(suite.DB(), nil, nil)
@@ -268,7 +268,7 @@ func (suite *HandlerSuite) TestGetMoveTaskOrder() {
 
 	suite.Run("Success - returns shipment with attached PpmShipment", func() {
 		handler := GetMoveTaskOrderHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			movetaskorder.NewMoveTaskOrderFetcher(waf),
 		}
 		move := factory.BuildAvailableToPrimeMove(suite.DB(), nil, nil)
@@ -304,7 +304,7 @@ func (suite *HandlerSuite) TestGetMoveTaskOrder() {
 	suite.Run("Success - returns all the fields at the mtoShipment level", func() {
 		// This tests fields that aren't other structs and Addresses
 		handler := GetMoveTaskOrderHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			movetaskorder.NewMoveTaskOrderFetcher(waf),
 		}
 		successMove := factory.BuildAvailableToPrimeMove(suite.DB(), nil, nil)
@@ -419,7 +419,7 @@ func (suite *HandlerSuite) TestGetMoveTaskOrder() {
 
 	suite.Run("Success - returns all the fields associated with StorageFacility within MtoShipments", func() {
 		handler := GetMoveTaskOrderHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			movetaskorder.NewMoveTaskOrderFetcher(waf),
 		}
 		successMove := factory.BuildAvailableToPrimeMove(suite.DB(), nil, nil)
@@ -475,7 +475,7 @@ func (suite *HandlerSuite) TestGetMoveTaskOrder() {
 
 	suite.Run("Success - returns all the fields associated with Agents within MtoShipments", func() {
 		handler := GetMoveTaskOrderHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			movetaskorder.NewMoveTaskOrderFetcher(waf),
 		}
 		successMove := factory.BuildAvailableToPrimeMove(suite.DB(), nil, nil)
@@ -526,7 +526,7 @@ func (suite *HandlerSuite) TestGetMoveTaskOrder() {
 
 	suite.Run("Success - return all base fields assoicated with the getMoveTaskOrder", func() {
 		handler := GetMoveTaskOrderHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			movetaskorder.NewMoveTaskOrderFetcher(waf),
 		}
 		now := time.Now()
@@ -579,7 +579,7 @@ func (suite *HandlerSuite) TestGetMoveTaskOrder() {
 
 	suite.Run("Success - return all Order fields assoicated with the getMoveTaskOrder", func() {
 		handler := GetMoveTaskOrderHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			movetaskorder.NewMoveTaskOrderFetcher(waf),
 		}
 		currentAddress := factory.BuildAddress(suite.DB(), nil, nil)
@@ -685,7 +685,7 @@ func (suite *HandlerSuite) TestGetMoveTaskOrder() {
 
 	suite.Run("Success - return all PaymentRequests fields assoicated with the getMoveTaskOrder", func() {
 		handler := GetMoveTaskOrderHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			movetaskorder.NewMoveTaskOrderFetcher(waf),
 		}
 
@@ -966,7 +966,7 @@ func (suite *HandlerSuite) TestGetMoveTaskOrder() {
 
 	suite.Run("Success - return all MTOServiceItemBasic fields assoicated with the getMoveTaskOrder", func() {
 		handler := GetMoveTaskOrderHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			movetaskorder.NewMoveTaskOrderFetcher(waf),
 		}
 
@@ -1045,7 +1045,7 @@ func (suite *HandlerSuite) TestGetMoveTaskOrder() {
 
 	suite.Run("Success - return all MTOServiceItemOriginSIT fields assoicated with the getMoveTaskOrder", func() {
 		handler := GetMoveTaskOrderHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			movetaskorder.NewMoveTaskOrderFetcher(waf),
 		}
 
@@ -1159,7 +1159,7 @@ func (suite *HandlerSuite) TestGetMoveTaskOrder() {
 
 	suite.Run("Success - return all MTOServiceItemDestSIT fields assoicated with the getMoveTaskOrder", func() {
 		handler := GetMoveTaskOrderHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			movetaskorder.NewMoveTaskOrderFetcher(waf),
 		}
 
@@ -1284,7 +1284,7 @@ func (suite *HandlerSuite) TestGetMoveTaskOrder() {
 
 	suite.Run("Success - return all MTOServiceItemDomesticShuttle fields assoicated with the getMoveTaskOrder", func() {
 		handler := GetMoveTaskOrderHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			movetaskorder.NewMoveTaskOrderFetcher(waf),
 		}
 
@@ -1370,7 +1370,7 @@ func (suite *HandlerSuite) TestGetMoveTaskOrder() {
 
 	suite.Run("Success - return all MTOServiceItemDomesticCrating fields assoicated with the getMoveTaskOrder", func() {
 		handler := GetMoveTaskOrderHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			movetaskorder.NewMoveTaskOrderFetcher(waf),
 		}
 
@@ -1498,7 +1498,7 @@ func (suite *HandlerSuite) TestGetMoveTaskOrder() {
 
 	suite.Run("Failure 'Not Found' for non-available move", func() {
 		handler := GetMoveTaskOrderHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			movetaskorder.NewMoveTaskOrderFetcher(waf),
 		}
 		failureMove := factory.BuildMove(suite.DB(), nil, nil) // default is not available to Prime

--- a/pkg/handlers/primeapiv2/mto_service_item_test.go
+++ b/pkg/handlers/primeapiv2/mto_service_item_test.go
@@ -113,7 +113,7 @@ func (suite *HandlerSuite) TestCreateMTOServiceItemHandler() {
 		).Return(400, nil)
 		creator := mtoserviceitem.NewMTOServiceItemCreator(planner, builder, moveRouter, ghcrateengine.NewDomesticUnpackPricer(), ghcrateengine.NewDomesticPackPricer(), ghcrateengine.NewDomesticLinehaulPricer(), ghcrateengine.NewDomesticShorthaulPricer(), ghcrateengine.NewDomesticOriginPricer(), ghcrateengine.NewDomesticDestinationPricer(), ghcrateengine.NewFuelSurchargePricer())
 		handler := CreateMTOServiceItemHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			creator,
 			mtoChecker,
 		}
@@ -171,7 +171,7 @@ func (suite *HandlerSuite) TestCreateMTOServiceItemHandler() {
 		).Return(400, nil)
 		creator := mtoserviceitem.NewMTOServiceItemCreator(planner, builder, moveRouter, ghcrateengine.NewDomesticUnpackPricer(), ghcrateengine.NewDomesticPackPricer(), ghcrateengine.NewDomesticLinehaulPricer(), ghcrateengine.NewDomesticShorthaulPricer(), ghcrateengine.NewDomesticOriginPricer(), ghcrateengine.NewDomesticDestinationPricer(), ghcrateengine.NewFuelSurchargePricer())
 		handler := CreateMTOServiceItemHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			creator,
 			mtoChecker,
 		}
@@ -225,7 +225,7 @@ func (suite *HandlerSuite) TestCreateMTOServiceItemHandler() {
 		).Return(400, nil)
 		creator := mtoserviceitem.NewMTOServiceItemCreator(planner, builder, moveRouter, ghcrateengine.NewDomesticUnpackPricer(), ghcrateengine.NewDomesticPackPricer(), ghcrateengine.NewDomesticLinehaulPricer(), ghcrateengine.NewDomesticShorthaulPricer(), ghcrateengine.NewDomesticOriginPricer(), ghcrateengine.NewDomesticDestinationPricer(), ghcrateengine.NewFuelSurchargePricer())
 		handler := CreateMTOServiceItemHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			creator,
 			mtoChecker,
 		}
@@ -244,7 +244,7 @@ func (suite *HandlerSuite) TestCreateMTOServiceItemHandler() {
 		subtestData := makeSubtestData()
 		mockCreator := mocks.MTOServiceItemCreator{}
 		handler := CreateMTOServiceItemHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			&mockCreator,
 			mtoChecker,
 		}
@@ -272,7 +272,7 @@ func (suite *HandlerSuite) TestCreateMTOServiceItemHandler() {
 		subtestData := makeSubtestData()
 		mockCreator := mocks.MTOServiceItemCreator{}
 		handler := CreateMTOServiceItemHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			&mockCreator,
 			mtoChecker,
 		}
@@ -302,7 +302,7 @@ func (suite *HandlerSuite) TestCreateMTOServiceItemHandler() {
 		subtestData := makeSubtestData()
 		mockCreator := mocks.MTOServiceItemCreator{}
 		handler := CreateMTOServiceItemHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			&mockCreator,
 			mtoChecker,
 		}
@@ -329,7 +329,7 @@ func (suite *HandlerSuite) TestCreateMTOServiceItemHandler() {
 		subtestData := makeSubtestData()
 		mockCreator := mocks.MTOServiceItemCreator{}
 		handler := CreateMTOServiceItemHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			&mockCreator,
 			mtoChecker,
 		}
@@ -363,7 +363,7 @@ func (suite *HandlerSuite) TestCreateMTOServiceItemHandler() {
 		).Return(400, nil)
 		creator := mtoserviceitem.NewMTOServiceItemCreator(planner, builder, moveRouter, ghcrateengine.NewDomesticUnpackPricer(), ghcrateengine.NewDomesticPackPricer(), ghcrateengine.NewDomesticLinehaulPricer(), ghcrateengine.NewDomesticShorthaulPricer(), ghcrateengine.NewDomesticOriginPricer(), ghcrateengine.NewDomesticDestinationPricer(), ghcrateengine.NewFuelSurchargePricer())
 		handler := CreateMTOServiceItemHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			creator,
 			mtoChecker,
 		}
@@ -407,7 +407,7 @@ func (suite *HandlerSuite) TestCreateMTOServiceItemHandler() {
 		).Return(400, nil)
 		creator := mtoserviceitem.NewMTOServiceItemCreator(planner, builder, moveRouter, ghcrateengine.NewDomesticUnpackPricer(), ghcrateengine.NewDomesticPackPricer(), ghcrateengine.NewDomesticLinehaulPricer(), ghcrateengine.NewDomesticShorthaulPricer(), ghcrateengine.NewDomesticOriginPricer(), ghcrateengine.NewDomesticDestinationPricer(), ghcrateengine.NewFuelSurchargePricer())
 		handler := CreateMTOServiceItemHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			creator,
 			mtoChecker,
 		}
@@ -436,7 +436,7 @@ func (suite *HandlerSuite) TestCreateMTOServiceItemHandler() {
 		subtestData := makeSubtestData()
 		mockCreator := mocks.MTOServiceItemCreator{}
 		handler := CreateMTOServiceItemHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			&mockCreator,
 			mtoChecker,
 		}
@@ -463,7 +463,7 @@ func (suite *HandlerSuite) TestCreateMTOServiceItemHandler() {
 		subtestData := makeSubtestData()
 		mockCreator := mocks.MTOServiceItemCreator{}
 		handler := CreateMTOServiceItemHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			&mockCreator,
 			mtoChecker,
 		}
@@ -509,7 +509,7 @@ func (suite *HandlerSuite) TestCreateMTOServiceItemHandler() {
 		).Return(400, nil)
 		creator := mtoserviceitem.NewMTOServiceItemCreator(planner, builder, moveRouter, ghcrateengine.NewDomesticUnpackPricer(), ghcrateengine.NewDomesticPackPricer(), ghcrateengine.NewDomesticLinehaulPricer(), ghcrateengine.NewDomesticShorthaulPricer(), ghcrateengine.NewDomesticOriginPricer(), ghcrateengine.NewDomesticDestinationPricer(), ghcrateengine.NewFuelSurchargePricer())
 		handler := CreateMTOServiceItemHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			creator,
 			mtoChecker,
 		}
@@ -541,7 +541,7 @@ func (suite *HandlerSuite) TestCreateMTOServiceItemHandler() {
 		).Return(400, nil)
 		creator := mtoserviceitem.NewMTOServiceItemCreator(planner, builder, moveRouter, ghcrateengine.NewDomesticUnpackPricer(), ghcrateengine.NewDomesticPackPricer(), ghcrateengine.NewDomesticLinehaulPricer(), ghcrateengine.NewDomesticShorthaulPricer(), ghcrateengine.NewDomesticOriginPricer(), ghcrateengine.NewDomesticDestinationPricer(), ghcrateengine.NewFuelSurchargePricer())
 		handler := CreateMTOServiceItemHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			creator,
 			mtoChecker,
 		}
@@ -620,7 +620,7 @@ func (suite *HandlerSuite) TestCreateMTOServiceItemDomesticCratingHandler() {
 		).Return(400, nil)
 		creator := mtoserviceitem.NewMTOServiceItemCreator(planner, builder, moveRouter, ghcrateengine.NewDomesticUnpackPricer(), ghcrateengine.NewDomesticPackPricer(), ghcrateengine.NewDomesticLinehaulPricer(), ghcrateengine.NewDomesticShorthaulPricer(), ghcrateengine.NewDomesticOriginPricer(), ghcrateengine.NewDomesticDestinationPricer(), ghcrateengine.NewFuelSurchargePricer())
 		handler := CreateMTOServiceItemHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			creator,
 			mtoChecker,
 		}
@@ -657,7 +657,7 @@ func (suite *HandlerSuite) TestCreateMTOServiceItemDomesticCratingHandler() {
 		).Return(400, nil)
 		creator := mtoserviceitem.NewMTOServiceItemCreator(planner, builder, moveRouter, ghcrateengine.NewDomesticUnpackPricer(), ghcrateengine.NewDomesticPackPricer(), ghcrateengine.NewDomesticLinehaulPricer(), ghcrateengine.NewDomesticShorthaulPricer(), ghcrateengine.NewDomesticOriginPricer(), ghcrateengine.NewDomesticDestinationPricer(), ghcrateengine.NewFuelSurchargePricer())
 		handler := CreateMTOServiceItemHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			creator,
 			mtoChecker,
 		}
@@ -687,7 +687,7 @@ func (suite *HandlerSuite) TestCreateMTOServiceItemDomesticCratingHandler() {
 		subtestData := makeSubtestData()
 		mockCreator := mocks.MTOServiceItemCreator{}
 		handler := CreateMTOServiceItemHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			&mockCreator,
 			mtoChecker,
 		}
@@ -780,7 +780,7 @@ func (suite *HandlerSuite) TestCreateMTOServiceItemOriginSITHandler() {
 		).Return(400, nil)
 		creator := mtoserviceitem.NewMTOServiceItemCreator(planner, builder, moveRouter, ghcrateengine.NewDomesticUnpackPricer(), ghcrateengine.NewDomesticPackPricer(), ghcrateengine.NewDomesticLinehaulPricer(), ghcrateengine.NewDomesticShorthaulPricer(), ghcrateengine.NewDomesticOriginPricer(), ghcrateengine.NewDomesticDestinationPricer(), ghcrateengine.NewFuelSurchargePricer())
 		handler := CreateMTOServiceItemHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			creator,
 			mtoChecker,
 		}
@@ -826,7 +826,7 @@ func (suite *HandlerSuite) TestCreateMTOServiceItemOriginSITHandler() {
 		).Return(400, nil)
 		creator := mtoserviceitem.NewMTOServiceItemCreator(planner, builder, moveRouter, ghcrateengine.NewDomesticUnpackPricer(), ghcrateengine.NewDomesticPackPricer(), ghcrateengine.NewDomesticLinehaulPricer(), ghcrateengine.NewDomesticShorthaulPricer(), ghcrateengine.NewDomesticOriginPricer(), ghcrateengine.NewDomesticDestinationPricer(), ghcrateengine.NewFuelSurchargePricer())
 		handler := CreateMTOServiceItemHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			creator,
 			mtoChecker,
 		}
@@ -895,7 +895,7 @@ func (suite *HandlerSuite) TestCreateMTOServiceItemOriginSITHandler() {
 		).Return(400, nil)
 		creator := mtoserviceitem.NewMTOServiceItemCreator(planner, builder, moveRouter, ghcrateengine.NewDomesticUnpackPricer(), ghcrateengine.NewDomesticPackPricer(), ghcrateengine.NewDomesticLinehaulPricer(), ghcrateengine.NewDomesticShorthaulPricer(), ghcrateengine.NewDomesticOriginPricer(), ghcrateengine.NewDomesticDestinationPricer(), ghcrateengine.NewFuelSurchargePricer())
 		handler := CreateMTOServiceItemHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			creator,
 			mtoChecker,
 		}
@@ -979,7 +979,7 @@ func (suite *HandlerSuite) TestCreateMTOServiceItemOriginSITHandlerWithDOFSITNoA
 		).Return(400, nil)
 		creator := mtoserviceitem.NewMTOServiceItemCreator(planner, builder, moveRouter, ghcrateengine.NewDomesticUnpackPricer(), ghcrateengine.NewDomesticPackPricer(), ghcrateengine.NewDomesticLinehaulPricer(), ghcrateengine.NewDomesticShorthaulPricer(), ghcrateengine.NewDomesticOriginPricer(), ghcrateengine.NewDomesticDestinationPricer(), ghcrateengine.NewFuelSurchargePricer())
 		handler := CreateMTOServiceItemHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			creator,
 			mtoChecker,
 		}
@@ -1087,7 +1087,7 @@ func (suite *HandlerSuite) TestCreateMTOServiceItemOriginSITHandlerWithDOFSITWit
 		).Return(400, nil)
 		creator := mtoserviceitem.NewMTOServiceItemCreator(planner, builder, moveRouter, ghcrateengine.NewDomesticUnpackPricer(), ghcrateengine.NewDomesticPackPricer(), ghcrateengine.NewDomesticLinehaulPricer(), ghcrateengine.NewDomesticShorthaulPricer(), ghcrateengine.NewDomesticOriginPricer(), ghcrateengine.NewDomesticDestinationPricer(), ghcrateengine.NewFuelSurchargePricer())
 		handler := CreateMTOServiceItemHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			creator,
 			mtoChecker,
 		}
@@ -1254,7 +1254,7 @@ func (suite *HandlerSuite) TestCreateMTOServiceItemDestSITHandler() {
 		).Return(400, nil)
 		creator := mtoserviceitem.NewMTOServiceItemCreator(planner, builder, moveRouter, ghcrateengine.NewDomesticUnpackPricer(), ghcrateengine.NewDomesticPackPricer(), ghcrateengine.NewDomesticLinehaulPricer(), ghcrateengine.NewDomesticShorthaulPricer(), ghcrateengine.NewDomesticOriginPricer(), ghcrateengine.NewDomesticDestinationPricer(), ghcrateengine.NewFuelSurchargePricer())
 		handler := CreateMTOServiceItemHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			creator,
 			mtoChecker,
 		}
@@ -1328,7 +1328,7 @@ func (suite *HandlerSuite) TestCreateMTOServiceItemDestSITHandler() {
 		).Return(400, nil)
 		creator := mtoserviceitem.NewMTOServiceItemCreator(planner, builder, moveRouter, ghcrateengine.NewDomesticUnpackPricer(), ghcrateengine.NewDomesticPackPricer(), ghcrateengine.NewDomesticLinehaulPricer(), ghcrateengine.NewDomesticShorthaulPricer(), ghcrateengine.NewDomesticOriginPricer(), ghcrateengine.NewDomesticDestinationPricer(), ghcrateengine.NewFuelSurchargePricer())
 		handler := CreateMTOServiceItemHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			creator,
 			mtoChecker,
 		}
@@ -1361,7 +1361,7 @@ func (suite *HandlerSuite) TestCreateMTOServiceItemDestSITHandler() {
 		).Return(400, nil)
 		creator := mtoserviceitem.NewMTOServiceItemCreator(planner, builder, moveRouter, ghcrateengine.NewDomesticUnpackPricer(), ghcrateengine.NewDomesticPackPricer(), ghcrateengine.NewDomesticLinehaulPricer(), ghcrateengine.NewDomesticShorthaulPricer(), ghcrateengine.NewDomesticOriginPricer(), ghcrateengine.NewDomesticDestinationPricer(), ghcrateengine.NewFuelSurchargePricer())
 		handler := CreateMTOServiceItemHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			creator,
 			mtoChecker,
 		}
@@ -1417,7 +1417,7 @@ func (suite *HandlerSuite) TestCreateMTOServiceItemDestSITHandler() {
 		).Return(400, nil)
 		creator := mtoserviceitem.NewMTOServiceItemCreator(planner, builder, moveRouter, ghcrateengine.NewDomesticUnpackPricer(), ghcrateengine.NewDomesticPackPricer(), ghcrateengine.NewDomesticLinehaulPricer(), ghcrateengine.NewDomesticShorthaulPricer(), ghcrateengine.NewDomesticOriginPricer(), ghcrateengine.NewDomesticDestinationPricer(), ghcrateengine.NewFuelSurchargePricer())
 		handler := CreateMTOServiceItemHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			creator,
 			mtoChecker,
 		}
@@ -1481,7 +1481,7 @@ func (suite *HandlerSuite) TestCreateMTOServiceItemDestSITHandler() {
 		).Return(400, nil)
 		creator := mtoserviceitem.NewMTOServiceItemCreator(planner, builder, moveRouter, ghcrateengine.NewDomesticUnpackPricer(), ghcrateengine.NewDomesticPackPricer(), ghcrateengine.NewDomesticLinehaulPricer(), ghcrateengine.NewDomesticShorthaulPricer(), ghcrateengine.NewDomesticOriginPricer(), ghcrateengine.NewDomesticDestinationPricer(), ghcrateengine.NewFuelSurchargePricer())
 		handler := CreateMTOServiceItemHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			creator,
 			mtoChecker,
 		}
@@ -1512,7 +1512,7 @@ func (suite *HandlerSuite) TestCreateMTOServiceItemDestSITHandler() {
 		planner := &routemocks.Planner{}
 		creator := mtoserviceitem.NewMTOServiceItemCreator(planner, builder, moveRouter, ghcrateengine.NewDomesticUnpackPricer(), ghcrateengine.NewDomesticPackPricer(), ghcrateengine.NewDomesticLinehaulPricer(), ghcrateengine.NewDomesticShorthaulPricer(), ghcrateengine.NewDomesticOriginPricer(), ghcrateengine.NewDomesticDestinationPricer(), ghcrateengine.NewFuelSurchargePricer())
 		handler := CreateMTOServiceItemHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			creator,
 			mtoChecker,
 		}

--- a/pkg/handlers/primeapiv2/mto_shipment_test.go
+++ b/pkg/handlers/primeapiv2/mto_shipment_test.go
@@ -316,7 +316,7 @@ func (suite *HandlerSuite) TestCreateMTOShipmentHandler() {
 			ApplicationName: auth.OfficeApp,
 			UserID:          user.ID,
 			IDToken:         "fake token",
-			CurrentRole:     roles.Role{},
+			ActiveRole:      roles.Role{},
 		}
 		ctx := auth.SetSessionInRequestContext(req, session)
 

--- a/pkg/handlers/primeapiv2/mto_shipment_test.go
+++ b/pkg/handlers/primeapiv2/mto_shipment_test.go
@@ -101,7 +101,7 @@ func (suite *HandlerSuite) TestCreateMTOShipmentHandler() {
 	setupTestData := func(ubFeatureFlag bool) (CreateMTOShipmentHandler, models.Move) {
 
 		move := factory.BuildAvailableToPrimeMove(suite.DB(), nil, nil)
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 		if ubFeatureFlag {
 			expectedFeatureFlag := services.FeatureFlag{
 				Key:   "unaccompanied_baggage",

--- a/pkg/handlers/primeapiv2/mto_shipment_test.go
+++ b/pkg/handlers/primeapiv2/mto_shipment_test.go
@@ -316,7 +316,7 @@ func (suite *HandlerSuite) TestCreateMTOShipmentHandler() {
 			ApplicationName: auth.OfficeApp,
 			UserID:          user.ID,
 			IDToken:         "fake token",
-			Roles:           roles.Roles{},
+			CurrentRole:     roles.Role{},
 		}
 		ctx := auth.SetSessionInRequestContext(req, session)
 

--- a/pkg/handlers/primeapiv3/move_task_order_test.go
+++ b/pkg/handlers/primeapiv3/move_task_order_test.go
@@ -55,7 +55,7 @@ func (suite *HandlerSuite) TestGetMoveTaskOrder() {
 			mock.AnythingOfType("models.Move"),
 		).Return(nil, nil)
 		handler := GetMoveTaskOrderHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			movetaskorder.NewMoveTaskOrderFetcher(waf),
 			mockShipmentRateAreaFinder,
 		}
@@ -1474,7 +1474,7 @@ func (suite *HandlerSuite) TestGetMoveTaskOrder() {
 
 	suite.Run("Failure 'Not Found' for non-available move", func() {
 		handler := GetMoveTaskOrderHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			movetaskorder.NewMoveTaskOrderFetcher(waf),
 			mtoshipment.NewMTOShipmentRateAreaFetcher(),
 		}
@@ -1507,7 +1507,7 @@ func (suite *HandlerSuite) TestGetMoveTaskOrder() {
 
 		// This tests fields that aren't other structs and Addresses
 		handler := GetMoveTaskOrderHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			movetaskorder.NewMoveTaskOrderFetcher(waf),
 			mockShipmentRateAreaFinder,
 		}
@@ -1626,7 +1626,7 @@ func (suite *HandlerSuite) TestGetMoveTaskOrder() {
 
 		// This tests fields that aren't other structs and Addresses
 		handler := GetMoveTaskOrderHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			movetaskorder.NewMoveTaskOrderFetcher(waf),
 			mockShipmentRateAreaFinder,
 		}

--- a/pkg/handlers/primeapiv3/mto_service_item_test.go
+++ b/pkg/handlers/primeapiv3/mto_service_item_test.go
@@ -114,7 +114,7 @@ func (suite *HandlerSuite) TestCreateMTOServiceItemHandler() {
 		moveRouter := moverouter.NewMoveRouter(transportationoffice.NewTransportationOfficesFetcher())
 		creator := mtoserviceitem.NewMTOServiceItemCreator(planner, builder, moveRouter, ghcrateengine.NewDomesticUnpackPricer(), ghcrateengine.NewDomesticPackPricer(), ghcrateengine.NewDomesticLinehaulPricer(), ghcrateengine.NewDomesticShorthaulPricer(), ghcrateengine.NewDomesticOriginPricer(), ghcrateengine.NewDomesticDestinationPricer(), ghcrateengine.NewFuelSurchargePricer())
 		handler := CreateMTOServiceItemHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			creator,
 			mtoChecker,
 		}
@@ -172,7 +172,7 @@ func (suite *HandlerSuite) TestCreateMTOServiceItemHandler() {
 		).Return(400, nil)
 		creator := mtoserviceitem.NewMTOServiceItemCreator(planner, builder, moveRouter, ghcrateengine.NewDomesticUnpackPricer(), ghcrateengine.NewDomesticPackPricer(), ghcrateengine.NewDomesticLinehaulPricer(), ghcrateengine.NewDomesticShorthaulPricer(), ghcrateengine.NewDomesticOriginPricer(), ghcrateengine.NewDomesticDestinationPricer(), ghcrateengine.NewFuelSurchargePricer())
 		handler := CreateMTOServiceItemHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			creator,
 			mtoChecker,
 		}
@@ -226,7 +226,7 @@ func (suite *HandlerSuite) TestCreateMTOServiceItemHandler() {
 		).Return(400, nil)
 		creator := mtoserviceitem.NewMTOServiceItemCreator(planner, builder, moveRouter, ghcrateengine.NewDomesticUnpackPricer(), ghcrateengine.NewDomesticPackPricer(), ghcrateengine.NewDomesticLinehaulPricer(), ghcrateengine.NewDomesticShorthaulPricer(), ghcrateengine.NewDomesticOriginPricer(), ghcrateengine.NewDomesticDestinationPricer(), ghcrateengine.NewFuelSurchargePricer())
 		handler := CreateMTOServiceItemHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			creator,
 			mtoChecker,
 		}
@@ -245,7 +245,7 @@ func (suite *HandlerSuite) TestCreateMTOServiceItemHandler() {
 		subtestData := makeSubtestData()
 		mockCreator := mocks.MTOServiceItemCreator{}
 		handler := CreateMTOServiceItemHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			&mockCreator,
 			mtoChecker,
 		}
@@ -273,7 +273,7 @@ func (suite *HandlerSuite) TestCreateMTOServiceItemHandler() {
 		subtestData := makeSubtestData()
 		mockCreator := mocks.MTOServiceItemCreator{}
 		handler := CreateMTOServiceItemHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			&mockCreator,
 			mtoChecker,
 		}
@@ -303,7 +303,7 @@ func (suite *HandlerSuite) TestCreateMTOServiceItemHandler() {
 		subtestData := makeSubtestData()
 		mockCreator := mocks.MTOServiceItemCreator{}
 		handler := CreateMTOServiceItemHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			&mockCreator,
 			mtoChecker,
 		}
@@ -330,7 +330,7 @@ func (suite *HandlerSuite) TestCreateMTOServiceItemHandler() {
 		subtestData := makeSubtestData()
 		mockCreator := mocks.MTOServiceItemCreator{}
 		handler := CreateMTOServiceItemHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			&mockCreator,
 			mtoChecker,
 		}
@@ -364,7 +364,7 @@ func (suite *HandlerSuite) TestCreateMTOServiceItemHandler() {
 		).Return(400, nil)
 		creator := mtoserviceitem.NewMTOServiceItemCreator(planner, builder, moveRouter, ghcrateengine.NewDomesticUnpackPricer(), ghcrateengine.NewDomesticPackPricer(), ghcrateengine.NewDomesticLinehaulPricer(), ghcrateengine.NewDomesticShorthaulPricer(), ghcrateengine.NewDomesticOriginPricer(), ghcrateengine.NewDomesticDestinationPricer(), ghcrateengine.NewFuelSurchargePricer())
 		handler := CreateMTOServiceItemHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			creator,
 			mtoChecker,
 		}
@@ -408,7 +408,7 @@ func (suite *HandlerSuite) TestCreateMTOServiceItemHandler() {
 		).Return(400, nil)
 		creator := mtoserviceitem.NewMTOServiceItemCreator(planner, builder, moveRouter, ghcrateengine.NewDomesticUnpackPricer(), ghcrateengine.NewDomesticPackPricer(), ghcrateengine.NewDomesticLinehaulPricer(), ghcrateengine.NewDomesticShorthaulPricer(), ghcrateengine.NewDomesticOriginPricer(), ghcrateengine.NewDomesticDestinationPricer(), ghcrateengine.NewFuelSurchargePricer())
 		handler := CreateMTOServiceItemHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			creator,
 			mtoChecker,
 		}
@@ -437,7 +437,7 @@ func (suite *HandlerSuite) TestCreateMTOServiceItemHandler() {
 		subtestData := makeSubtestData()
 		mockCreator := mocks.MTOServiceItemCreator{}
 		handler := CreateMTOServiceItemHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			&mockCreator,
 			mtoChecker,
 		}
@@ -464,7 +464,7 @@ func (suite *HandlerSuite) TestCreateMTOServiceItemHandler() {
 		subtestData := makeSubtestData()
 		mockCreator := mocks.MTOServiceItemCreator{}
 		handler := CreateMTOServiceItemHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			&mockCreator,
 			mtoChecker,
 		}
@@ -510,7 +510,7 @@ func (suite *HandlerSuite) TestCreateMTOServiceItemHandler() {
 		).Return(400, nil)
 		creator := mtoserviceitem.NewMTOServiceItemCreator(planner, builder, moveRouter, ghcrateengine.NewDomesticUnpackPricer(), ghcrateengine.NewDomesticPackPricer(), ghcrateengine.NewDomesticLinehaulPricer(), ghcrateengine.NewDomesticShorthaulPricer(), ghcrateengine.NewDomesticOriginPricer(), ghcrateengine.NewDomesticDestinationPricer(), ghcrateengine.NewFuelSurchargePricer())
 		handler := CreateMTOServiceItemHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			creator,
 			mtoChecker,
 		}
@@ -542,7 +542,7 @@ func (suite *HandlerSuite) TestCreateMTOServiceItemHandler() {
 		).Return(400, nil)
 		creator := mtoserviceitem.NewMTOServiceItemCreator(planner, builder, moveRouter, ghcrateengine.NewDomesticUnpackPricer(), ghcrateengine.NewDomesticPackPricer(), ghcrateengine.NewDomesticLinehaulPricer(), ghcrateengine.NewDomesticShorthaulPricer(), ghcrateengine.NewDomesticOriginPricer(), ghcrateengine.NewDomesticDestinationPricer(), ghcrateengine.NewFuelSurchargePricer())
 		handler := CreateMTOServiceItemHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			creator,
 			mtoChecker,
 		}
@@ -621,7 +621,7 @@ func (suite *HandlerSuite) TestCreateMTOServiceItemDomesticCratingHandler() {
 		).Return(400, nil)
 		creator := mtoserviceitem.NewMTOServiceItemCreator(planner, builder, moveRouter, ghcrateengine.NewDomesticUnpackPricer(), ghcrateengine.NewDomesticPackPricer(), ghcrateengine.NewDomesticLinehaulPricer(), ghcrateengine.NewDomesticShorthaulPricer(), ghcrateengine.NewDomesticOriginPricer(), ghcrateengine.NewDomesticDestinationPricer(), ghcrateengine.NewFuelSurchargePricer())
 		handler := CreateMTOServiceItemHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			creator,
 			mtoChecker,
 		}
@@ -658,7 +658,7 @@ func (suite *HandlerSuite) TestCreateMTOServiceItemDomesticCratingHandler() {
 		).Return(400, nil)
 		creator := mtoserviceitem.NewMTOServiceItemCreator(planner, builder, moveRouter, ghcrateengine.NewDomesticUnpackPricer(), ghcrateengine.NewDomesticPackPricer(), ghcrateengine.NewDomesticLinehaulPricer(), ghcrateengine.NewDomesticShorthaulPricer(), ghcrateengine.NewDomesticOriginPricer(), ghcrateengine.NewDomesticDestinationPricer(), ghcrateengine.NewFuelSurchargePricer())
 		handler := CreateMTOServiceItemHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			creator,
 			mtoChecker,
 		}
@@ -688,7 +688,7 @@ func (suite *HandlerSuite) TestCreateMTOServiceItemDomesticCratingHandler() {
 		subtestData := makeSubtestData()
 		mockCreator := mocks.MTOServiceItemCreator{}
 		handler := CreateMTOServiceItemHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			&mockCreator,
 			mtoChecker,
 		}
@@ -781,7 +781,7 @@ func (suite *HandlerSuite) TestCreateMTOServiceItemOriginSITHandler() {
 		).Return(400, nil)
 		creator := mtoserviceitem.NewMTOServiceItemCreator(planner, builder, moveRouter, ghcrateengine.NewDomesticUnpackPricer(), ghcrateengine.NewDomesticPackPricer(), ghcrateengine.NewDomesticLinehaulPricer(), ghcrateengine.NewDomesticShorthaulPricer(), ghcrateengine.NewDomesticOriginPricer(), ghcrateengine.NewDomesticDestinationPricer(), ghcrateengine.NewFuelSurchargePricer())
 		handler := CreateMTOServiceItemHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			creator,
 			mtoChecker,
 		}
@@ -827,7 +827,7 @@ func (suite *HandlerSuite) TestCreateMTOServiceItemOriginSITHandler() {
 		).Return(400, nil)
 		creator := mtoserviceitem.NewMTOServiceItemCreator(planner, builder, moveRouter, ghcrateengine.NewDomesticUnpackPricer(), ghcrateengine.NewDomesticPackPricer(), ghcrateengine.NewDomesticLinehaulPricer(), ghcrateengine.NewDomesticShorthaulPricer(), ghcrateengine.NewDomesticOriginPricer(), ghcrateengine.NewDomesticDestinationPricer(), ghcrateengine.NewFuelSurchargePricer())
 		handler := CreateMTOServiceItemHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			creator,
 			mtoChecker,
 		}
@@ -896,7 +896,7 @@ func (suite *HandlerSuite) TestCreateMTOServiceItemOriginSITHandler() {
 		).Return(400, nil)
 		creator := mtoserviceitem.NewMTOServiceItemCreator(planner, builder, moveRouter, ghcrateengine.NewDomesticUnpackPricer(), ghcrateengine.NewDomesticPackPricer(), ghcrateengine.NewDomesticLinehaulPricer(), ghcrateengine.NewDomesticShorthaulPricer(), ghcrateengine.NewDomesticOriginPricer(), ghcrateengine.NewDomesticDestinationPricer(), ghcrateengine.NewFuelSurchargePricer())
 		handler := CreateMTOServiceItemHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			creator,
 			mtoChecker,
 		}
@@ -980,7 +980,7 @@ func (suite *HandlerSuite) TestCreateMTOServiceItemOriginSITHandlerWithDOFSITNoA
 		).Return(400, nil)
 		creator := mtoserviceitem.NewMTOServiceItemCreator(planner, builder, moveRouter, ghcrateengine.NewDomesticUnpackPricer(), ghcrateengine.NewDomesticPackPricer(), ghcrateengine.NewDomesticLinehaulPricer(), ghcrateengine.NewDomesticShorthaulPricer(), ghcrateengine.NewDomesticOriginPricer(), ghcrateengine.NewDomesticDestinationPricer(), ghcrateengine.NewFuelSurchargePricer())
 		handler := CreateMTOServiceItemHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			creator,
 			mtoChecker,
 		}
@@ -1088,7 +1088,7 @@ func (suite *HandlerSuite) TestCreateMTOServiceItemOriginSITHandlerWithDOFSITWit
 		).Return(400, nil)
 		creator := mtoserviceitem.NewMTOServiceItemCreator(planner, builder, moveRouter, ghcrateengine.NewDomesticUnpackPricer(), ghcrateengine.NewDomesticPackPricer(), ghcrateengine.NewDomesticLinehaulPricer(), ghcrateengine.NewDomesticShorthaulPricer(), ghcrateengine.NewDomesticOriginPricer(), ghcrateengine.NewDomesticDestinationPricer(), ghcrateengine.NewFuelSurchargePricer())
 		handler := CreateMTOServiceItemHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			creator,
 			mtoChecker,
 		}
@@ -1255,7 +1255,7 @@ func (suite *HandlerSuite) TestCreateMTOServiceItemDestSITHandler() {
 		).Return(400, nil)
 		creator := mtoserviceitem.NewMTOServiceItemCreator(planner, builder, moveRouter, ghcrateengine.NewDomesticUnpackPricer(), ghcrateengine.NewDomesticPackPricer(), ghcrateengine.NewDomesticLinehaulPricer(), ghcrateengine.NewDomesticShorthaulPricer(), ghcrateengine.NewDomesticOriginPricer(), ghcrateengine.NewDomesticDestinationPricer(), ghcrateengine.NewFuelSurchargePricer())
 		handler := CreateMTOServiceItemHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			creator,
 			mtoChecker,
 		}
@@ -1329,7 +1329,7 @@ func (suite *HandlerSuite) TestCreateMTOServiceItemDestSITHandler() {
 		).Return(400, nil)
 		creator := mtoserviceitem.NewMTOServiceItemCreator(planner, builder, moveRouter, ghcrateengine.NewDomesticUnpackPricer(), ghcrateengine.NewDomesticPackPricer(), ghcrateengine.NewDomesticLinehaulPricer(), ghcrateengine.NewDomesticShorthaulPricer(), ghcrateengine.NewDomesticOriginPricer(), ghcrateengine.NewDomesticDestinationPricer(), ghcrateengine.NewFuelSurchargePricer())
 		handler := CreateMTOServiceItemHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			creator,
 			mtoChecker,
 		}
@@ -1362,7 +1362,7 @@ func (suite *HandlerSuite) TestCreateMTOServiceItemDestSITHandler() {
 		).Return(400, nil)
 		creator := mtoserviceitem.NewMTOServiceItemCreator(planner, builder, moveRouter, ghcrateengine.NewDomesticUnpackPricer(), ghcrateengine.NewDomesticPackPricer(), ghcrateengine.NewDomesticLinehaulPricer(), ghcrateengine.NewDomesticShorthaulPricer(), ghcrateengine.NewDomesticOriginPricer(), ghcrateengine.NewDomesticDestinationPricer(), ghcrateengine.NewFuelSurchargePricer())
 		handler := CreateMTOServiceItemHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			creator,
 			mtoChecker,
 		}
@@ -1418,7 +1418,7 @@ func (suite *HandlerSuite) TestCreateMTOServiceItemDestSITHandler() {
 		).Return(400, nil)
 		creator := mtoserviceitem.NewMTOServiceItemCreator(planner, builder, moveRouter, ghcrateengine.NewDomesticUnpackPricer(), ghcrateengine.NewDomesticPackPricer(), ghcrateengine.NewDomesticLinehaulPricer(), ghcrateengine.NewDomesticShorthaulPricer(), ghcrateengine.NewDomesticOriginPricer(), ghcrateengine.NewDomesticDestinationPricer(), ghcrateengine.NewFuelSurchargePricer())
 		handler := CreateMTOServiceItemHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			creator,
 			mtoChecker,
 		}
@@ -1482,7 +1482,7 @@ func (suite *HandlerSuite) TestCreateMTOServiceItemDestSITHandler() {
 		).Return(400, nil)
 		creator := mtoserviceitem.NewMTOServiceItemCreator(planner, builder, moveRouter, ghcrateengine.NewDomesticUnpackPricer(), ghcrateengine.NewDomesticPackPricer(), ghcrateengine.NewDomesticLinehaulPricer(), ghcrateengine.NewDomesticShorthaulPricer(), ghcrateengine.NewDomesticOriginPricer(), ghcrateengine.NewDomesticDestinationPricer(), ghcrateengine.NewFuelSurchargePricer())
 		handler := CreateMTOServiceItemHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			creator,
 			mtoChecker,
 		}
@@ -1518,7 +1518,7 @@ func (suite *HandlerSuite) TestCreateMTOServiceItemDestSITHandler() {
 		).Return(400, nil)
 		creator := mtoserviceitem.NewMTOServiceItemCreator(planner, builder, moveRouter, ghcrateengine.NewDomesticUnpackPricer(), ghcrateengine.NewDomesticPackPricer(), ghcrateengine.NewDomesticLinehaulPricer(), ghcrateengine.NewDomesticShorthaulPricer(), ghcrateengine.NewDomesticOriginPricer(), ghcrateengine.NewDomesticDestinationPricer(), ghcrateengine.NewFuelSurchargePricer())
 		handler := CreateMTOServiceItemHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			creator,
 			mtoChecker,
 		}

--- a/pkg/handlers/primeapiv3/mto_shipment_test.go
+++ b/pkg/handlers/primeapiv3/mto_shipment_test.go
@@ -181,7 +181,7 @@ func (suite *HandlerSuite) TestCreateMTOShipmentHandler() {
 	setupTestData := func(boatFeatureFlag bool, ubFeatureFlag bool) (CreateMTOShipmentHandler, models.Move) {
 		vLocationServices := address.NewVLocation()
 		move := factory.BuildAvailableToPrimeMove(suite.DB(), nil, nil)
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 		expectedFeatureFlag := services.FeatureFlag{
 			Key:   "",
 			Match: true,
@@ -273,7 +273,7 @@ func (suite *HandlerSuite) TestCreateMTOShipmentHandler() {
 		move := factory.BuildAvailableToPrimeMove(suite.DB(), nil, nil)
 
 		handler := CreateMTOShipmentHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			shipmentCreator,
 			mtoChecker,
 			vLocationServices,
@@ -610,7 +610,7 @@ func (suite *HandlerSuite) TestCreateMTOShipmentHandler() {
 			Return(nil, nil)
 
 		patchHandler := UpdateMTOShipmentHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			shipmentUpdater,
 			planner,
 			vLocationServices,
@@ -909,7 +909,7 @@ func (suite *HandlerSuite) TestCreateMTOShipmentHandler() {
 			Return(nil, nil)
 
 		patchHandler := UpdateMTOShipmentHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			shipmentUpdater,
 			planner,
 			vLocationServices,
@@ -1630,7 +1630,7 @@ func (suite *HandlerSuite) TestCreateMTOShipmentHandler() {
 
 		shipmentUpdater := shipmentorchestrator.NewShipmentUpdater(mtoShipmentUpdater, ppmShipmentUpdater, boatShipmentUpdater, mobileHomeShipmentUpdater, mtoServiceItemCreator)
 		patchHandler := UpdateMTOShipmentHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			shipmentUpdater,
 			planner,
 			vLocationServices,
@@ -1707,7 +1707,7 @@ func (suite *HandlerSuite) TestCreateMTOShipmentHandler() {
 
 		shipmentUpdater := shipmentorchestrator.NewShipmentUpdater(mtoShipmentUpdater, ppmShipmentUpdater, boatShipmentUpdater, mobileHomeShipmentUpdater, mtoServiceItemCreator)
 		patchHandler := UpdateMTOShipmentHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			shipmentUpdater,
 			planner,
 			vLocationServices,
@@ -1757,7 +1757,7 @@ func (suite *HandlerSuite) TestCreateMTOShipmentHandler() {
 
 		shipmentUpdater := shipmentorchestrator.NewShipmentUpdater(mtoShipmentUpdater, ppmShipmentUpdater, boatShipmentUpdater, mobileHomeShipmentUpdater, mtoServiceItemCreator)
 		patchHandler := UpdateMTOShipmentHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			shipmentUpdater,
 			planner,
 			vLocationServices,
@@ -1850,7 +1850,7 @@ func (suite *HandlerSuite) TestCreateMTOShipmentHandler() {
 
 		shipmentUpdater := shipmentorchestrator.NewShipmentUpdater(mtoShipmentUpdater, ppmShipmentUpdater, boatShipmentUpdater, mobileHomeShipmentUpdater, mtoServiceItemCreator)
 		patchHandler := UpdateMTOShipmentHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			shipmentUpdater,
 			planner,
 			vLocationServices,
@@ -2001,7 +2001,7 @@ func (suite *HandlerSuite) TestCreateMTOShipmentHandler() {
 
 		shipmentUpdater := shipmentorchestrator.NewShipmentUpdater(mtoShipmentUpdater, ppmShipmentUpdater, boatShipmentUpdater, mobileHomeShipmentUpdater, mtoServiceItemCreator)
 		patchHandler := UpdateMTOShipmentHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			shipmentUpdater,
 			planner,
 			vLocationServices,
@@ -2098,7 +2098,7 @@ func (suite *HandlerSuite) TestCreateMTOShipmentHandler() {
 		}
 
 		// setting the AK flag to true
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 
 		expectedFeatureFlag := services.FeatureFlag{
 			Key:   "enable_alaska",
@@ -2126,7 +2126,7 @@ func (suite *HandlerSuite) TestCreateMTOShipmentHandler() {
 
 		shipmentUpdater := shipmentorchestrator.NewShipmentUpdater(mtoShipmentUpdater, ppmShipmentUpdater, boatShipmentUpdater, mobileHomeShipmentUpdater, mtoServiceItemCreator)
 		patchHandler := UpdateMTOShipmentHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			shipmentUpdater,
 			planner,
 			vLocationServices,
@@ -2223,7 +2223,7 @@ func (suite *HandlerSuite) TestCreateMTOShipmentHandler() {
 		}
 
 		// setting the HI flag to true
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 
 		expectedFeatureFlag := services.FeatureFlag{
 			Key:   "enable_hawaii",
@@ -2251,7 +2251,7 @@ func (suite *HandlerSuite) TestCreateMTOShipmentHandler() {
 
 		shipmentUpdater := shipmentorchestrator.NewShipmentUpdater(mtoShipmentUpdater, ppmShipmentUpdater, boatShipmentUpdater, mobileHomeShipmentUpdater, mtoServiceItemCreator)
 		patchHandler := UpdateMTOShipmentHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			shipmentUpdater,
 			planner,
 			vLocationServices,
@@ -2357,7 +2357,7 @@ func (suite *HandlerSuite) TestCreateMTOShipmentHandler() {
 		}
 
 		// setting the AK flag to false
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 
 		expectedFeatureFlag := services.FeatureFlag{
 			Key:   "enable_alaska",
@@ -2385,7 +2385,7 @@ func (suite *HandlerSuite) TestCreateMTOShipmentHandler() {
 
 		shipmentUpdater := shipmentorchestrator.NewShipmentUpdater(mtoShipmentUpdater, ppmShipmentUpdater, boatShipmentUpdater, mobileHomeShipmentUpdater, mtoServiceItemCreator)
 		patchHandler := UpdateMTOShipmentHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			shipmentUpdater,
 			planner,
 			vLocationServices,
@@ -2491,7 +2491,7 @@ func (suite *HandlerSuite) TestCreateMTOShipmentHandler() {
 		}
 
 		// setting the HI flag to false
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 
 		expectedFeatureFlag := services.FeatureFlag{
 			Key:   "enable_hawaii",
@@ -2575,7 +2575,7 @@ func (suite *HandlerSuite) TestCreateMTOShipmentHandler() {
 		}
 
 		// setting the AK flag to false and use a valid address
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 
 		expectedFeatureFlag := services.FeatureFlag{
 			Key:   "enable_alaska",
@@ -2637,7 +2637,7 @@ func (suite *HandlerSuite) TestCreateMTOShipmentHandler() {
 		}
 
 		// setting the HI flag to false and use a valid address
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 
 		expectedFeatureFlag := services.FeatureFlag{
 			Key:   "enable_hawaii",
@@ -2699,7 +2699,7 @@ func (suite *HandlerSuite) TestCreateMTOShipmentHandler() {
 		}
 
 		// setting the AK flag to false and use a valid address
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 
 		expectedFeatureFlag := services.FeatureFlag{
 			Key:   "enable_alaska",
@@ -2761,7 +2761,7 @@ func (suite *HandlerSuite) TestCreateMTOShipmentHandler() {
 		}
 
 		// setting the HI flag to false and use a valid address
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 
 		expectedFeatureFlag := services.FeatureFlag{
 			Key:   "enable_hawaii",

--- a/pkg/handlers/primeapiv3/mto_shipment_test.go
+++ b/pkg/handlers/primeapiv3/mto_shipment_test.go
@@ -506,7 +506,7 @@ func (suite *HandlerSuite) TestCreateMTOShipmentHandler() {
 			ApplicationName: auth.OfficeApp,
 			UserID:          user.ID,
 			IDToken:         "fake token",
-			Roles:           roles.Roles{},
+			CurrentRole:     roles.Role{},
 		}
 		ctx := auth.SetSessionInRequestContext(req, session)
 
@@ -825,7 +825,7 @@ func (suite *HandlerSuite) TestCreateMTOShipmentHandler() {
 			ApplicationName: auth.OfficeApp,
 			UserID:          user.ID,
 			IDToken:         "fake token",
-			Roles:           roles.Roles{},
+			CurrentRole:     roles.Role{},
 		}
 		ctx := auth.SetSessionInRequestContext(req, session)
 

--- a/pkg/handlers/primeapiv3/mto_shipment_test.go
+++ b/pkg/handlers/primeapiv3/mto_shipment_test.go
@@ -506,7 +506,7 @@ func (suite *HandlerSuite) TestCreateMTOShipmentHandler() {
 			ApplicationName: auth.OfficeApp,
 			UserID:          user.ID,
 			IDToken:         "fake token",
-			CurrentRole:     roles.Role{},
+			ActiveRole:      roles.Role{},
 		}
 		ctx := auth.SetSessionInRequestContext(req, session)
 
@@ -825,7 +825,7 @@ func (suite *HandlerSuite) TestCreateMTOShipmentHandler() {
 			ApplicationName: auth.OfficeApp,
 			UserID:          user.ID,
 			IDToken:         "fake token",
-			CurrentRole:     roles.Role{},
+			ActiveRole:      roles.Role{},
 		}
 		ctx := auth.SetSessionInRequestContext(req, session)
 

--- a/pkg/handlers/routing/base_routing_suite.go
+++ b/pkg/handlers/routing/base_routing_suite.go
@@ -56,9 +56,9 @@ func NewBaseRoutingSuite() BaseRoutingSuite {
 	}
 }
 
-// override HandlerConfig to use the version saved in routing config
+// override NewHandlerConfig to use the version saved in routing config
 // so the same session manager(s) are used
-func (suite *BaseRoutingSuite) HandlerConfig() handlers.HandlerConfig {
+func (suite *BaseRoutingSuite) NewHandlerConfig() handlers.HandlerConfig {
 	return suite.RoutingConfig().HandlerConfig
 }
 
@@ -181,9 +181,9 @@ func (suite *BaseRoutingSuite) SetupCustomSiteHandlerWithTelemetry(routingConfig
 }
 
 func (suite *BaseRoutingSuite) setupRequestSession(req *http.Request, user models.User, hostname string) {
-	app, err := auth.ApplicationName(hostname, suite.HandlerConfig().AppNames())
+	app, err := auth.ApplicationName(hostname, suite.NewHandlerConfig().AppNames())
 	suite.FatalNoError(err)
-	sessionManager := suite.HandlerConfig().SessionManagers().SessionManagerForApplication(app)
+	sessionManager := suite.NewHandlerConfig().SessionManagers().SessionManagerForApplication(app)
 
 	fakeAuthContext, err := sessionManager.Load(context.Background(), "")
 	suite.NoError(err)
@@ -238,15 +238,15 @@ func (suite *BaseRoutingSuite) setupRequestSession(req *http.Request, user model
 }
 
 func (suite *BaseRoutingSuite) SetupAdminRequestSession(req *http.Request, adminUser models.AdminUser) {
-	suite.setupRequestSession(req, adminUser.User, suite.HandlerConfig().AppNames().AdminServername)
+	suite.setupRequestSession(req, adminUser.User, suite.NewHandlerConfig().AppNames().AdminServername)
 }
 
 func (suite *BaseRoutingSuite) SetupMilRequestSession(req *http.Request, serviceMember models.ServiceMember) {
-	suite.setupRequestSession(req, serviceMember.User, suite.HandlerConfig().AppNames().MilServername)
+	suite.setupRequestSession(req, serviceMember.User, suite.NewHandlerConfig().AppNames().MilServername)
 }
 
 func (suite *BaseRoutingSuite) SetupOfficeRequestSession(req *http.Request, officeUser models.OfficeUser) {
-	suite.setupRequestSession(req, officeUser.User, suite.HandlerConfig().AppNames().OfficeServername)
+	suite.setupRequestSession(req, officeUser.User, suite.NewHandlerConfig().AppNames().OfficeServername)
 }
 
 func (suite *BaseRoutingSuite) NewRequest(method string, hostname string, relativePath string, body io.Reader) *http.Request {
@@ -259,7 +259,7 @@ func (suite *BaseRoutingSuite) NewRequest(method string, hostname string, relati
 
 func (suite *BaseRoutingSuite) NewAdminRequest(method string, relativePath string, body io.Reader) *http.Request {
 	return suite.NewRequest(method,
-		suite.HandlerConfig().AppNames().AdminServername,
+		suite.NewHandlerConfig().AppNames().AdminServername,
 		relativePath,
 		body)
 }
@@ -272,7 +272,7 @@ func (suite *BaseRoutingSuite) NewAuthenticatedAdminRequest(method string, relat
 
 func (suite *BaseRoutingSuite) NewMilRequest(method string, relativePath string, body io.Reader) *http.Request {
 	return suite.NewRequest(method,
-		suite.HandlerConfig().AppNames().MilServername,
+		suite.NewHandlerConfig().AppNames().MilServername,
 		relativePath,
 		body)
 }
@@ -285,7 +285,7 @@ func (suite *BaseRoutingSuite) NewAuthenticatedMilRequest(method string, relativ
 
 func (suite *BaseRoutingSuite) NewOfficeRequest(method string, relativePath string, body io.Reader) *http.Request {
 	return suite.NewRequest(method,
-		suite.HandlerConfig().AppNames().OfficeServername,
+		suite.NewHandlerConfig().AppNames().OfficeServername,
 		relativePath,
 		body)
 }
@@ -298,7 +298,7 @@ func (suite *BaseRoutingSuite) NewAuthenticatedOfficeRequest(method string, rela
 
 func (suite *BaseRoutingSuite) NewPrimeRequest(method string, relativePath string, body io.Reader) *http.Request {
 	return suite.NewRequest(method,
-		suite.HandlerConfig().AppNames().PrimeServername,
+		suite.NewHandlerConfig().AppNames().PrimeServername,
 		relativePath,
 		body)
 }
@@ -314,7 +314,7 @@ func (suite *BaseRoutingSuite) NewAuthenticatedPrimeRequest(method string, relat
 
 func (suite *BaseRoutingSuite) NewPPTASRequest(method string, relativePath string, body io.Reader) *http.Request {
 	return suite.NewRequest(method,
-		suite.HandlerConfig().AppNames().PPTASServerName,
+		suite.NewHandlerConfig().AppNames().PPTASServerName,
 		relativePath,
 		body)
 }

--- a/pkg/handlers/routing/base_routing_suite.go
+++ b/pkg/handlers/routing/base_routing_suite.go
@@ -82,7 +82,7 @@ func (suite *BaseRoutingSuite) RoutingConfig() *Config {
 	// ensure the routing config is reset when the test context is finished
 	suite.T().Cleanup(func() { suite.routingConfig = nil })
 	// Test that we can initialize routing and serve the index file
-	handlerConfig := suite.BaseHandlerTestSuite.HandlerConfig()
+	handlerConfig := suite.BaseHandlerTestSuite.NewHandlerConfig()
 	handlerConfig.SetAppNames(handlers.ApplicationTestServername())
 	handlerConfig.SetNotificationSender(suite.TestNotificationSender())
 	handlerConfig.SetNotificationReceiver(suite.TestNotificationReceiver())

--- a/pkg/handlers/routing/ghcapi_test/uploads_test.go
+++ b/pkg/handlers/routing/ghcapi_test/uploads_test.go
@@ -29,7 +29,7 @@ func (suite *GhcAPISuite) TestUploads() {
 			},
 		}, nil)
 		file := suite.Fixture("test.pdf")
-		_, err := suite.HandlerConfig().FileStorer().Store(uploadUser1.Upload.StorageKey, file.Data, "somehash", nil)
+		_, err := suite.NewHandlerConfig().FileStorer().Store(uploadUser1.Upload.StorageKey, file.Data, "somehash", nil)
 		suite.NoError(err)
 
 		officeUser := factory.BuildOfficeUserWithRoles(suite.DB(), factory.GetTraitActiveOfficeUser(),
@@ -60,7 +60,7 @@ func (suite *GhcAPISuite) TestUploads() {
 			},
 		}, nil)
 		file := suite.Fixture("test.pdf")
-		_, err := suite.HandlerConfig().FileStorer().Store(uploadUser1.Upload.StorageKey, file.Data, "somehash", nil)
+		_, err := suite.NewHandlerConfig().FileStorer().Store(uploadUser1.Upload.StorageKey, file.Data, "somehash", nil)
 		suite.NoError(err)
 
 		officeUser := factory.BuildOfficeUserWithRoles(suite.DB(), factory.GetTraitActiveOfficeUser(),
@@ -68,7 +68,7 @@ func (suite *GhcAPISuite) TestUploads() {
 		req := suite.NewAuthenticatedOfficeRequest("GET", "/ghc/v1/uploads/"+uploadUser1.Upload.ID.String()+"/status", nil, officeUser)
 		rr := httptest.NewRecorder()
 
-		fakeS3, ok := suite.HandlerConfig().FileStorer().(*storageTest.FakeS3Storage)
+		fakeS3, ok := suite.NewHandlerConfig().FileStorer().(*storageTest.FakeS3Storage)
 		suite.True(ok)
 		suite.NotNil(fakeS3, "FileStorer should be fakeS3")
 

--- a/pkg/handlers/supportapi/move_task_order_test.go
+++ b/pkg/handlers/supportapi/move_task_order_test.go
@@ -54,7 +54,7 @@ func (suite *HandlerSuite) TestListMTOsHandler() {
 	request := httptest.NewRequest("GET", "/move-task-orders", nil)
 
 	params := movetaskorderops.ListMTOsParams{HTTPRequest: request}
-	handlerConfig := suite.HandlerConfig()
+	handlerConfig := suite.NewHandlerConfig()
 
 	handler := ListMTOsHandler{
 		HandlerConfig:        handlerConfig,
@@ -78,7 +78,7 @@ func (suite *HandlerSuite) TestHideNonFakeMoveTaskOrdersHandler() {
 
 	suite.Run("successfully hide fake moves", func() {
 		handler := HideNonFakeMoveTaskOrdersHandlerFunc{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			movetaskorder.NewMoveTaskOrderHider(),
 		}
 		var moves models.Moves
@@ -113,7 +113,7 @@ func (suite *HandlerSuite) TestHideNonFakeMoveTaskOrdersHandler() {
 		}
 		mockHider := &mocks.MoveTaskOrderHider{}
 		handler := HideNonFakeMoveTaskOrdersHandlerFunc{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			mockHider,
 		}
 
@@ -141,7 +141,7 @@ func (suite *HandlerSuite) TestHideNonFakeMoveTaskOrdersHandler() {
 
 		mockHider := &mocks.MoveTaskOrderHider{}
 		handler := HideNonFakeMoveTaskOrdersHandlerFunc{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			mockHider,
 		}
 		mockHider.On("Hide",
@@ -168,7 +168,7 @@ func (suite *HandlerSuite) TestMakeMoveAvailableHandlerIntegrationSuccess() {
 		MoveTaskOrderID: move.ID.String(),
 		IfMatch:         etag.GenerateEtag(move.UpdatedAt),
 	}
-	handlerConfig := suite.HandlerConfig()
+	handlerConfig := suite.NewHandlerConfig()
 	queryBuilder := query.NewQueryBuilder()
 	moveRouter := moverouter.NewMoveRouter(transportationoffice.NewTransportationOfficesFetcher())
 	planner := &routemocks.Planner{}
@@ -230,7 +230,7 @@ func (suite *HandlerSuite) TestGetMoveTaskOrder() {
 	}
 	waf := entitlements.NewWeightAllotmentFetcher()
 
-	handlerConfig := suite.HandlerConfig()
+	handlerConfig := suite.NewHandlerConfig()
 	handler := GetMoveTaskOrderHandlerFunc{handlerConfig,
 		movetaskorder.NewMoveTaskOrderFetcher(waf),
 	}
@@ -307,7 +307,7 @@ func (suite *HandlerSuite) TestCreateMoveTaskOrderRequestHandler() {
 
 	setupHandler := func() CreateMoveTaskOrderHandler {
 		return CreateMoveTaskOrderHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			internalmovetaskorder.NewInternalMoveTaskOrderCreator(),
 		}
 	}
@@ -424,7 +424,7 @@ func (suite *HandlerSuite) TestCreateMoveTaskOrderRequestHandler() {
 		ppmEstimator := &mocks.PPMEstimator{}
 		// Submit the request to approve the MTO
 		approvalHandler := MakeMoveTaskOrderAvailableHandlerFunc{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			movetaskorder.NewMoveTaskOrderUpdater(queryBuilder, siCreator, moveRouter, setUpSignedCertificationCreatorMock(nil, nil), setUpSignedCertificationUpdaterMock(nil, nil), ppmEstimator),
 		}
 		approvalResponse := approvalHandler.Handle(approvalParams)
@@ -637,7 +637,7 @@ func (suite *HandlerSuite) TestCreateMoveTaskOrderRequestHandler() {
 		}
 
 		handler := CreateMoveTaskOrderHandler{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			internalmovetaskorder.NewInternalMoveTaskOrderCreator(),
 		}
 

--- a/pkg/handlers/supportapi/mto_service_item_test.go
+++ b/pkg/handlers/supportapi/mto_service_item_test.go
@@ -76,7 +76,7 @@ func (suite *HandlerSuite) TestUpdateMTOServiceItemStatusHandlerApproveSuccess()
 		IfMatch:          etag.GenerateEtag(mtoServiceItem.UpdatedAt),
 	}
 
-	handlerConfig := suite.HandlerConfig()
+	handlerConfig := suite.NewHandlerConfig()
 	queryBuilder := query.NewQueryBuilder()
 	moveRouter := moverouter.NewMoveRouter(transportationoffice.NewTransportationOfficesFetcher())
 	shipmentFetcher := mtoshipment.NewMTOShipmentFetcher()
@@ -133,7 +133,7 @@ func (suite *HandlerSuite) TestUpdateMTOServiceItemStatusHandlerRejectSuccess() 
 		IfMatch:          etag.GenerateEtag(mtoServiceItem.UpdatedAt),
 	}
 
-	handlerConfig := suite.HandlerConfig()
+	handlerConfig := suite.NewHandlerConfig()
 	queryBuilder := query.NewQueryBuilder()
 	moveRouter := moverouter.NewMoveRouter(transportationoffice.NewTransportationOfficesFetcher())
 	shipmentFetcher := mtoshipment.NewMTOShipmentFetcher()
@@ -190,7 +190,7 @@ func (suite *HandlerSuite) TestUpdateMTOServiceItemStatusHandlerRejectionFailedN
 		IfMatch:          etag.GenerateEtag(mtoServiceItem.UpdatedAt),
 	}
 
-	handlerConfig := suite.HandlerConfig()
+	handlerConfig := suite.NewHandlerConfig()
 	queryBuilder := query.NewQueryBuilder()
 	moveRouter := moverouter.NewMoveRouter(transportationoffice.NewTransportationOfficesFetcher())
 	shipmentFetcher := mtoshipment.NewMTOShipmentFetcher()

--- a/pkg/handlers/supportapi/mto_shipment_test.go
+++ b/pkg/handlers/supportapi/mto_shipment_test.go
@@ -114,7 +114,7 @@ func (suite *HandlerSuite) TestUpdateMTOShipmentStatusHandler() {
 
 	setupHandler := func() UpdateMTOShipmentStatusHandlerFunc {
 		return UpdateMTOShipmentStatusHandlerFunc{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			fetcher,
 			updater,
 		}
@@ -124,7 +124,7 @@ func (suite *HandlerSuite) TestUpdateMTOShipmentStatusHandler() {
 		mockFetcher := mocks.Fetcher{}
 		mockUpdater := mocks.MTOShipmentStatusUpdater{}
 		mockHandler := UpdateMTOShipmentStatusHandlerFunc{
-			suite.HandlerConfig(),
+			suite.NewHandlerConfig(),
 			&mockFetcher,
 			&mockUpdater,
 		}

--- a/pkg/handlers/supportapi/payment_request_test.go
+++ b/pkg/handlers/supportapi/payment_request_test.go
@@ -51,7 +51,7 @@ func (suite *HandlerSuite) TestUpdatePaymentRequestStatusHandler() {
 		queryBuilder := query.NewQueryBuilder()
 
 		handler := UpdatePaymentRequestStatusHandler{
-			HandlerConfig:               suite.HandlerConfig(),
+			HandlerConfig:               suite.NewHandlerConfig(),
 			PaymentRequestStatusUpdater: paymentrequest.NewPaymentRequestStatusUpdater(queryBuilder),
 			PaymentRequestFetcher:       paymentrequest.NewPaymentRequestFetcher(),
 		}
@@ -92,7 +92,7 @@ func (suite *HandlerSuite) TestUpdatePaymentRequestStatusHandler() {
 		queryBuilder := query.NewQueryBuilder()
 
 		handler := UpdatePaymentRequestStatusHandler{
-			HandlerConfig:               suite.HandlerConfig(),
+			HandlerConfig:               suite.NewHandlerConfig(),
 			PaymentRequestStatusUpdater: paymentrequest.NewPaymentRequestStatusUpdater(queryBuilder),
 			PaymentRequestFetcher:       paymentrequest.NewPaymentRequestFetcher(),
 		}
@@ -126,7 +126,7 @@ func (suite *HandlerSuite) TestUpdatePaymentRequestStatusHandler() {
 		}
 
 		handler := UpdatePaymentRequestStatusHandler{
-			HandlerConfig:               suite.HandlerConfig(),
+			HandlerConfig:               suite.NewHandlerConfig(),
 			PaymentRequestStatusUpdater: paymentRequestStatusUpdater,
 			PaymentRequestFetcher:       paymentRequestFetcher,
 		}
@@ -159,7 +159,7 @@ func (suite *HandlerSuite) TestUpdatePaymentRequestStatusHandler() {
 		}
 
 		handler := UpdatePaymentRequestStatusHandler{
-			HandlerConfig:               suite.HandlerConfig(),
+			HandlerConfig:               suite.NewHandlerConfig(),
 			PaymentRequestStatusUpdater: paymentRequestStatusUpdater,
 			PaymentRequestFetcher:       paymentRequestFetcher,
 		}
@@ -189,7 +189,7 @@ func (suite *HandlerSuite) TestUpdatePaymentRequestStatusHandler() {
 		}
 
 		handler := UpdatePaymentRequestStatusHandler{
-			HandlerConfig:               suite.HandlerConfig(),
+			HandlerConfig:               suite.NewHandlerConfig(),
 			PaymentRequestStatusUpdater: paymentRequestStatusUpdater,
 			PaymentRequestFetcher:       paymentRequestFetcher,
 		}
@@ -218,7 +218,7 @@ func (suite *HandlerSuite) TestUpdatePaymentRequestStatusHandler() {
 		}
 
 		handler := UpdatePaymentRequestStatusHandler{
-			HandlerConfig:               suite.HandlerConfig(),
+			HandlerConfig:               suite.NewHandlerConfig(),
 			PaymentRequestStatusUpdater: paymentRequestStatusUpdater,
 			PaymentRequestFetcher:       paymentRequestFetcher,
 		}
@@ -241,7 +241,7 @@ func (suite *HandlerSuite) TestListMTOPaymentRequestHandler() {
 		}
 
 		handler := ListMTOPaymentRequestsHandler{
-			HandlerConfig: suite.HandlerConfig(),
+			HandlerConfig: suite.NewHandlerConfig(),
 		}
 
 		response := handler.Handle(params)
@@ -263,7 +263,7 @@ func (suite *HandlerSuite) TestListMTOPaymentRequestHandler() {
 		}
 
 		handler := ListMTOPaymentRequestsHandler{
-			HandlerConfig: suite.HandlerConfig(),
+			HandlerConfig: suite.NewHandlerConfig(),
 		}
 
 		response := handler.Handle(params)
@@ -338,7 +338,7 @@ func (suite *HandlerSuite) TestGetPaymentRequestEDIHandler() {
 	setupHandler := func() GetPaymentRequestEDIHandler {
 		icnSequencer := sequence.NewDatabaseSequencer(ediinvoice.ICNSequenceName)
 		return GetPaymentRequestEDIHandler{
-			HandlerConfig:                     suite.HandlerConfig(),
+			HandlerConfig:                     suite.NewHandlerConfig(),
 			PaymentRequestFetcher:             paymentrequest.NewPaymentRequestFetcher(),
 			GHCPaymentRequestInvoiceGenerator: invoice.NewGHCPaymentRequestInvoiceGenerator(icnSequencer, clock.NewMock(), loaFetcher),
 		}
@@ -417,7 +417,7 @@ func (suite *HandlerSuite) TestGetPaymentRequestEDIHandler() {
 		mockGenerator.On("Generate", mock.AnythingOfType("*appcontext.appContext"), mock.Anything, mock.Anything).Return(ediinvoice.Invoice858C{}, apperror.NewInvalidInputError(paymentRequest.ID, nil, validate.NewErrors(), ""))
 
 		mockGeneratorHandler := GetPaymentRequestEDIHandler{
-			HandlerConfig:                     suite.HandlerConfig(),
+			HandlerConfig:                     suite.NewHandlerConfig(),
 			PaymentRequestFetcher:             paymentrequest.NewPaymentRequestFetcher(),
 			GHCPaymentRequestInvoiceGenerator: mockGenerator,
 		}
@@ -440,7 +440,7 @@ func (suite *HandlerSuite) TestGetPaymentRequestEDIHandler() {
 		mockGenerator.On("Generate", mock.AnythingOfType("*appcontext.appContext"), mock.Anything, mock.Anything).Return(ediinvoice.Invoice858C{}, apperror.NewConflictError(paymentRequest.ID, "conflict error"))
 
 		mockGeneratorHandler := GetPaymentRequestEDIHandler{
-			HandlerConfig:                     suite.HandlerConfig(),
+			HandlerConfig:                     suite.NewHandlerConfig(),
 			PaymentRequestFetcher:             paymentrequest.NewPaymentRequestFetcher(),
 			GHCPaymentRequestInvoiceGenerator: mockGenerator,
 		}
@@ -478,7 +478,7 @@ func (suite *HandlerSuite) TestGetPaymentRequestEDIHandler() {
 		mockGenerator.On("Generate", mock.AnythingOfType("*appcontext.appContext"), mock.Anything, mock.Anything).Return(ediinvoice.Invoice858C{}, errors.New(errStr)).Once()
 
 		mockGeneratorHandler := GetPaymentRequestEDIHandler{
-			HandlerConfig:                     suite.HandlerConfig(),
+			HandlerConfig:                     suite.NewHandlerConfig(),
 			PaymentRequestFetcher:             paymentrequest.NewPaymentRequestFetcher(),
 			GHCPaymentRequestInvoiceGenerator: mockGenerator,
 		}
@@ -627,7 +627,7 @@ func (suite *HandlerSuite) TestProcessReviewedPaymentRequestsHandler() {
 
 		paymentRequestFetcher := &mocks.PaymentRequestFetcher{}
 		paymentRequestFetcher.On("FetchPaymentRequest", mock.AnythingOfType("*appcontext.appContext"), mock.Anything).Return(reviewedPRs[0], nil)
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 		handlerConfig.SetICNSequencer(sequence.NewDatabaseSequencer(ediinvoice.ICNSequenceName))
 		handler := ProcessReviewedPaymentRequestsHandler{
 			HandlerConfig:                 handlerConfig,
@@ -787,7 +787,7 @@ func (suite *HandlerSuite) TestProcessReviewedPaymentRequestsHandler() {
 		paymentRequestFetcher.On("FetchPaymentRequest", mock.AnythingOfType("*appcontext.appContext"), mock.Anything).Return(nilPr, errors.New("could not fetch payment request"))
 
 		handler := ProcessReviewedPaymentRequestsHandler{
-			HandlerConfig:                 suite.HandlerConfig(),
+			HandlerConfig:                 suite.NewHandlerConfig(),
 			PaymentRequestFetcher:         paymentRequestFetcher,
 			PaymentRequestStatusUpdater:   paymentRequestStatusUpdater,
 			PaymentRequestReviewedFetcher: paymentRequestReviewedFetcher,
@@ -827,7 +827,7 @@ func (suite *HandlerSuite) TestProcessReviewedPaymentRequestsHandler() {
 		paymentRequestFetcher.On("FetchPaymentRequest", mock.AnythingOfType("*appcontext.appContext"), mock.Anything).Return(reviewedPRs[0], nil)
 
 		handler := ProcessReviewedPaymentRequestsHandler{
-			HandlerConfig:                 suite.HandlerConfig(),
+			HandlerConfig:                 suite.NewHandlerConfig(),
 			PaymentRequestFetcher:         paymentRequestFetcher,
 			PaymentRequestStatusUpdater:   paymentRequestStatusUpdater,
 			PaymentRequestReviewedFetcher: paymentRequestReviewedFetcher,
@@ -876,7 +876,7 @@ func (suite *HandlerSuite) TestRecalculatePaymentRequestHandler() {
 			paymentRequestID,
 		).Return(&samplePaymentRequest, nil).Once()
 		handler := RecalculatePaymentRequestHandler{
-			HandlerConfig:              suite.HandlerConfig(),
+			HandlerConfig:              suite.NewHandlerConfig(),
 			PaymentRequestRecalculator: mockRecalculator,
 		}
 
@@ -950,7 +950,7 @@ func (suite *HandlerSuite) TestRecalculatePaymentRequestHandler() {
 				paymentRequestID,
 			).Return(nil, testCase.testErr)
 			handler := RecalculatePaymentRequestHandler{
-				HandlerConfig:              suite.HandlerConfig(),
+				HandlerConfig:              suite.NewHandlerConfig(),
 				PaymentRequestRecalculator: mockRecalculator,
 			}
 

--- a/pkg/handlers/supportapi/webhook_notification_test.go
+++ b/pkg/handlers/supportapi/webhook_notification_test.go
@@ -40,7 +40,7 @@ func (suite *HandlerSuite) TestCreateWebhookNotification() {
 			Body:        requestPayload,
 		}
 
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 		handler := CreateWebhookNotificationHandler{handlerConfig}
 
 		// CALL FUNCTION UNDER TEST
@@ -77,7 +77,7 @@ func (suite *HandlerSuite) TestCreateWebhookNotification() {
 			HTTPRequest: request,
 		}
 
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 		handler := CreateWebhookNotificationHandler{handlerConfig}
 
 		// CALL FUNCTION UNDER TEST
@@ -122,7 +122,7 @@ func (suite *HandlerSuite) TestCreateWebhookNotification() {
 			Body:        requestPayload,
 		}
 
-		handlerConfig := suite.HandlerConfig()
+		handlerConfig := suite.NewHandlerConfig()
 		handler := CreateWebhookNotificationHandler{handlerConfig}
 
 		// CALL FUNCTION UNDER TEST

--- a/pkg/handlers/testharnessapi/api_test.go
+++ b/pkg/handlers/testharnessapi/api_test.go
@@ -34,7 +34,7 @@ func (suite *TestHarnessAPISuite) TestNewDefaultBuilderNoAcceptHeader() {
 	chiRouteCtx.URLParams.Add("action", "DefaultMove")
 	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, chiRouteCtx))
 	rr := httptest.NewRecorder()
-	handler := NewDefaultBuilder(suite.HandlerConfig())
+	handler := NewDefaultBuilder(suite.NewHandlerConfig())
 	handler.ServeHTTP(rr, req)
 
 	suite.Equal(http.StatusOK, rr.Code)
@@ -49,7 +49,7 @@ func (suite *TestHarnessAPISuite) TestNewDefaultBuilderWithAcceptHeader() {
 	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, chiRouteCtx))
 	req.Header.Add("Accept", "text/html")
 	rr := httptest.NewRecorder()
-	handler := NewDefaultBuilder(suite.HandlerConfig())
+	handler := NewDefaultBuilder(suite.NewHandlerConfig())
 	handler.ServeHTTP(rr, req)
 
 	suite.Equal(http.StatusOK, rr.Code)
@@ -60,7 +60,7 @@ func (suite *TestHarnessAPISuite) TestNewDefaultBuilderWithAcceptHeader() {
 func (suite *TestHarnessAPISuite) TestNewBuilderList() {
 	req := httptest.NewRequest("POST", "/list", nil)
 	rr := httptest.NewRecorder()
-	handler := NewBuilderList(suite.HandlerConfig())
+	handler := NewBuilderList(suite.NewHandlerConfig())
 	handler.ServeHTTP(rr, req)
 
 	suite.Equal(http.StatusOK, rr.Code)

--- a/pkg/models/roles/roles.go
+++ b/pkg/models/roles/roles.go
@@ -1,6 +1,7 @@
 package roles
 
 import (
+	"errors"
 	"time"
 
 	"github.com/gobuffalo/pop/v6"
@@ -56,6 +57,23 @@ func (r Role) TableName() string {
 
 // Roles is a slice of Role objects
 type Roles []Role
+
+// Default returns the Role whose RoleName is first alphabetically.
+// Returns an error if the slice is empty.
+func (r Roles) Default() (*Role, error) {
+	if len(r) == 0 {
+		return nil, errors.New("no roles available")
+	}
+	earliestRole := r[0]
+	// Loop over each role recording the earliest alphabet character we can find
+	for _, role := range r[1:] {
+		// Go lets us compare strings with > and <
+		if role.RoleName < earliestRole.RoleName {
+			earliestRole = role
+		}
+	}
+	return &earliestRole, nil
+}
 
 // HasRole validates if Role has a role of a particular type
 func (rs Roles) HasRole(roleType RoleType) bool {

--- a/pkg/services/lock_move/move_locker_test.go
+++ b/pkg/services/lock_move/move_locker_test.go
@@ -21,7 +21,7 @@ func (suite *MoveLockerServiceSuite) TestLockMove() {
 		suite.FatalNoError(err)
 		appCtx := suite.AppContextWithSessionForTest(&auth.Session{
 			ApplicationName: auth.OfficeApp,
-			CurrentRole:     *defaultRole,
+			ActiveRole:      *defaultRole,
 			OfficeUserID:    tooUser.ID,
 			IDToken:         "fake_token",
 			AccessToken:     "fakeAccessToken",
@@ -48,7 +48,7 @@ func (suite *MoveLockerServiceSuite) TestLockMove() {
 		suite.FatalNoError(err)
 		appCtx := suite.AppContextWithSessionForTest(&auth.Session{
 			ApplicationName: auth.OfficeApp,
-			CurrentRole:     *defaultRole,
+			ActiveRole:      *defaultRole,
 			OfficeUserID:    tooUser.ID,
 			IDToken:         "fake_token",
 			AccessToken:     "fakeAccessToken",
@@ -75,7 +75,7 @@ func (suite *MoveLockerServiceSuite) TestLockMoves() {
 		suite.FatalNoError(err)
 		appCtx := suite.AppContextWithSessionForTest(&auth.Session{
 			ApplicationName: auth.OfficeApp,
-			CurrentRole:     *defaultRole,
+			ActiveRole:      *defaultRole,
 			OfficeUserID:    tooUser.ID,
 			IDToken:         "fake_token",
 			AccessToken:     "fakeAccessToken",
@@ -127,7 +127,7 @@ func (suite *MoveLockerServiceSuite) TestLockMoves() {
 		suite.FatalNoError(err)
 		appCtx := suite.AppContextWithSessionForTest(&auth.Session{
 			ApplicationName: auth.OfficeApp,
-			CurrentRole:     *defaultRole,
+			ActiveRole:      *defaultRole,
 			OfficeUserID:    tooUser.ID,
 			IDToken:         "fake_token",
 			AccessToken:     "fakeAccessToken",

--- a/pkg/services/lock_move/move_locker_test.go
+++ b/pkg/services/lock_move/move_locker_test.go
@@ -17,9 +17,11 @@ func (suite *MoveLockerServiceSuite) TestLockMove() {
 
 	suite.Run("successfully returns move with office user values and lockExpiresAt value", func() {
 		tooUser := factory.BuildOfficeUserWithRoles(suite.DB(), nil, []roles.RoleType{roles.RoleTypeTOO})
+		defaultRole, err := tooUser.User.Roles.Default()
+		suite.FatalNoError(err)
 		appCtx := suite.AppContextWithSessionForTest(&auth.Session{
 			ApplicationName: auth.OfficeApp,
-			Roles:           tooUser.User.Roles,
+			CurrentRole:     *defaultRole,
 			OfficeUserID:    tooUser.ID,
 			IDToken:         "fake_token",
 			AccessToken:     "fakeAccessToken",
@@ -42,9 +44,11 @@ func (suite *MoveLockerServiceSuite) TestLockMove() {
 
 	suite.Run("locking a move doesn't change the moves updated_at value", func() {
 		tooUser := factory.BuildOfficeUserWithRoles(suite.DB(), nil, []roles.RoleType{roles.RoleTypeTOO})
+		defaultRole, err := tooUser.User.Roles.Default()
+		suite.FatalNoError(err)
 		appCtx := suite.AppContextWithSessionForTest(&auth.Session{
 			ApplicationName: auth.OfficeApp,
-			Roles:           tooUser.User.Roles,
+			CurrentRole:     *defaultRole,
 			OfficeUserID:    tooUser.ID,
 			IDToken:         "fake_token",
 			AccessToken:     "fakeAccessToken",
@@ -67,9 +71,11 @@ func (suite *MoveLockerServiceSuite) TestLockMoves() {
 
 	suite.Run("successfully returns move with office user values and lockExpiresAt value", func() {
 		tooUser := factory.BuildOfficeUserWithRoles(suite.DB(), nil, []roles.RoleType{roles.RoleTypeTOO})
+		defaultRole, err := tooUser.User.Roles.Default()
+		suite.FatalNoError(err)
 		appCtx := suite.AppContextWithSessionForTest(&auth.Session{
 			ApplicationName: auth.OfficeApp,
-			Roles:           tooUser.User.Roles,
+			CurrentRole:     *defaultRole,
 			OfficeUserID:    tooUser.ID,
 			IDToken:         "fake_token",
 			AccessToken:     "fakeAccessToken",
@@ -85,7 +91,7 @@ func (suite *MoveLockerServiceSuite) TestLockMoves() {
 		idsToLock[1] = move2.ID
 		idsToLock[2] = move3.ID
 
-		err := moveLocker.LockMoves(appCtx, idsToLock, tooUser.ID)
+		err = moveLocker.LockMoves(appCtx, idsToLock, tooUser.ID)
 		suite.FatalNoError(err)
 
 		moveFetcher := movefetcher.NewMoveFetcher()
@@ -117,9 +123,11 @@ func (suite *MoveLockerServiceSuite) TestLockMoves() {
 
 	suite.Run("locking moves doesn't change the moves' updated_at value", func() {
 		tooUser := factory.BuildOfficeUserWithRoles(suite.DB(), nil, []roles.RoleType{roles.RoleTypeTOO})
+		defaultRole, err := tooUser.User.Roles.Default()
+		suite.FatalNoError(err)
 		appCtx := suite.AppContextWithSessionForTest(&auth.Session{
 			ApplicationName: auth.OfficeApp,
-			Roles:           tooUser.User.Roles,
+			CurrentRole:     *defaultRole,
 			OfficeUserID:    tooUser.ID,
 			IDToken:         "fake_token",
 			AccessToken:     "fakeAccessToken",
@@ -132,7 +140,7 @@ func (suite *MoveLockerServiceSuite) TestLockMoves() {
 		idsToLock[0] = move1.ID
 		idsToLock[1] = move2.ID
 
-		err := moveLocker.LockMoves(appCtx, idsToLock, tooUser.ID)
+		err = moveLocker.LockMoves(appCtx, idsToLock, tooUser.ID)
 		suite.FatalNoError(err)
 
 		moveFetcher := movefetcher.NewMoveFetcher()

--- a/pkg/services/lock_move/move_unlocker_test.go
+++ b/pkg/services/lock_move/move_unlocker_test.go
@@ -13,9 +13,11 @@ func (suite *MoveLockerServiceSuite) TestMoveUnlocker() {
 
 	suite.Run("successfully returns move with no values in locked_by or lock_expires_at column", func() {
 		tooUser := factory.BuildOfficeUserWithRoles(suite.DB(), nil, []roles.RoleType{roles.RoleTypeTOO})
+		defaultRole, err := tooUser.User.Roles.Default()
+		suite.FatalNoError(err)
 		appCtx := suite.AppContextWithSessionForTest(&auth.Session{
 			ApplicationName: auth.OfficeApp,
-			Roles:           tooUser.User.Roles,
+			CurrentRole:     *defaultRole,
 			OfficeUserID:    tooUser.ID,
 			IDToken:         "fake_token",
 			AccessToken:     "fakeAccessToken",
@@ -48,9 +50,11 @@ func (suite *MoveLockerServiceSuite) TestCheckForLockedMovesAndUnlock() {
 
 	suite.Run("successfully clears all moves that user has locked", func() {
 		tooUser := factory.BuildOfficeUserWithRoles(suite.DB(), nil, []roles.RoleType{roles.RoleTypeTOO})
+		defaultRole, err := tooUser.User.Roles.Default()
+		suite.FatalNoError(err)
 		appCtx := suite.AppContextWithSessionForTest(&auth.Session{
 			ApplicationName: auth.OfficeApp,
-			Roles:           tooUser.User.Roles,
+			CurrentRole:     *defaultRole,
 			OfficeUserID:    tooUser.ID,
 			IDToken:         "fake_token",
 			AccessToken:     "fakeAccessToken",
@@ -107,9 +111,11 @@ func (suite *MoveLockerServiceSuite) TestCheckForLockedMovesAndUnlock() {
 
 	suite.Run("successfully unlock move without changing updated_at", func() {
 		tooUser := factory.BuildOfficeUserWithRoles(suite.DB(), nil, []roles.RoleType{roles.RoleTypeTOO})
+		defaultRole, err := tooUser.User.Roles.Default()
+		suite.FatalNoError(err)
 		appCtx := suite.AppContextWithSessionForTest(&auth.Session{
 			ApplicationName: auth.OfficeApp,
-			Roles:           tooUser.User.Roles,
+			CurrentRole:     *defaultRole,
 			OfficeUserID:    tooUser.ID,
 			IDToken:         "fake_token",
 			AccessToken:     "fakeAccessToken",

--- a/pkg/services/lock_move/move_unlocker_test.go
+++ b/pkg/services/lock_move/move_unlocker_test.go
@@ -17,7 +17,7 @@ func (suite *MoveLockerServiceSuite) TestMoveUnlocker() {
 		suite.FatalNoError(err)
 		appCtx := suite.AppContextWithSessionForTest(&auth.Session{
 			ApplicationName: auth.OfficeApp,
-			CurrentRole:     *defaultRole,
+			ActiveRole:      *defaultRole,
 			OfficeUserID:    tooUser.ID,
 			IDToken:         "fake_token",
 			AccessToken:     "fakeAccessToken",
@@ -54,7 +54,7 @@ func (suite *MoveLockerServiceSuite) TestCheckForLockedMovesAndUnlock() {
 		suite.FatalNoError(err)
 		appCtx := suite.AppContextWithSessionForTest(&auth.Session{
 			ApplicationName: auth.OfficeApp,
-			CurrentRole:     *defaultRole,
+			ActiveRole:      *defaultRole,
 			OfficeUserID:    tooUser.ID,
 			IDToken:         "fake_token",
 			AccessToken:     "fakeAccessToken",
@@ -115,7 +115,7 @@ func (suite *MoveLockerServiceSuite) TestCheckForLockedMovesAndUnlock() {
 		suite.FatalNoError(err)
 		appCtx := suite.AppContextWithSessionForTest(&auth.Session{
 			ApplicationName: auth.OfficeApp,
-			CurrentRole:     *defaultRole,
+			ActiveRole:      *defaultRole,
 			OfficeUserID:    tooUser.ID,
 			IDToken:         "fake_token",
 			AccessToken:     "fakeAccessToken",

--- a/pkg/services/move/move_searcher_test.go
+++ b/pkg/services/move/move_searcher_test.go
@@ -15,9 +15,11 @@ func (suite *MoveServiceSuite) TestMoveSearch() {
 
 	suite.Run("search with no filters should fail", func() {
 		qaeUser := factory.BuildOfficeUserWithRoles(suite.DB(), nil, []roles.RoleType{roles.RoleTypeQae})
+		defaultRole, err := qaeUser.User.Roles.Default()
+		suite.FatalNoError(err)
 		session := auth.Session{
 			ApplicationName: auth.OfficeApp,
-			Roles:           qaeUser.User.Roles,
+			CurrentRole:     *defaultRole,
 			OfficeUserID:    qaeUser.ID,
 			IDToken:         "fake_token",
 			AccessToken:     "fakeAccessToken",
@@ -39,14 +41,16 @@ func (suite *MoveServiceSuite) TestMoveSearch() {
 			},
 		}, nil)
 
-		_, _, err := searcher.SearchMoves(suite.AppContextWithSessionForTest(&session), &services.SearchMovesParams{})
+		_, _, err = searcher.SearchMoves(suite.AppContextWithSessionForTest(&session), &services.SearchMovesParams{})
 		suite.Error(err)
 	})
 	suite.Run("search with valid locator", func() {
 		qaeUser := factory.BuildOfficeUserWithRoles(suite.DB(), nil, []roles.RoleType{roles.RoleTypeQae})
+		defaultRole, err := qaeUser.User.Roles.Default()
+		suite.FatalNoError(err)
 		session := auth.Session{
 			ApplicationName: auth.OfficeApp,
-			Roles:           qaeUser.User.Roles,
+			CurrentRole:     *defaultRole,
 			OfficeUserID:    qaeUser.ID,
 			IDToken:         "fake_token",
 			AccessToken:     "fakeAccessToken",
@@ -75,9 +79,11 @@ func (suite *MoveServiceSuite) TestMoveSearch() {
 	})
 	suite.Run("search with valid DOD ID", func() {
 		qaeUser := factory.BuildOfficeUserWithRoles(suite.DB(), nil, []roles.RoleType{roles.RoleTypeQae})
+		defaultRole, err := qaeUser.User.Roles.Default()
+		suite.FatalNoError(err)
 		session := auth.Session{
 			ApplicationName: auth.OfficeApp,
-			Roles:           qaeUser.User.Roles,
+			CurrentRole:     *defaultRole,
 			OfficeUserID:    qaeUser.ID,
 			IDToken:         "fake_token",
 			AccessToken:     "fakeAccessToken",
@@ -106,9 +112,11 @@ func (suite *MoveServiceSuite) TestMoveSearch() {
 	})
 	suite.Run("search with customer name", func() {
 		qaeUser := factory.BuildOfficeUserWithRoles(suite.DB(), nil, []roles.RoleType{roles.RoleTypeQae})
+		defaultRole, err := qaeUser.User.Roles.Default()
+		suite.FatalNoError(err)
 		session := auth.Session{
 			ApplicationName: auth.OfficeApp,
-			Roles:           qaeUser.User.Roles,
+			CurrentRole:     *defaultRole,
 			OfficeUserID:    qaeUser.ID,
 			IDToken:         "fake_token",
 			AccessToken:     "fakeAccessToken",
@@ -143,9 +151,11 @@ func (suite *MoveServiceSuite) TestMoveSearch() {
 	})
 	suite.Run("search with both DOD ID and locator filters should fail", func() {
 		qaeUser := factory.BuildOfficeUserWithRoles(suite.DB(), nil, []roles.RoleType{roles.RoleTypeQae})
+		defaultRole, err := qaeUser.User.Roles.Default()
+		suite.FatalNoError(err)
 		session := auth.Session{
 			ApplicationName: auth.OfficeApp,
-			Roles:           qaeUser.User.Roles,
+			CurrentRole:     *defaultRole,
 			OfficeUserID:    qaeUser.ID,
 			IDToken:         "fake_token",
 			AccessToken:     "fakeAccessToken",
@@ -168,7 +178,7 @@ func (suite *MoveServiceSuite) TestMoveSearch() {
 		}, nil)
 
 		// Search for Locator of one move and DOD ID of another move
-		_, _, err := searcher.SearchMoves(suite.AppContextWithSessionForTest(&session), &services.SearchMovesParams{
+		_, _, err = searcher.SearchMoves(suite.AppContextWithSessionForTest(&session), &services.SearchMovesParams{
 			Locator: &firstMove.Locator,
 			DodID:   secondMove.Orders.ServiceMember.Edipi,
 		})
@@ -176,9 +186,11 @@ func (suite *MoveServiceSuite) TestMoveSearch() {
 	})
 	suite.Run("search with no results", func() {
 		qaeUser := factory.BuildOfficeUserWithRoles(suite.DB(), nil, []roles.RoleType{roles.RoleTypeQae})
+		defaultRole, err := qaeUser.User.Roles.Default()
+		suite.FatalNoError(err)
 		session := auth.Session{
 			ApplicationName: auth.OfficeApp,
-			Roles:           qaeUser.User.Roles,
+			CurrentRole:     *defaultRole,
 			OfficeUserID:    qaeUser.ID,
 			IDToken:         "fake_token",
 			AccessToken:     "fakeAccessToken",
@@ -191,9 +203,11 @@ func (suite *MoveServiceSuite) TestMoveSearch() {
 	})
 	suite.Run("test pagination", func() {
 		qaeUser := factory.BuildOfficeUserWithRoles(suite.DB(), nil, []roles.RoleType{roles.RoleTypeQae})
+		defaultRole, err := qaeUser.User.Roles.Default()
+		suite.FatalNoError(err)
 		session := auth.Session{
 			ApplicationName: auth.OfficeApp,
-			Roles:           qaeUser.User.Roles,
+			CurrentRole:     *defaultRole,
 			OfficeUserID:    qaeUser.ID,
 			IDToken:         "fake_token",
 			AccessToken:     "fakeAccessToken",
@@ -251,9 +265,11 @@ func (suite *MoveServiceSuite) TestMoveSearch() {
 	suite.Run("filtering mto shipments search results", func() {
 		qaeUser := factory.BuildOfficeUserWithRoles(suite.DB(), nil, []roles.RoleType{roles.RoleTypeQae})
 
+		defaultRole, err := qaeUser.User.Roles.Default()
+		suite.FatalNoError(err)
 		session := auth.Session{
 			ApplicationName: auth.OfficeApp,
-			Roles:           qaeUser.User.Roles,
+			CurrentRole:     *defaultRole,
 			OfficeUserID:    qaeUser.ID,
 			IDToken:         "fake_token",
 			AccessToken:     "fakeAccessToken",
@@ -458,9 +474,11 @@ func (suite *MoveServiceSuite) TestMoveSearchOrdering() {
 		suite.NoError(suite.DB().EagerPreload("Orders", "Orders.NewDutyLocation", "Orders.NewDutyLocation.Address").All(&testMoves))
 
 		qaeUser := factory.BuildOfficeUserWithRoles(suite.DB(), nil, []roles.RoleType{roles.RoleTypeQae})
+		defaultRole, err := qaeUser.User.Roles.Default()
+		suite.FatalNoError(err)
 		session := auth.Session{
 			ApplicationName: auth.OfficeApp,
-			Roles:           qaeUser.User.Roles,
+			CurrentRole:     *defaultRole,
 			OfficeUserID:    qaeUser.ID,
 			IDToken:         "fake_token",
 			AccessToken:     "fakeAccessToken",
@@ -496,9 +514,11 @@ func (suite *MoveServiceSuite) TestMoveSearchOrdering() {
 		searcher := NewMoveSearcher()
 
 		qaeUser := factory.BuildOfficeUserWithRoles(suite.DB(), nil, []roles.RoleType{roles.RoleTypeQae})
+		defaultRole, err := qaeUser.User.Roles.Default()
+		suite.FatalNoError(err)
 		session := auth.Session{
 			ApplicationName: auth.OfficeApp,
-			Roles:           qaeUser.User.Roles,
+			CurrentRole:     *defaultRole,
 			OfficeUserID:    qaeUser.ID,
 			IDToken:         "fake_token",
 			AccessToken:     "fakeAccessToken",

--- a/pkg/services/move/move_searcher_test.go
+++ b/pkg/services/move/move_searcher_test.go
@@ -19,7 +19,7 @@ func (suite *MoveServiceSuite) TestMoveSearch() {
 		suite.FatalNoError(err)
 		session := auth.Session{
 			ApplicationName: auth.OfficeApp,
-			CurrentRole:     *defaultRole,
+			ActiveRole:      *defaultRole,
 			OfficeUserID:    qaeUser.ID,
 			IDToken:         "fake_token",
 			AccessToken:     "fakeAccessToken",
@@ -50,7 +50,7 @@ func (suite *MoveServiceSuite) TestMoveSearch() {
 		suite.FatalNoError(err)
 		session := auth.Session{
 			ApplicationName: auth.OfficeApp,
-			CurrentRole:     *defaultRole,
+			ActiveRole:      *defaultRole,
 			OfficeUserID:    qaeUser.ID,
 			IDToken:         "fake_token",
 			AccessToken:     "fakeAccessToken",
@@ -83,7 +83,7 @@ func (suite *MoveServiceSuite) TestMoveSearch() {
 		suite.FatalNoError(err)
 		session := auth.Session{
 			ApplicationName: auth.OfficeApp,
-			CurrentRole:     *defaultRole,
+			ActiveRole:      *defaultRole,
 			OfficeUserID:    qaeUser.ID,
 			IDToken:         "fake_token",
 			AccessToken:     "fakeAccessToken",
@@ -116,7 +116,7 @@ func (suite *MoveServiceSuite) TestMoveSearch() {
 		suite.FatalNoError(err)
 		session := auth.Session{
 			ApplicationName: auth.OfficeApp,
-			CurrentRole:     *defaultRole,
+			ActiveRole:      *defaultRole,
 			OfficeUserID:    qaeUser.ID,
 			IDToken:         "fake_token",
 			AccessToken:     "fakeAccessToken",
@@ -155,7 +155,7 @@ func (suite *MoveServiceSuite) TestMoveSearch() {
 		suite.FatalNoError(err)
 		session := auth.Session{
 			ApplicationName: auth.OfficeApp,
-			CurrentRole:     *defaultRole,
+			ActiveRole:      *defaultRole,
 			OfficeUserID:    qaeUser.ID,
 			IDToken:         "fake_token",
 			AccessToken:     "fakeAccessToken",
@@ -190,7 +190,7 @@ func (suite *MoveServiceSuite) TestMoveSearch() {
 		suite.FatalNoError(err)
 		session := auth.Session{
 			ApplicationName: auth.OfficeApp,
-			CurrentRole:     *defaultRole,
+			ActiveRole:      *defaultRole,
 			OfficeUserID:    qaeUser.ID,
 			IDToken:         "fake_token",
 			AccessToken:     "fakeAccessToken",
@@ -207,7 +207,7 @@ func (suite *MoveServiceSuite) TestMoveSearch() {
 		suite.FatalNoError(err)
 		session := auth.Session{
 			ApplicationName: auth.OfficeApp,
-			CurrentRole:     *defaultRole,
+			ActiveRole:      *defaultRole,
 			OfficeUserID:    qaeUser.ID,
 			IDToken:         "fake_token",
 			AccessToken:     "fakeAccessToken",
@@ -269,7 +269,7 @@ func (suite *MoveServiceSuite) TestMoveSearch() {
 		suite.FatalNoError(err)
 		session := auth.Session{
 			ApplicationName: auth.OfficeApp,
-			CurrentRole:     *defaultRole,
+			ActiveRole:      *defaultRole,
 			OfficeUserID:    qaeUser.ID,
 			IDToken:         "fake_token",
 			AccessToken:     "fakeAccessToken",
@@ -478,7 +478,7 @@ func (suite *MoveServiceSuite) TestMoveSearchOrdering() {
 		suite.FatalNoError(err)
 		session := auth.Session{
 			ApplicationName: auth.OfficeApp,
-			CurrentRole:     *defaultRole,
+			ActiveRole:      *defaultRole,
 			OfficeUserID:    qaeUser.ID,
 			IDToken:         "fake_token",
 			AccessToken:     "fakeAccessToken",
@@ -518,7 +518,7 @@ func (suite *MoveServiceSuite) TestMoveSearchOrdering() {
 		suite.FatalNoError(err)
 		session := auth.Session{
 			ApplicationName: auth.OfficeApp,
-			CurrentRole:     *defaultRole,
+			ActiveRole:      *defaultRole,
 			OfficeUserID:    qaeUser.ID,
 			IDToken:         "fake_token",
 			AccessToken:     "fakeAccessToken",

--- a/pkg/services/mto_shipment/mto_shipment_updater_test.go
+++ b/pkg/services/mto_shipment/mto_shipment_updater_test.go
@@ -1174,7 +1174,7 @@ func (suite *MTOShipmentServiceSuite) TestMTOShipmentUpdater() {
 		}
 		defaultRole, err := too.User.Roles.Default()
 		suite.FatalNoError(err)
-		session.CurrentRole = *defaultRole
+		session.ActiveRole = *defaultRole
 		newShipment, err := mtoShipmentUpdaterOffice.UpdateMTOShipment(suite.AppContextWithSessionForTest(&session), &updatedShipment, eTag, "test")
 
 		suite.Require().NoError(err)
@@ -1391,7 +1391,7 @@ func (suite *MTOShipmentServiceSuite) TestMTOShipmentUpdater() {
 		}
 		defaultRole, err := too.User.Roles.Default()
 		suite.FatalNoError(err)
-		session.CurrentRole = *defaultRole
+		session.ActiveRole = *defaultRole
 		updatedMTOShipment, err := mtoShipmentUpdaterOffice.UpdateMTOShipment(suite.AppContextWithSessionForTest(&session), &updatedShipment, eTag, "test")
 
 		suite.Require().NoError(err)
@@ -1458,7 +1458,7 @@ func (suite *MTOShipmentServiceSuite) TestMTOShipmentUpdater() {
 		}
 		defaultRole, err := too.User.Roles.Default()
 		suite.FatalNoError(err)
-		session.CurrentRole = *defaultRole
+		session.ActiveRole = *defaultRole
 		updatedShipment, err := mtoShipmentUpdaterOffice.UpdateMTOShipment(suite.AppContextWithSessionForTest(&session), &newShipment, eTag, "test")
 		suite.Require().NoError(err)
 		suite.NotEqual(uuid.Nil, updatedShipment.ID)
@@ -1492,7 +1492,7 @@ func (suite *MTOShipmentServiceSuite) TestMTOShipmentUpdater() {
 		}
 		defaultRole, err := too.User.Roles.Default()
 		suite.FatalNoError(err)
-		session.CurrentRole = *defaultRole
+		session.ActiveRole = *defaultRole
 		updatedMTOShipment, err := mtoShipmentUpdaterOffice.UpdateMTOShipment(suite.AppContextWithSessionForTest(&session), &updatedShipment, eTag, "test")
 
 		suite.Require().NoError(err)
@@ -1526,7 +1526,7 @@ func (suite *MTOShipmentServiceSuite) TestMTOShipmentUpdater() {
 		}
 		defaultRole, err := too.User.Roles.Default()
 		suite.FatalNoError(err)
-		session.CurrentRole = *defaultRole
+		session.ActiveRole = *defaultRole
 		updatedMTOShipment, err := mtoShipmentUpdaterOffice.UpdateMTOShipment(suite.AppContextWithSessionForTest(&session), &updatedShipment, eTag, "test")
 
 		suite.Require().Error(err)
@@ -3743,7 +3743,7 @@ func (suite *MTOShipmentServiceSuite) TestUpdateShipmentNullableFields() {
 		}
 		defaultRole, err := too.User.Roles.Default()
 		suite.FatalNoError(err)
-		session.CurrentRole = *defaultRole
+		session.ActiveRole = *defaultRole
 		_, err = mockedUpdater.UpdateMTOShipment(suite.AppContextWithSessionForTest(&session), requestedUpdate, etag.GenerateEtag(ntsMove.MTOShipments[0].UpdatedAt), "test")
 		suite.NoError(err)
 		suite.Equal(nil, nil)
@@ -3790,7 +3790,7 @@ func (suite *MTOShipmentServiceSuite) TestUpdateShipmentNullableFields() {
 		}
 		defaultRole, err := too.User.Roles.Default()
 		suite.FatalNoError(err)
-		session.CurrentRole = *defaultRole
+		session.ActiveRole = *defaultRole
 		updatedMtoShipment, err := mockedUpdater.UpdateMTOShipment(suite.AppContextWithSessionForTest(&session), requestedUpdate, etag.GenerateEtag(shipment.UpdatedAt), "test")
 		suite.NoError(err)
 		suite.Equal(*requestedUpdate.TACType, *updatedMtoShipment.TACType)

--- a/pkg/services/mto_shipment/mto_shipment_updater_test.go
+++ b/pkg/services/mto_shipment/mto_shipment_updater_test.go
@@ -1172,7 +1172,9 @@ func (suite *MTOShipmentServiceSuite) TestMTOShipmentUpdater() {
 			UserID:          *too.UserID,
 			OfficeUserID:    too.ID,
 		}
-		session.Roles = append(session.Roles, too.User.Roles...)
+		defaultRole, err := too.User.Roles.Default()
+		suite.FatalNoError(err)
+		session.CurrentRole = *defaultRole
 		newShipment, err := mtoShipmentUpdaterOffice.UpdateMTOShipment(suite.AppContextWithSessionForTest(&session), &updatedShipment, eTag, "test")
 
 		suite.Require().NoError(err)
@@ -1387,7 +1389,9 @@ func (suite *MTOShipmentServiceSuite) TestMTOShipmentUpdater() {
 			UserID:          *too.UserID,
 			OfficeUserID:    too.ID,
 		}
-		session.Roles = append(session.Roles, too.User.Roles...)
+		defaultRole, err := too.User.Roles.Default()
+		suite.FatalNoError(err)
+		session.CurrentRole = *defaultRole
 		updatedMTOShipment, err := mtoShipmentUpdaterOffice.UpdateMTOShipment(suite.AppContextWithSessionForTest(&session), &updatedShipment, eTag, "test")
 
 		suite.Require().NoError(err)
@@ -1452,7 +1456,9 @@ func (suite *MTOShipmentServiceSuite) TestMTOShipmentUpdater() {
 			UserID:          *too.UserID,
 			OfficeUserID:    too.ID,
 		}
-		session.Roles = append(session.Roles, too.User.Roles...)
+		defaultRole, err := too.User.Roles.Default()
+		suite.FatalNoError(err)
+		session.CurrentRole = *defaultRole
 		updatedShipment, err := mtoShipmentUpdaterOffice.UpdateMTOShipment(suite.AppContextWithSessionForTest(&session), &newShipment, eTag, "test")
 		suite.Require().NoError(err)
 		suite.NotEqual(uuid.Nil, updatedShipment.ID)
@@ -1484,7 +1490,9 @@ func (suite *MTOShipmentServiceSuite) TestMTOShipmentUpdater() {
 			UserID:          *too.UserID,
 			OfficeUserID:    too.ID,
 		}
-		session.Roles = append(session.Roles, too.User.Roles...)
+		defaultRole, err := too.User.Roles.Default()
+		suite.FatalNoError(err)
+		session.CurrentRole = *defaultRole
 		updatedMTOShipment, err := mtoShipmentUpdaterOffice.UpdateMTOShipment(suite.AppContextWithSessionForTest(&session), &updatedShipment, eTag, "test")
 
 		suite.Require().NoError(err)
@@ -1516,7 +1524,9 @@ func (suite *MTOShipmentServiceSuite) TestMTOShipmentUpdater() {
 			UserID:          *too.UserID,
 			OfficeUserID:    too.ID,
 		}
-		session.Roles = append(session.Roles, too.User.Roles...)
+		defaultRole, err := too.User.Roles.Default()
+		suite.FatalNoError(err)
+		session.CurrentRole = *defaultRole
 		updatedMTOShipment, err := mtoShipmentUpdaterOffice.UpdateMTOShipment(suite.AppContextWithSessionForTest(&session), &updatedShipment, eTag, "test")
 
 		suite.Require().Error(err)
@@ -3731,8 +3741,10 @@ func (suite *MTOShipmentServiceSuite) TestUpdateShipmentNullableFields() {
 			UserID:          *too.UserID,
 			OfficeUserID:    too.ID,
 		}
-		session.Roles = append(session.Roles, too.User.Roles...)
-		_, err := mockedUpdater.UpdateMTOShipment(suite.AppContextWithSessionForTest(&session), requestedUpdate, etag.GenerateEtag(ntsMove.MTOShipments[0].UpdatedAt), "test")
+		defaultRole, err := too.User.Roles.Default()
+		suite.FatalNoError(err)
+		session.CurrentRole = *defaultRole
+		_, err = mockedUpdater.UpdateMTOShipment(suite.AppContextWithSessionForTest(&session), requestedUpdate, etag.GenerateEtag(ntsMove.MTOShipments[0].UpdatedAt), "test")
 		suite.NoError(err)
 		suite.Equal(nil, nil)
 		suite.Equal(nil, nil)
@@ -3776,7 +3788,9 @@ func (suite *MTOShipmentServiceSuite) TestUpdateShipmentNullableFields() {
 			UserID:          *too.UserID,
 			OfficeUserID:    too.ID,
 		}
-		session.Roles = append(session.Roles, too.User.Roles...)
+		defaultRole, err := too.User.Roles.Default()
+		suite.FatalNoError(err)
+		session.CurrentRole = *defaultRole
 		updatedMtoShipment, err := mockedUpdater.UpdateMTOShipment(suite.AppContextWithSessionForTest(&session), requestedUpdate, etag.GenerateEtag(shipment.UpdatedAt), "test")
 		suite.NoError(err)
 		suite.Equal(*requestedUpdate.TACType, *updatedMtoShipment.TACType)

--- a/pkg/services/mto_shipment/rules.go
+++ b/pkg/services/mto_shipment/rules.go
@@ -90,9 +90,9 @@ func checkUpdateAllowed() validator {
 		err := apperror.NewForbiddenError(msg)
 
 		if appCtx.Session().IsOfficeApp() && appCtx.Session().IsOfficeUser() {
-			isServiceCounselor := appCtx.Session().CurrentRole.RoleType == roles.RoleTypeServicesCounselor
-			isTOO := appCtx.Session().CurrentRole.RoleType == roles.RoleTypeTOO
-			isTIO := appCtx.Session().CurrentRole.RoleType == roles.RoleTypeTIO
+			isServiceCounselor := appCtx.Session().ActiveRole.RoleType == roles.RoleTypeServicesCounselor
+			isTOO := appCtx.Session().ActiveRole.RoleType == roles.RoleTypeTOO
+			isTIO := appCtx.Session().ActiveRole.RoleType == roles.RoleTypeTIO
 			switch older.Status {
 			case models.MTOShipmentStatusSubmitted:
 				if isServiceCounselor || isTOO {
@@ -130,13 +130,13 @@ func checkDeleteAllowed() validator {
 	return validatorFunc(func(appCtx appcontext.AppContext, _ *models.MTOShipment, older *models.MTOShipment) error {
 		move := older.MoveTaskOrder
 
-		if appCtx.Session().CurrentRole.RoleType == roles.RoleTypeServicesCounselor {
+		if appCtx.Session().ActiveRole.RoleType == roles.RoleTypeServicesCounselor {
 			if move.Status != models.MoveStatusDRAFT && move.Status != models.MoveStatusNeedsServiceCounseling {
 				return apperror.NewForbiddenError("Service Counselor: A shipment can only be deleted if the move is in 'Draft' or 'NeedsServiceCounseling' status")
 			}
 		}
 
-		if appCtx.Session().CurrentRole.RoleType == roles.RoleTypeTOO {
+		if appCtx.Session().ActiveRole.RoleType == roles.RoleTypeTOO {
 			if older.Status == models.MTOShipmentStatusApproved {
 				return apperror.NewForbiddenError("TOO: APPROVED shipments cannot be deleted")
 			}

--- a/pkg/services/mto_shipment/rules.go
+++ b/pkg/services/mto_shipment/rules.go
@@ -90,9 +90,9 @@ func checkUpdateAllowed() validator {
 		err := apperror.NewForbiddenError(msg)
 
 		if appCtx.Session().IsOfficeApp() && appCtx.Session().IsOfficeUser() {
-			isServiceCounselor := appCtx.Session().Roles.HasRole(roles.RoleTypeServicesCounselor)
-			isTOO := appCtx.Session().Roles.HasRole(roles.RoleTypeTOO)
-			isTIO := appCtx.Session().Roles.HasRole(roles.RoleTypeTIO)
+			isServiceCounselor := appCtx.Session().CurrentRole.RoleType == roles.RoleTypeServicesCounselor
+			isTOO := appCtx.Session().CurrentRole.RoleType == roles.RoleTypeTOO
+			isTIO := appCtx.Session().CurrentRole.RoleType == roles.RoleTypeTIO
 			switch older.Status {
 			case models.MTOShipmentStatusSubmitted:
 				if isServiceCounselor || isTOO {
@@ -130,13 +130,13 @@ func checkDeleteAllowed() validator {
 	return validatorFunc(func(appCtx appcontext.AppContext, _ *models.MTOShipment, older *models.MTOShipment) error {
 		move := older.MoveTaskOrder
 
-		if appCtx.Session().Roles.HasRole(roles.RoleTypeServicesCounselor) {
+		if appCtx.Session().CurrentRole.RoleType == roles.RoleTypeServicesCounselor {
 			if move.Status != models.MoveStatusDRAFT && move.Status != models.MoveStatusNeedsServiceCounseling {
 				return apperror.NewForbiddenError("Service Counselor: A shipment can only be deleted if the move is in 'Draft' or 'NeedsServiceCounseling' status")
 			}
 		}
 
-		if appCtx.Session().Roles.HasRole(roles.RoleTypeTOO) {
+		if appCtx.Session().CurrentRole.RoleType == roles.RoleTypeTOO {
 			if older.Status == models.MTOShipmentStatusApproved {
 				return apperror.NewForbiddenError("TOO: APPROVED shipments cannot be deleted")
 			}

--- a/pkg/services/mto_shipment/rules_test.go
+++ b/pkg/services/mto_shipment/rules_test.go
@@ -239,7 +239,7 @@ func (suite *MTOShipmentServiceSuite) TestUpdateValidations() {
 			ApplicationName: auth.OfficeApp,
 			UserID:          *servicesCounselor.UserID,
 			OfficeUserID:    servicesCounselor.ID,
-			CurrentRole:     servicesCounselor.User.Roles[0],
+			ActiveRole:      servicesCounselor.User.Roles[0],
 		}
 
 		too := factory.BuildOfficeUserWithRoles(suite.DB(), nil, []roles.RoleType{roles.RoleTypeTOO})
@@ -247,7 +247,7 @@ func (suite *MTOShipmentServiceSuite) TestUpdateValidations() {
 			ApplicationName: auth.OfficeApp,
 			UserID:          *too.UserID,
 			OfficeUserID:    too.ID,
-			CurrentRole:     too.User.Roles[0],
+			ActiveRole:      too.User.Roles[0],
 		}
 
 		tio := factory.BuildOfficeUserWithRoles(suite.DB(), nil, []roles.RoleType{roles.RoleTypeTIO})
@@ -255,7 +255,7 @@ func (suite *MTOShipmentServiceSuite) TestUpdateValidations() {
 			ApplicationName: auth.OfficeApp,
 			UserID:          *tio.UserID,
 			OfficeUserID:    tio.ID,
-			CurrentRole:     tio.User.Roles[0],
+			ActiveRole:      tio.User.Roles[0],
 		}
 
 		testCases := map[string]struct {
@@ -343,7 +343,7 @@ func (suite *MTOShipmentServiceSuite) TestDeleteValidations() {
 				officeUser := factory.BuildOfficeUserWithRoles(nil, nil, []roles.RoleType{roles.RoleTypeTOO})
 
 				appContext := suite.AppContextWithSessionForTest(&auth.Session{
-					CurrentRole:     officeUser.User.Roles[0],
+					ActiveRole:      officeUser.User.Roles[0],
 					ApplicationName: auth.OfficeApp,
 				})
 
@@ -374,7 +374,7 @@ func (suite *MTOShipmentServiceSuite) TestDeleteValidations() {
 		officeUser := factory.BuildOfficeUserWithRoles(nil, nil, []roles.RoleType{roles.RoleTypeTOO})
 
 		appContext := suite.AppContextWithSessionForTest(&auth.Session{
-			CurrentRole:     officeUser.User.Roles[0],
+			ActiveRole:      officeUser.User.Roles[0],
 			ApplicationName: auth.OfficeApp,
 		})
 
@@ -415,7 +415,7 @@ func (suite *MTOShipmentServiceSuite) TestDeleteValidations() {
 				officeUser := factory.BuildOfficeUserWithRoles(nil, nil, []roles.RoleType{roles.RoleTypeServicesCounselor})
 
 				appContext := suite.AppContextWithSessionForTest(&auth.Session{
-					CurrentRole:     officeUser.User.Roles[0],
+					ActiveRole:      officeUser.User.Roles[0],
 					ApplicationName: auth.OfficeApp,
 				})
 

--- a/pkg/services/mto_shipment/rules_test.go
+++ b/pkg/services/mto_shipment/rules_test.go
@@ -239,24 +239,24 @@ func (suite *MTOShipmentServiceSuite) TestUpdateValidations() {
 			ApplicationName: auth.OfficeApp,
 			UserID:          *servicesCounselor.UserID,
 			OfficeUserID:    servicesCounselor.ID,
+			CurrentRole:     servicesCounselor.User.Roles[0],
 		}
-		servicesCounselorSession.Roles = append(servicesCounselorSession.Roles, servicesCounselor.User.Roles...)
 
 		too := factory.BuildOfficeUserWithRoles(suite.DB(), nil, []roles.RoleType{roles.RoleTypeTOO})
 		tooSession := auth.Session{
 			ApplicationName: auth.OfficeApp,
 			UserID:          *too.UserID,
 			OfficeUserID:    too.ID,
+			CurrentRole:     too.User.Roles[0],
 		}
-		tooSession.Roles = append(tooSession.Roles, too.User.Roles...)
 
 		tio := factory.BuildOfficeUserWithRoles(suite.DB(), nil, []roles.RoleType{roles.RoleTypeTIO})
 		tioSession := auth.Session{
 			ApplicationName: auth.OfficeApp,
 			UserID:          *tio.UserID,
 			OfficeUserID:    tio.ID,
+			CurrentRole:     tio.User.Roles[0],
 		}
-		tioSession.Roles = append(tioSession.Roles, tio.User.Roles...)
 
 		testCases := map[string]struct {
 			session auth.Session
@@ -343,7 +343,7 @@ func (suite *MTOShipmentServiceSuite) TestDeleteValidations() {
 				officeUser := factory.BuildOfficeUserWithRoles(nil, nil, []roles.RoleType{roles.RoleTypeTOO})
 
 				appContext := suite.AppContextWithSessionForTest(&auth.Session{
-					Roles:           officeUser.User.Roles,
+					CurrentRole:     officeUser.User.Roles[0],
 					ApplicationName: auth.OfficeApp,
 				})
 
@@ -374,7 +374,7 @@ func (suite *MTOShipmentServiceSuite) TestDeleteValidations() {
 		officeUser := factory.BuildOfficeUserWithRoles(nil, nil, []roles.RoleType{roles.RoleTypeTOO})
 
 		appContext := suite.AppContextWithSessionForTest(&auth.Session{
-			Roles:           officeUser.User.Roles,
+			CurrentRole:     officeUser.User.Roles[0],
 			ApplicationName: auth.OfficeApp,
 		})
 
@@ -415,7 +415,7 @@ func (suite *MTOShipmentServiceSuite) TestDeleteValidations() {
 				officeUser := factory.BuildOfficeUserWithRoles(nil, nil, []roles.RoleType{roles.RoleTypeServicesCounselor})
 
 				appContext := suite.AppContextWithSessionForTest(&auth.Session{
-					Roles:           officeUser.User.Roles,
+					CurrentRole:     officeUser.User.Roles[0],
 					ApplicationName: auth.OfficeApp,
 				})
 

--- a/pkg/services/mto_shipment/shipment_deleter_test.go
+++ b/pkg/services/mto_shipment/shipment_deleter_test.go
@@ -87,7 +87,7 @@ func (suite *MTOShipmentServiceSuite) TestShipmentDeleter() {
 		session := suite.AppContextWithSessionForTest(&auth.Session{
 			ApplicationName: auth.OfficeApp,
 			OfficeUserID:    uuid.Must(uuid.NewV4()),
-			Roles:           factory.BuildOfficeUserWithRoles(nil, nil, []roles.RoleType{roles.RoleTypeServicesCounselor}).User.Roles,
+			CurrentRole:     factory.BuildOfficeUserWithRoles(nil, nil, []roles.RoleType{roles.RoleTypeServicesCounselor}).User.Roles[0],
 		})
 
 		_, err := shipmentDeleter.DeleteShipment(session, shipment.ID)

--- a/pkg/services/mto_shipment/shipment_deleter_test.go
+++ b/pkg/services/mto_shipment/shipment_deleter_test.go
@@ -87,7 +87,7 @@ func (suite *MTOShipmentServiceSuite) TestShipmentDeleter() {
 		session := suite.AppContextWithSessionForTest(&auth.Session{
 			ApplicationName: auth.OfficeApp,
 			OfficeUserID:    uuid.Must(uuid.NewV4()),
-			CurrentRole:     factory.BuildOfficeUserWithRoles(nil, nil, []roles.RoleType{roles.RoleTypeServicesCounselor}).User.Roles[0],
+			ActiveRole:      factory.BuildOfficeUserWithRoles(nil, nil, []roles.RoleType{roles.RoleTypeServicesCounselor}).User.Roles[0],
 		})
 
 		_, err := shipmentDeleter.DeleteShipment(session, shipment.ID)

--- a/pkg/services/office_user/customer/customer_searcher.go
+++ b/pkg/services/office_user/customer/customer_searcher.go
@@ -34,7 +34,7 @@ func (s customerSearcher) SearchCustomers(appCtx appcontext.AppContext, params *
 		return models.ServiceMemberSearchResults{}, 0, apperror.NewInvalidInputError(uuid.Nil, nil, verrs, "")
 	}
 
-	if !(appCtx.Session().CurrentRole.RoleType == roles.RoleTypeServicesCounselor) && !(appCtx.Session().CurrentRole.RoleType == roles.RoleTypeHQ) {
+	if !(appCtx.Session().ActiveRole.RoleType == roles.RoleTypeServicesCounselor) && !(appCtx.Session().ActiveRole.RoleType == roles.RoleTypeHQ) {
 		return models.ServiceMemberSearchResults{}, 0, apperror.NewForbiddenError("not authorized to preform this search")
 	}
 

--- a/pkg/services/office_user/customer/customer_searcher.go
+++ b/pkg/services/office_user/customer/customer_searcher.go
@@ -34,7 +34,7 @@ func (s customerSearcher) SearchCustomers(appCtx appcontext.AppContext, params *
 		return models.ServiceMemberSearchResults{}, 0, apperror.NewInvalidInputError(uuid.Nil, nil, verrs, "")
 	}
 
-	if !appCtx.Session().Roles.HasRole(roles.RoleTypeServicesCounselor) && !appCtx.Session().Roles.HasRole(roles.RoleTypeHQ) {
+	if !(appCtx.Session().CurrentRole.RoleType == roles.RoleTypeServicesCounselor) && !(appCtx.Session().CurrentRole.RoleType == roles.RoleTypeHQ) {
 		return models.ServiceMemberSearchResults{}, 0, apperror.NewForbiddenError("not authorized to preform this search")
 	}
 

--- a/pkg/services/office_user/customer/customer_searcher_test.go
+++ b/pkg/services/office_user/customer/customer_searcher_test.go
@@ -15,7 +15,7 @@ func (suite CustomerServiceSuite) TestCustomerSearch() {
 		scUser := factory.BuildOfficeUserWithRoles(suite.DB(), nil, []roles.RoleType{roles.RoleTypeServicesCounselor})
 		session := auth.Session{
 			ApplicationName: auth.OfficeApp,
-			Roles:           scUser.User.Roles,
+			CurrentRole:     scUser.User.Roles[0],
 			OfficeUserID:    scUser.ID,
 			IDToken:         "fake_token",
 			AccessToken:     "fakeAccessToken",
@@ -39,7 +39,7 @@ func (suite CustomerServiceSuite) TestCustomerSearch() {
 		scUser := factory.BuildOfficeUserWithRoles(suite.DB(), nil, []roles.RoleType{roles.RoleTypeServicesCounselor})
 		session := auth.Session{
 			ApplicationName: auth.OfficeApp,
-			Roles:           scUser.User.Roles,
+			CurrentRole:     scUser.User.Roles[0],
 			OfficeUserID:    scUser.ID,
 			IDToken:         "fake_token",
 			AccessToken:     "fakeAccessToken",
@@ -65,7 +65,7 @@ func (suite CustomerServiceSuite) TestCustomerSearch() {
 		scUser := factory.BuildOfficeUserWithRoles(suite.DB(), nil, []roles.RoleType{roles.RoleTypeServicesCounselor})
 		session := auth.Session{
 			ApplicationName: auth.OfficeApp,
-			Roles:           scUser.User.Roles,
+			CurrentRole:     scUser.User.Roles[0],
 			OfficeUserID:    scUser.ID,
 			IDToken:         "fake_token",
 			AccessToken:     "fakeAccessToken",
@@ -91,7 +91,7 @@ func (suite CustomerServiceSuite) TestCustomerSearch() {
 		scUser := factory.BuildOfficeUserWithRoles(suite.DB(), nil, []roles.RoleType{roles.RoleTypeServicesCounselor})
 		session := auth.Session{
 			ApplicationName: auth.OfficeApp,
-			Roles:           scUser.User.Roles,
+			CurrentRole:     scUser.User.Roles[0],
 			OfficeUserID:    scUser.ID,
 			IDToken:         "fake_token",
 			AccessToken:     "fakeAccessToken",
@@ -118,7 +118,7 @@ func (suite CustomerServiceSuite) TestCustomerSearch() {
 		scUser := factory.BuildOfficeUserWithRoles(suite.DB(), nil, []roles.RoleType{roles.RoleTypeServicesCounselor})
 		session := auth.Session{
 			ApplicationName: auth.OfficeApp,
-			Roles:           scUser.User.Roles,
+			CurrentRole:     scUser.User.Roles[0],
 			OfficeUserID:    scUser.ID,
 			IDToken:         "fake_token",
 			AccessToken:     "fakeAccessToken",
@@ -133,7 +133,7 @@ func (suite CustomerServiceSuite) TestCustomerSearch() {
 		officeUser := factory.BuildOfficeUserWithRoles(suite.DB(), nil, []roles.RoleType{roles.RoleTypeServicesCounselor})
 		session := auth.Session{
 			ApplicationName: auth.OfficeApp,
-			Roles:           officeUser.User.Roles,
+			CurrentRole:     officeUser.User.Roles[0],
 			OfficeUserID:    officeUser.ID,
 			IDToken:         "fake_token",
 			AccessToken:     "fakeAccessToken",
@@ -184,7 +184,7 @@ func (suite CustomerServiceSuite) TestCustomerSearch() {
 
 		session := auth.Session{
 			ApplicationName: auth.OfficeApp,
-			Roles:           privilegedUserSC.User.Roles,
+			CurrentRole:     privilegedUserSC.User.Roles[0],
 			OfficeUserID:    privilegedUserSC.ID,
 			IDToken:         "fake_token",
 			AccessToken:     "fakeAccessToken",
@@ -227,7 +227,7 @@ func (suite CustomerServiceSuite) TestCustomerSearch() {
 		hqUser := factory.BuildOfficeUserWithRoles(suite.DB(), nil, []roles.RoleType{roles.RoleTypeHQ})
 		session := auth.Session{
 			ApplicationName: auth.OfficeApp,
-			Roles:           hqUser.User.Roles,
+			CurrentRole:     hqUser.User.Roles[0],
 			OfficeUserID:    hqUser.ID,
 			IDToken:         "fake_token",
 			AccessToken:     "fakeAccessToken",

--- a/pkg/services/office_user/customer/customer_searcher_test.go
+++ b/pkg/services/office_user/customer/customer_searcher_test.go
@@ -15,7 +15,7 @@ func (suite CustomerServiceSuite) TestCustomerSearch() {
 		scUser := factory.BuildOfficeUserWithRoles(suite.DB(), nil, []roles.RoleType{roles.RoleTypeServicesCounselor})
 		session := auth.Session{
 			ApplicationName: auth.OfficeApp,
-			CurrentRole:     scUser.User.Roles[0],
+			ActiveRole:      scUser.User.Roles[0],
 			OfficeUserID:    scUser.ID,
 			IDToken:         "fake_token",
 			AccessToken:     "fakeAccessToken",
@@ -39,7 +39,7 @@ func (suite CustomerServiceSuite) TestCustomerSearch() {
 		scUser := factory.BuildOfficeUserWithRoles(suite.DB(), nil, []roles.RoleType{roles.RoleTypeServicesCounselor})
 		session := auth.Session{
 			ApplicationName: auth.OfficeApp,
-			CurrentRole:     scUser.User.Roles[0],
+			ActiveRole:      scUser.User.Roles[0],
 			OfficeUserID:    scUser.ID,
 			IDToken:         "fake_token",
 			AccessToken:     "fakeAccessToken",
@@ -65,7 +65,7 @@ func (suite CustomerServiceSuite) TestCustomerSearch() {
 		scUser := factory.BuildOfficeUserWithRoles(suite.DB(), nil, []roles.RoleType{roles.RoleTypeServicesCounselor})
 		session := auth.Session{
 			ApplicationName: auth.OfficeApp,
-			CurrentRole:     scUser.User.Roles[0],
+			ActiveRole:      scUser.User.Roles[0],
 			OfficeUserID:    scUser.ID,
 			IDToken:         "fake_token",
 			AccessToken:     "fakeAccessToken",
@@ -91,7 +91,7 @@ func (suite CustomerServiceSuite) TestCustomerSearch() {
 		scUser := factory.BuildOfficeUserWithRoles(suite.DB(), nil, []roles.RoleType{roles.RoleTypeServicesCounselor})
 		session := auth.Session{
 			ApplicationName: auth.OfficeApp,
-			CurrentRole:     scUser.User.Roles[0],
+			ActiveRole:      scUser.User.Roles[0],
 			OfficeUserID:    scUser.ID,
 			IDToken:         "fake_token",
 			AccessToken:     "fakeAccessToken",
@@ -118,7 +118,7 @@ func (suite CustomerServiceSuite) TestCustomerSearch() {
 		scUser := factory.BuildOfficeUserWithRoles(suite.DB(), nil, []roles.RoleType{roles.RoleTypeServicesCounselor})
 		session := auth.Session{
 			ApplicationName: auth.OfficeApp,
-			CurrentRole:     scUser.User.Roles[0],
+			ActiveRole:      scUser.User.Roles[0],
 			OfficeUserID:    scUser.ID,
 			IDToken:         "fake_token",
 			AccessToken:     "fakeAccessToken",
@@ -133,7 +133,7 @@ func (suite CustomerServiceSuite) TestCustomerSearch() {
 		officeUser := factory.BuildOfficeUserWithRoles(suite.DB(), nil, []roles.RoleType{roles.RoleTypeServicesCounselor})
 		session := auth.Session{
 			ApplicationName: auth.OfficeApp,
-			CurrentRole:     officeUser.User.Roles[0],
+			ActiveRole:      officeUser.User.Roles[0],
 			OfficeUserID:    officeUser.ID,
 			IDToken:         "fake_token",
 			AccessToken:     "fakeAccessToken",
@@ -184,7 +184,7 @@ func (suite CustomerServiceSuite) TestCustomerSearch() {
 
 		session := auth.Session{
 			ApplicationName: auth.OfficeApp,
-			CurrentRole:     privilegedUserSC.User.Roles[0],
+			ActiveRole:      privilegedUserSC.User.Roles[0],
 			OfficeUserID:    privilegedUserSC.ID,
 			IDToken:         "fake_token",
 			AccessToken:     "fakeAccessToken",
@@ -227,7 +227,7 @@ func (suite CustomerServiceSuite) TestCustomerSearch() {
 		hqUser := factory.BuildOfficeUserWithRoles(suite.DB(), nil, []roles.RoleType{roles.RoleTypeHQ})
 		session := auth.Session{
 			ApplicationName: auth.OfficeApp,
-			CurrentRole:     hqUser.User.Roles[0],
+			ActiveRole:      hqUser.User.Roles[0],
 			OfficeUserID:    hqUser.ID,
 			IDToken:         "fake_token",
 			AccessToken:     "fakeAccessToken",

--- a/pkg/services/office_user/office_user_fetcher.go
+++ b/pkg/services/office_user/office_user_fetcher.go
@@ -61,7 +61,7 @@ func (o *officeUserFetcherPop) FetchOfficeUserByID(appCtx appcontext.AppContext,
 
 func (o *officeUserFetcherPop) FetchOfficeUserByIDWithTransportationOfficeAssignments(appCtx appcontext.AppContext, id uuid.UUID) (models.OfficeUser, error) {
 	var officeUser models.OfficeUser
-	err := appCtx.DB().Eager("TransportationOffice", "TransportationOfficeAssignments", "TransportationOfficeAssignments.TransportationOffice").Find(&officeUser, id)
+	err := appCtx.DB().Eager("TransportationOffice", "TransportationOfficeAssignments", "TransportationOfficeAssignments.TransportationOffice", "User.Roles").Find(&officeUser, id)
 	if err != nil {
 		switch err {
 		case sql.ErrNoRows:

--- a/pkg/services/orchestrators/shipment/shipment_creator.go
+++ b/pkg/services/orchestrators/shipment/shipment_creator.go
@@ -92,7 +92,7 @@ func (s *shipmentCreator) CreateShipment(appCtx appcontext.AppContext, shipment 
 				return err
 			}
 
-			if txnAppCtx.Session().CurrentRole.RoleType == roles.RoleTypeServicesCounselor {
+			if txnAppCtx.Session().ActiveRole.RoleType == roles.RoleTypeServicesCounselor {
 				err = s.moveTaskOrderUpdater.SignCertificationPPMCounselingCompleted(txnAppCtx, mtoShipment.MoveTaskOrderID, mtoShipment.PPMShipment.ID)
 				if err != nil {
 					return err

--- a/pkg/services/orchestrators/shipment/shipment_creator.go
+++ b/pkg/services/orchestrators/shipment/shipment_creator.go
@@ -92,7 +92,7 @@ func (s *shipmentCreator) CreateShipment(appCtx appcontext.AppContext, shipment 
 				return err
 			}
 
-			if txnAppCtx.Session().Roles.HasRole(roles.RoleTypeServicesCounselor) {
+			if txnAppCtx.Session().CurrentRole.RoleType == roles.RoleTypeServicesCounselor {
 				err = s.moveTaskOrderUpdater.SignCertificationPPMCounselingCompleted(txnAppCtx, mtoShipment.MoveTaskOrderID, mtoShipment.PPMShipment.ID)
 				if err != nil {
 					return err

--- a/pkg/services/orchestrators/shipment/shipment_creator_test.go
+++ b/pkg/services/orchestrators/shipment/shipment_creator_test.go
@@ -229,7 +229,7 @@ func (suite *ShipmentSuite) TestCreateShipment() {
 				ApplicationName: auth.OfficeApp,
 				UserID:          user.ID,
 				IDToken:         "fake token",
-				Roles:           roles.Roles{},
+				CurrentRole:     roles.Role{},
 			}
 
 			mtoShipment, err := subtestData.shipmentCreatorOrchestrator.CreateShipment(suite.AppContextWithSessionForTest(session), &tc.shipment)
@@ -259,7 +259,9 @@ func (suite *ShipmentSuite) TestCreateShipment() {
 			UserID:          *scOfficeUser.UserID,
 			IDToken:         "fake token",
 		}
-		session.Roles = append(session.Roles, identity.Roles...)
+		defaultRole, err := identity.Roles.Default()
+		suite.FatalNoError(err)
+		session.CurrentRole = *defaultRole
 		appCtx := suite.AppContextWithSessionForTest(session)
 
 		mtoShipment, err := subtestData.shipmentCreatorOrchestrator.CreateShipment(appCtx, &shipment)
@@ -301,7 +303,7 @@ func (suite *ShipmentSuite) TestCreateShipment() {
 				ApplicationName: auth.OfficeApp,
 				UserID:          user.ID,
 				IDToken:         "fake token",
-				Roles:           roles.Roles{},
+				CurrentRole:     roles.Role{},
 			}
 
 			appCtx := suite.AppContextWithSessionForTest(session)
@@ -365,7 +367,7 @@ func (suite *ShipmentSuite) TestCreateShipment() {
 			ApplicationName: auth.OfficeApp,
 			UserID:          user.ID,
 			IDToken:         "fake token",
-			Roles:           roles.Roles{},
+			CurrentRole:     roles.Role{},
 		}
 
 		mtoShipment, err := subtestData.shipmentCreatorOrchestrator.CreateShipment(suite.AppContextWithSessionForTest(session), shipment)
@@ -430,7 +432,9 @@ func (suite *ShipmentSuite) TestCreateShipment() {
 				UserID:          *scOfficeUser.UserID,
 				IDToken:         "fake token",
 			}
-			session.Roles = append(session.Roles, identity.Roles...)
+			defaultRole, err := identity.Roles.Default()
+			suite.FatalNoError(err)
+			session.CurrentRole = *defaultRole
 			appCtx := suite.AppContextWithSessionForTest(session)
 
 			mtoShipment, err := subtestData.shipmentCreatorOrchestrator.CreateShipment(appCtx, &shipment)

--- a/pkg/services/orchestrators/shipment/shipment_creator_test.go
+++ b/pkg/services/orchestrators/shipment/shipment_creator_test.go
@@ -229,7 +229,7 @@ func (suite *ShipmentSuite) TestCreateShipment() {
 				ApplicationName: auth.OfficeApp,
 				UserID:          user.ID,
 				IDToken:         "fake token",
-				CurrentRole:     roles.Role{},
+				ActiveRole:      roles.Role{},
 			}
 
 			mtoShipment, err := subtestData.shipmentCreatorOrchestrator.CreateShipment(suite.AppContextWithSessionForTest(session), &tc.shipment)
@@ -261,7 +261,7 @@ func (suite *ShipmentSuite) TestCreateShipment() {
 		}
 		defaultRole, err := identity.Roles.Default()
 		suite.FatalNoError(err)
-		session.CurrentRole = *defaultRole
+		session.ActiveRole = *defaultRole
 		appCtx := suite.AppContextWithSessionForTest(session)
 
 		mtoShipment, err := subtestData.shipmentCreatorOrchestrator.CreateShipment(appCtx, &shipment)
@@ -303,7 +303,7 @@ func (suite *ShipmentSuite) TestCreateShipment() {
 				ApplicationName: auth.OfficeApp,
 				UserID:          user.ID,
 				IDToken:         "fake token",
-				CurrentRole:     roles.Role{},
+				ActiveRole:      roles.Role{},
 			}
 
 			appCtx := suite.AppContextWithSessionForTest(session)
@@ -367,7 +367,7 @@ func (suite *ShipmentSuite) TestCreateShipment() {
 			ApplicationName: auth.OfficeApp,
 			UserID:          user.ID,
 			IDToken:         "fake token",
-			CurrentRole:     roles.Role{},
+			ActiveRole:      roles.Role{},
 		}
 
 		mtoShipment, err := subtestData.shipmentCreatorOrchestrator.CreateShipment(suite.AppContextWithSessionForTest(session), shipment)
@@ -434,7 +434,7 @@ func (suite *ShipmentSuite) TestCreateShipment() {
 			}
 			defaultRole, err := identity.Roles.Default()
 			suite.FatalNoError(err)
-			session.CurrentRole = *defaultRole
+			session.ActiveRole = *defaultRole
 			appCtx := suite.AppContextWithSessionForTest(session)
 
 			mtoShipment, err := subtestData.shipmentCreatorOrchestrator.CreateShipment(appCtx, &shipment)

--- a/pkg/services/order/order_fetcher.go
+++ b/pkg/services/order/order_fetcher.go
@@ -212,7 +212,7 @@ func (f orderFetcher) ListOrders(appCtx appcontext.AppContext, officeUserID uuid
 					Where("(ppm_shipments.status IS NULL OR ppm_shipments.status NOT IN (?))", models.PPMShipmentStatusWaitingOnCustomer, models.PPMShipmentStatusNeedsCloseout, models.PPMShipmentStatusCloseoutComplete)
 			}
 		} else {
-			if appCtx.Session().CurrentRole.RoleType == roles.RoleTypeTOO {
+			if appCtx.Session().ActiveRole.RoleType == roles.RoleTypeTOO {
 				query.Where("(moves.ppm_type IS NULL OR (moves.ppm_type = 'PARTIAL' or (moves.ppm_type = 'FULL' and origin_dl.provides_services_counseling = 'false')))")
 			}
 			// TODO  not sure we'll need this once we're in a situation where closeout param is always passed
@@ -572,7 +572,7 @@ func (f orderFetcher) ListAllOrderLocations(appCtx appcontext.AppContext, office
 					Where("(ppm_shipments.status IS NULL OR ppm_shipments.status NOT IN (?))", models.PPMShipmentStatusWaitingOnCustomer, models.PPMShipmentStatusNeedsCloseout, models.PPMShipmentStatusCloseoutComplete)
 			}
 		} else {
-			if appCtx.Session().CurrentRole.RoleType == roles.RoleTypeTOO {
+			if appCtx.Session().ActiveRole.RoleType == roles.RoleTypeTOO {
 				query.Where("(moves.ppm_type IS NULL OR (moves.ppm_type = (?) or (moves.ppm_type = (?) and origin_dl.provides_services_counseling = 'false')))", models.MovePPMTypePARTIAL, models.MovePPMTypeFULL)
 			}
 			query.LeftJoin("ppm_shipments", "ppm_shipments.shipment_id = mto_shipments.id")

--- a/pkg/services/order/order_fetcher.go
+++ b/pkg/services/order/order_fetcher.go
@@ -212,7 +212,7 @@ func (f orderFetcher) ListOrders(appCtx appcontext.AppContext, officeUserID uuid
 					Where("(ppm_shipments.status IS NULL OR ppm_shipments.status NOT IN (?))", models.PPMShipmentStatusWaitingOnCustomer, models.PPMShipmentStatusNeedsCloseout, models.PPMShipmentStatusCloseoutComplete)
 			}
 		} else {
-			if appCtx.Session().Roles.HasRole(roles.RoleTypeTOO) {
+			if appCtx.Session().CurrentRole.RoleType == roles.RoleTypeTOO {
 				query.Where("(moves.ppm_type IS NULL OR (moves.ppm_type = 'PARTIAL' or (moves.ppm_type = 'FULL' and origin_dl.provides_services_counseling = 'false')))")
 			}
 			// TODO  not sure we'll need this once we're in a situation where closeout param is always passed
@@ -572,7 +572,7 @@ func (f orderFetcher) ListAllOrderLocations(appCtx appcontext.AppContext, office
 					Where("(ppm_shipments.status IS NULL OR ppm_shipments.status NOT IN (?))", models.PPMShipmentStatusWaitingOnCustomer, models.PPMShipmentStatusNeedsCloseout, models.PPMShipmentStatusCloseoutComplete)
 			}
 		} else {
-			if appCtx.Session().Roles.HasRole(roles.RoleTypeTOO) {
+			if appCtx.Session().CurrentRole.RoleType == roles.RoleTypeTOO {
 				query.Where("(moves.ppm_type IS NULL OR (moves.ppm_type = (?) or (moves.ppm_type = (?) and origin_dl.provides_services_counseling = 'false')))", models.MovePPMTypePARTIAL, models.MovePPMTypeFULL)
 			}
 			query.LeftJoin("ppm_shipments", "ppm_shipments.shipment_id = mto_shipments.id")

--- a/pkg/services/order/order_fetcher_test.go
+++ b/pkg/services/order/order_fetcher_test.go
@@ -1832,7 +1832,8 @@ func (suite *OrderServiceSuite) TestListOrdersWithEmptyFields() {
 		},
 	}, nil)
 
-	officeUser := factory.BuildOfficeUser(suite.DB(), nil, nil)
+	officeUser := factory.BuildOfficeUserWithRoles(suite.DB(), nil, []roles.RoleType{roles.RoleTypeServicesCounselor})
+	suite.NotEmpty(officeUser.User.Roles)
 	session := auth.Session{
 		ApplicationName: auth.OfficeApp,
 		ActiveRole:      officeUser.User.Roles[0],

--- a/pkg/services/order/order_fetcher_test.go
+++ b/pkg/services/order/order_fetcher_test.go
@@ -86,7 +86,7 @@ func (suite *OrderServiceSuite) TestListOrders() {
 		officeUser := factory.BuildOfficeUserWithRoles(suite.DB(), nil, []roles.RoleType{roles.RoleTypeTOO})
 		session := auth.Session{
 			ApplicationName: auth.OfficeApp,
-			CurrentRole:     officeUser.User.Roles[0],
+			ActiveRole:      officeUser.User.Roles[0],
 			OfficeUserID:    officeUser.ID,
 			IDToken:         "fake_token",
 			AccessToken:     "fakeAccessToken",
@@ -638,7 +638,7 @@ func (suite *OrderServiceSuite) TestListOrders() {
 		officeUser := factory.BuildOfficeUserWithRoles(suite.DB(), nil, []roles.RoleType{roles.RoleTypeTOO})
 		session := auth.Session{
 			ApplicationName: auth.OfficeApp,
-			CurrentRole:     officeUser.User.Roles[0],
+			ActiveRole:      officeUser.User.Roles[0],
 			OfficeUserID:    officeUser.ID,
 			IDToken:         "fake_token",
 			AccessToken:     "fakeAccessToken",
@@ -702,7 +702,7 @@ func (suite *OrderServiceSuite) TestListOrders() {
 		officeUser := factory.BuildOfficeUserWithRoles(suite.DB(), nil, []roles.RoleType{roles.RoleTypeTOO})
 		session := auth.Session{
 			ApplicationName: auth.OfficeApp,
-			CurrentRole:     officeUser.User.Roles[0],
+			ActiveRole:      officeUser.User.Roles[0],
 			OfficeUserID:    officeUser.ID,
 			IDToken:         "fake_token",
 			AccessToken:     "fakeAccessToken",
@@ -779,7 +779,7 @@ func (suite *OrderServiceSuite) TestListOrders() {
 		officeUser := factory.BuildOfficeUserWithRoles(suite.DB(), nil, []roles.RoleType{roles.RoleTypeTOO})
 		session := auth.Session{
 			ApplicationName: auth.OfficeApp,
-			CurrentRole:     officeUser.User.Roles[0],
+			ActiveRole:      officeUser.User.Roles[0],
 			OfficeUserID:    officeUser.ID,
 			IDToken:         "fake_token",
 			AccessToken:     "fakeAccessToken",
@@ -840,7 +840,7 @@ func (suite *OrderServiceSuite) TestListOrders() {
 		officeUser := factory.BuildOfficeUserWithRoles(suite.DB(), nil, []roles.RoleType{roles.RoleTypeTOO})
 		session := auth.Session{
 			ApplicationName: auth.OfficeApp,
-			CurrentRole:     officeUser.User.Roles[0],
+			ActiveRole:      officeUser.User.Roles[0],
 			OfficeUserID:    officeUser.ID,
 			IDToken:         "fake_token",
 			AccessToken:     "fakeAccessToken",
@@ -886,7 +886,7 @@ func (suite *OrderServiceSuite) TestListOrders() {
 		officeUser := factory.BuildOfficeUserWithRoles(suite.DB(), nil, []roles.RoleType{roles.RoleTypeTOO})
 		session := auth.Session{
 			ApplicationName: auth.OfficeApp,
-			CurrentRole:     officeUser.User.Roles[0],
+			ActiveRole:      officeUser.User.Roles[0],
 			OfficeUserID:    officeUser.ID,
 			IDToken:         "fake_token",
 			AccessToken:     "fakeAccessToken",
@@ -945,7 +945,7 @@ func (suite *OrderServiceSuite) TestListOrders() {
 		officeUser := factory.BuildOfficeUserWithRoles(suite.DB(), nil, []roles.RoleType{roles.RoleTypeTOO})
 		session := auth.Session{
 			ApplicationName: auth.OfficeApp,
-			CurrentRole:     officeUser.User.Roles[0],
+			ActiveRole:      officeUser.User.Roles[0],
 			OfficeUserID:    officeUser.ID,
 			IDToken:         "fake_token",
 			AccessToken:     "fakeAccessToken",
@@ -991,7 +991,7 @@ func (suite *OrderServiceSuite) TestListOrders() {
 		officeUser := factory.BuildOfficeUserWithRoles(suite.DB(), nil, []roles.RoleType{roles.RoleTypeTOO})
 		session := auth.Session{
 			ApplicationName: auth.OfficeApp,
-			CurrentRole:     officeUser.User.Roles[0],
+			ActiveRole:      officeUser.User.Roles[0],
 			OfficeUserID:    officeUser.ID,
 			IDToken:         "fake_token",
 			AccessToken:     "fakeAccessToken",
@@ -1037,7 +1037,7 @@ func (suite *OrderServiceSuite) TestListOrders() {
 		officeUser := factory.BuildOfficeUserWithRoles(suite.DB(), nil, []roles.RoleType{roles.RoleTypeTOO})
 		session := auth.Session{
 			ApplicationName: auth.OfficeApp,
-			CurrentRole:     officeUser.User.Roles[0],
+			ActiveRole:      officeUser.User.Roles[0],
 			OfficeUserID:    officeUser.ID,
 			IDToken:         "fake_token",
 			AccessToken:     "fakeAccessToken",
@@ -1096,7 +1096,7 @@ func (suite *OrderServiceSuite) TestListOrders() {
 		officeUser := factory.BuildOfficeUserWithRoles(suite.DB(), nil, []roles.RoleType{roles.RoleTypeTOO})
 		session := auth.Session{
 			ApplicationName: auth.OfficeApp,
-			CurrentRole:     officeUser.User.Roles[0],
+			ActiveRole:      officeUser.User.Roles[0],
 			OfficeUserID:    officeUser.ID,
 			IDToken:         "fake_token",
 			AccessToken:     "fakeAccessToken",
@@ -1132,7 +1132,7 @@ func (suite *OrderServiceSuite) TestListOrders() {
 		officeUser := factory.BuildOfficeUserWithRoles(suite.DB(), nil, []roles.RoleType{roles.RoleTypeTOO})
 		session := auth.Session{
 			ApplicationName: auth.OfficeApp,
-			CurrentRole:     officeUser.User.Roles[0],
+			ActiveRole:      officeUser.User.Roles[0],
 			OfficeUserID:    officeUser.ID,
 			IDToken:         "fake_token",
 			AccessToken:     "fakeAccessToken",
@@ -1168,7 +1168,7 @@ func (suite *OrderServiceSuite) TestListOrders() {
 		officeUser := factory.BuildOfficeUserWithRoles(suite.DB(), nil, []roles.RoleType{roles.RoleTypeTOO})
 		session := auth.Session{
 			ApplicationName: auth.OfficeApp,
-			CurrentRole:     officeUser.User.Roles[0],
+			ActiveRole:      officeUser.User.Roles[0],
 			OfficeUserID:    officeUser.ID,
 			IDToken:         "fake_token",
 			AccessToken:     "fakeAccessToken",
@@ -1231,7 +1231,7 @@ func (suite *OrderServiceSuite) TestListOrders() {
 		officeUser := factory.BuildOfficeUserWithRoles(suite.DB(), nil, []roles.RoleType{roles.RoleTypeTOO})
 		session := auth.Session{
 			ApplicationName: auth.OfficeApp,
-			CurrentRole:     officeUser.User.Roles[0],
+			ActiveRole:      officeUser.User.Roles[0],
 			OfficeUserID:    officeUser.ID,
 			IDToken:         "fake_token",
 			AccessToken:     "fakeAccessToken",
@@ -1294,7 +1294,7 @@ func (suite *OrderServiceSuite) TestListOrders() {
 		officeUser := factory.BuildOfficeUserWithRoles(suite.DB(), nil, []roles.RoleType{roles.RoleTypeTOO})
 		session := auth.Session{
 			ApplicationName: auth.OfficeApp,
-			CurrentRole:     officeUser.User.Roles[0],
+			ActiveRole:      officeUser.User.Roles[0],
 			OfficeUserID:    officeUser.ID,
 			IDToken:         "fake_token",
 			AccessToken:     "fakeAccessToken",
@@ -1371,7 +1371,7 @@ func (suite *OrderServiceSuite) TestListOrderWithAssignedUserSingle() {
 	var orderFetcherTest orderFetcher
 	session := auth.Session{
 		ApplicationName: auth.OfficeApp,
-		CurrentRole:     scUser.User.Roles[0],
+		ActiveRole:      scUser.User.Roles[0],
 		OfficeUserID:    scUser.ID,
 		IDToken:         "fake_token",
 		AccessToken:     "fakeAccessToken",
@@ -1432,7 +1432,7 @@ func (suite *OrderServiceSuite) TestListOrdersUSMCGBLOC() {
 		officeUser := factory.BuildOfficeUserWithRoles(suite.DB(), nil, []roles.RoleType{roles.RoleTypeTOO})
 		session := auth.Session{
 			ApplicationName: auth.OfficeApp,
-			CurrentRole:     officeUser.User.Roles[0],
+			ActiveRole:      officeUser.User.Roles[0],
 			OfficeUserID:    officeUser.ID,
 			IDToken:         "fake_token",
 			AccessToken:     "fakeAccessToken",
@@ -1544,7 +1544,7 @@ func (suite *OrderServiceSuite) TestListOrdersPPMCloseoutForArmyAirforce() {
 
 		session = auth.Session{
 			ApplicationName: auth.OfficeApp,
-			CurrentRole:     officeUserSC.User.Roles[0],
+			ActiveRole:      officeUserSC.User.Roles[0],
 			OfficeUserID:    officeUserSC.ID,
 			IDToken:         "fake_token",
 			AccessToken:     "fakeAccessToken",
@@ -1572,7 +1572,7 @@ func (suite *OrderServiceSuite) TestListOrdersPPMCloseoutForArmyAirforce() {
 
 		session = auth.Session{
 			ApplicationName: auth.OfficeApp,
-			CurrentRole:     officeUserSC.User.Roles[0],
+			ActiveRole:      officeUserSC.User.Roles[0],
 			OfficeUserID:    officeUserSC.ID,
 			IDToken:         "fake_token",
 			AccessToken:     "fakeAccessToken",
@@ -1618,7 +1618,7 @@ func (suite *OrderServiceSuite) TestListOrdersPPMCloseoutForNavyCoastGuardAndMar
 
 		session := auth.Session{
 			ApplicationName: auth.OfficeApp,
-			CurrentRole:     officeUserSC.User.Roles[0],
+			ActiveRole:      officeUserSC.User.Roles[0],
 			OfficeUserID:    officeUserSC.ID,
 			IDToken:         "fake_token",
 			AccessToken:     "fakeAccessToken",
@@ -1652,7 +1652,7 @@ func (suite *OrderServiceSuite) TestListOrdersPPMCloseoutForNavyCoastGuardAndMar
 
 		session := auth.Session{
 			ApplicationName: auth.OfficeApp,
-			CurrentRole:     officeUserSC.User.Roles[0],
+			ActiveRole:      officeUserSC.User.Roles[0],
 			OfficeUserID:    officeUserSC.ID,
 			IDToken:         "fake_token",
 			AccessToken:     "fakeAccessToken",
@@ -1686,7 +1686,7 @@ func (suite *OrderServiceSuite) TestListOrdersPPMCloseoutForNavyCoastGuardAndMar
 
 		session := auth.Session{
 			ApplicationName: auth.OfficeApp,
-			CurrentRole:     officeUserSC.User.Roles[0],
+			ActiveRole:      officeUserSC.User.Roles[0],
 			OfficeUserID:    officeUserSC.ID,
 			IDToken:         "fake_token",
 			AccessToken:     "fakeAccessToken",
@@ -1745,7 +1745,7 @@ func (suite *OrderServiceSuite) TestListOrdersPPMCloseoutForNavyCoastGuardAndMar
 
 		session := auth.Session{
 			ApplicationName: auth.OfficeApp,
-			CurrentRole:     officeUserSC.User.Roles[0],
+			ActiveRole:      officeUserSC.User.Roles[0],
 			OfficeUserID:    officeUserSC.ID,
 			IDToken:         "fake_token",
 			AccessToken:     "fakeAccessToken",
@@ -1775,7 +1775,7 @@ func (suite *OrderServiceSuite) TestListOrdersMarines() {
 		officeUser := factory.BuildOfficeUserWithRoles(suite.DB(), nil, []roles.RoleType{roles.RoleTypeTOO})
 		session := auth.Session{
 			ApplicationName: auth.OfficeApp,
-			CurrentRole:     officeUser.User.Roles[0],
+			ActiveRole:      officeUser.User.Roles[0],
 			OfficeUserID:    officeUser.ID,
 			IDToken:         "fake_token",
 			AccessToken:     "fakeAccessToken",
@@ -1835,7 +1835,7 @@ func (suite *OrderServiceSuite) TestListOrdersWithEmptyFields() {
 	officeUser := factory.BuildOfficeUser(suite.DB(), nil, nil)
 	session := auth.Session{
 		ApplicationName: auth.OfficeApp,
-		CurrentRole:     officeUser.User.Roles[0],
+		ActiveRole:      officeUser.User.Roles[0],
 		OfficeUserID:    officeUser.ID,
 		IDToken:         "fake_token",
 		AccessToken:     "fakeAccessToken",
@@ -1854,7 +1854,7 @@ func (suite *OrderServiceSuite) TestListOrdersWithPagination() {
 	waf := entitlements.NewWeightAllotmentFetcher()
 	session := auth.Session{
 		ApplicationName: auth.OfficeApp,
-		CurrentRole:     officeUser.User.Roles[0],
+		ActiveRole:      officeUser.User.Roles[0],
 		OfficeUserID:    officeUser.ID,
 		IDToken:         "fake_token",
 		AccessToken:     "fakeAccessToken",
@@ -1937,7 +1937,7 @@ func (suite *OrderServiceSuite) TestListOrdersWithSortOrder() {
 		officeUser = factory.BuildOfficeUserWithRoles(suite.DB(), nil, []roles.RoleType{roles.RoleTypeTOO})
 		session := auth.Session{
 			ApplicationName: auth.OfficeApp,
-			CurrentRole:     officeUser.User.Roles[0],
+			ActiveRole:      officeUser.User.Roles[0],
 			OfficeUserID:    officeUser.ID,
 			IDToken:         "fake_token",
 			AccessToken:     "fakeAccessToken",
@@ -2025,7 +2025,7 @@ func (suite *OrderServiceSuite) TestListOrdersWithSortOrder() {
 		officeUser = factory.BuildOfficeUserWithRoles(suite.DB(), nil, []roles.RoleType{roles.RoleTypeTOO})
 		session := auth.Session{
 			ApplicationName: auth.OfficeApp,
-			CurrentRole:     officeUser.User.Roles[0],
+			ActiveRole:      officeUser.User.Roles[0],
 			OfficeUserID:    officeUser.ID,
 			IDToken:         "fake_token",
 			AccessToken:     "fakeAccessToken",
@@ -2475,7 +2475,7 @@ func (suite *OrderServiceSuite) TestListOrdersNeedingServicesCounselingWithGBLOC
 		officeUser := factory.BuildOfficeUserWithRoles(suite.DB(), nil, []roles.RoleType{roles.RoleTypeServicesCounselor})
 		session := auth.Session{
 			ApplicationName: auth.OfficeApp,
-			CurrentRole:     officeUser.User.Roles[0],
+			ActiveRole:      officeUser.User.Roles[0],
 			OfficeUserID:    officeUser.ID,
 			IDToken:         "fake_token",
 			AccessToken:     "fakeAccessToken",
@@ -2556,7 +2556,7 @@ func (suite *OrderServiceSuite) TestListOrdersForTOOWithNTSRelease() {
 	tooOfficeUser := factory.BuildOfficeUserWithRoles(suite.DB(), nil, []roles.RoleType{roles.RoleTypeTOO})
 	session := auth.Session{
 		ApplicationName: auth.OfficeApp,
-		CurrentRole:     tooOfficeUser.User.Roles[0],
+		ActiveRole:      tooOfficeUser.User.Roles[0],
 		OfficeUserID:    tooOfficeUser.ID,
 		IDToken:         "fake_token",
 		AccessToken:     "fakeAccessToken",
@@ -2597,7 +2597,7 @@ func (suite *OrderServiceSuite) TestListOrdersForTOOWithPPM() {
 	tooOfficeUser := factory.BuildOfficeUserWithRoles(suite.DB(), nil, []roles.RoleType{roles.RoleTypeTOO})
 	session := auth.Session{
 		ApplicationName: auth.OfficeApp,
-		CurrentRole:     tooOfficeUser.User.Roles[0],
+		ActiveRole:      tooOfficeUser.User.Roles[0],
 		OfficeUserID:    tooOfficeUser.ID,
 		IDToken:         "fake_token",
 		AccessToken:     "fakeAccessToken",
@@ -2673,7 +2673,7 @@ func (suite *OrderServiceSuite) TestListOrdersWithViewAsGBLOCParam() {
 		hqOfficeUser = factory.BuildOfficeUserWithRoles(suite.DB(), nil, []roles.RoleType{roles.RoleTypeHQ})
 		hqSession := auth.Session{
 			ApplicationName: auth.OfficeApp,
-			CurrentRole:     hqOfficeUser.User.Roles[0],
+			ActiveRole:      hqOfficeUser.User.Roles[0],
 			OfficeUserID:    hqOfficeUser.ID,
 			IDToken:         "fake_token",
 			AccessToken:     "fakeAccessToken",
@@ -2689,7 +2689,7 @@ func (suite *OrderServiceSuite) TestListOrdersWithViewAsGBLOCParam() {
 		}, []roles.RoleType{roles.RoleTypeHQ})
 		hqSessionAGFM := auth.Session{
 			ApplicationName: auth.OfficeApp,
-			CurrentRole:     hqOfficeUserAGFM.User.Roles[0],
+			ActiveRole:      hqOfficeUserAGFM.User.Roles[0],
 			OfficeUserID:    hqOfficeUserAGFM.ID,
 			IDToken:         "fake_token",
 			AccessToken:     "fakeAccessToken",
@@ -2775,7 +2775,7 @@ func (suite *OrderServiceSuite) TestListOrdersForTOOWithPPMWithDeletedShipment()
 	tooOfficeUser := factory.BuildOfficeUserWithRoles(suite.DB(), nil, []roles.RoleType{roles.RoleTypeTOO})
 	session := auth.Session{
 		ApplicationName: auth.OfficeApp,
-		CurrentRole:     tooOfficeUser.User.Roles[0],
+		ActiveRole:      tooOfficeUser.User.Roles[0],
 		OfficeUserID:    tooOfficeUser.ID,
 		IDToken:         "fake_token",
 		AccessToken:     "fakeAccessToken",
@@ -2856,7 +2856,7 @@ func (suite *OrderServiceSuite) TestListOrdersForTOOWithPPMWithOneDeletedShipmen
 	tooOfficeUser := factory.BuildOfficeUserWithRoles(suite.DB(), nil, []roles.RoleType{roles.RoleTypeTOO})
 	session := auth.Session{
 		ApplicationName: auth.OfficeApp,
-		CurrentRole:     tooOfficeUser.User.Roles[0],
+		ActiveRole:      tooOfficeUser.User.Roles[0],
 		OfficeUserID:    tooOfficeUser.ID,
 		IDToken:         "fake_token",
 		AccessToken:     "fakeAccessToken",
@@ -2876,7 +2876,7 @@ func (suite *OrderServiceSuite) TestListAllOrderLocations() {
 		officeUser := factory.BuildOfficeUserWithRoles(suite.DB(), nil, []roles.RoleType{roles.RoleTypeServicesCounselor})
 		session := auth.Session{
 			ApplicationName: auth.OfficeApp,
-			CurrentRole:     officeUser.User.Roles[0],
+			ActiveRole:      officeUser.User.Roles[0],
 			OfficeUserID:    officeUser.ID,
 			IDToken:         "fake_token",
 			AccessToken:     "fakeAccessToken",
@@ -2942,7 +2942,7 @@ func (suite *OrderServiceSuite) TestListOrdersFilteredByCustomerName() {
 		officeUser = factory.BuildOfficeUserWithRoles(suite.DB(), nil, []roles.RoleType{roles.RoleTypeTOO})
 		session = auth.Session{
 			ApplicationName: auth.OfficeApp,
-			CurrentRole:     officeUser.User.Roles[0],
+			ActiveRole:      officeUser.User.Roles[0],
 			OfficeUserID:    officeUser.ID,
 			IDToken:         "fake_token",
 			AccessToken:     "fakeAccessToken",
@@ -3060,7 +3060,7 @@ func (suite *OrderServiceSuite) TestListAllOrderLocationsWithViewAsGBLOCParam() 
 		}, nil)
 		session := auth.Session{
 			ApplicationName: auth.OfficeApp,
-			CurrentRole:     officeUser.User.Roles[0],
+			ActiveRole:      officeUser.User.Roles[0],
 			OfficeUserID:    officeUser.ID,
 			IDToken:         "fake_token",
 			AccessToken:     "fakeAccessToken",
@@ -3133,7 +3133,7 @@ func (suite *OrderServiceSuite) TestOriginDutyLocationFilter() {
 		officeUser := factory.BuildOfficeUserWithRoles(suite.DB(), nil, []roles.RoleType{roles.RoleTypeTOO})
 		session := auth.Session{
 			ApplicationName: auth.OfficeApp,
-			CurrentRole:     officeUser.User.Roles[0],
+			ActiveRole:      officeUser.User.Roles[0],
 			OfficeUserID:    officeUser.ID,
 			IDToken:         "fake_token",
 			AccessToken:     "fakeAccessToken",
@@ -3189,7 +3189,7 @@ func (suite *OrderServiceSuite) TestListDestinationRequestsOrders() {
 
 		session := auth.Session{
 			ApplicationName: auth.OfficeApp,
-			CurrentRole:     officeUser.User.Roles[0],
+			ActiveRole:      officeUser.User.Roles[0],
 			OfficeUserID:    officeUser.ID,
 			IDToken:         "fake_token",
 			AccessToken:     "fakeAccessToken",
@@ -3756,7 +3756,7 @@ func (suite *OrderServiceSuite) TestListDestinationRequestsOrders() {
 		suite.Equal("KKFA", secondaryTransportationOfficeAssignment.TransportationOffice.Gbloc)
 		session := auth.Session{
 			ApplicationName: auth.OfficeApp,
-			CurrentRole:     officeUser.User.Roles[0],
+			ActiveRole:      officeUser.User.Roles[0],
 			OfficeUserID:    officeUser.ID,
 			IDToken:         "fake_token",
 			AccessToken:     "fakeAccessToken",

--- a/pkg/services/order/order_fetcher_test.go
+++ b/pkg/services/order/order_fetcher_test.go
@@ -86,7 +86,7 @@ func (suite *OrderServiceSuite) TestListOrders() {
 		officeUser := factory.BuildOfficeUserWithRoles(suite.DB(), nil, []roles.RoleType{roles.RoleTypeTOO})
 		session := auth.Session{
 			ApplicationName: auth.OfficeApp,
-			Roles:           officeUser.User.Roles,
+			CurrentRole:     officeUser.User.Roles[0],
 			OfficeUserID:    officeUser.ID,
 			IDToken:         "fake_token",
 			AccessToken:     "fakeAccessToken",
@@ -638,7 +638,7 @@ func (suite *OrderServiceSuite) TestListOrders() {
 		officeUser := factory.BuildOfficeUserWithRoles(suite.DB(), nil, []roles.RoleType{roles.RoleTypeTOO})
 		session := auth.Session{
 			ApplicationName: auth.OfficeApp,
-			Roles:           officeUser.User.Roles,
+			CurrentRole:     officeUser.User.Roles[0],
 			OfficeUserID:    officeUser.ID,
 			IDToken:         "fake_token",
 			AccessToken:     "fakeAccessToken",
@@ -702,7 +702,7 @@ func (suite *OrderServiceSuite) TestListOrders() {
 		officeUser := factory.BuildOfficeUserWithRoles(suite.DB(), nil, []roles.RoleType{roles.RoleTypeTOO})
 		session := auth.Session{
 			ApplicationName: auth.OfficeApp,
-			Roles:           officeUser.User.Roles,
+			CurrentRole:     officeUser.User.Roles[0],
 			OfficeUserID:    officeUser.ID,
 			IDToken:         "fake_token",
 			AccessToken:     "fakeAccessToken",
@@ -779,7 +779,7 @@ func (suite *OrderServiceSuite) TestListOrders() {
 		officeUser := factory.BuildOfficeUserWithRoles(suite.DB(), nil, []roles.RoleType{roles.RoleTypeTOO})
 		session := auth.Session{
 			ApplicationName: auth.OfficeApp,
-			Roles:           officeUser.User.Roles,
+			CurrentRole:     officeUser.User.Roles[0],
 			OfficeUserID:    officeUser.ID,
 			IDToken:         "fake_token",
 			AccessToken:     "fakeAccessToken",
@@ -840,7 +840,7 @@ func (suite *OrderServiceSuite) TestListOrders() {
 		officeUser := factory.BuildOfficeUserWithRoles(suite.DB(), nil, []roles.RoleType{roles.RoleTypeTOO})
 		session := auth.Session{
 			ApplicationName: auth.OfficeApp,
-			Roles:           officeUser.User.Roles,
+			CurrentRole:     officeUser.User.Roles[0],
 			OfficeUserID:    officeUser.ID,
 			IDToken:         "fake_token",
 			AccessToken:     "fakeAccessToken",
@@ -886,7 +886,7 @@ func (suite *OrderServiceSuite) TestListOrders() {
 		officeUser := factory.BuildOfficeUserWithRoles(suite.DB(), nil, []roles.RoleType{roles.RoleTypeTOO})
 		session := auth.Session{
 			ApplicationName: auth.OfficeApp,
-			Roles:           officeUser.User.Roles,
+			CurrentRole:     officeUser.User.Roles[0],
 			OfficeUserID:    officeUser.ID,
 			IDToken:         "fake_token",
 			AccessToken:     "fakeAccessToken",
@@ -945,7 +945,7 @@ func (suite *OrderServiceSuite) TestListOrders() {
 		officeUser := factory.BuildOfficeUserWithRoles(suite.DB(), nil, []roles.RoleType{roles.RoleTypeTOO})
 		session := auth.Session{
 			ApplicationName: auth.OfficeApp,
-			Roles:           officeUser.User.Roles,
+			CurrentRole:     officeUser.User.Roles[0],
 			OfficeUserID:    officeUser.ID,
 			IDToken:         "fake_token",
 			AccessToken:     "fakeAccessToken",
@@ -991,7 +991,7 @@ func (suite *OrderServiceSuite) TestListOrders() {
 		officeUser := factory.BuildOfficeUserWithRoles(suite.DB(), nil, []roles.RoleType{roles.RoleTypeTOO})
 		session := auth.Session{
 			ApplicationName: auth.OfficeApp,
-			Roles:           officeUser.User.Roles,
+			CurrentRole:     officeUser.User.Roles[0],
 			OfficeUserID:    officeUser.ID,
 			IDToken:         "fake_token",
 			AccessToken:     "fakeAccessToken",
@@ -1037,7 +1037,7 @@ func (suite *OrderServiceSuite) TestListOrders() {
 		officeUser := factory.BuildOfficeUserWithRoles(suite.DB(), nil, []roles.RoleType{roles.RoleTypeTOO})
 		session := auth.Session{
 			ApplicationName: auth.OfficeApp,
-			Roles:           officeUser.User.Roles,
+			CurrentRole:     officeUser.User.Roles[0],
 			OfficeUserID:    officeUser.ID,
 			IDToken:         "fake_token",
 			AccessToken:     "fakeAccessToken",
@@ -1096,7 +1096,7 @@ func (suite *OrderServiceSuite) TestListOrders() {
 		officeUser := factory.BuildOfficeUserWithRoles(suite.DB(), nil, []roles.RoleType{roles.RoleTypeTOO})
 		session := auth.Session{
 			ApplicationName: auth.OfficeApp,
-			Roles:           officeUser.User.Roles,
+			CurrentRole:     officeUser.User.Roles[0],
 			OfficeUserID:    officeUser.ID,
 			IDToken:         "fake_token",
 			AccessToken:     "fakeAccessToken",
@@ -1132,7 +1132,7 @@ func (suite *OrderServiceSuite) TestListOrders() {
 		officeUser := factory.BuildOfficeUserWithRoles(suite.DB(), nil, []roles.RoleType{roles.RoleTypeTOO})
 		session := auth.Session{
 			ApplicationName: auth.OfficeApp,
-			Roles:           officeUser.User.Roles,
+			CurrentRole:     officeUser.User.Roles[0],
 			OfficeUserID:    officeUser.ID,
 			IDToken:         "fake_token",
 			AccessToken:     "fakeAccessToken",
@@ -1168,7 +1168,7 @@ func (suite *OrderServiceSuite) TestListOrders() {
 		officeUser := factory.BuildOfficeUserWithRoles(suite.DB(), nil, []roles.RoleType{roles.RoleTypeTOO})
 		session := auth.Session{
 			ApplicationName: auth.OfficeApp,
-			Roles:           officeUser.User.Roles,
+			CurrentRole:     officeUser.User.Roles[0],
 			OfficeUserID:    officeUser.ID,
 			IDToken:         "fake_token",
 			AccessToken:     "fakeAccessToken",
@@ -1231,7 +1231,7 @@ func (suite *OrderServiceSuite) TestListOrders() {
 		officeUser := factory.BuildOfficeUserWithRoles(suite.DB(), nil, []roles.RoleType{roles.RoleTypeTOO})
 		session := auth.Session{
 			ApplicationName: auth.OfficeApp,
-			Roles:           officeUser.User.Roles,
+			CurrentRole:     officeUser.User.Roles[0],
 			OfficeUserID:    officeUser.ID,
 			IDToken:         "fake_token",
 			AccessToken:     "fakeAccessToken",
@@ -1294,7 +1294,7 @@ func (suite *OrderServiceSuite) TestListOrders() {
 		officeUser := factory.BuildOfficeUserWithRoles(suite.DB(), nil, []roles.RoleType{roles.RoleTypeTOO})
 		session := auth.Session{
 			ApplicationName: auth.OfficeApp,
-			Roles:           officeUser.User.Roles,
+			CurrentRole:     officeUser.User.Roles[0],
 			OfficeUserID:    officeUser.ID,
 			IDToken:         "fake_token",
 			AccessToken:     "fakeAccessToken",
@@ -1371,7 +1371,7 @@ func (suite *OrderServiceSuite) TestListOrderWithAssignedUserSingle() {
 	var orderFetcherTest orderFetcher
 	session := auth.Session{
 		ApplicationName: auth.OfficeApp,
-		Roles:           scUser.User.Roles,
+		CurrentRole:     scUser.User.Roles[0],
 		OfficeUserID:    scUser.ID,
 		IDToken:         "fake_token",
 		AccessToken:     "fakeAccessToken",
@@ -1432,7 +1432,7 @@ func (suite *OrderServiceSuite) TestListOrdersUSMCGBLOC() {
 		officeUser := factory.BuildOfficeUserWithRoles(suite.DB(), nil, []roles.RoleType{roles.RoleTypeTOO})
 		session := auth.Session{
 			ApplicationName: auth.OfficeApp,
-			Roles:           officeUser.User.Roles,
+			CurrentRole:     officeUser.User.Roles[0],
 			OfficeUserID:    officeUser.ID,
 			IDToken:         "fake_token",
 			AccessToken:     "fakeAccessToken",
@@ -1544,7 +1544,7 @@ func (suite *OrderServiceSuite) TestListOrdersPPMCloseoutForArmyAirforce() {
 
 		session = auth.Session{
 			ApplicationName: auth.OfficeApp,
-			Roles:           officeUserSC.User.Roles,
+			CurrentRole:     officeUserSC.User.Roles[0],
 			OfficeUserID:    officeUserSC.ID,
 			IDToken:         "fake_token",
 			AccessToken:     "fakeAccessToken",
@@ -1572,7 +1572,7 @@ func (suite *OrderServiceSuite) TestListOrdersPPMCloseoutForArmyAirforce() {
 
 		session = auth.Session{
 			ApplicationName: auth.OfficeApp,
-			Roles:           officeUserSC.User.Roles,
+			CurrentRole:     officeUserSC.User.Roles[0],
 			OfficeUserID:    officeUserSC.ID,
 			IDToken:         "fake_token",
 			AccessToken:     "fakeAccessToken",
@@ -1618,7 +1618,7 @@ func (suite *OrderServiceSuite) TestListOrdersPPMCloseoutForNavyCoastGuardAndMar
 
 		session := auth.Session{
 			ApplicationName: auth.OfficeApp,
-			Roles:           officeUserSC.User.Roles,
+			CurrentRole:     officeUserSC.User.Roles[0],
 			OfficeUserID:    officeUserSC.ID,
 			IDToken:         "fake_token",
 			AccessToken:     "fakeAccessToken",
@@ -1652,7 +1652,7 @@ func (suite *OrderServiceSuite) TestListOrdersPPMCloseoutForNavyCoastGuardAndMar
 
 		session := auth.Session{
 			ApplicationName: auth.OfficeApp,
-			Roles:           officeUserSC.User.Roles,
+			CurrentRole:     officeUserSC.User.Roles[0],
 			OfficeUserID:    officeUserSC.ID,
 			IDToken:         "fake_token",
 			AccessToken:     "fakeAccessToken",
@@ -1686,7 +1686,7 @@ func (suite *OrderServiceSuite) TestListOrdersPPMCloseoutForNavyCoastGuardAndMar
 
 		session := auth.Session{
 			ApplicationName: auth.OfficeApp,
-			Roles:           officeUserSC.User.Roles,
+			CurrentRole:     officeUserSC.User.Roles[0],
 			OfficeUserID:    officeUserSC.ID,
 			IDToken:         "fake_token",
 			AccessToken:     "fakeAccessToken",
@@ -1745,7 +1745,7 @@ func (suite *OrderServiceSuite) TestListOrdersPPMCloseoutForNavyCoastGuardAndMar
 
 		session := auth.Session{
 			ApplicationName: auth.OfficeApp,
-			Roles:           officeUserSC.User.Roles,
+			CurrentRole:     officeUserSC.User.Roles[0],
 			OfficeUserID:    officeUserSC.ID,
 			IDToken:         "fake_token",
 			AccessToken:     "fakeAccessToken",
@@ -1775,7 +1775,7 @@ func (suite *OrderServiceSuite) TestListOrdersMarines() {
 		officeUser := factory.BuildOfficeUserWithRoles(suite.DB(), nil, []roles.RoleType{roles.RoleTypeTOO})
 		session := auth.Session{
 			ApplicationName: auth.OfficeApp,
-			Roles:           officeUser.User.Roles,
+			CurrentRole:     officeUser.User.Roles[0],
 			OfficeUserID:    officeUser.ID,
 			IDToken:         "fake_token",
 			AccessToken:     "fakeAccessToken",
@@ -1835,7 +1835,7 @@ func (suite *OrderServiceSuite) TestListOrdersWithEmptyFields() {
 	officeUser := factory.BuildOfficeUser(suite.DB(), nil, nil)
 	session := auth.Session{
 		ApplicationName: auth.OfficeApp,
-		Roles:           officeUser.User.Roles,
+		CurrentRole:     officeUser.User.Roles[0],
 		OfficeUserID:    officeUser.ID,
 		IDToken:         "fake_token",
 		AccessToken:     "fakeAccessToken",
@@ -1854,7 +1854,7 @@ func (suite *OrderServiceSuite) TestListOrdersWithPagination() {
 	waf := entitlements.NewWeightAllotmentFetcher()
 	session := auth.Session{
 		ApplicationName: auth.OfficeApp,
-		Roles:           officeUser.User.Roles,
+		CurrentRole:     officeUser.User.Roles[0],
 		OfficeUserID:    officeUser.ID,
 		IDToken:         "fake_token",
 		AccessToken:     "fakeAccessToken",
@@ -1937,7 +1937,7 @@ func (suite *OrderServiceSuite) TestListOrdersWithSortOrder() {
 		officeUser = factory.BuildOfficeUserWithRoles(suite.DB(), nil, []roles.RoleType{roles.RoleTypeTOO})
 		session := auth.Session{
 			ApplicationName: auth.OfficeApp,
-			Roles:           officeUser.User.Roles,
+			CurrentRole:     officeUser.User.Roles[0],
 			OfficeUserID:    officeUser.ID,
 			IDToken:         "fake_token",
 			AccessToken:     "fakeAccessToken",
@@ -2025,7 +2025,7 @@ func (suite *OrderServiceSuite) TestListOrdersWithSortOrder() {
 		officeUser = factory.BuildOfficeUserWithRoles(suite.DB(), nil, []roles.RoleType{roles.RoleTypeTOO})
 		session := auth.Session{
 			ApplicationName: auth.OfficeApp,
-			Roles:           officeUser.User.Roles,
+			CurrentRole:     officeUser.User.Roles[0],
 			OfficeUserID:    officeUser.ID,
 			IDToken:         "fake_token",
 			AccessToken:     "fakeAccessToken",
@@ -2475,7 +2475,7 @@ func (suite *OrderServiceSuite) TestListOrdersNeedingServicesCounselingWithGBLOC
 		officeUser := factory.BuildOfficeUserWithRoles(suite.DB(), nil, []roles.RoleType{roles.RoleTypeServicesCounselor})
 		session := auth.Session{
 			ApplicationName: auth.OfficeApp,
-			Roles:           officeUser.User.Roles,
+			CurrentRole:     officeUser.User.Roles[0],
 			OfficeUserID:    officeUser.ID,
 			IDToken:         "fake_token",
 			AccessToken:     "fakeAccessToken",
@@ -2556,7 +2556,7 @@ func (suite *OrderServiceSuite) TestListOrdersForTOOWithNTSRelease() {
 	tooOfficeUser := factory.BuildOfficeUserWithRoles(suite.DB(), nil, []roles.RoleType{roles.RoleTypeTOO})
 	session := auth.Session{
 		ApplicationName: auth.OfficeApp,
-		Roles:           tooOfficeUser.User.Roles,
+		CurrentRole:     tooOfficeUser.User.Roles[0],
 		OfficeUserID:    tooOfficeUser.ID,
 		IDToken:         "fake_token",
 		AccessToken:     "fakeAccessToken",
@@ -2597,7 +2597,7 @@ func (suite *OrderServiceSuite) TestListOrdersForTOOWithPPM() {
 	tooOfficeUser := factory.BuildOfficeUserWithRoles(suite.DB(), nil, []roles.RoleType{roles.RoleTypeTOO})
 	session := auth.Session{
 		ApplicationName: auth.OfficeApp,
-		Roles:           tooOfficeUser.User.Roles,
+		CurrentRole:     tooOfficeUser.User.Roles[0],
 		OfficeUserID:    tooOfficeUser.ID,
 		IDToken:         "fake_token",
 		AccessToken:     "fakeAccessToken",
@@ -2673,7 +2673,7 @@ func (suite *OrderServiceSuite) TestListOrdersWithViewAsGBLOCParam() {
 		hqOfficeUser = factory.BuildOfficeUserWithRoles(suite.DB(), nil, []roles.RoleType{roles.RoleTypeHQ})
 		hqSession := auth.Session{
 			ApplicationName: auth.OfficeApp,
-			Roles:           hqOfficeUser.User.Roles,
+			CurrentRole:     hqOfficeUser.User.Roles[0],
 			OfficeUserID:    hqOfficeUser.ID,
 			IDToken:         "fake_token",
 			AccessToken:     "fakeAccessToken",
@@ -2689,7 +2689,7 @@ func (suite *OrderServiceSuite) TestListOrdersWithViewAsGBLOCParam() {
 		}, []roles.RoleType{roles.RoleTypeHQ})
 		hqSessionAGFM := auth.Session{
 			ApplicationName: auth.OfficeApp,
-			Roles:           hqOfficeUserAGFM.User.Roles,
+			CurrentRole:     hqOfficeUserAGFM.User.Roles[0],
 			OfficeUserID:    hqOfficeUserAGFM.ID,
 			IDToken:         "fake_token",
 			AccessToken:     "fakeAccessToken",
@@ -2775,7 +2775,7 @@ func (suite *OrderServiceSuite) TestListOrdersForTOOWithPPMWithDeletedShipment()
 	tooOfficeUser := factory.BuildOfficeUserWithRoles(suite.DB(), nil, []roles.RoleType{roles.RoleTypeTOO})
 	session := auth.Session{
 		ApplicationName: auth.OfficeApp,
-		Roles:           tooOfficeUser.User.Roles,
+		CurrentRole:     tooOfficeUser.User.Roles[0],
 		OfficeUserID:    tooOfficeUser.ID,
 		IDToken:         "fake_token",
 		AccessToken:     "fakeAccessToken",
@@ -2856,7 +2856,7 @@ func (suite *OrderServiceSuite) TestListOrdersForTOOWithPPMWithOneDeletedShipmen
 	tooOfficeUser := factory.BuildOfficeUserWithRoles(suite.DB(), nil, []roles.RoleType{roles.RoleTypeTOO})
 	session := auth.Session{
 		ApplicationName: auth.OfficeApp,
-		Roles:           tooOfficeUser.User.Roles,
+		CurrentRole:     tooOfficeUser.User.Roles[0],
 		OfficeUserID:    tooOfficeUser.ID,
 		IDToken:         "fake_token",
 		AccessToken:     "fakeAccessToken",
@@ -2876,7 +2876,7 @@ func (suite *OrderServiceSuite) TestListAllOrderLocations() {
 		officeUser := factory.BuildOfficeUserWithRoles(suite.DB(), nil, []roles.RoleType{roles.RoleTypeServicesCounselor})
 		session := auth.Session{
 			ApplicationName: auth.OfficeApp,
-			Roles:           officeUser.User.Roles,
+			CurrentRole:     officeUser.User.Roles[0],
 			OfficeUserID:    officeUser.ID,
 			IDToken:         "fake_token",
 			AccessToken:     "fakeAccessToken",
@@ -2942,7 +2942,7 @@ func (suite *OrderServiceSuite) TestListOrdersFilteredByCustomerName() {
 		officeUser = factory.BuildOfficeUserWithRoles(suite.DB(), nil, []roles.RoleType{roles.RoleTypeTOO})
 		session = auth.Session{
 			ApplicationName: auth.OfficeApp,
-			Roles:           officeUser.User.Roles,
+			CurrentRole:     officeUser.User.Roles[0],
 			OfficeUserID:    officeUser.ID,
 			IDToken:         "fake_token",
 			AccessToken:     "fakeAccessToken",
@@ -3060,7 +3060,7 @@ func (suite *OrderServiceSuite) TestListAllOrderLocationsWithViewAsGBLOCParam() 
 		}, nil)
 		session := auth.Session{
 			ApplicationName: auth.OfficeApp,
-			Roles:           officeUser.User.Roles,
+			CurrentRole:     officeUser.User.Roles[0],
 			OfficeUserID:    officeUser.ID,
 			IDToken:         "fake_token",
 			AccessToken:     "fakeAccessToken",
@@ -3133,7 +3133,7 @@ func (suite *OrderServiceSuite) TestOriginDutyLocationFilter() {
 		officeUser := factory.BuildOfficeUserWithRoles(suite.DB(), nil, []roles.RoleType{roles.RoleTypeTOO})
 		session := auth.Session{
 			ApplicationName: auth.OfficeApp,
-			Roles:           officeUser.User.Roles,
+			CurrentRole:     officeUser.User.Roles[0],
 			OfficeUserID:    officeUser.ID,
 			IDToken:         "fake_token",
 			AccessToken:     "fakeAccessToken",
@@ -3189,7 +3189,7 @@ func (suite *OrderServiceSuite) TestListDestinationRequestsOrders() {
 
 		session := auth.Session{
 			ApplicationName: auth.OfficeApp,
-			Roles:           officeUser.User.Roles,
+			CurrentRole:     officeUser.User.Roles[0],
 			OfficeUserID:    officeUser.ID,
 			IDToken:         "fake_token",
 			AccessToken:     "fakeAccessToken",
@@ -3756,7 +3756,7 @@ func (suite *OrderServiceSuite) TestListDestinationRequestsOrders() {
 		suite.Equal("KKFA", secondaryTransportationOfficeAssignment.TransportationOffice.Gbloc)
 		session := auth.Session{
 			ApplicationName: auth.OfficeApp,
-			Roles:           officeUser.User.Roles,
+			CurrentRole:     officeUser.User.Roles[0],
 			OfficeUserID:    officeUser.ID,
 			IDToken:         "fake_token",
 			AccessToken:     "fakeAccessToken",

--- a/pkg/services/payment_request/payment_request_list_fetcher_test.go
+++ b/pkg/services/payment_request/payment_request_list_fetcher_test.go
@@ -66,7 +66,7 @@ func (suite *PaymentRequestServiceSuite) TestFetchPaymentRequestList() {
 
 		session = auth.Session{
 			ApplicationName: auth.OfficeApp,
-			Roles:           officeUser.User.Roles,
+			CurrentRole:     officeUser.User.Roles[0],
 			OfficeUserID:    officeUser.ID,
 			IDToken:         "fake_token",
 			AccessToken:     "fakeAccessToken",
@@ -197,7 +197,7 @@ func (suite *PaymentRequestServiceSuite) TestFetchPaymentRequestListStatusFilter
 
 		session = auth.Session{
 			ApplicationName: auth.OfficeApp,
-			Roles:           officeUser.User.Roles,
+			CurrentRole:     officeUser.User.Roles[0],
 			OfficeUserID:    officeUser.ID,
 			IDToken:         "fake_token",
 			AccessToken:     "fakeAccessToken",
@@ -388,7 +388,7 @@ func (suite *PaymentRequestServiceSuite) TestFetchPaymentRequestListUSMCGBLOC() 
 
 		session = auth.Session{
 			ApplicationName: auth.OfficeApp,
-			Roles:           officeUser.User.Roles,
+			CurrentRole:     officeUser.User.Roles[0],
 			OfficeUserID:    officeUser.ID,
 			IDToken:         "fake_token",
 			AccessToken:     "fakeAccessToken",
@@ -511,7 +511,7 @@ func (suite *PaymentRequestServiceSuite) TestFetchPaymentRequestListNoGBLOCMatch
 
 		session := auth.Session{
 			ApplicationName: auth.OfficeApp,
-			Roles:           officeUser.User.Roles,
+			CurrentRole:     officeUser.User.Roles[0],
 			OfficeUserID:    officeUser.ID,
 			IDToken:         "fake_token",
 			AccessToken:     "fakeAccessToken",
@@ -562,7 +562,7 @@ func (suite *PaymentRequestServiceSuite) TestFetchPaymentRequestListWithPaginati
 
 	session := auth.Session{
 		ApplicationName: auth.OfficeApp,
-		Roles:           officeUser.User.Roles,
+		CurrentRole:     officeUser.User.Roles[0],
 		OfficeUserID:    officeUser.ID,
 		IDToken:         "fake_token",
 		AccessToken:     "fakeAccessToken",
@@ -624,7 +624,7 @@ func (suite *PaymentRequestServiceSuite) TestListPaymentRequestWithSortOrder() {
 
 		session = auth.Session{
 			ApplicationName: auth.OfficeApp,
-			Roles:           officeUser.User.Roles,
+			CurrentRole:     officeUser.User.Roles[0],
 			OfficeUserID:    officeUser.ID,
 			IDToken:         "fake_token",
 			AccessToken:     "fakeAccessToken",
@@ -1091,7 +1091,7 @@ func (suite *PaymentRequestServiceSuite) TestListPaymentRequestNameFilter() {
 		officeUser = factory.BuildOfficeUserWithRoles(suite.DB(), nil, []roles.RoleType{roles.RoleTypeTIO})
 		session = auth.Session{
 			ApplicationName: auth.OfficeApp,
-			Roles:           officeUser.User.Roles,
+			CurrentRole:     officeUser.User.Roles[0],
 			OfficeUserID:    officeUser.ID,
 			IDToken:         "fake_token",
 			AccessToken:     "fakeAccessToken",

--- a/pkg/services/payment_request/payment_request_list_fetcher_test.go
+++ b/pkg/services/payment_request/payment_request_list_fetcher_test.go
@@ -66,7 +66,7 @@ func (suite *PaymentRequestServiceSuite) TestFetchPaymentRequestList() {
 
 		session = auth.Session{
 			ApplicationName: auth.OfficeApp,
-			CurrentRole:     officeUser.User.Roles[0],
+			ActiveRole:      officeUser.User.Roles[0],
 			OfficeUserID:    officeUser.ID,
 			IDToken:         "fake_token",
 			AccessToken:     "fakeAccessToken",
@@ -197,7 +197,7 @@ func (suite *PaymentRequestServiceSuite) TestFetchPaymentRequestListStatusFilter
 
 		session = auth.Session{
 			ApplicationName: auth.OfficeApp,
-			CurrentRole:     officeUser.User.Roles[0],
+			ActiveRole:      officeUser.User.Roles[0],
 			OfficeUserID:    officeUser.ID,
 			IDToken:         "fake_token",
 			AccessToken:     "fakeAccessToken",
@@ -388,7 +388,7 @@ func (suite *PaymentRequestServiceSuite) TestFetchPaymentRequestListUSMCGBLOC() 
 
 		session = auth.Session{
 			ApplicationName: auth.OfficeApp,
-			CurrentRole:     officeUser.User.Roles[0],
+			ActiveRole:      officeUser.User.Roles[0],
 			OfficeUserID:    officeUser.ID,
 			IDToken:         "fake_token",
 			AccessToken:     "fakeAccessToken",
@@ -511,7 +511,7 @@ func (suite *PaymentRequestServiceSuite) TestFetchPaymentRequestListNoGBLOCMatch
 
 		session := auth.Session{
 			ApplicationName: auth.OfficeApp,
-			CurrentRole:     officeUser.User.Roles[0],
+			ActiveRole:      officeUser.User.Roles[0],
 			OfficeUserID:    officeUser.ID,
 			IDToken:         "fake_token",
 			AccessToken:     "fakeAccessToken",
@@ -562,7 +562,7 @@ func (suite *PaymentRequestServiceSuite) TestFetchPaymentRequestListWithPaginati
 
 	session := auth.Session{
 		ApplicationName: auth.OfficeApp,
-		CurrentRole:     officeUser.User.Roles[0],
+		ActiveRole:      officeUser.User.Roles[0],
 		OfficeUserID:    officeUser.ID,
 		IDToken:         "fake_token",
 		AccessToken:     "fakeAccessToken",
@@ -624,7 +624,7 @@ func (suite *PaymentRequestServiceSuite) TestListPaymentRequestWithSortOrder() {
 
 		session = auth.Session{
 			ApplicationName: auth.OfficeApp,
-			CurrentRole:     officeUser.User.Roles[0],
+			ActiveRole:      officeUser.User.Roles[0],
 			OfficeUserID:    officeUser.ID,
 			IDToken:         "fake_token",
 			AccessToken:     "fakeAccessToken",
@@ -1091,7 +1091,7 @@ func (suite *PaymentRequestServiceSuite) TestListPaymentRequestNameFilter() {
 		officeUser = factory.BuildOfficeUserWithRoles(suite.DB(), nil, []roles.RoleType{roles.RoleTypeTIO})
 		session = auth.Session{
 			ApplicationName: auth.OfficeApp,
-			CurrentRole:     officeUser.User.Roles[0],
+			ActiveRole:      officeUser.User.Roles[0],
 			OfficeUserID:    officeUser.ID,
 			IDToken:         "fake_token",
 			AccessToken:     "fakeAccessToken",

--- a/pkg/services/ppmshipment/ppm_shipment_creator.go
+++ b/pkg/services/ppmshipment/ppm_shipment_creator.go
@@ -165,7 +165,7 @@ func (f *ppmShipmentCreator) createPPMShipment(appCtx appcontext.AppContext, ppm
 			return err
 		}
 
-		if appCtx.Session().Roles.HasRole(roles.RoleTypeServicesCounselor) {
+		if appCtx.Session().CurrentRole.RoleType == roles.RoleTypeServicesCounselor {
 			mtoShipment.Status = models.MTOShipmentStatusApproved
 			ppmShipment.Status = models.PPMShipmentStatusWaitingOnCustomer
 			now := time.Now()

--- a/pkg/services/ppmshipment/ppm_shipment_creator.go
+++ b/pkg/services/ppmshipment/ppm_shipment_creator.go
@@ -165,7 +165,7 @@ func (f *ppmShipmentCreator) createPPMShipment(appCtx appcontext.AppContext, ppm
 			return err
 		}
 
-		if appCtx.Session().CurrentRole.RoleType == roles.RoleTypeServicesCounselor {
+		if appCtx.Session().ActiveRole.RoleType == roles.RoleTypeServicesCounselor {
 			mtoShipment.Status = models.MTOShipmentStatusApproved
 			ppmShipment.Status = models.PPMShipmentStatusWaitingOnCustomer
 			now := time.Now()

--- a/pkg/services/ppmshipment/ppm_shipment_creator_test.go
+++ b/pkg/services/ppmshipment/ppm_shipment_creator_test.go
@@ -78,7 +78,7 @@ func (suite *PPMShipmentSuite) TestPPMShipmentCreator() {
 			ApplicationName: auth.OfficeApp,
 			UserID:          user.ID,
 			IDToken:         "fake token",
-			CurrentRole:     roles.Role{},
+			ActiveRole:      roles.Role{},
 		}
 
 		appCtx := suite.AppContextWithSessionForTest(session)
@@ -145,7 +145,7 @@ func (suite *PPMShipmentSuite) TestPPMShipmentCreator() {
 			ApplicationName: auth.OfficeApp,
 			UserID:          user.ID,
 			IDToken:         "fake token",
-			CurrentRole:     roles.Role{},
+			ActiveRole:      roles.Role{},
 		}
 
 		appCtx := suite.AppContextWithSessionForTest(session)
@@ -257,7 +257,7 @@ func (suite *PPMShipmentSuite) TestPPMShipmentCreator() {
 				ApplicationName: auth.OfficeApp,
 				UserID:          user.ID,
 				IDToken:         "fake token",
-				CurrentRole:     roles.Role{},
+				ActiveRole:      roles.Role{},
 			}
 
 			appCtx := suite.AppContextWithSessionForTest(session)
@@ -288,7 +288,7 @@ func (suite *PPMShipmentSuite) TestPPMShipmentCreator() {
 		}
 		defaultRole, err := identity.Roles.Default()
 		suite.FatalNoError(err)
-		session.CurrentRole = *defaultRole
+		session.ActiveRole = *defaultRole
 
 		appCtx := suite.AppContextWithSessionForTest(session)
 

--- a/pkg/services/ppmshipment/ppm_shipment_creator_test.go
+++ b/pkg/services/ppmshipment/ppm_shipment_creator_test.go
@@ -78,7 +78,7 @@ func (suite *PPMShipmentSuite) TestPPMShipmentCreator() {
 			ApplicationName: auth.OfficeApp,
 			UserID:          user.ID,
 			IDToken:         "fake token",
-			Roles:           roles.Roles{},
+			CurrentRole:     roles.Role{},
 		}
 
 		appCtx := suite.AppContextWithSessionForTest(session)
@@ -145,7 +145,7 @@ func (suite *PPMShipmentSuite) TestPPMShipmentCreator() {
 			ApplicationName: auth.OfficeApp,
 			UserID:          user.ID,
 			IDToken:         "fake token",
-			Roles:           roles.Roles{},
+			CurrentRole:     roles.Role{},
 		}
 
 		appCtx := suite.AppContextWithSessionForTest(session)
@@ -257,7 +257,7 @@ func (suite *PPMShipmentSuite) TestPPMShipmentCreator() {
 				ApplicationName: auth.OfficeApp,
 				UserID:          user.ID,
 				IDToken:         "fake token",
-				Roles:           roles.Roles{},
+				CurrentRole:     roles.Role{},
 			}
 
 			appCtx := suite.AppContextWithSessionForTest(session)
@@ -286,7 +286,9 @@ func (suite *PPMShipmentSuite) TestPPMShipmentCreator() {
 			UserID:          *scOfficeUser.UserID,
 			IDToken:         "fake token",
 		}
-		session.Roles = append(session.Roles, identity.Roles...)
+		defaultRole, err := identity.Roles.Default()
+		suite.FatalNoError(err)
+		session.CurrentRole = *defaultRole
 
 		appCtx := suite.AppContextWithSessionForTest(session)
 

--- a/pkg/testdatagen/testharness/dispatch.go
+++ b/pkg/testdatagen/testharness/dispatch.go
@@ -230,6 +230,9 @@ var actionDispatcher = map[string]actionFunc{
 	"OfficeUserWithTOOAndTIO": func(appCtx appcontext.AppContext) testHarnessResponse {
 		return MakeOfficeUserWithTOOAndTIO(appCtx)
 	},
+	"OfficeUserWithMultirole": func(appCtx appcontext.AppContext) testHarnessResponse {
+		return MakeOfficeUserWithMultirole(appCtx)
+	},
 	"RequestedOfficeUser": func(appCtx appcontext.AppContext) testHarnessResponse {
 		return MakeRequestedOfficeUserWithTOO(appCtx)
 	},

--- a/playwright/tests/utils/office/officeTest.js
+++ b/playwright/tests/utils/office/officeTest.js
@@ -110,6 +110,14 @@ export class OfficePage extends BaseTestPage {
   }
 
   /**
+   * Use devlocal auth to sign in as office user with multirole
+   */
+  async signInAsNewMultiroleUser() {
+    const user = await this.testHarness.buildOfficeUserWithMultirole();
+    await this.signInAsExistingOfficeUser(user.okta_email);
+  }
+
+  /**
    * Use devlocal auth to sign in as office user with both TOO and TIO roles
    */
   async signInAsNewTIOAndTOOUser() {

--- a/playwright/tests/utils/testharness.js
+++ b/playwright/tests/utils/testharness.js
@@ -116,6 +116,14 @@ export class TestHarness {
   }
 
   /**
+   * build office user with multirole
+   * @returns {Promise<User>}
+   */
+  async buildOfficeUserWithMultirole() {
+    return this.buildDefault('OfficeUserWithTOOAndTIO');
+  }
+
+  /**
    * @returns {Promise<User>}
    */
   async buildNeedsOrdersUser() {

--- a/src/containers/Headers/OfficeLoggedInHeader.jsx
+++ b/src/containers/Headers/OfficeLoggedInHeader.jsx
@@ -41,11 +41,11 @@ const OfficeLoggedInHeader = ({ officeUser, activeRole, logOut }) => {
     roleTypes.GSR,
     roleTypes.HQ,
   ];
-  if (activeRole === roleTypes.TOO) {
+  if (activeRole.roleType === roleTypes.TOO) {
     queueText = 'moves';
-  } else if (activeRole === roleTypes.TIO) {
+  } else if (activeRole.roleType === roleTypes.TIO) {
     queueText = 'payment requests';
-  } else if (validUnlockingOfficers.includes(activeRole) && location.pathname === '/') {
+  } else if (validUnlockingOfficers.includes(activeRole.roleType) && location.pathname === '/') {
     checkForLockedMovesAndUnlock(officeUser.id);
   }
 

--- a/src/containers/Headers/OfficeLoggedInHeader.jsx
+++ b/src/containers/Headers/OfficeLoggedInHeader.jsx
@@ -41,11 +41,11 @@ const OfficeLoggedInHeader = ({ officeUser, activeRole, logOut }) => {
     roleTypes.GSR,
     roleTypes.HQ,
   ];
-  if (activeRole.roleType === roleTypes.TOO) {
+  if (activeRole === roleTypes.TOO) {
     queueText = 'moves';
-  } else if (activeRole.roleType === roleTypes.TIO) {
+  } else if (activeRole === roleTypes.TIO) {
     queueText = 'payment requests';
-  } else if (validUnlockingOfficers.includes(activeRole.roleType) && location.pathname === '/') {
+  } else if (validUnlockingOfficers.includes(activeRole) && location.pathname === '/') {
     checkForLockedMovesAndUnlock(officeUser.id);
   }
 

--- a/src/containers/PrivateRoute.jsx
+++ b/src/containers/PrivateRoute.jsx
@@ -4,26 +4,24 @@ import { Navigate } from 'react-router-dom';
 import { connect } from 'react-redux';
 
 import { selectLoggedInUser } from 'store/entities/selectors';
-import getRoleTypesFromRoles from 'utils/user';
 import { useTitle } from 'hooks/custom';
-import { UserRolesShape } from 'types';
+import { UserRoleShape } from 'types';
 
-export function userIsAuthorized(userRoles, requiredRoles) {
+export function userIsAuthorized(userActiveRole, requiredRoles) {
   // Return true if no roles are required
   if (!requiredRoles || !requiredRoles.length) return true;
 
-  // Return false if user has no roles
-  if (!userRoles || !userRoles.length) return false;
+  // Return false if user has no role
+  if (!userActiveRole) return false;
 
-  // User must have at least one of the roles defined in requiredRoles
-  return !!userRoles?.find((r) => requiredRoles.indexOf(r) > -1);
+  // User active role must be defined in requiredRoles
+  return requiredRoles.includes(userActiveRole);
 }
 
-function PrivateRoute({ requiredRoles, userRoles, children }) {
+function PrivateRoute({ requiredRoles, userActiveRole, children }) {
   useTitle();
-  const userRoleTypes = getRoleTypesFromRoles(userRoles);
 
-  if (!userIsAuthorized(userRoleTypes, requiredRoles)) {
+  if (!userIsAuthorized(userActiveRole, requiredRoles)) {
     return <Navigate to="/invalid-permissions" />;
   }
 
@@ -34,19 +32,19 @@ PrivateRoute.displayName = 'PrivateRoute';
 
 PrivateRoute.propTypes = {
   requiredRoles: PropTypes.arrayOf(PropTypes.string),
-  userRoles: UserRolesShape,
+  userActiveRole: UserRoleShape,
 };
 
 PrivateRoute.defaultProps = {
   requiredRoles: [],
-  userRoles: [],
+  userActiveRole: null,
 };
 
 const mapStateToProps = (state) => {
   const user = selectLoggedInUser(state);
 
   return {
-    userRoles: user?.roles || [],
+    userActiveRole: user?.userActiveRole,
   };
 };
 

--- a/src/containers/PrivateRoute.jsx
+++ b/src/containers/PrivateRoute.jsx
@@ -3,25 +3,23 @@ import PropTypes from 'prop-types';
 import { Navigate } from 'react-router-dom';
 import { connect } from 'react-redux';
 
-import { selectLoggedInUser } from 'store/entities/selectors';
 import { useTitle } from 'hooks/custom';
-import { UserRoleShape } from 'types';
 
-export function userIsAuthorized(userActiveRole, requiredRoles) {
+export function userIsAuthorized(activeRole, requiredRoles) {
   // Return true if no roles are required
   if (!requiredRoles || !requiredRoles.length) return true;
 
   // Return false if user has no role
-  if (!userActiveRole) return false;
+  if (!activeRole) return false;
 
   // User active role must be defined in requiredRoles
-  return requiredRoles.includes(userActiveRole);
+  return requiredRoles.includes(activeRole);
 }
 
-function PrivateRoute({ requiredRoles, userActiveRole, children }) {
+function PrivateRoute({ requiredRoles, activeRole, children }) {
   useTitle();
 
-  if (!userIsAuthorized(userActiveRole, requiredRoles)) {
+  if (!userIsAuthorized(activeRole, requiredRoles)) {
     return <Navigate to="/invalid-permissions" />;
   }
 
@@ -32,19 +30,17 @@ PrivateRoute.displayName = 'PrivateRoute';
 
 PrivateRoute.propTypes = {
   requiredRoles: PropTypes.arrayOf(PropTypes.string),
-  userActiveRole: UserRoleShape,
+  activeRole: PropTypes.string,
 };
 
 PrivateRoute.defaultProps = {
   requiredRoles: [],
-  userActiveRole: null,
+  activeRole: null,
 };
 
 const mapStateToProps = (state) => {
-  const user = selectLoggedInUser(state);
-
   return {
-    userActiveRole: user?.userActiveRole,
+    activeRole: state.auth.activeRole,
   };
 };
 

--- a/src/containers/PrivateRoute.test.jsx
+++ b/src/containers/PrivateRoute.test.jsx
@@ -23,12 +23,12 @@ const tioUserInitialState = {
   auth: {
     isLoading: false,
     isLoggedIn: true,
+    activeRole: roleTypes.TIO,
   },
   entities: {
     user: {
       userId123: {
         id: 'userId123',
-        roles: [{ roleType: roleTypes.TIO }],
       },
     },
   },
@@ -44,17 +44,11 @@ describe('userIsAuthorized function', () => {
   });
 
   it('returns true if the user has at least one required role', () => {
-    expect(userIsAuthorized([roleTypes.TIO], [roleTypes.TIO, roleTypes.SERVICES_COUNSELOR])).toEqual(true);
-  });
-
-  it('returns true if the user has at multiple required roles', () => {
-    expect(
-      userIsAuthorized([roleTypes.TIO, roleTypes.TOO], [roleTypes.TOO, roleTypes.TIO, roleTypes.SERVICES_COUNSELOR]),
-    ).toEqual(true);
+    expect(userIsAuthorized(roleTypes.TIO, [roleTypes.TIO, roleTypes.SERVICES_COUNSELOR])).toEqual(true);
   });
 
   it('returns false if the user does not have a required role', () => {
-    expect(userIsAuthorized([roleTypes.TIO], [roleTypes.TOO])).toEqual(false);
+    expect(userIsAuthorized(roleTypes.TIO, [roleTypes.TOO])).toEqual(false);
   });
 });
 

--- a/src/pages/Office/index.jsx
+++ b/src/pages/Office/index.jsx
@@ -38,7 +38,7 @@ import { roleTypes } from 'constants/userRoles';
 import { pageNames } from 'constants/signInPageNames';
 import LoadingPlaceholder from 'shared/LoadingPlaceholder';
 import { withContext } from 'shared/AppContext';
-import { RouterShape, UserRolesShape } from 'types/index';
+import { RouterShape, UserRoleShape, UserRolesShape } from 'types/index';
 import {
   servicesCounselingRoutes,
   primeSimulatorRoutes,
@@ -124,7 +124,7 @@ const OfficeApp = ({ loadUser, loadInternalSchema, loadPublicSchema, ...props })
   const location = useLocation();
   const displayChangeRole =
     props.userIsLoggedIn &&
-    props.userRoles?.length > 1 &&
+    props.userInactiveRoles?.length > 1 &&
     !matchPath(
       {
         path: '/select-application',
@@ -628,7 +628,8 @@ OfficeApp.propTypes = {
   loginIsLoading: PropTypes.bool,
   userIsLoggedIn: PropTypes.bool,
   userPermissions: PropTypes.arrayOf(PropTypes.string),
-  userRoles: UserRolesShape,
+  userActiveRole: UserRoleShape,
+  userInactiveRoles: UserRolesShape,
   activeRole: PropTypes.string,
   hasRecentError: PropTypes.bool.isRequired,
   traceId: PropTypes.string.isRequired,
@@ -645,7 +646,8 @@ OfficeApp.defaultProps = {
   loginIsLoading: false,
   userIsLoggedIn: false,
   userPermissions: [],
-  userRoles: [],
+  userActiveRole: null,
+  userInactiveRoles: [],
   activeRole: null,
   userPrivileges: [],
   underMaintenance: false,
@@ -662,7 +664,8 @@ const mapStateToProps = (state) => {
     loginIsLoading: selectGetCurrentUserIsLoading(state),
     userIsLoggedIn: selectIsLoggedIn(state),
     userPermissions: user?.permissions || [],
-    userRoles: user?.roles || [],
+    userActiveRole: user?.activeRole,
+    userInactiveRoles: user?.inactiveRoles || [],
     activeRole: state.auth.activeRole,
     hasRecentError: state.interceptor.hasRecentError,
     traceId: state.interceptor.traceId,

--- a/src/pages/Office/index.jsx
+++ b/src/pages/Office/index.jsx
@@ -38,7 +38,7 @@ import { roleTypes } from 'constants/userRoles';
 import { pageNames } from 'constants/signInPageNames';
 import LoadingPlaceholder from 'shared/LoadingPlaceholder';
 import { withContext } from 'shared/AppContext';
-import { RouterShape, UserRoleShape, UserRolesShape } from 'types/index';
+import { RouterShape, UserRolesShape } from 'types/index';
 import {
   servicesCounselingRoutes,
   primeSimulatorRoutes,
@@ -628,7 +628,6 @@ OfficeApp.propTypes = {
   loginIsLoading: PropTypes.bool,
   userIsLoggedIn: PropTypes.bool,
   userPermissions: PropTypes.arrayOf(PropTypes.string),
-  userActiveRole: UserRoleShape,
   userInactiveRoles: UserRolesShape,
   activeRole: PropTypes.string,
   hasRecentError: PropTypes.bool.isRequired,
@@ -646,7 +645,6 @@ OfficeApp.defaultProps = {
   loginIsLoading: false,
   userIsLoggedIn: false,
   userPermissions: [],
-  userActiveRole: null,
   userInactiveRoles: [],
   activeRole: null,
   userPrivileges: [],
@@ -657,6 +655,7 @@ OfficeApp.defaultProps = {
 };
 
 const mapStateToProps = (state) => {
+  // TODO: Investigate user state not matching server session
   const user = selectLoggedInUser(state);
   return {
     swaggerError: state.swaggerInternal?.hasErrored,
@@ -664,7 +663,6 @@ const mapStateToProps = (state) => {
     loginIsLoading: selectGetCurrentUserIsLoading(state),
     userIsLoggedIn: selectIsLoggedIn(state),
     userPermissions: user?.permissions || [],
-    userActiveRole: user?.activeRole,
     userInactiveRoles: user?.inactiveRoles || [],
     activeRole: state.auth.activeRole,
     hasRecentError: state.interceptor.hasRecentError,

--- a/src/pages/SelectApplication/SelectApplication.jsx
+++ b/src/pages/SelectApplication/SelectApplication.jsx
@@ -10,7 +10,7 @@ import { roleTypes } from 'constants/userRoles';
 import { UserRolesShape } from 'types';
 import getRoleTypesFromRoles from 'utils/user';
 
-const SelectApplication = ({ userRoles, setActiveRole, activeRole }) => {
+const SelectApplication = ({ userInactiveRoles, setActiveRole, activeRole }) => {
   const navigate = useNavigate();
 
   const handleSelectRole = (roleType) => {
@@ -18,7 +18,7 @@ const SelectApplication = ({ userRoles, setActiveRole, activeRole }) => {
     navigate('/');
   };
 
-  const userRoleTypes = getRoleTypesFromRoles(userRoles);
+  const userRoleTypes = getRoleTypesFromRoles(userInactiveRoles);
 
   return (
     <GridContainer>
@@ -57,7 +57,7 @@ const SelectApplication = ({ userRoles, setActiveRole, activeRole }) => {
 SelectApplication.propTypes = {
   activeRole: PropTypes.string,
   setActiveRole: PropTypes.func.isRequired,
-  userRoles: UserRolesShape.isRequired,
+  userInactiveRoles: UserRolesShape.isRequired,
 };
 
 SelectApplication.defaultProps = {
@@ -69,7 +69,7 @@ const mapStateToProps = (state) => {
 
   return {
     activeRole: state.auth.activeRole,
-    userRoles: user.roles || [],
+    userInactiveRoles: user.inactiveRoles || [],
   };
 };
 

--- a/src/pages/SelectApplication/SelectApplication.jsx
+++ b/src/pages/SelectApplication/SelectApplication.jsx
@@ -1,10 +1,11 @@
-import React from 'react';
-import { connect } from 'react-redux';
+import React, { useEffect, useState } from 'react';
+import { connect, useSelector } from 'react-redux';
 import { useNavigate } from 'react-router-dom';
 import PropTypes from 'prop-types';
 import { Button, GridContainer } from '@trussworks/react-uswds';
 
 import { selectLoggedInUser } from 'store/entities/selectors';
+import { selectIsSettingActiveRole } from 'store/auth/selectors';
 import { setActiveRole as setActiveRoleAction } from 'store/auth/actions';
 import { roleTypes } from 'constants/userRoles';
 import { UserRolesShape } from 'types';
@@ -12,10 +13,30 @@ import getRoleTypesFromRoles from 'utils/user';
 
 const SelectApplication = ({ userInactiveRoles, setActiveRole, activeRole }) => {
   const navigate = useNavigate();
+  const isSettingActiveRole = useSelector(selectIsSettingActiveRole);
+  const [pendingRole, setPendingRole] = useState(null);
+
+  useEffect(() => {
+    if (pendingRole !== null && !isSettingActiveRole) {
+      // Pending role has been set and the auth saga
+      // has received a response from the server.
+      // This prevents a saga/action race condition between
+      // index rendering on '/' and the SelectApplication component.
+      // Previous race condition:
+      // Select application requests to update the server session,
+      // select application routes to index before hearing back,
+      // index requests the current logged in user
+      // the server begins handling the index with the old AppCtx session
+      // the old AppCtx session has not been finished updating via SetActiveRole saga
+      // then index is now rendering the old role, not the new role, thus a race condition
+      setPendingRole(null);
+      navigate('/');
+    }
+  }, [pendingRole, isSettingActiveRole, navigate]);
 
   const handleSelectRole = (roleType) => {
+    setPendingRole(roleType);
     setActiveRole(roleType);
-    navigate('/');
   };
 
   const userRoleTypes = getRoleTypesFromRoles(userInactiveRoles);

--- a/src/pages/SelectApplication/SelectApplication.test.jsx
+++ b/src/pages/SelectApplication/SelectApplication.test.jsx
@@ -1,8 +1,10 @@
 import React from 'react';
 import { mount } from 'enzyme';
+import { Provider } from 'react-redux';
 
 import SelectApplication from './SelectApplication';
 
+import store from 'shared/store';
 import { roleTypes } from 'constants/userRoles';
 
 jest.mock('react-router-dom', () => ({
@@ -13,17 +15,24 @@ jest.mock('react-router-dom', () => ({
 describe('SelectApplication component', () => {
   it('renders the active role if one exists', () => {
     const mockSetActiveRole = jest.fn();
-    const wrapper = mount(<SelectApplication activeRole="myRole" userRoles={[]} setActiveRole={mockSetActiveRole} />);
+    const wrapper = mount(
+      <Provider store={store}>
+        <SelectApplication activeRole="myRole" userInactiveRoles={[]} setActiveRole={mockSetActiveRole} />
+      </Provider>,
+    );
     expect(wrapper.containsMatchingElement(<h2>Current role: myRole</h2>)).toEqual(true);
   });
 
   it('renders the first user role if there is no active role', () => {
     const mockSetActiveRole = jest.fn();
     const wrapper = mount(
-      <SelectApplication
-        userRoles={[{ roleType: 'myFirstRole' }, { roleType: 'myOtherRole' }]}
-        setActiveRole={mockSetActiveRole}
-      />,
+      <Provider store={store}>
+        <SelectApplication
+          userInactiveRoles={[{ roleType: 'myFirstRole' }, { roleType: 'myOtherRole' }]}
+          setActiveRole={mockSetActiveRole}
+        />
+        ,
+      </Provider>,
     );
     expect(wrapper.containsMatchingElement(<h2>Current role: myFirstRole</h2>)).toEqual(true);
   });
@@ -31,16 +40,19 @@ describe('SelectApplication component', () => {
   it('renders buttons for each of the user’s roles, and does not render buttons for roles the user doesn’t have', () => {
     const mockSetActiveRole = jest.fn();
     const wrapper = mount(
-      <SelectApplication
-        userRoles={[
-          { roleType: roleTypes.TOO },
-          { roleType: roleTypes.TIO },
-          { roleType: roleTypes.SERVICES_COUNSELOR },
-          { roleType: roleTypes.QAE },
-          { roleType: roleTypes.CUSTOMER_SERVICE_REPRESENTATIVE },
-        ]}
-        setActiveRole={mockSetActiveRole}
-      />,
+      <Provider store={store}>
+        <SelectApplication
+          userInactiveRoles={[
+            { roleType: roleTypes.TOO },
+            { roleType: roleTypes.TIO },
+            { roleType: roleTypes.SERVICES_COUNSELOR },
+            { roleType: roleTypes.QAE },
+            { roleType: roleTypes.CUSTOMER_SERVICE_REPRESENTATIVE },
+          ]}
+          setActiveRole={mockSetActiveRole}
+        />
+        ,
+      </Provider>,
     );
 
     expect(wrapper.containsMatchingElement(<button type="button">Select {roleTypes.TOO}</button>)).toEqual(true);
@@ -59,10 +71,13 @@ describe('SelectApplication component', () => {
   it('handles setActiveRole with the selected role', () => {
     const mockSetActiveRole = jest.fn();
     const wrapper = mount(
-      <SelectApplication
-        userRoles={[{ roleType: roleTypes.TOO }, { roleType: roleTypes.TIO }]}
-        setActiveRole={mockSetActiveRole}
-      />,
+      <Provider store={store}>
+        <SelectApplication
+          userInactiveRoles={[{ roleType: roleTypes.TOO }, { roleType: roleTypes.TIO }]}
+          setActiveRole={mockSetActiveRole}
+        />
+        ,
+      </Provider>,
     );
 
     const selectRoleButton = wrapper.find('button').first();

--- a/src/sagas/auth.js
+++ b/src/sagas/auth.js
@@ -3,13 +3,16 @@ import { normalize } from 'normalizr';
 
 import {
   LOAD_USER,
+  SET_ACTIVE_ROLE,
   getLoggedInUserStart,
   getLoggedInUserSuccess,
   getLoggedInUserFailure,
   setUnderMaintenance,
+  setActiveRoleSuccess,
+  setActiveRoleFailure,
 } from 'store/auth/actions';
 import { setFlashMessage } from 'store/flash/actions';
-import { GetAdminUser, GetIsLoggedIn, GetLoggedInUser, GetOktaUser } from 'utils/api';
+import { GetAdminUser, GetIsLoggedIn, GetLoggedInUser, GetOktaUser, UpdateActiveRoleServerSession } from 'utils/api';
 import { loggedInUser } from 'shared/Entities/schema';
 import { addEntities, setAdminUser, setOktaUser } from 'shared/Entities/actions';
 import { isAdminSite, serviceName } from 'shared/constants';
@@ -71,6 +74,31 @@ export function* fetchUser() {
   }
 }
 
-export default function* watchFetchUser() {
+export function* watchFetchUser() {
   yield takeLatest(LOAD_USER, fetchUser);
+}
+
+/**
+ * This saga is triggered by the 'SET_ACTIVE_ROLE' action to alert the server
+ * to update the session
+ */
+export function* handleSetActiveRole({ payload: roleType }) {
+  try {
+    yield call(UpdateActiveRoleServerSession, roleType);
+    yield put(setActiveRoleSuccess(roleType));
+  } catch (e) {
+    yield put(setActiveRoleFailure());
+    yield put(
+      setFlashMessage(
+        'USER_ACTIVE_ROLE_SET_ERROR',
+        'error',
+        'There was an error updating your active role.',
+        'An error occurred',
+      ),
+    );
+  }
+}
+
+export function* watchHandleSetActiveRole() {
+  yield takeLatest(SET_ACTIVE_ROLE, handleSetActiveRole);
 }

--- a/src/sagas/auth.js
+++ b/src/sagas/auth.js
@@ -3,6 +3,7 @@ import { normalize } from 'normalizr';
 
 import {
   LOAD_USER,
+  loadUser,
   SET_ACTIVE_ROLE,
   getLoggedInUserStart,
   getLoggedInUserSuccess,
@@ -86,6 +87,7 @@ export function* handleSetActiveRole({ payload: roleType }) {
   try {
     yield call(UpdateActiveRoleServerSession, roleType);
     yield put(setActiveRoleSuccess(roleType));
+    yield put(loadUser()); // Trigger redux to update entity state
   } catch (e) {
     yield put(setActiveRoleFailure(e));
     yield put(

--- a/src/sagas/auth.js
+++ b/src/sagas/auth.js
@@ -87,7 +87,7 @@ export function* handleSetActiveRole({ payload: roleType }) {
     yield call(UpdateActiveRoleServerSession, roleType);
     yield put(setActiveRoleSuccess(roleType));
   } catch (e) {
-    yield put(setActiveRoleFailure());
+    yield put(setActiveRoleFailure(e));
     yield put(
       setFlashMessage(
         'USER_ACTIVE_ROLE_SET_ERROR',

--- a/src/sagas/auth.test.js
+++ b/src/sagas/auth.test.js
@@ -1,10 +1,17 @@
 import { takeLatest, put, call } from 'redux-saga/effects';
 
-import watchFetchUser, { fetchUser } from './auth';
+import { watchFetchUser, fetchUser, watchHandleSetActiveRole, handleSetActiveRole } from './auth';
 
 import { setFlashMessage } from 'store/flash/actions';
-import { GetIsLoggedIn, GetLoggedInUser, GetOktaUser, GetAdminUser } from 'utils/api';
-import { LOAD_USER, getLoggedInUserStart, getLoggedInUserFailure } from 'store/auth/actions';
+import { GetIsLoggedIn, GetLoggedInUser, GetOktaUser, GetAdminUser, UpdateActiveRoleServerSession } from 'utils/api';
+import {
+  LOAD_USER,
+  getLoggedInUserStart,
+  getLoggedInUserFailure,
+  SET_ACTIVE_ROLE,
+  setActiveRoleSuccess,
+  setActiveRoleFailure,
+} from 'store/auth/actions';
 import { setAdminUser } from 'shared/Entities/actions';
 import { serviceName } from 'shared/constants';
 
@@ -166,5 +173,68 @@ describe('fetch underMaintenance', () => {
     expect(generator.next().value).toEqual(call(GetIsLoggedIn));
     expect(generator.next({ isLoggedIn: true, underMaintenance: false }).value).toEqual(call(GetLoggedInUser));
     // expect(generator.next().value).toEqual(put(setUnderMaintenance));
+  });
+});
+
+describe('watchHandleSetActiveRole saga', () => {
+  const generator = watchHandleSetActiveRole();
+
+  it('takes the latest SET_ACTIVE_ROLE and calls handleSetActiveRole', () => {
+    expect(generator.next().value).toEqual(takeLatest(SET_ACTIVE_ROLE, handleSetActiveRole));
+  });
+
+  it('is done', () => {
+    expect(generator.next().done).toBe(true);
+  });
+});
+
+describe('handleSetActiveRole saga', () => {
+  const roleType = 'someRole';
+
+  describe('when the API call succeeds', () => {
+    const gen = handleSetActiveRole({ payload: roleType });
+
+    it('calls UpdateActiveRoleServerSession with the roleType', () => {
+      expect(gen.next().value).toEqual(call(UpdateActiveRoleServerSession, roleType));
+    });
+
+    it('dispatches setActiveRoleSuccess', () => {
+      // next() simulates the API having resolved
+      expect(gen.next().value).toEqual(put(setActiveRoleSuccess(roleType)));
+    });
+
+    it('then finishes', () => {
+      expect(gen.next().done).toBe(true);
+    });
+  });
+
+  describe('when the API call throws an error', () => {
+    const error = new Error('some error');
+    const gen = handleSetActiveRole({ payload: roleType });
+
+    it('first calls UpdateActiveRoleServerSession', () => {
+      expect(gen.next().value).toEqual(call(UpdateActiveRoleServerSession, roleType));
+    });
+
+    it('dispatches setActiveRoleFailure on throw', () => {
+      expect(gen.throw(error).value).toEqual(put(setActiveRoleFailure(error)));
+    });
+
+    it('then dispatches a flash message', () => {
+      expect(gen.next().value).toEqual(
+        put(
+          setFlashMessage(
+            'USER_ACTIVE_ROLE_SET_ERROR',
+            'error',
+            'There was an error updating your active role.',
+            'An error occurred',
+          ),
+        ),
+      );
+    });
+
+    it('finally completes', () => {
+      expect(gen.next().done).toBe(true);
+    });
   });
 });

--- a/src/sagas/auth.test.js
+++ b/src/sagas/auth.test.js
@@ -11,6 +11,7 @@ import {
   SET_ACTIVE_ROLE,
   setActiveRoleSuccess,
   setActiveRoleFailure,
+  loadUser,
 } from 'store/auth/actions';
 import { setAdminUser } from 'shared/Entities/actions';
 import { serviceName } from 'shared/constants';
@@ -201,6 +202,11 @@ describe('handleSetActiveRole saga', () => {
     it('dispatches setActiveRoleSuccess', () => {
       // next() simulates the API having resolved
       expect(gen.next().value).toEqual(put(setActiveRoleSuccess(roleType)));
+    });
+
+    it('dispatches loadUser', () => {
+      // this makes sure the entity state fetches the latest session from the server
+      expect(gen.next().value).toEqual(put(loadUser()));
     });
 
     it('then finishes', () => {

--- a/src/sagas/index.js
+++ b/src/sagas/index.js
@@ -1,11 +1,11 @@
 import { all } from 'redux-saga/effects';
 
-import watchFetchUser from './auth';
+import { watchFetchUser, watchHandleSetActiveRole } from './auth';
 import { watchInitializeOnboarding } from './onboarding';
 import { watchUpdateEntities } from './entities';
 
 export default function* rootSaga() {
-  yield all([watchFetchUser()]);
+  yield all([watchFetchUser(), watchHandleSetActiveRole()]);
 }
 
 export function* rootCustomerSaga() {

--- a/src/store/auth/actions.js
+++ b/src/store/auth/actions.js
@@ -7,13 +7,11 @@ export const setActiveRole = (roleType) => ({
   payload: roleType,
 });
 
-// TODO: Use me after redis is g2g
 export const setActiveRoleSuccess = (roleType) => ({
   type: SET_ACTIVE_ROLE_SUCCESS,
   payload: roleType,
 });
 
-// TODO: Use me after redis is g2g
 export const setActiveRoleFailure = (error) => ({
   type: SET_ACTIVE_ROLE_FAILURE,
   error,

--- a/src/store/auth/actions.js
+++ b/src/store/auth/actions.js
@@ -1,8 +1,22 @@
 export const SET_ACTIVE_ROLE = 'SET_ACTIVE_ROLE';
+export const SET_ACTIVE_ROLE_SUCCESS = 'SET_ACTIVE_ROLE_SUCCESS';
+export const SET_ACTIVE_ROLE_FAILURE = 'SET_ACTIVE_ROLE_FAILURE';
 
 export const setActiveRole = (roleType) => ({
   type: SET_ACTIVE_ROLE,
   payload: roleType,
+});
+
+// TODO: Use me after redis is g2g
+export const setActiveRoleSuccess = (roleType) => ({
+  type: SET_ACTIVE_ROLE_SUCCESS,
+  payload: roleType,
+});
+
+// TODO: Use me after redis is g2g
+export const setActiveRoleFailure = (error) => ({
+  type: SET_ACTIVE_ROLE_FAILURE,
+  error,
 });
 
 export const LOAD_USER = 'LOAD_USER';

--- a/src/store/auth/reducer.js
+++ b/src/store/auth/reducer.js
@@ -1,7 +1,5 @@
 import { LOG_OUT, SET_ACTIVE_ROLE } from './actions';
 
-import { officeRoles } from 'constants/userRoles';
-
 export const initialState = {
   activeRole: null,
   isLoggedIn: false,
@@ -32,23 +30,13 @@ const authReducer = (state = initialState, action = {}) => {
       };
     }
     case 'GET_LOGGED_IN_USER_SUCCESS': {
-      if (state.activeRole)
-        return {
-          ...state,
-          hasSucceeded: true,
-          hasErrored: false,
-          isLoading: false,
-          isLoggedIn: true,
-        };
-
       const {
-        payload: { roles = [] },
+        payload: { activeRole },
       } = action;
-      const firstOfficeRole = roles?.find((r) => officeRoles.indexOf(r.roleType) > -1)?.roleType;
 
       return {
         ...state,
-        activeRole: firstOfficeRole,
+        activeRole: activeRole.roleType,
         hasSucceeded: true,
         hasErrored: false,
         isLoading: false,

--- a/src/store/auth/reducer.js
+++ b/src/store/auth/reducer.js
@@ -1,4 +1,4 @@
-import { LOG_OUT, SET_ACTIVE_ROLE } from './actions';
+import { LOG_OUT, SET_ACTIVE_ROLE, SET_ACTIVE_ROLE_SUCCESS, SET_ACTIVE_ROLE_FAILURE } from './actions';
 
 export const initialState = {
   activeRole: null,
@@ -7,6 +7,7 @@ export const initialState = {
   hasErrored: false,
   isLoading: true,
   underMaintenance: false,
+  isSettingActiveRole: false,
 };
 
 const authReducer = (state = initialState, action = {}) => {
@@ -54,10 +55,22 @@ const authReducer = (state = initialState, action = {}) => {
     case SET_ACTIVE_ROLE: {
       return {
         ...state,
-        activeRole: action.payload,
+        isSettingActiveRole: true,
       };
     }
-
+    case SET_ACTIVE_ROLE_SUCCESS: {
+      return {
+        ...state,
+        activeRole: action.payload,
+        isSettingActiveRole: false,
+      };
+    }
+    case SET_ACTIVE_ROLE_FAILURE: {
+      return {
+        ...state,
+        isSettingActiveRole: false,
+      };
+    }
     default:
       return state;
   }

--- a/src/store/auth/reducer.test.js
+++ b/src/store/auth/reducer.test.js
@@ -1,5 +1,5 @@
 import authReducer, { initialState } from './reducer';
-import { setActiveRole, logOut } from './actions';
+import { setActiveRole, logOut, setActiveRoleSuccess, setActiveRoleFailure } from './actions';
 import { selectIsLoggedIn, selectUnderMaintenance } from './selectors';
 
 import { roleTypes } from 'constants/userRoles';
@@ -21,7 +21,22 @@ describe('authReducer', () => {
   it('handles the setActiveRole action', () => {
     expect(authReducer(initialState, setActiveRole('myRole'))).toEqual({
       ...initialState,
+      isSettingActiveRole: true,
+    });
+  });
+
+  it('handles the setActiveRoleSucces action', () => {
+    expect(authReducer(initialState, setActiveRoleSuccess('myRole'))).toEqual({
+      ...initialState,
       activeRole: 'myRole',
+      isSettingActiveRole: false,
+    });
+  });
+
+  it('handles the setActiveRoleFailure action', () => {
+    expect(authReducer(initialState, setActiveRoleFailure())).toEqual({
+      ...initialState,
+      isSettingActiveRole: false,
     });
   });
 
@@ -38,14 +53,9 @@ describe('authReducer', () => {
     const action = {
       type: 'GET_LOGGED_IN_USER_SUCCESS',
       payload: {
-        roles: [
-          {
-            roleType: roleTypes.CUSTOMER,
-          },
-          {
-            roleType: roleTypes.TOO,
-          },
-        ],
+        activeRole: {
+          roleType: roleTypes.TOO,
+        },
       },
     };
 
@@ -72,14 +82,9 @@ describe('authReducer', () => {
     const action = {
       type: 'GET_LOGGED_IN_USER_SUCCESS',
       payload: {
-        roles: [
-          {
-            roleType: roleTypes.CUSTOMER,
-          },
-          {
-            roleType: roleTypes.TOO,
-          },
-        ],
+        activeRole: {
+          roleType: roleTypes.TOO,
+        },
       },
     };
 

--- a/src/store/auth/selectors.js
+++ b/src/store/auth/selectors.js
@@ -29,3 +29,7 @@ export const selectShowLoadingSpinner = (state) => {
 export const selectLoadingSpinnerMessage = (state) => {
   return state.generalState.loadingSpinnerMessage;
 };
+
+export const selectIsSettingActiveRole = (state) => {
+  return state.auth.isSettingActiveRole;
+};

--- a/src/store/entities/actions.js
+++ b/src/store/entities/actions.js
@@ -5,6 +5,7 @@ export const UPDATE_MTO_SHIPMENT = 'UPDATE_MTO_SHIPMENT';
 export const UPDATE_MTO_SHIPMENTS = 'UPDATE_MTO_SHIPMENTS';
 export const UPDATE_ORDERS = 'UPDATE_ORDERS';
 export const UPDATE_OKTA_USER_STATE = 'SET_OKTA_USER';
+export const UPDATE_ACTIVE_ROLE = 'UPDATE_ACTIVE_ROLE';
 export const UPDATE_ALL_MOVES = 'UPDATE_ALL_MOVES';
 
 export const updateOktaUserState = (oktaUser) => ({

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -70,3 +70,20 @@ export function LogoutUserWithOktaRedirect() {
   };
   return Swagger.http(req);
 }
+
+// updates a users server-side session
+// with their new active role
+export function UpdateActiveRoleServerSession(roleType) {
+  const updateActiveRoleEndpoint = '/auth/activeRole';
+  const req = {
+    url: updateActiveRoleEndpoint,
+    method: 'PATCH',
+    credentials: 'same-origin',
+    requestInterceptor,
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ roleType }),
+  };
+  return Swagger.http(req);
+}

--- a/swagger-def/internal.yaml
+++ b/swagger-def/internal.yaml
@@ -129,7 +129,11 @@ definitions:
         $ref: '#/definitions/ServiceMemberPayload'
       office_user:
         $ref: '#/definitions/OfficeUser'
-      roles:
+      activeRole:
+        $ref: '#/definitions/Role'
+        # The user can sign in without a role, they'll just have no permissions
+        x-nullable: true
+      inactiveRoles:
         type: array
         items:
           $ref: '#/definitions/Role'

--- a/swagger/internal.yaml
+++ b/swagger/internal.yaml
@@ -132,7 +132,10 @@ definitions:
         $ref: '#/definitions/ServiceMemberPayload'
       office_user:
         $ref: '#/definitions/OfficeUser'
-      roles:
+      activeRole:
+        $ref: '#/definitions/Role'
+        x-nullable: true
+      inactiveRoles:
         type: array
         items:
           $ref: '#/definitions/Role'


### PR DESCRIPTION
## [B-23278](https://www13.v1host.com/USTRANSCOM38/story.mvc/Summary?oidToken=Story%3A1097934&RoomContext=TeamRoom%3A808731&concept=TeamRoom)

## Summary

Refactors our session and permission handling to go from all encompassing, eg a user being assigned multiple roles will inherently always have access to all of the routes and permissions of each role, to only being allowed one role at a time. There's a new internal endpoint where users can swap their active role, and on initial session granting / login, the default role is alphabetically sorted.

Frontend required some state changes, and the backend required session changes.

[Integration PR](https://github.com/transcom/mymove/pull/15453)