### PR TITLE
B23301-INT-change UI backup contact name field

### DIFF
--- a/src/components/Customer/BackupContactForm/BackupContactForm.test.jsx
+++ b/src/components/Customer/BackupContactForm/BackupContactForm.test.jsx
@@ -6,7 +6,8 @@ import BackupContactForm from './index';
 
 describe('BackupContactForm Component', () => {
   const initialValues = {
-    name: '',
+    firstName: '',
+    lastName: '',
     telephone: '',
     email: '',
   };
@@ -20,8 +21,10 @@ describe('BackupContactForm Component', () => {
     const { getByLabelText } = render(<BackupContactForm {...testProps} />);
 
     await waitFor(() => {
-      expect(getByLabelText(/Name/)).toBeInstanceOf(HTMLInputElement);
-      expect(getByLabelText(/Name/)).toBeRequired();
+      expect(getByLabelText(/First Name/)).toBeInstanceOf(HTMLInputElement);
+      expect(getByLabelText(/First Name/)).toBeRequired();
+      expect(getByLabelText(/Last Name/)).toBeInstanceOf(HTMLInputElement);
+      expect(getByLabelText(/Last Name/)).toBeRequired();
       expect(getByLabelText(/Phone/)).toBeInstanceOf(HTMLInputElement);
       expect(getByLabelText(/Phone/)).toBeRequired();
       expect(getByLabelText(/Email/)).toBeInstanceOf(HTMLInputElement);
@@ -56,13 +59,16 @@ describe('BackupContactForm Component', () => {
     const submitBtn = getByRole('button', { name: 'Next' });
 
     // Touch all of the required fields so that they show error messages
-    await userEvent.click(getByLabelText(/Name/));
+    await userEvent.click(getByLabelText(/First Name/));
+    await userEvent.click(getByLabelText(/Last Name/));
     await userEvent.click(getByLabelText(/Phone/));
     await userEvent.click(getByLabelText(/Email/));
     await userEvent.click(submitBtn);
 
+    const numberOfContactFields = 4;
+
     await waitFor(() => {
-      expect(getAllByTestId('errorMessage').length).toBe(3);
+      expect(getAllByTestId('errorMessage').length).toBe(numberOfContactFields);
     });
 
     expect(testProps.onSubmit).not.toHaveBeenCalled();
@@ -72,7 +78,8 @@ describe('BackupContactForm Component', () => {
     const { getByRole, getByLabelText } = render(<BackupContactForm {...testProps} />);
     const submitBtn = getByRole('button', { name: 'Next' });
 
-    await userEvent.type(getByLabelText(/Name/), 'Joe Schmoe');
+    await userEvent.type(getByLabelText(/First Name/), 'Joe');
+    await userEvent.type(getByLabelText(/Last Name/), 'Schmoe');
     await userEvent.type(getByLabelText(/Phone/), '555-555-5555');
     await userEvent.type(getByLabelText(/Email/), 'test@sample.com');
     await userEvent.click(submitBtn);
@@ -86,7 +93,8 @@ describe('BackupContactForm Component', () => {
     const { getByRole, getByLabelText } = render(<BackupContactForm {...testProps} />);
     const backBtn = getByRole('button', { name: 'Back' });
 
-    await userEvent.type(getByLabelText(/Name/), 'Janey Profaney');
+    await userEvent.type(getByLabelText(/First Name/), 'Janey');
+    await userEvent.type(getByLabelText(/Last Name/), 'Profaney');
     await userEvent.type(getByLabelText(/Phone/), '555-555-1111');
     await userEvent.click(getByLabelText(/Email/));
     await userEvent.click(backBtn);

--- a/src/components/Customer/EditContactInfoForm/EditContactInfoForm.test.jsx
+++ b/src/components/Customer/EditContactInfoForm/EditContactInfoForm.test.jsx
@@ -30,7 +30,8 @@ describe('EditContactInfoForm component', () => {
         postalCode: '79936',
       },
       backup_contact: {
-        name: 'Peyton Wing',
+        firstName: 'Peyton',
+        lastName: 'Wing',
         email: 'pw@example.com',
         telephone: '915-555-8761',
       },
@@ -66,11 +67,13 @@ describe('EditContactInfoForm component', () => {
 
     expect(personalEmailInput).toHaveValue(testProps.initialValues.personal_email);
 
-    const nameInput = await screen.findByLabelText(/Name/);
+    const firstNameInput = await screen.findByLabelText(/First Name/);
+    expect(firstNameInput).toBeInstanceOf(HTMLInputElement);
+    expect(firstNameInput).toHaveValue(testProps.initialValues.backup_contact.firstName);
 
-    expect(nameInput).toBeInstanceOf(HTMLInputElement);
-
-    expect(nameInput).toHaveValue(testProps.initialValues.backup_contact.name);
+    const lastNameInput = await screen.findByLabelText(/Last Name/);
+    expect(lastNameInput).toBeInstanceOf(HTMLInputElement);
+    expect(lastNameInput).toHaveValue(testProps.initialValues.backup_contact.lastName);
 
     // We have two sets of addresses and the labels are the same across both
     const address1Inputs = await screen.findAllByLabelText(/Address 1/);

--- a/src/components/Office/CustomerContactInfoForm/CustomerContactInfoForm.jsx
+++ b/src/components/Office/CustomerContactInfoForm/CustomerContactInfoForm.jsx
@@ -17,6 +17,8 @@ import { phoneSchema, requiredAddressSchema } from 'utils/validation';
 import { ResidentialAddressShape } from 'types/address';
 import Hint from 'components/Hint';
 
+export const backupContactName = 'backup_contact';
+
 const CustomerContactInfoForm = ({ initialValues, onSubmit, onBack }) => {
   const validationSchema = Yup.object().shape({
     firstName: Yup.string().required('Required'),
@@ -30,16 +32,19 @@ const CustomerContactInfoForm = ({ initialValues, onSubmit, onBack }) => {
     secondaryPhone: phoneSchema,
     customerAddress: requiredAddressSchema.required(),
     backupAddress: requiredAddressSchema.required(),
-    name: Yup.string().required('Required'),
-    email: Yup.string()
-      .matches(/^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+.[a-zA-Z]{2,}$/, 'Must be a valid email address')
-      .required('Required'),
-    telephone: Yup.string()
-      .min(12, 'Please enter a valid phone number. Phone numbers must be entered as ###-###-####.')
-      .required('Required'), // min 12 includes hyphens
     phoneIsPreferred: Yup.boolean(),
     emailIsPreferred: Yup.boolean(),
     cacUser: Yup.boolean().required('Required'),
+    [backupContactName]: Yup.object().shape({
+      firstName: Yup.string().required('Required'),
+      lastName: Yup.string().required('Required'),
+      email: Yup.string()
+        .matches(/^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+.[a-zA-Z]{2,}$/, 'Must be a valid email address')
+        .required('Required'),
+      telephone: Yup.string()
+        .min(12, 'Please enter a valid phone number. Phone numbers must be entered as ###-###-####.')
+        .required('Required'), // min 12 includes hyphens
+    }),
   });
 
   return (
@@ -73,7 +78,7 @@ const CustomerContactInfoForm = ({ initialValues, onSubmit, onBack }) => {
                   <SectionWrapper className={`${formStyles.formSection} ${styles.formSectionHeader}`}>
                     <h2 className={styles.sectionHeader}>Backup contact</h2>
 
-                    <BackupContactInfoFields />
+                    <BackupContactInfoFields name={backupContactName} />
                   </SectionWrapper>
                   <SectionWrapper className={`${formStyles.formSection} ${styles.formSectionHeader}`}>
                     <h3>CAC Validation</h3>
@@ -133,11 +138,14 @@ CustomerContactInfoForm.propTypes = {
     suffix: PropTypes.string,
     customerTelephone: PropTypes.string,
     customerEmail: PropTypes.string,
-    name: PropTypes.string,
-    telephone: PropTypes.string,
-    email: PropTypes.string,
     customerAddress: ResidentialAddressShape,
     cacUser: PropTypes.bool,
+    backupContactName: PropTypes.shape({
+      firstName: PropTypes.string,
+      lastName: PropTypes.string,
+      email: PropTypes.string,
+      telephone: PropTypes.string,
+    }),
   }).isRequired,
   onSubmit: PropTypes.func,
   onBack: PropTypes.func,

--- a/src/components/Office/CustomerContactInfoForm/CustomerContactInfoForm.test.jsx
+++ b/src/components/Office/CustomerContactInfoForm/CustomerContactInfoForm.test.jsx
@@ -1,8 +1,8 @@
 import React from 'react';
-import { render, waitFor, screen } from '@testing-library/react';
+import { render, waitFor, screen, within } from '@testing-library/react';
 import { Provider } from 'react-redux';
 
-import CustomerContactInfoForm from './CustomerContactInfoForm';
+import CustomerContactInfoForm, { backupContactName } from './CustomerContactInfoForm';
 
 import { roleTypes } from 'constants/userRoles';
 import { configureStore } from 'shared/store';
@@ -37,10 +37,13 @@ describe('CustomerContactInfoForm Component', () => {
       state: 'MT',
       postalCode: '59802',
     },
-    name: '',
-    telephone: '',
-    email: '',
     cacUser: true,
+    [backupContactName]: {
+      firstName: '',
+      lastName: '',
+      telephone: '',
+      email: '',
+    },
   };
   const testProps = {
     initialValues,
@@ -63,10 +66,13 @@ describe('CustomerContactInfoForm Component', () => {
       postalCode: '59802',
       county: 'MISSOULA',
     },
-    name: 'joe bob',
-    telephone: '855-222-1111',
-    email: 'joebob@gmail.com',
     cacUser: null,
+    [backupContactName]: {
+      firstName: 'joe',
+      lastName: 'bob',
+      telephone: '855-222-1111',
+      email: 'joebob@gmail.com',
+    },
   };
   const testPropsCacValidated = {
     initialValuesCacValidated,
@@ -83,6 +89,9 @@ describe('CustomerContactInfoForm Component', () => {
         <CustomerContactInfoForm {...testProps} />
       </Provider>,
     );
+
+    const backupContactHeading = screen.getByRole('heading', { name: /backup contact/i });
+    const backupContactSection = backupContactHeading.closest('section') || backupContactHeading.parentElement;
 
     await waitFor(() => {
       expect(screen.getByText('Contact info')).toBeInstanceOf(HTMLHeadingElement);
@@ -113,9 +122,10 @@ describe('CustomerContactInfoForm Component', () => {
       expect(screen.getByText('59802')).toBeInstanceOf(HTMLLabelElement);
       expect(screen.getByText('Missoula, MT 59802 ()')).toBeInstanceOf(HTMLSpanElement);
 
-      expect(screen.getByLabelText('Name')).toBeInstanceOf(HTMLInputElement);
-      expect(screen.getAllByLabelText('Phone')[1]).toBeInstanceOf(HTMLInputElement);
-      expect(screen.getAllByLabelText('Email')[1]).toBeInstanceOf(HTMLInputElement);
+      expect(within(backupContactSection).getByLabelText('First Name')).toBeInstanceOf(HTMLInputElement);
+      expect(within(backupContactSection).getByLabelText('Last Name')).toBeInstanceOf(HTMLInputElement);
+      expect(within(backupContactSection).getByLabelText('Phone')).toBeInstanceOf(HTMLInputElement);
+      expect(within(backupContactSection).getByLabelText('Email')).toBeInstanceOf(HTMLInputElement);
 
       expect(screen.getByText('CAC Validation')).toBeInstanceOf(HTMLHeadingElement);
       expect(

--- a/src/components/Office/DefinitionLists/CustomerInfoList.jsx
+++ b/src/components/Office/DefinitionLists/CustomerInfoList.jsx
@@ -10,6 +10,17 @@ import { formatCustomerContactFullAddress } from 'utils/formatters';
 import departmentIndicators from 'constants/departmentIndicators';
 
 const CustomerInfoList = ({ customerInfo }) => {
+  let backupContactName = '-';
+  if (customerInfo.backupContact?.name) {
+    const fullName = customerInfo.backupContact?.name;
+    const [firstName = '', lastName = ''] = fullName.split(/ (.+)/).filter(Boolean);
+    if (lastName.length > 0) {
+      backupContactName = `${lastName}, ${firstName}`;
+    } else {
+      backupContactName = firstName;
+    }
+  }
+
   return (
     <div className={styles.OfficeDefinitionLists}>
       <dl className={descriptionListStyles.descriptionList}>
@@ -57,9 +68,7 @@ const CustomerInfoList = ({ customerInfo }) => {
         </div>
         <div className={descriptionListStyles.row}>
           <dt>Backup contact name</dt>
-          <dd data-testid="backupContactName">
-            {customerInfo.backupContact?.name ? customerInfo.backupContact.name : '—'}
-          </dd>
+          <dd data-testid="backupContactName">{backupContactName}</dd>
         </div>
         <div className={descriptionListStyles.row}>
           <dt>Backup contact email</dt>

--- a/src/components/Office/DefinitionLists/CustomerInfoList.test.jsx
+++ b/src/components/Office/DefinitionLists/CustomerInfoList.test.jsx
@@ -58,7 +58,7 @@ describe('CustomerInfoList', () => {
 
   it('renders formatted backup contact name', () => {
     render(<CustomerInfoList customerInfo={info} />);
-    expect(screen.getByText('Quinn Ocampo')).toBeInTheDocument();
+    expect(screen.getByText('Ocampo, Quinn')).toBeInTheDocument();
   });
 
   it('renders formatted backup contact email', () => {

--- a/src/components/form/BackupContactInfoFields/BackupContactInfoFields.test.jsx
+++ b/src/components/form/BackupContactInfoFields/BackupContactInfoFields.test.jsx
@@ -12,7 +12,8 @@ describe('BackupContactInfoFields component', () => {
       </Formik>,
     );
     expect(screen.getByText('Backup contact')).toBeInstanceOf(HTMLLegendElement);
-    expect(screen.getByLabelText('Name')).toBeInstanceOf(HTMLInputElement);
+    expect(screen.getByLabelText('First Name')).toBeInstanceOf(HTMLInputElement);
+    expect(screen.getByLabelText('Last Name')).toBeInstanceOf(HTMLInputElement);
     expect(screen.getByLabelText('Email')).toBeInstanceOf(HTMLInputElement);
     expect(screen.getByLabelText('Phone')).toBeInstanceOf(HTMLInputElement);
   });
@@ -21,7 +22,8 @@ describe('BackupContactInfoFields component', () => {
     it('renders a legend and all backup contact info inputs', async () => {
       const initialValues = {
         email: 'test@example.com',
-        name: 'test',
+        firstName: 'test',
+        lastName: 'case',
         telephone: '555-123-4567',
       };
 
@@ -30,7 +32,8 @@ describe('BackupContactInfoFields component', () => {
           <BackupContactInfoFields legend="Backup contact" />
         </Formik>,
       );
-      expect(await screen.findByLabelText('Name')).toHaveValue(initialValues.name);
+      expect(await screen.findByLabelText('First Name')).toHaveValue(initialValues.firstName);
+      expect(await screen.findByLabelText('Last Name')).toHaveValue(initialValues.lastName);
       expect(await screen.findByLabelText('Email')).toHaveValue(initialValues.email);
       expect(await screen.findByLabelText('Phone')).toHaveValue(initialValues.telephone);
     });
@@ -41,7 +44,8 @@ describe('BackupContactInfoFields component', () => {
 
     const initialBackupInfo = {
       email: 'test@example.com',
-      name: 'test',
+      firstName: 'test',
+      lastName: 'test',
       telephone: '555-123-4567',
     };
 
@@ -55,7 +59,8 @@ describe('BackupContactInfoFields component', () => {
       </Formik>,
     );
 
-    expect(await screen.findByLabelText('Name')).toHaveValue(initialBackupInfo.name);
+    expect(await screen.findByLabelText('First Name')).toHaveValue(initialBackupInfo.firstName);
+    expect(await screen.findByLabelText('Last Name')).toHaveValue(initialBackupInfo.lastName);
     expect(await screen.findByLabelText('Email')).toHaveValue(initialBackupInfo.email);
     expect(await screen.findByLabelText('Phone')).toHaveValue(initialBackupInfo.telephone);
   });

--- a/src/components/form/BackupContactInfoFields/index.jsx
+++ b/src/components/form/BackupContactInfoFields/index.jsx
@@ -9,12 +9,14 @@ import MaskedTextField from 'components/form/fields/MaskedTextField/MaskedTextFi
 export const BackupContactInfoFields = ({ name, legend, className, render, labelHint: labelHintProp }) => {
   const backupContactInfoFieldsUUID = useRef(uuidv4());
 
-  let nameFieldName = 'name';
+  let firstNameFieldName = 'firstName';
+  let lastNameFieldName = 'lastName';
   let emailFieldName = 'email';
   let phoneFieldName = 'telephone';
 
   if (name !== '') {
-    nameFieldName = `${name}.name`;
+    firstNameFieldName = `${name}.firstName`;
+    lastNameFieldName = `${name}.lastName`;
     emailFieldName = `${name}.email`;
     phoneFieldName = `${name}.telephone`;
   }
@@ -24,9 +26,16 @@ export const BackupContactInfoFields = ({ name, legend, className, render, label
       {render(
         <>
           <TextField
-            label="Name"
-            id={`name_${backupContactInfoFieldsUUID.current}`}
-            name={nameFieldName}
+            label="First Name"
+            id={`firstName_${backupContactInfoFieldsUUID.current}`}
+            name={firstNameFieldName}
+            required
+            labelHint={labelHintProp}
+          />
+          <TextField
+            label="Last Name"
+            id={`lastName_${backupContactInfoFieldsUUID.current}`}
+            name={lastNameFieldName}
             required
             labelHint={labelHintProp}
           />

--- a/src/pages/MyMove/Profile/BackupContact.jsx
+++ b/src/pages/MyMove/Profile/BackupContact.jsx
@@ -25,8 +25,11 @@ import scrollToTop from 'shared/scrollToTop';
 
 export const BackupContact = ({ serviceMember, currentBackupContacts, updateServiceMember, updateBackupContact }) => {
   const navigate = useNavigate();
+  const fullName = currentBackupContacts[0]?.name || '';
+  const [firstName, lastName] = fullName.split(/ (.+)/).filter(Boolean);
   const initialValues = {
-    name: currentBackupContacts[0]?.name || '',
+    firstName: firstName || '',
+    lastName: lastName || '',
     telephone: currentBackupContacts[0]?.telephone || '',
     email: currentBackupContacts[0]?.email || '',
   };
@@ -41,7 +44,7 @@ export const BackupContact = ({ serviceMember, currentBackupContacts, updateServ
 
   const handleSubmit = (values) => {
     const payload = {
-      name: values?.name || '',
+      name: `${values?.firstName || ''} ${values?.lastName || ''}`,
       email: values?.email || '',
       telephone: values?.telephone || '',
       permission: values.permission === undefined ? NonePermission : values.permission,

--- a/src/pages/MyMove/Profile/BackupContact.test.jsx
+++ b/src/pages/MyMove/Profile/BackupContact.test.jsx
@@ -129,7 +129,8 @@ describe('BackupContact page', () => {
 
       const submitButton = queryByText('Next');
       expect(submitButton).toBeInTheDocument();
-      await userEvent.type(getByLabelText(/Name/), 'Joe Schmoe');
+      await userEvent.type(getByLabelText(/First Name/), 'Joe');
+      await userEvent.type(getByLabelText(/Last Name/), 'Schmoe');
       await userEvent.type(getByLabelText(/Phone/), '555-555-5555');
       await userEvent.type(getByLabelText(/Email/), 'test@sample.com');
       await userEvent.click(submitButton);
@@ -163,7 +164,8 @@ describe('BackupContact page', () => {
 
       const submitButton = queryByText('Next');
       expect(submitButton).toBeInTheDocument();
-      await userEvent.type(getByLabelText(/Name/), 'Joe Schmitty');
+      await userEvent.type(getByLabelText(/First Name/), 'Joe');
+      await userEvent.type(getByLabelText(/Last Name/), 'Schmitty');
       await userEvent.type(getByLabelText(/Phone/), '555-555-5555');
       await userEvent.type(getByLabelText(/Email/), 'test@sample.com');
       await userEvent.click(submitButton);

--- a/src/pages/MyMove/Profile/EditContactInfo.jsx
+++ b/src/pages/MyMove/Profile/EditContactInfo.jsx
@@ -31,6 +31,11 @@ export const EditContactInfo = ({
   const { state } = useLocation();
   const [serverError, setServerError] = useState(null);
 
+  const currentBackupContactFullName = currentBackupContacts[0]?.name || '';
+  const [currentBackupContactFirstName, currentBackupContactLastName] = currentBackupContactFullName
+    .split(/ (.+)/)
+    .filter(Boolean);
+
   const initialValues = {
     telephone: serviceMember?.telephone || '',
     secondary_telephone: serviceMember?.secondary_telephone || '',
@@ -58,7 +63,8 @@ export const EditContactInfo = ({
       usPostRegionCitiesID: serviceMember.backup_mailing_address?.usPostRegionCitiesID || '',
     },
     [backupContactName]: {
-      name: currentBackupContacts[0]?.name || '',
+      firstName: currentBackupContactFirstName,
+      lastName: currentBackupContactLastName,
       telephone: currentBackupContacts[0]?.telephone || '',
       email: currentBackupContacts[0]?.email || '',
     },
@@ -81,16 +87,21 @@ export const EditContactInfo = ({
 
     serviceMemberPayload.secondary_telephone = values?.secondary_telephone;
 
+    const backupFirstName = values[backupContactName.toString()]?.firstName || '';
+    const backupLastName = values[backupContactName.toString()]?.lastName || '';
+    const backupFullName = `${backupFirstName} ${backupLastName}`;
+
     const backupContactPayload = {
       id: currentBackupContacts[0].id,
-      name: values[backupContactName.toString()]?.name || '',
+      name: backupFullName,
       email: values[backupContactName.toString()]?.email || '',
       telephone: values[backupContactName.toString()]?.telephone || '',
       permission: currentBackupContacts[0].permission,
     };
 
     const backupContactChanged =
-      initialValues[backupContactName.toString()].name !== backupContactPayload.name ||
+      initialValues[backupContactName.toString()].firstName !== backupFirstName ||
+      initialValues[backupContactName.toString()].lastName !== backupLastName ||
       initialValues[backupContactName.toString()].email !== backupContactPayload.email ||
       initialValues[backupContactName.toString()].telephone !== backupContactPayload.telephone;
 

--- a/src/pages/MyMove/Profile/EditContactInfo.test.jsx
+++ b/src/pages/MyMove/Profile/EditContactInfo.test.jsx
@@ -112,6 +112,7 @@ describe('EditContactInfo page', () => {
 
   it('saves backup contact info when it is updated and the save button is clicked', async () => {
     const newName = 'Rosalie Wexler';
+    const [newFirstName, newLastName] = newName.split(/ (.+)/).filter(Boolean);
 
     const expectedPayload = { ...testProps.currentBackupContacts[0], name: newName };
 
@@ -131,11 +132,13 @@ describe('EditContactInfo page', () => {
       </MockProviders>,
     );
 
-    const backupNameInput = await screen.findByLabelText(/Name/);
+    const backupFirstNameInput = await screen.findByLabelText(/First Name/);
+    const backupLastNameInput = await screen.findByLabelText(/Last Name/);
 
-    await userEvent.clear(backupNameInput);
-
-    await userEvent.type(backupNameInput, newName);
+    await userEvent.clear(backupFirstNameInput);
+    await userEvent.type(backupFirstNameInput, newFirstName);
+    await userEvent.clear(backupLastNameInput);
+    await userEvent.type(backupLastNameInput, newLastName);
 
     const saveButton = screen.getByRole('button', { name: 'Save' });
 
@@ -168,11 +171,13 @@ describe('EditContactInfo page', () => {
       </MockProviders>,
     );
 
-    const backupNameInput = await screen.findByLabelText(/Name/);
+    const backupFirstNameInput = await screen.findByLabelText(/First Name/);
+    const backupLastNameInput = await screen.findByLabelText(/Last Name/);
 
-    await userEvent.clear(backupNameInput);
-
-    await userEvent.type(backupNameInput, 'Rosalie Wexler');
+    await userEvent.clear(backupFirstNameInput);
+    await userEvent.type(backupFirstNameInput, 'Rosalie');
+    await userEvent.clear(backupLastNameInput);
+    await userEvent.type(backupLastNameInput, 'Wexler');
 
     const saveButton = screen.getByRole('button', { name: 'Save' });
 

--- a/src/pages/Office/CreateMoveCustomerInfo/CreateMoveCustomerInfo.jsx
+++ b/src/pages/Office/CreateMoveCustomerInfo/CreateMoveCustomerInfo.jsx
@@ -3,7 +3,9 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { generatePath, useNavigate, useParams } from 'react-router';
 import { GridContainer } from '@trussworks/react-uswds';
 
-import CustomerContactInfoForm from 'components/Office/CustomerContactInfoForm/CustomerContactInfoForm';
+import CustomerContactInfoForm, {
+  backupContactName,
+} from 'components/Office/CustomerContactInfoForm/CustomerContactInfoForm';
 import { CUSTOMER } from 'constants/queryKeys';
 import { servicesCounselingRoutes } from 'constants/routes';
 import { updateCustomerInfo } from 'services/ghcApi';
@@ -55,14 +57,15 @@ const CreateMoveCustomerInfo = () => {
       customerAddress,
       suffix,
       middleName,
-      name,
-      email,
-      telephone,
       backupAddress,
       phoneIsPreferred,
       emailIsPreferred,
       secondaryPhone,
     } = values;
+
+    const backupFirstName = values[backupContactName.toString()]?.firstName || '';
+    const backupLastName = values[backupContactName.toString()]?.lastName || '';
+    const backupFullName = `${backupFirstName} ${backupLastName}`;
 
     const body = {
       first_name: firstName,
@@ -73,9 +76,9 @@ const CreateMoveCustomerInfo = () => {
       suffix,
       middle_name: middleName,
       backup_contact: {
-        name,
-        email,
-        phone: telephone,
+        name: backupFullName,
+        email: values[backupContactName.toString()]?.email || '',
+        phone: values[backupContactName.toString()]?.telephone || '',
       },
       backupAddress,
       phoneIsPreferred,
@@ -85,6 +88,10 @@ const CreateMoveCustomerInfo = () => {
     };
     mutateCustomerInfo({ customerId: customerData.id, ifMatchETag: customerData.eTag, body });
   };
+
+  const backupContactFullName = customerData?.backup_contact?.name || '';
+  const [backupContactFirstName, backupContactLastName] = backupContactFullName.split(/ (.+)/).filter(Boolean);
+
   const initialValues = {
     firstName: customerData?.first_name || '',
     lastName: customerData?.last_name || '',
@@ -92,15 +99,18 @@ const CreateMoveCustomerInfo = () => {
     suffix: customerData?.suffix || '',
     customerTelephone: customerData?.phone || '',
     customerEmail: customerData?.email || '',
-    name: customerData?.backup_contact?.name || '',
-    telephone: customerData?.backup_contact?.phone || '',
     secondaryPhone: customerData?.secondaryTelephone || '',
-    email: customerData?.backup_contact?.email || '',
     customerAddress: customerData?.current_address || '',
     backupAddress: customerData?.backupAddress || '',
     emailIsPreferred: customerData?.emailIsPreferred || false,
     phoneIsPreferred: customerData?.phoneIsPreferred || false,
     cacUser: formatTrueFalseInputValue(customerData?.cacValidated),
+    [backupContactName]: {
+      firstName: backupContactFirstName,
+      lastName: backupContactLastName,
+      email: customerData?.backup_contact?.email || '',
+      telephone: customerData?.backup_contact?.phone || '',
+    },
   };
 
   return (

--- a/src/pages/Office/CreateMoveCustomerInfo/CreateMoveCustomerInfo.test.jsx
+++ b/src/pages/Office/CreateMoveCustomerInfo/CreateMoveCustomerInfo.test.jsx
@@ -100,6 +100,11 @@ describe('CreateMoveCustomerInfo', () => {
 
     renderWithProviders(<CreateMoveCustomerInfo />, mockRoutingConfig);
     const { customerData } = useCustomerQueryReturnValue;
+
+    const [backupContactFirstName, backupContactLastName] = customerData.backup_contact.name
+      .split(/ (.+)/)
+      .filter(Boolean);
+
     await waitFor(() => {
       expect(screen.getByLabelText('First name').value).toEqual(customerData.first_name);
       expect(screen.getByLabelText(/Middle name/i).value).toEqual(customerData.middle_name);
@@ -120,7 +125,8 @@ describe('CreateMoveCustomerInfo', () => {
       expect(screen.getByText('CA')).toHaveTextContent(customerData.current_address.state);
       expect(screen.getByText('90210')).toHaveTextContent(customerData.current_address.postalCode);
       expect(screen.getByText('Beverly Hills, CA 90210 ()'));
-      expect(screen.getByDisplayValue('Jane Backup').value).toEqual(customerData.backup_contact.name);
+      expect(screen.getByDisplayValue('Jane').value).toEqual(backupContactFirstName);
+      expect(screen.getByDisplayValue('Backup').value).toEqual(backupContactLastName);
     });
   });
 

--- a/src/pages/Office/CustomerInfo/CustomerInfo.jsx
+++ b/src/pages/Office/CustomerInfo/CustomerInfo.jsx
@@ -5,7 +5,9 @@ import { useQueryClient, useMutation } from '@tanstack/react-query';
 import { useNavigate } from 'react-router-dom';
 import { GridContainer } from '@trussworks/react-uswds';
 
-import CustomerContactInfoForm from '../../../components/Office/CustomerContactInfoForm/CustomerContactInfoForm';
+import CustomerContactInfoForm, {
+  backupContactName,
+} from '../../../components/Office/CustomerContactInfoForm/CustomerContactInfoForm';
 
 import styles from './CustomerInfo.module.scss';
 
@@ -57,14 +59,15 @@ const CustomerInfo = ({ customer, isLoading, isError, ordersId, onUpdate }) => {
       customerAddress,
       suffix,
       middleName,
-      name,
-      email,
-      telephone,
       backupAddress,
       phoneIsPreferred,
       emailIsPreferred,
       secondaryPhone,
     } = values;
+
+    const backupFirstName = values[backupContactName.toString()]?.firstName || '';
+    const backupLastName = values[backupContactName.toString()]?.lastName || '';
+    const backupFullName = `${backupFirstName} ${backupLastName}`;
 
     const body = {
       first_name: firstName,
@@ -75,9 +78,9 @@ const CustomerInfo = ({ customer, isLoading, isError, ordersId, onUpdate }) => {
       suffix,
       middle_name: middleName,
       backup_contact: {
-        name,
-        email,
-        phone: telephone,
+        name: backupFullName,
+        email: values[backupContactName.toString()]?.email || '',
+        phone: values[backupContactName.toString()]?.telephone || '',
       },
       backupAddress,
       phoneIsPreferred,
@@ -87,6 +90,8 @@ const CustomerInfo = ({ customer, isLoading, isError, ordersId, onUpdate }) => {
     };
     mutateCustomerInfo({ customerId: customer.id, ifMatchETag: customer.eTag, body });
   };
+
+  const [backupContactFirstName, backupContactLastName] = customer.backup_contact.name.split(/ (.+)/).filter(Boolean);
 
   const initialValues = {
     firstName: customer.first_name,
@@ -104,6 +109,12 @@ const CustomerInfo = ({ customer, isLoading, isError, ordersId, onUpdate }) => {
     emailIsPreferred: customer.emailIsPreferred,
     phoneIsPreferred: customer.phoneIsPreferred,
     cacUser: formatTrueFalseInputValue(customer?.cacValidated),
+    [backupContactName]: {
+      firstName: backupContactFirstName,
+      lastName: backupContactLastName,
+      telephone: customer.backup_contact.phone,
+      email: customer.backup_contact.email,
+    },
   };
 
   return (

--- a/src/pages/Office/CustomerInfo/CustomerInfo.test.jsx
+++ b/src/pages/Office/CustomerInfo/CustomerInfo.test.jsx
@@ -106,6 +106,11 @@ describe('CustomerInfo', () => {
         />
       </MockProviders>,
     );
+
+    const [backupContactFirstName, backupContactLastName] = mockCustomer.backup_contact.name
+      .split(/ (.+)/)
+      .filter(Boolean);
+
     await waitFor(() => {
       expect(screen.getByLabelText('First name').value).toEqual(mockCustomer.first_name);
       expect(screen.getByLabelText(/Middle name/i).value).toEqual(mockCustomer.middle_name);
@@ -131,7 +136,8 @@ describe('CustomerInfo', () => {
           `${mockCustomer.current_address.city}, ${mockCustomer.current_address.state} ${mockCustomer.current_address.postalCode} ()`,
         ),
       );
-      expect(screen.getByDisplayValue('Jane Backup').value).toEqual(mockCustomer.backup_contact.name);
+      expect(screen.getByDisplayValue('Jane').value).toEqual(backupContactFirstName);
+      expect(screen.getByDisplayValue('Backup').value).toEqual(backupContactLastName);
     });
   });
 

--- a/src/pages/Office/CustomerOnboarding/CreateCustomerForm.jsx
+++ b/src/pages/Office/CustomerOnboarding/CreateCustomerForm.jsx
@@ -90,7 +90,8 @@ export const CreateCustomerForm = ({ userPrivileges, setFlashMessage, setCanAddO
       postalCode: '',
     },
     [backupContactName]: {
-      name: '',
+      firstName: '',
+      lastName: '',
       telephone: '',
       email: '',
     },
@@ -109,6 +110,10 @@ export const CreateCustomerForm = ({ userPrivileges, setFlashMessage, setCanAddO
     const createOktaAccount = values.create_okta_account === 'true';
     const cacUser = values.cac_user === 'true';
 
+    const backupContactFirstName = values[backupContactName].firstName;
+    const backupContactLastName = values[backupContactName].lastName;
+    const backupContactFullName = `${backupContactFirstName} ${backupContactLastName}`;
+
     const body = {
       affiliation: values.affiliation,
       edipi: values.edipi,
@@ -125,7 +130,7 @@ export const CreateCustomerForm = ({ userPrivileges, setFlashMessage, setCanAddO
       residentialAddress: values[residentialAddressName],
       backupMailingAddress: values[backupAddressName],
       backupContact: {
-        name: values[backupContactName].name,
+        name: backupContactFullName,
         email: values[backupContactName].email,
         phone: values[backupContactName].telephone,
       },
@@ -443,7 +448,13 @@ export const CreateCustomerForm = ({ userPrivileges, setFlashMessage, setCanAddO
                   </SectionWrapper>
                   <SectionWrapper className={sectionStyles}>
                     <h3>Backup Contact</h3>
-                    <TextField label="Name" id="backupContactName" name="backup_contact.name" required />
+                    <TextField
+                      label="First Name"
+                      id="backupContactFirstName"
+                      name="backup_contact.firstName"
+                      required
+                    />
+                    <TextField label="Last Name" id="backupContactLastName" name="backup_contact.lastName" required />
                     <TextField label="Email" id="backupContactEmail" name="backup_contact.email" required />
                     <MaskedTextField
                       label="Phone"

--- a/src/pages/Office/CustomerOnboarding/CreateCustomerForm.test.jsx
+++ b/src/pages/Office/CustomerOnboarding/CreateCustomerForm.test.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, fireEvent, waitFor, screen, act } from '@testing-library/react';
+import { render, fireEvent, waitFor, screen, act, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { generatePath } from 'react-router';
 
@@ -317,7 +317,16 @@ describe('CreateCustomerForm', () => {
       await userEvent.click(selectedBackupLocation);
     });
 
-    await user.type(getByLabelText('Name'), fakePayload.backup_contact.name);
+    const backupContactSection =
+      getByRole('heading', { name: /backup contact/i }).closest('section') ||
+      getByRole('heading', { name: /backup contact/i }).parentElement;
+
+    const [backupContactFirstName, backupContactLastName] = fakePayload.backup_contact.name
+      .split(/ (.+)/)
+      .filter(Boolean);
+
+    await user.type(within(backupContactSection).getByLabelText('First Name'), backupContactFirstName);
+    await user.type(within(backupContactSection).getByLabelText('Last Name'), backupContactLastName);
     await user.type(getByRole('textbox', { name: 'Email' }), fakePayload.backup_contact.email);
     await user.type(getByRole('textbox', { name: 'Phone' }), fakePayload.backup_contact.telephone);
 
@@ -407,7 +416,16 @@ describe('CreateCustomerForm', () => {
       await userEvent.click(selectedBackupLocation);
     });
 
-    await userEvent.type(getByLabelText('Name'), fakePayload.backup_contact.name);
+    const backupContactSection =
+      getByRole('heading', { name: /backup contact/i }).closest('section') ||
+      getByRole('heading', { name: /backup contact/i }).parentElement;
+
+    const [backupContactFirstName, backupContactLastName] = fakePayload.backup_contact.name
+      .split(/ (.+)/)
+      .filter(Boolean);
+
+    await user.type(within(backupContactSection).getByLabelText('First Name'), backupContactFirstName);
+    await user.type(within(backupContactSection).getByLabelText('Last Name'), backupContactLastName);
     await userEvent.type(getByRole('textbox', { name: 'Email' }), fakePayload.backup_contact.email);
     await userEvent.type(getByRole('textbox', { name: 'Phone' }), fakePayload.backup_contact.telephone);
 
@@ -485,7 +503,16 @@ describe('CreateCustomerForm', () => {
       await userEvent.click(selectedBackupLocation);
     });
 
-    await userEvent.type(getByLabelText('Name'), fakePayload.backup_contact.name);
+    const backupContactSection =
+      getByRole('heading', { name: /backup contact/i }).closest('section') ||
+      getByRole('heading', { name: /backup contact/i }).parentElement;
+
+    const [backupContactFirstName, backupContactLastName] = fakePayload.backup_contact.name
+      .split(/ (.+)/)
+      .filter(Boolean);
+
+    await user.type(within(backupContactSection).getByLabelText('First Name'), backupContactFirstName);
+    await user.type(within(backupContactSection).getByLabelText('Last Name'), backupContactLastName);
     await userEvent.type(getByRole('textbox', { name: 'Email' }), fakePayload.backup_contact.email);
     await userEvent.type(getByRole('textbox', { name: 'Phone' }), fakePayload.backup_contact.telephone);
 
@@ -561,7 +588,16 @@ describe('CreateCustomerForm', () => {
       await userEvent.click(selectedBackupLocation);
     });
 
-    await userEvent.type(getByLabelText('Name'), safetyPayload.backup_contact.name);
+    const backupContactSection =
+      getByRole('heading', { name: /backup contact/i }).closest('section') ||
+      getByRole('heading', { name: /backup contact/i }).parentElement;
+
+    const [backupContactFirstName, backupContactLastName] = fakePayload.backup_contact.name
+      .split(/ (.+)/)
+      .filter(Boolean);
+
+    await user.type(within(backupContactSection).getByLabelText('First Name'), backupContactFirstName);
+    await user.type(within(backupContactSection).getByLabelText('Last Name'), backupContactLastName);
     await userEvent.type(getByRole('textbox', { name: 'Email' }), safetyPayload.backup_contact.email);
     await userEvent.type(getByRole('textbox', { name: 'Phone' }), safetyPayload.backup_contact.telephone);
 
@@ -639,7 +675,16 @@ describe('CreateCustomerForm', () => {
       await userEvent.click(selectedBackupLocation);
     });
 
-    await userEvent.type(getByLabelText('Name'), safetyPayload.backup_contact.name);
+    const backupContactSection =
+      getByRole('heading', { name: /backup contact/i }).closest('section') ||
+      getByRole('heading', { name: /backup contact/i }).parentElement;
+
+    const [backupContactFirstName, backupContactLastName] = fakePayload.backup_contact.name
+      .split(/ (.+)/)
+      .filter(Boolean);
+
+    await user.type(within(backupContactSection).getByLabelText('First Name'), backupContactFirstName);
+    await user.type(within(backupContactSection).getByLabelText('Last Name'), backupContactLastName);
     await userEvent.type(getByRole('textbox', { name: 'Email' }), safetyPayload.backup_contact.email);
     await userEvent.type(getByRole('textbox', { name: 'Phone' }), safetyPayload.backup_contact.telephone);
 
@@ -715,7 +760,16 @@ describe('CreateCustomerForm', () => {
       await userEvent.click(selectedBackupLocation);
     });
 
-    await userEvent.type(getByLabelText('Name'), safetyPayload.backup_contact.name);
+    const backupContactSection =
+      getByRole('heading', { name: /backup contact/i }).closest('section') ||
+      getByRole('heading', { name: /backup contact/i }).parentElement;
+
+    const [backupContactFirstName, backupContactLastName] = fakePayload.backup_contact.name
+      .split(/ (.+)/)
+      .filter(Boolean);
+
+    await user.type(within(backupContactSection).getByLabelText('First Name'), backupContactFirstName);
+    await user.type(within(backupContactSection).getByLabelText('Last Name'), backupContactLastName);
     await userEvent.type(getByRole('textbox', { name: 'Email' }), safetyPayload.backup_contact.email);
     await userEvent.type(getByRole('textbox', { name: 'Phone' }), safetyPayload.backup_contact.telephone);
 

--- a/src/utils/validation.js
+++ b/src/utils/validation.js
@@ -149,7 +149,8 @@ export const contactInfoSchema = Yup.object()
   .test('contactMethodRequired', 'Please select a preferred method of contact.', preferredContactMethodValidation);
 
 export const backupContactInfoSchema = Yup.object().shape({
-  name: Yup.string().required('Required'),
+  firstName: Yup.string().required('Required'),
+  lastName: Yup.string().required('Required'),
   email: emailSchema.required('Required'),
   telephone: phoneSchema.required('Required'),
 });


### PR DESCRIPTION
## [Agility ticket](tbd)

## Summary

Is there anything you would like reviewers to give additional scrutiny?

[this article](tbd) explains more about the approach used.

## Verification Steps for the Author

These are to be checked by the author.

- [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
- [ ] Have the Agility acceptance criteria been met for this change?

## Verification Steps for Reviewers

These are to be checked by a reviewer.

- [ ] Has the branch been pulled in and checked out?
- [ ] Have the BL acceptance criteria been met for this change?
- [ ] Was the CircleCI build successful?
- [ ] Has the code been reviewed from a standards and best practices point of view?

### Setup to Run the Code

- [Instructions for starting storybook](https://transcom.github.io/mymove-docs/docs/frontend/setup/storybook)
- [Instructions for starting the MilMove application](https://transcom.github.io/mymove-docs/docs/getting-started/application-setup/)
- [Instructions for running tests](https://transcom.github.io/mymove-docs/docs/getting-started/development/testing)

### How to test

1. Access the
2. Login as a
3.

### Frontend

- [ ] There are no aXe warnings for UI.
- [ ] This works in [Supported Browsers and their phone views](https://transcom.github.io/mymove-docs/docs/adrs/Browser-Support/#minimum-browser-requirements) (Chrome, Firefox, Edge).
- [ ] There are no new console errors in the browser devtools.
- [ ] There are no new console errors in the test output.
- [ ] If this PR adds a new component to Storybook, it ensures the component is fully responsive, OR if it is intentionally not, a wrapping div using the `officeApp` class or custom `min-width` styling is used to hide any states the would not be visible to the user.
- [ ] This change meets the standards for [Section 508 compliance](https://www.ssa.gov/accessibility/andi/help/install.html).

### Backend

- [ ] Code follows the guidelines for [Logging](https://transcom.github.io/mymove-docs/docs/getting-started/development/logging).
- [ ] The requirements listed in [Querying the Database Safely](https://transcom.github.io/mymove-docs/docs/backend/guides/golang-guide#querying-the-database-safely) have been satisfied.

### Database

#### Any new migrations/schema changes:

- [ ] Follows our guidelines for [Zero-Downtime Deploys](https://transcom.github.io/mymove-docs/docs/backend/setup/database-migrations#zero-downtime-migrations).
- [ ] Have been communicated to #g-database.
- [ ] Secure migrations have been tested following the instructions in our [docs](https://transcom.github.io/mymove-docs/docs/backend/setup/database-migrations#secure-migrations).

## Screenshots
