### PR TITLE
INT B-23446

### DIFF
--- a/pkg/models/order.go
+++ b/pkg/models/order.go
@@ -134,6 +134,19 @@ func (o *Order) Validate(_ *pop.Connection) (*validate.Errors, error) {
 		&OptionalUUIDIsPresent{Field: o.EntitlementID, Name: "EntitlementID"},
 		&OptionalUUIDIsPresent{Field: o.OriginDutyLocationID, Name: "OriginDutyLocationID"},
 		&OptionalRegexMatch{Name: "TransportationAccountingCode", Field: o.TAC, Expr: `\A([A-Za-z0-9]){4}\z`, Message: "TAC must be exactly 4 alphanumeric characters."},
+		// block * and " in TAC & SAC
+		&OptionalRegexMatch{
+			Name:    "TransportationAccountingCode",
+			Field:   o.TAC,
+			Expr:    `\A[^*"]*\z`,
+			Message: `TAC cannot contain * or " characters.`,
+		},
+		&OptionalRegexMatch{
+			Name:    "SAC",
+			Field:   o.SAC,
+			Expr:    `\A[^*"]*\z`,
+			Message: `SAC cannot contain * or " characters.`,
+		},
 		&validators.UUIDIsPresent{Field: o.UploadedOrdersID, Name: "UploadedOrdersID"},
 		&OptionalUUIDIsPresent{Field: o.UploadedAmendedOrdersID, Name: "UploadedAmendedOrdersID"},
 		&StringIsNilOrNotBlank{Field: o.OriginDutyLocationGBLOC, Name: "OriginDutyLocationGBLOC"},

--- a/pkg/models/order_test.go
+++ b/pkg/models/order_test.go
@@ -2,6 +2,7 @@ package models_test
 
 import (
 	"encoding/json"
+	"fmt"
 	"time"
 
 	"github.com/gofrs/uuid"
@@ -9,7 +10,6 @@ import (
 	"github.com/transcom/mymove/pkg/auth"
 	"github.com/transcom/mymove/pkg/factory"
 	"github.com/transcom/mymove/pkg/gen/internalmessages"
-	"github.com/transcom/mymove/pkg/models"
 	m "github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/services/address"
 	"github.com/transcom/mymove/pkg/testdatagen"
@@ -115,6 +115,55 @@ func (suite *ModelSuite) TestTacFormat() {
 	}
 }
 
+func (suite *ModelSuite) TestTacForbiddenCharacters() {
+	invalidTacs := []string{
+		"AB*C",
+		"A\"BC",
+		"*ABC",
+		"ABC\"",
+	}
+	for _, bad := range invalidTacs {
+		suite.Run(fmt.Sprintf("TAC with %q", bad), func() {
+			move := factory.BuildStubbedMoveWithStatus(m.MoveStatusSUBMITTED)
+			order := move.Orders
+			order.TAC = &bad
+			order.Moves = append(order.Moves, move)
+
+			expErrors := map[string][]string{
+				"transportation_accounting_code": {
+					`TAC cannot contain * or " characters.`,
+					"TAC must be exactly 4 alphanumeric characters.",
+				},
+			}
+
+			suite.verifyValidationErrors(&order, expErrors, nil)
+		})
+	}
+}
+
+func (suite *ModelSuite) TestSacForbiddenCharacters() {
+	invalidSacs := []string{
+		"12*4",
+		"1\"34",
+		"*234",
+		"234\"",
+	}
+	for _, bad := range invalidSacs {
+		suite.Run(fmt.Sprintf("SAC with %q", bad), func() {
+			move := factory.BuildStubbedMoveWithStatus(m.MoveStatusSUBMITTED)
+			order := move.Orders
+			order.SAC = &bad
+			order.Moves = append(order.Moves, move)
+
+			expErrors := map[string][]string{
+				"sac": {"SAC cannot contain * or \" characters."},
+			}
+
+			suite.verifyValidationErrors(&order, expErrors, nil)
+		})
+	}
+}
+
 func (suite *ModelSuite) TestFetchOrderForUser() {
 	setupHhgStudentAllowanceParameter := func() {
 		paramJSON := `{
@@ -126,8 +175,8 @@ func (suite *ModelSuite) TestFetchOrderForUser() {
         }`
 		rawMessage := json.RawMessage(paramJSON)
 
-		parameter := models.ApplicationParameters{
-			ParameterName: models.StringPointer("studentTravelHhgAllowance"),
+		parameter := m.ApplicationParameters{
+			ParameterName: m.StringPointer("studentTravelHhgAllowance"),
 			ParameterJson: &rawMessage,
 		}
 		suite.MustCreate(&parameter)
@@ -160,7 +209,7 @@ func (suite *ModelSuite) TestFetchOrderForUser() {
 		setupHhgStudentAllowanceParameter()
 		order := factory.BuildOrder(suite.DB(), []factory.Customization{
 			{
-				Model: models.Order{
+				Model: m.Order{
 					OrdersType: internalmessages.OrdersTypeSTUDENTTRAVEL,
 				},
 			},
@@ -327,7 +376,7 @@ func (suite *ModelSuite) TestFetchOrderNotForUser() {
 	suite.MustSave(&uploadedOrder)
 	contractor := factory.FetchOrBuildDefaultContractor(suite.DB(), nil, nil)
 	packingAndShippingInstructions := m.InstructionsBeforeContractNumber + " " + contractor.ContractNumber + " " + m.InstructionsAfterContractNumber
-	newGBLOC, gblocErr := models.FetchGBLOCForPostalCode(suite.DB(), dutyLocation.Address.PostalCode)
+	newGBLOC, gblocErr := m.FetchGBLOCForPostalCode(suite.DB(), dutyLocation.Address.PostalCode)
 	suite.NoError(gblocErr)
 	order := m.Order{
 		ServiceMemberID:                serviceMember1.ID,
@@ -381,7 +430,7 @@ func (suite *ModelSuite) TestOrderStateMachine() {
 	contractor := factory.FetchOrBuildDefaultContractor(suite.DB(), nil, nil)
 	packingAndShippingInstructions := m.InstructionsBeforeContractNumber + " " + contractor.ContractNumber + " " + m.InstructionsAfterContractNumber
 	suite.MustSave(&uploadedOrder)
-	newGBLOC, gblocErr := models.FetchGBLOCForPostalCode(suite.DB(), dutyLocation.Address.PostalCode)
+	newGBLOC, gblocErr := m.FetchGBLOCForPostalCode(suite.DB(), dutyLocation.Address.PostalCode)
 	suite.NoError(gblocErr)
 	order := m.Order{
 		ServiceMemberID:                serviceMember1.ID,
@@ -462,7 +511,7 @@ func (suite *ModelSuite) TestSaveOrder() {
 	order.NewDutyLocation = location
 
 	postalCodeToGBLOC := factory.FetchOrBuildPostalCodeToGBLOC(suite.DB(), "12345", "UUUU") // Build a postal code -> GBLOC association for test DB
-	newGBLOC, gblocErr := models.FetchGBLOCForPostalCode(suite.DB(), postalCodeToGBLOC.PostalCode)
+	newGBLOC, gblocErr := m.FetchGBLOCForPostalCode(suite.DB(), postalCodeToGBLOC.PostalCode)
 
 	suite.NoError(gblocErr)
 	order.DestinationGBLOC = &newGBLOC.GBLOC

--- a/src/pages/Office/Orders/Orders.jsx
+++ b/src/pages/Office/Orders/Orders.jsx
@@ -1,6 +1,6 @@
-import React, { useEffect, useReducer, useCallback } from 'react';
+import React, { useEffect, useReducer, useCallback, useState } from 'react';
 import { Link, useNavigate, useParams, useLocation, generatePath } from 'react-router-dom';
-import { Button } from '@trussworks/react-uswds';
+import { Button, ErrorMessage } from '@trussworks/react-uswds';
 import { Formik } from 'formik';
 import { useQueryClient, useMutation } from '@tanstack/react-query';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
@@ -9,7 +9,7 @@ import ordersFormValidationSchema from './ordersFormValidationSchema';
 
 import styles from 'styles/documentViewerWithSidebar.module.scss';
 import { milmoveLogger } from 'utils/milmoveLog';
-import { getTacValid, getLoa, updateOrder } from 'services/ghcApi';
+import { getTacValid, getLoa, updateOrder, getResponseError } from 'services/ghcApi';
 import LoadingPlaceholder from 'shared/LoadingPlaceholder';
 import { tooRoutes, tioRoutes } from 'constants/routes';
 import SomethingWentWrong from 'shared/SomethingWentWrong';
@@ -38,6 +38,7 @@ const Orders = ({ files, amendedDocumentId, updateAmendedDocument, onAddFile }) 
   const { moveCode } = useParams();
   const [tacValidationState, tacValidationDispatch] = useReducer(tacReducer, null, initialTacState);
   const [loaValidationState, loaValidationDispatch] = useReducer(loaReducer, null, initialLoaState);
+  const [serverError, setServerError] = useState(null);
 
   const { move, orders, isLoading, isError } = useOrdersDocumentQueries(moveCode);
   const { state } = useLocation();
@@ -71,6 +72,11 @@ const Orders = ({ files, amendedDocumentId, updateAmendedDocument, onAddFile }) 
       handleClose();
     },
     onError: (error) => {
+      const message = getResponseError(
+        error,
+        'Something went wrong, and your changes were not saved. Please refresh the page and try again.',
+      );
+      setServerError(message);
       const errorMsg = error?.response?.body;
       milmoveLogger.error(errorMsg);
     },
@@ -436,6 +442,7 @@ const Orders = ({ files, amendedDocumentId, updateAmendedDocument, onAddFile }) 
                     />
                   </Restricted>
                 </div>
+                {serverError && <ErrorMessage>{serverError}</ErrorMessage>}
                 <Restricted to={permissionTypes.updateOrders}>
                   <div className={styles.bottom}>
                     <div className={styles.buttonGroup}>

--- a/src/pages/Office/Orders/Orders.test.jsx
+++ b/src/pages/Office/Orders/Orders.test.jsx
@@ -250,7 +250,89 @@ describe('Orders page', () => {
         expect(screen.getByText(/This TAC does not appear in TGET/)).toBeInTheDocument();
       });
     });
+
+    it('validates TAC', async () => {
+      useOrdersDocumentQueries.mockReturnValue(useOrdersDocumentQueriesReturnValue);
+
+      render(
+        <MockProviders permissions={[permissionTypes.updateOrders]}>
+          <Orders {...ordersMockProps} />
+        </MockProviders>,
+      );
+
+      const hhgTacInput = screen.getByTestId('hhgTacInput');
+      await userEvent.clear(hhgTacInput);
+      await userEvent.type(hhgTacInput, '****');
+      await waitFor(() => {
+        // no *
+        expect(screen.getByText('TAC cannot contain * or " characters')).toBeInTheDocument();
+      });
+
+      await userEvent.clear(hhgTacInput);
+      await userEvent.type(hhgTacInput, '""""');
+      await waitFor(() => {
+        // no "
+        expect(screen.getByText('TAC cannot contain * or " characters')).toBeInTheDocument();
+      });
+
+      // NTS TAC
+      const ntsTacInput = screen.getByTestId('ntsTacInput');
+      await userEvent.clear(ntsTacInput);
+      await userEvent.type(ntsTacInput, '****');
+      await waitFor(() => {
+        expect(screen.getByText('TAC cannot contain * or " characters')).toBeInTheDocument();
+      });
+
+      await userEvent.clear(ntsTacInput);
+      await userEvent.type(ntsTacInput, '""""');
+      await waitFor(() => {
+        expect(screen.getByText('TAC cannot contain * or " characters')).toBeInTheDocument();
+      });
+    });
+
+    it('validates SAC', async () => {
+      useOrdersDocumentQueries.mockReturnValue(useOrdersDocumentQueriesReturnValue);
+
+      render(
+        <MockProviders permissions={[permissionTypes.updateOrders]}>
+          <Orders {...ordersMockProps} />
+        </MockProviders>,
+      );
+
+      // SAC
+      const hhgSacInput = screen.getByTestId('hhgSacInput');
+      await userEvent.clear(hhgSacInput);
+      await userEvent.type(hhgSacInput, '****');
+      hhgSacInput.blur();
+      await waitFor(() => {
+        // no *
+        expect(screen.getByText('SAC cannot contain * or " characters')).toBeInTheDocument();
+      });
+
+      await userEvent.clear(hhgSacInput);
+      await userEvent.type(hhgSacInput, '""""');
+      await waitFor(() => {
+        // no "
+        expect(screen.getByText('SAC cannot contain * or " characters')).toBeInTheDocument();
+      });
+
+      // NTS SAC
+      const ntsSacInput = screen.getByTestId('ntsSacInput');
+      await userEvent.clear(ntsSacInput);
+      await userEvent.type(ntsSacInput, '****');
+      ntsSacInput.blur();
+      await waitFor(() => {
+        expect(screen.getByText('NTS SAC cannot contain * or " characters')).toBeInTheDocument();
+      });
+
+      await userEvent.clear(ntsSacInput);
+      await userEvent.type(ntsSacInput, '""""');
+      await waitFor(() => {
+        expect(screen.getByText('NTS SAC cannot contain * or " characters')).toBeInTheDocument();
+      });
+    });
   });
+
   describe('LOA validation', () => {
     beforeEach(() => {
       useOrdersDocumentQueries.mockReturnValue(useOrdersDocumentQueriesReturnValue);

--- a/src/pages/Office/Orders/ordersFormValidationSchema.js
+++ b/src/pages/Office/Orders/ordersFormValidationSchema.js
@@ -1,5 +1,7 @@
 import * as Yup from 'yup';
 
+const noStarOrQuote = /^[^*"]*$/;
+
 const ordersFormValidationSchema = Yup.object({
   originDutyLocation: Yup.object().defined('Required'),
   newDutyLocation: Yup.object().required('Required'),
@@ -13,8 +15,13 @@ const ordersFormValidationSchema = Yup.object({
   ordersNumber: Yup.string().required('Required'),
   ordersType: Yup.string().required('Required'),
   ordersTypeDetail: Yup.string().required('Required'),
-  tac: Yup.string().min(4, 'Enter a 4-character TAC').required('Required'),
-  sac: Yup.string(),
+  tac: Yup.string()
+    .min(4, 'Enter a 4-character TAC')
+    .matches(noStarOrQuote, 'TAC cannot contain * or " characters')
+    .required('Required'),
+  sac: Yup.string().matches(noStarOrQuote, 'SAC cannot contain * or " characters'),
+  ntsTac: Yup.string().matches(noStarOrQuote, 'NTS TAC cannot contain * or " characters'),
+  ntsSac: Yup.string().matches(noStarOrQuote, 'NTS SAC cannot contain * or " characters'),
 });
 
 export default ordersFormValidationSchema;

--- a/src/services/ghcApi.js
+++ b/src/services/ghcApi.js
@@ -1125,8 +1125,28 @@ export async function submitPPMShipmentSignedCertification(ppmShipmentId) {
   );
 }
 
-// Attempt at catch-all error handling
-// TODO improve this function when we have better standardized errors
-export function getResponseError(response, defaultErrorMessage) {
-  return response?.body?.detail || response?.statusText || defaultErrorMessage;
+export function getResponseError(errorOrResponse, defaultErrorMessage) {
+  const response = errorOrResponse?.response || errorOrResponse;
+  if (!response) return defaultErrorMessage;
+
+  const body = response.body || response.data || {};
+
+  const detail = body.detail || response.statusText || defaultErrorMessage;
+
+  const invalidFields = body.invalid_fields || body.invalidFields;
+
+  if (invalidFields && typeof invalidFields === 'object') {
+    const fieldErrors = Object.entries(invalidFields)
+      .map(([field, messages]) => {
+        if (Array.isArray(messages)) {
+          return `${field}: ${messages.join(', ')}`;
+        }
+        return `${field}: ${messages}`;
+      })
+      .join('\n');
+
+    return `${detail}\n${fieldErrors}`;
+  }
+
+  return detail;
 }


### PR DESCRIPTION
## [Agility ticket](https://www13.v1host.com/USTRANSCOM38/assetdetail.v1?number=B-23446)

## Summary

We ain't want no `*` or `"` characters in the SAC or TAC fields - this PR handles that by updating the validation rules to both UI and backend.

### How to test

1. Access MM as an office user
2. Go into the edit orders page
3. Confirm you are unable to submit when trying to save `*` or `"` characters in any of the TAC/SAC fields
4. In order to test the backend, you'll need to comment out some code (see screenshot below)

## Screenshots
- easily testable
![Screenshot 2025-05-19 at 2 46 28 PM](https://github.com/user-attachments/assets/a2a11564-b5ed-4a67-bc92-0cb7bcd6b3b1)

- this one you will have to comment out these lines in `ordersFormvalidationSchema.js`
```
  tac: Yup.string()
    .min(4, 'Enter a 4-character TAC')
    .matches(noStarOrQuote, 'TAC cannot contain * or " characters')
    .required('Required'),
  sac: Yup.string().matches(noStarOrQuote, 'SAC cannot contain * or " characters'),
  ntsTac: Yup.string().matches(noStarOrQuote, 'NTS TAC cannot contain * or " characters'),
  ntsSac: Yup.string().matches(noStarOrQuote, 'NTS SAC cannot contain * or " characters'),
```
![Screenshot 2025-05-19 at 2 44 14 PM](https://github.com/user-attachments/assets/bb468f5c-1843-4d80-86a2-8c7dcbac30f8)

