### PR TITLE
MAIN B-23447

### DIFF
--- a/pkg/gen/ghcapi/embedded_spec.go
+++ b/pkg/gen/ghcapi/embedded_spec.go
@@ -12378,7 +12378,6 @@ func init() {
       "enum": [
         "APPROVED",
         "REJECTED",
-        "EDITED",
         "RECEIVED",
         "NOT_RECEIVED"
       ],
@@ -30952,7 +30951,6 @@ func init() {
       "enum": [
         "APPROVED",
         "REJECTED",
-        "EDITED",
         "RECEIVED",
         "NOT_RECEIVED"
       ],

--- a/pkg/gen/ghcmessages/p_p_m_advance_status.go
+++ b/pkg/gen/ghcmessages/p_p_m_advance_status.go
@@ -38,9 +38,6 @@ const (
 	// PPMAdvanceStatusREJECTED captures enum value "REJECTED"
 	PPMAdvanceStatusREJECTED PPMAdvanceStatus = "REJECTED"
 
-	// PPMAdvanceStatusEDITED captures enum value "EDITED"
-	PPMAdvanceStatusEDITED PPMAdvanceStatus = "EDITED"
-
 	// PPMAdvanceStatusRECEIVED captures enum value "RECEIVED"
 	PPMAdvanceStatusRECEIVED PPMAdvanceStatus = "RECEIVED"
 
@@ -53,7 +50,7 @@ var pPMAdvanceStatusEnum []interface{}
 
 func init() {
 	var res []PPMAdvanceStatus
-	if err := json.Unmarshal([]byte(`["APPROVED","REJECTED","EDITED","RECEIVED","NOT_RECEIVED"]`), &res); err != nil {
+	if err := json.Unmarshal([]byte(`["APPROVED","REJECTED","RECEIVED","NOT_RECEIVED"]`), &res); err != nil {
 		panic(err)
 	}
 	for _, v := range res {

--- a/pkg/gen/internalapi/embedded_spec.go
+++ b/pkg/gen/internalapi/embedded_spec.go
@@ -6387,7 +6387,6 @@ func init() {
       "enum": [
         "APPROVED",
         "REJECTED",
-        "EDITED",
         "RECEIVED",
         "NOT_RECEIVED"
       ],
@@ -15849,7 +15848,6 @@ func init() {
       "enum": [
         "APPROVED",
         "REJECTED",
-        "EDITED",
         "RECEIVED",
         "NOT_RECEIVED"
       ],

--- a/pkg/gen/internalmessages/p_p_m_advance_status.go
+++ b/pkg/gen/internalmessages/p_p_m_advance_status.go
@@ -38,9 +38,6 @@ const (
 	// PPMAdvanceStatusREJECTED captures enum value "REJECTED"
 	PPMAdvanceStatusREJECTED PPMAdvanceStatus = "REJECTED"
 
-	// PPMAdvanceStatusEDITED captures enum value "EDITED"
-	PPMAdvanceStatusEDITED PPMAdvanceStatus = "EDITED"
-
 	// PPMAdvanceStatusRECEIVED captures enum value "RECEIVED"
 	PPMAdvanceStatusRECEIVED PPMAdvanceStatus = "RECEIVED"
 
@@ -53,7 +50,7 @@ var pPMAdvanceStatusEnum []interface{}
 
 func init() {
 	var res []PPMAdvanceStatus
-	if err := json.Unmarshal([]byte(`["APPROVED","REJECTED","EDITED","RECEIVED","NOT_RECEIVED"]`), &res); err != nil {
+	if err := json.Unmarshal([]byte(`["APPROVED","REJECTED","RECEIVED","NOT_RECEIVED"]`), &res); err != nil {
 		panic(err)
 	}
 	for _, v := range res {

--- a/pkg/models/ppm_shipment.go
+++ b/pkg/models/ppm_shipment.go
@@ -112,8 +112,6 @@ type PPMAdvanceStatus string
 const (
 	// PPMAdvanceStatusApproved captures enum value "APPROVED"
 	PPMAdvanceStatusApproved PPMAdvanceStatus = "APPROVED"
-	// PPMAdvanceStatusEdited captures enum value "EDITED"
-	PPMAdvanceStatusEdited PPMAdvanceStatus = "EDITED"
 	// PPMAdvanceStatusRejected captures enum value "REJECTED"
 	PPMAdvanceStatusRejected PPMAdvanceStatus = "REJECTED"
 	// PPMAdvanceStatusReceived captures enum value "RECEIVED"
@@ -126,7 +124,6 @@ const (
 // for validation.
 var AllowedPPMAdvanceStatuses = []string{
 	string(PPMAdvanceStatusApproved),
-	string(PPMAdvanceStatusEdited),
 	string(PPMAdvanceStatusRejected),
 	string(PPMAdvanceStatusReceived),
 	string(PPMAdvanceStatusNotReceived),

--- a/pkg/services/ppmshipment/ppm_shipment_updater.go
+++ b/pkg/services/ppmshipment/ppm_shipment_updater.go
@@ -245,21 +245,6 @@ func (f *ppmShipmentUpdater) updatePPMShipment(appCtx appcontext.AppContext, ppm
 		}
 
 		if appCtx.Session() != nil {
-			if appCtx.Session().IsOfficeUser() {
-				edited := models.PPMAdvanceStatusEdited
-				if oldPPMShipment.HasRequestedAdvance != nil && updatedPPMShipment.HasRequestedAdvance != nil {
-					if !*oldPPMShipment.HasRequestedAdvance && *updatedPPMShipment.HasRequestedAdvance {
-						updatedPPMShipment.AdvanceStatus = &edited
-					} else if *oldPPMShipment.HasRequestedAdvance && !*updatedPPMShipment.HasRequestedAdvance {
-						updatedPPMShipment.AdvanceStatus = &edited
-					}
-				}
-				if oldPPMShipment.AdvanceAmountRequested != nil && updatedPPMShipment.AdvanceAmountRequested != nil {
-					if *oldPPMShipment.AdvanceAmountRequested != *updatedPPMShipment.AdvanceAmountRequested {
-						updatedPPMShipment.AdvanceStatus = &edited
-					}
-				}
-			}
 			if appCtx.Session().IsMilApp() {
 				if isPrimeCounseled && updatedPPMShipment.HasRequestedAdvance != nil {
 					received := models.PPMAdvanceStatusReceived

--- a/pkg/services/ppmshipment/ppm_shipment_updater_test.go
+++ b/pkg/services/ppmshipment/ppm_shipment_updater_test.go
@@ -848,12 +848,14 @@ func (suite *PPMShipmentSuite) TestUpdatePPMShipment() {
 		appCtx := suite.AppContextWithSessionForTest(&auth.Session{
 			OfficeUserID: uuid.Must(uuid.NewV4()),
 		})
+		approved := models.PPMAdvanceStatusApproved
 		originalPPM := factory.BuildPPMShipment(suite.DB(), []factory.Customization{
 			{
 				Model: models.PPMShipment{
 					EstimatedIncentive:     fakeEstimatedIncentive,
 					HasRequestedAdvance:    models.BoolPointer(true),
 					AdvanceAmountRequested: models.CentPointer(unit.Cents(400000)),
+					AdvanceStatus:          &approved,
 				},
 			},
 		}, nil)
@@ -878,10 +880,9 @@ func (suite *PPMShipmentSuite) TestUpdatePPMShipment() {
 		suite.Equal(*originalPPM.EstimatedIncentive, *updatedPPM.EstimatedIncentive)
 
 		// Fields that should now be updated
-		edited := models.PPMAdvanceStatusEdited
 		suite.Equal(*newPPM.HasRequestedAdvance, *updatedPPM.HasRequestedAdvance)
 		suite.Equal(*newPPM.AdvanceAmountRequested, *updatedPPM.AdvanceAmountRequested)
-		suite.Equal(&edited, updatedPPM.AdvanceStatus)
+		suite.Equal(&approved, updatedPPM.AdvanceStatus)
 	})
 
 	suite.Run("Can successfully update a PPMShipment - office user approves advance request", func() {
@@ -1006,50 +1007,9 @@ func (suite *PPMShipmentSuite) TestUpdatePPMShipment() {
 		suite.Equal(*originalPPM.EstimatedIncentive, *updatedPPM.EstimatedIncentive)
 
 		// Fields that should now be updated
-		edited := models.PPMAdvanceStatusEdited
 		suite.Equal(*newPPM.HasRequestedAdvance, *updatedPPM.HasRequestedAdvance)
 		suite.Equal(*newPPM.AdvanceAmountRequested, *updatedPPM.AdvanceAmountRequested)
-		suite.Equal(&edited, updatedPPM.AdvanceStatus)
-	})
-
-	suite.Run("Can successfully update a PPMShipment - edit advance - advance requested yes to no", func() {
-		appCtx := suite.AppContextWithSessionForTest(&auth.Session{
-			OfficeUserID: uuid.Must(uuid.NewV4()),
-		})
-
-		originalPPM := factory.BuildPPMShipment(suite.DB(), []factory.Customization{
-			{
-				Model: models.PPMShipment{
-					EstimatedIncentive:     fakeEstimatedIncentive,
-					HasRequestedAdvance:    models.BoolPointer(true),
-					AdvanceAmountRequested: models.CentPointer(unit.Cents(300000)),
-				},
-			},
-		}, nil)
-		newPPM := models.PPMShipment{
-			HasRequestedAdvance: models.BoolPointer(false),
-		}
-
-		subtestData := setUpForTests(originalPPM.EstimatedIncentive, nil, nil, nil)
-
-		updatedPPM, err := subtestData.ppmShipmentUpdater.UpdatePPMShipmentWithDefaultCheck(appCtx, &newPPM, originalPPM.ShipmentID)
-
-		suite.NilOrNoVerrs(err)
-
-		// Fields that shouldn't have changed
-		suite.Equal(originalPPM.ExpectedDepartureDate.Format(dateOnly), updatedPPM.ExpectedDepartureDate.Format(dateOnly))
-		suite.Equal(originalPPM.SITExpected, updatedPPM.SITExpected)
-		suite.Equal(*originalPPM.EstimatedWeight, *updatedPPM.EstimatedWeight)
-		suite.Equal(*originalPPM.HasProGear, *updatedPPM.HasProGear)
-		suite.Equal(*originalPPM.ProGearWeight, *updatedPPM.ProGearWeight)
-		suite.Equal(*originalPPM.SpouseProGearWeight, *updatedPPM.SpouseProGearWeight)
-		suite.Equal(*originalPPM.EstimatedIncentive, *updatedPPM.EstimatedIncentive)
-
-		// Fields that should now be updated
-		edited := models.PPMAdvanceStatusEdited
-		suite.Equal(*newPPM.HasRequestedAdvance, *updatedPPM.HasRequestedAdvance)
-		suite.Nil(updatedPPM.AdvanceAmountRequested)
-		suite.Equal(&edited, updatedPPM.AdvanceStatus)
+		suite.Equal(&approved, updatedPPM.AdvanceStatus)
 	})
 
 	suite.Run("Can successfully update a PPMShipment - edit SIT - yes to no", func() {

--- a/swagger-def/definitions/PPMAdvanceStatus.yaml
+++ b/swagger-def/definitions/PPMAdvanceStatus.yaml
@@ -5,6 +5,5 @@ x-nullable: true
 enum:
   - APPROVED
   - REJECTED
-  - EDITED
   - RECEIVED
   - NOT_RECEIVED

--- a/swagger/ghc.yaml
+++ b/swagger/ghc.yaml
@@ -10338,7 +10338,6 @@ definitions:
     enum:
       - APPROVED
       - REJECTED
-      - EDITED
       - RECEIVED
       - NOT_RECEIVED
   OmittablePPMDocumentStatus:

--- a/swagger/internal.yaml
+++ b/swagger/internal.yaml
@@ -3110,7 +3110,6 @@ definitions:
     enum:
       - APPROVED
       - REJECTED
-      - EDITED
       - RECEIVED
       - NOT_RECEIVED
   SITLocationType:


### PR DESCRIPTION
## [Agility ticket](https://www13.v1host.com/USTRANSCOM38/assetdetail.v1?number=B-23447)

## Summary

We are wanting to get rid of the advance status "edited" to not confuse the user when they look at their AOA or SSW packet. We want to show the advance's actual status (`Approved` or `Rejected`) so we can have transparency of the SC's decision when the service member is viewing the AOA.

We don't want this
![Screenshot 2025-05-19 at 1 40 02 PM](https://github.com/user-attachments/assets/89ab6ea2-7114-42f1-b4e0-a81bc4c2da58)

### How to test

1. Access MM as a customer, create a move with a PPM and request an advance
2. Review as SC, either approve/reject and submit the move details
3. View the AOA as a customer, should see the advance decision
4. Change the advance amount/status as a SC
5. Redownload the AOA as a service member or SC
6. Should not see `Edited` as the advance status


## Screenshots

<img width="328" alt="Screenshot 2025-05-19 at 1 38 13 PM" src="https://github.com/user-attachments/assets/fa30111b-58d0-403c-8a7f-4a9aabc8fd27" />
<img width="330" alt="Screenshot 2025-05-19 at 1 38 17 PM" src="https://github.com/user-attachments/assets/3d45290e-8b2c-4fd8-a4a7-0ea8f5806fed" />

