### PR TITLE
fix javascript printing falsey 0 on screen

### DIFF
--- a/src/pages/Office/index.jsx
+++ b/src/pages/Office/index.jsx
@@ -127,7 +127,7 @@ const OfficeApp = ({ loadUser, loadInternalSchema, loadPublicSchema, ...props })
   const location = useLocation();
   const displayChangeRole =
     props.userIsLoggedIn &&
-    props.userInactiveRoles?.length &&
+    !!props.userInactiveRoles?.length &&
     !matchPath(
       {
         path: '/select-application',


### PR DESCRIPTION
## [B-23278](https://www13.v1host.com/USTRANSCOM38/story.mvc/Summary?oidToken=Story%3A1097934&RoomContext=TeamRoom%3A808731&concept=TeamRoom)

## Summary
Makes this:
![image](https://github.com/user-attachments/assets/19498723-a3fa-4ec9-9990-1e781e972981)
 
Become this:
![image](https://github.com/user-attachments/assets/c402a96f-20e8-41db-89fc-77ced2d522af)



Javascript saw `0` as falsey and printed it on the page. Swapped to to be `true`/`false` only