### PR TITLE
INT B-23540 I-14209

### DIFF
--- a/migrations/app/ddl_migrations/ddl_functions/20250509183824_fn_get_origin_queue.up.sql
+++ b/migrations/app/ddl_migrations/ddl_functions/20250509183824_fn_get_origin_queue.up.sql
@@ -59,7 +59,7 @@ BEGIN
             WHEN 'customerName' THEN sort_column := 'base.sm_last_name, base.sm_first_name';
             WHEN 'edipi' THEN sort_column := 'base.sm_edipi';
             WHEN 'emplid' THEN sort_column := 'base.sm_emplid';
-            WHEN 'requestedMoveDate' THEN sort_column := 'base.earliest_requested_pickup_date';
+            WHEN 'requestedMoveDate' THEN sort_column := 'LEAST(base.earliest_requested_pickup_date, base.earliest_expected_departure_date, base.earliest_requested_delivery_date)';
             WHEN 'appearedInTooAt' THEN sort_column := 'GREATEST(base.submitted_at, base.service_counseling_completed_at, base.approvals_requested_at)';
             WHEN 'branch' THEN sort_column := 'base.sm_affiliation';
             WHEN 'originDutyLocation' THEN sort_column := 'base.origin_duty_location_name';
@@ -142,6 +142,7 @@ BEGIN
                         ''status'', ms.status,
                         ''requested_pickup_date'', TO_CHAR(ms.requested_pickup_date, ''YYYY-MM-DD"T00:00:00Z"''),
                         ''scheduled_pickup_date'', TO_CHAR(ms.scheduled_pickup_date, ''YYYY-MM-DD"T00:00:00Z"''),
+                        ''requested_delivery_date'', TO_CHAR(ms.requested_delivery_date, ''YYYY-MM-DD"T00:00:00Z"''),
                         ''approved_date'', TO_CHAR(ms.approved_date, ''YYYY-MM-DD"T00:00:00Z"''),
                         ''prime_estimated_weight'', ms.prime_estimated_weight,
                         ''ppm_shipment'', CASE

--- a/pkg/services/order/order_fetcher_test.go
+++ b/pkg/services/order/order_fetcher_test.go
@@ -2034,6 +2034,70 @@ func (suite *OrderServiceSuite) TestListOrdersWithSortOrder() {
 		suite.Equal(requestedMoveDate1.Format("2006/01/02"), moves[0].MTOShipments[0].RequestedPickupDate.Format("2006/01/02"))
 	})
 
+	suite.Run("Sort by request move date including pickup, delivery, and PPM expected departure", func() {
+		_, _, session := setupTestData()
+
+		expectedDepartureDate := time.Date(testdatagen.GHCTestYear, 01, 01, 0, 0, 0, 0, time.UTC)
+		requestedDeliveryDate := time.Date(testdatagen.GHCTestYear, 01, 02, 0, 0, 0, 0, time.UTC)
+
+		// PPM (expected departure date only)
+		movePPM := factory.BuildMove(suite.DB(), []factory.Customization{
+			{
+				Model: models.Move{
+					Locator: "PPM001",
+					Status:  models.MoveStatusAPPROVED,
+				},
+			},
+		}, nil)
+
+		shipmentPPM := factory.BuildMTOShipmentWithMove(&movePPM, suite.DB(), nil, nil)
+		factory.BuildPPMShipment(suite.DB(), []factory.Customization{
+			{
+				Model: models.PPMShipment{
+					ShipmentID:            shipmentPPM.ID,
+					ExpectedDepartureDate: expectedDepartureDate,
+				},
+			},
+		}, nil)
+
+		// NTSr (delivery date only)
+		factory.BuildMoveWithShipment(suite.DB(), []factory.Customization{
+			{
+				Model: models.Move{
+					Locator: "NTS001",
+					Status:  models.MoveStatusAPPROVED,
+				},
+			},
+			{
+				Model: models.MTOShipment{
+					ShipmentType:          models.MTOShipmentTypeHHGOutOfNTS,
+					RequestedPickupDate:   nil,
+					RequestedDeliveryDate: &requestedDeliveryDate,
+				},
+			},
+		}, nil)
+
+		// sort by requestedMoveDate asc and validate order
+		params := services.ListOrderParams{Sort: models.StringPointer("requestedMoveDate"), Order: models.StringPointer("asc")}
+		moves, _, err := orderFetcher.ListOriginRequestsOrders(suite.AppContextWithSessionForTest(&session), officeUser.ID, &params)
+		suite.NoError(err)
+		suite.True(len(moves) >= 4)
+
+		suite.Equal("PPM001", moves[0].Locator) // jan 1
+		suite.Equal("NTS001", moves[1].Locator) // jan 2
+		suite.Equal("TTZ123", moves[2].Locator) // jan 3 (pickup)
+		suite.Equal("AA1234", moves[3].Locator) // feb 20
+
+		params.Order = models.StringPointer("desc")
+		moves, _, err = orderFetcher.ListOriginRequestsOrders(suite.AppContextWithSessionForTest(&session), officeUser.ID, &params)
+		suite.NoError(err)
+
+		suite.Equal("AA1234", moves[0].Locator)
+		suite.Equal("TTZ123", moves[1].Locator)
+		suite.Equal("NTS001", moves[2].Locator)
+		suite.Equal("PPM001", moves[3].Locator)
+	})
+
 	suite.Run("Sort by submitted date (appearedInTooAt) in TOO queue ", func() {
 		// Scenario: In order to sort the moves the submitted_at, service_counseling_completed_at, and approvals_requested_at are checked to which are the minimum
 		// Expected: The moves appear in the order they are created below


### PR DESCRIPTION
## [Agility ticket](https://www13.v1host.com/USTRANSCOM38/assetdetail.v1?number=B-23540)
## [Issue ticket](https://www13.v1host.com/USTRANSCOM38/Issue.mvc/Summary?oidToken=Issue%3A1108706)

## Summary

Including PPM expected departure date and NTSr requested delivery date in the sort. Applied it in the filter, but forgot about the sort.

### How to test

1. Find a move or create a move and have HHG, PPM, and NTSr shipments
2. In the origin TOO queue, sort by requested delivery date
3. Should see them in order

![Screenshot 2025-05-20 at 3 32 06 PM](https://github.com/user-attachments/assets/4498e286-a971-4b9a-816f-fd3d2bd8fdbc)

## Screenshots
![Screenshot 2025-05-20 at 3 31 56 PM](https://github.com/user-attachments/assets/abb4823d-9f0e-4e0b-9d59-455888928455)


