### PR TITLE
Int b 20875 move details 508

### DIFF
--- a/src/components/Office/DefinitionLists/OfficeDefinitionLists.module.scss
+++ b/src/components/Office/DefinitionLists/OfficeDefinitionLists.module.scss
@@ -15,10 +15,11 @@
     width: 75%;
   }
 
-  .missingInfoError {
-    color: $error;
+  .missingInfoError.missingInfoError {
+    color: $secondary;
     @include u-border-left(0.5); //4px
-    @include u-border-left('error');
+    @include u-border-left('secondary');
     @include u-font-weight(bold);
+    @include u-font-size('body', 'md');
   }
 }

--- a/src/shared/styles/colors.scss
+++ b/src/shared/styles/colors.scss
@@ -46,11 +46,14 @@ $accent-default: $base-light;
 $info: #5994f6;
 $info-light: #ecf1f7;
 
-//USWDS Colorrs
+//USWDS Colors
 $primary: #0050d8;
 $primary-dark: #1a4480;
 $primary-darker: #162e51;
 $disabled: #c9c9c9;
+$secondary: #d83933;
+$secondary-dark: #b50909;
+$secondary-darker: #8b0a03;
 
 //Last Group: these were here when I got here.
 $color-gold: #fdb81e;


### PR DESCRIPTION
## [Agility ticket](https://www13.v1host.com/USTRANSCOM38/story.mvc/Summary?oidToken=Story%3A989894)

## Summary

Missing warning is a larger font and uses the USWDS secondary color red to pass 508 color contrast tests

## Verification Steps for the Author

These are to be checked by the author.

- [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
- [ ] Have the Agility acceptance criteria been met for this change?

## Verification Steps for Reviewers

These are to be checked by a reviewer.

- [ ] Has the branch been pulled in and checked out?
- [ ] Have the BL acceptance criteria been met for this change?
- [ ] Was the CircleCI build successful?
- [ ] Has the code been reviewed from a standards and best practices point of view?

### Setup to Run the Code

- [Instructions for starting storybook](https://transcom.github.io/mymove-docs/docs/frontend/setup/storybook)
- [Instructions for starting the MilMove application](https://transcom.github.io/mymove-docs/docs/getting-started/application-setup/)
- [Instructions for running tests](https://transcom.github.io/mymove-docs/docs/getting-started/development/testing)

### How to test

1. Access the office application
2. Login as a service counselor
3. Find a customer and create a new move
4. After completing the the new move wizard, you will see the Move Details page for this move
5. There will be a few "Missing" warnings on the Orders container
6. Run ANDI color contrast test on the "Missing" text and see that it passes

### Frontend

- [ ] There are no aXe warnings for UI.
- [ ] This works in [Supported Browsers and their phone views](https://transcom.github.io/mymove-docs/docs/adrs/Browser-Support/#minimum-browser-requirements) (Chrome, Firefox, Edge).
- [ ] There are no new console errors in the browser devtools.
- [ ] There are no new console errors in the test output.
- [ ] If this PR adds a new component to Storybook, it ensures the component is fully responsive, OR if it is intentionally not, a wrapping div using the `officeApp` class or custom `min-width` styling is used to hide any states the would not be visible to the user.
- [ ] This change meets the standards for [Section 508 compliance](https://www.ssa.gov/accessibility/andi/help/install.html).

## Screenshots
![Screenshot 2025-05-16 at 4 32 38 AM](https://github.com/user-attachments/assets/3eb836b1-990f-4b8d-b67c-5514193cd20b)
