### PR TITLE
INT B-23676

### DIFF
--- a/pkg/services/shipment_summary_worksheet/shipment_summary_worksheet.go
+++ b/pkg/services/shipment_summary_worksheet/shipment_summary_worksheet.go
@@ -686,7 +686,7 @@ func formatSSWDate(signedCertifications []*models.SignedCertification, ppmid uui
 	for _, cert := range signedCertifications {
 		if cert.PpmID != nil { // Required to avoid error, service members signatures have nil ppm ids
 			if *cert.PpmID == ppmid { // PPM ID needs to be checked to prevent signatures from other PPMs on the same move from populating
-				if *cert.CertificationType == models.SignedCertificationTypeCloseoutReviewedPPMPAYMENT {
+				if *cert.CertificationType == models.SignedCertificationTypeCloseoutReviewedPPMPAYMENT || *cert.CertificationType == models.SignedCertificationTypePreCloseoutReviewedPPMPAYMENT {
 					sswDate := FormatDate(cert.UpdatedAt) // We use updatedat to get the most recent signature dates
 					return sswDate, nil
 				}

--- a/pkg/services/shipment_summary_worksheet/shipment_summary_worksheet_test.go
+++ b/pkg/services/shipment_summary_worksheet/shipment_summary_worksheet_test.go
@@ -2329,7 +2329,7 @@ func (suite *ShipmentSummaryWorksheetServiceSuite) TestAOAPaymentPacketWithNilFi
 			PaidWithGTCC:      models.BoolPointer(true),
 		},
 	}
-	signedCertType := models.SignedCertificationTypeCloseoutReviewedPPMPAYMENT
+	signedCertType := models.SignedCertificationTypePreCloseoutReviewedPPMPAYMENT
 	cert := models.SignedCertification{
 		CertificationType: &signedCertType,
 		CertificationText: "APPROVED",

--- a/playwright/tests/office/servicescounseling/servicesCounselingBoat.spec.js
+++ b/playwright/tests/office/servicescounseling/servicesCounselingBoat.spec.js
@@ -6,7 +6,7 @@ test.describe('Services counselor user', () => {
     const move = await scPage.testHarness.buildHHGMoveWithNTSAndNeedsSC();
     await scPage.navigateToMove(move.locator);
 
-    const deliveryDate = new Date().toLocaleDateString('en-US');
+    const deliveryDate = new Date(Date.now() + 24 * 60 * 60 * 1000).toLocaleDateString('en-US');
     await page.getByTestId('dropdown').selectOption({ label: 'Boat' });
 
     await expect(page.getByRole('heading', { level: 1 })).toHaveText('Add shipment details');
@@ -56,7 +56,7 @@ test.describe('Services counselor user', () => {
     const move = await scPage.testHarness.buildBoatHaulAwayMoveNeedsSC();
     await scPage.navigateToMove(move.locator);
 
-    const deliveryDate = new Date().toLocaleDateString('en-US');
+    const deliveryDate = new Date(Date.now() + 24 * 60 * 60 * 1000).toLocaleDateString('en-US');
 
     await expect(page.getByText('Shipment method')).toBeVisible();
     await expect(page.getByTestId('shipmentType')).not.toHaveText('BTA');
@@ -126,7 +126,7 @@ test.describe('Services counselor user', () => {
     await expect(page.getByTestId('tag')).toHaveText('Boat');
     await page.getByRole('button', { name: 'Delete shipment' }).click();
 
-    await expect(page.getByRole('heading', { level: 3 })).toHaveText('Are you sure?');
+    await expect(page.getByText('Are you sure?')).toBeVisible();
     await page.getByTestId('modal').getByTestId('button').click();
     await scPage.waitForPage.moveDetails();
 

--- a/playwright/tests/office/servicescounseling/servicesCounselingFlows.spec.js
+++ b/playwright/tests/office/servicescounseling/servicesCounselingFlows.spec.js
@@ -389,6 +389,18 @@ test.describe('Services counselor user', () => {
 
   test('can complete review of PPM shipment documents and view documents after', async ({ page, scPage }) => {
     test.slow();
+    await page.route('**/ghc/v1/ppm-shipments/*/payment-packet', async (route) => {
+      // mocked blob
+      const fakePdfBlob = new Blob(['%PDF-1.4 foo'], { type: 'application/pdf' });
+      const arrayBuffer = await fakePdfBlob.arrayBuffer();
+      // playwright route mocks only want a Buffer or string
+      const bodyBuffer = Buffer.from(arrayBuffer);
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/pdf',
+        body: bodyBuffer,
+      });
+    });
     const move = await scPage.testHarness.buildApprovedMoveWithPPMAllDocTypesOffice();
     await scPage.navigateToCloseoutMove(move.locator);
 
@@ -413,7 +425,10 @@ test.describe('Services counselor user', () => {
 
     await scPage.waitForPage.reviewDocumentsConfirmation();
 
-    await page.getByRole('button', { name: 'PPM Review Complete' }).click();
+    await page.getByRole('button', { name: 'Preview PPM Payment Packet' }).click();
+    await expect(page.getByTestId('loading-spinner')).not.toBeVisible();
+    await page.getByRole('button', { name: 'Complete PPM Review' }).click();
+    await page.getByRole('button', { name: 'Yes' }).click();
     await scPage.waitForPage.moveDetails();
 
     await expect(page.getByText('PACKET READY FOR DOWNLOAD')).toBeVisible();

--- a/playwright/tests/office/servicescounseling/servicesCounselingMovingExpenses.spec.js
+++ b/playwright/tests/office/servicescounseling/servicesCounselingMovingExpenses.spec.js
@@ -2,6 +2,18 @@ import { test, expect } from './servicesCounselingTestFixture';
 
 test('A service counselor can approve/reject moving expenses', async ({ page, scPage }) => {
   test.slow();
+  await page.route('**/ghc/v1/ppm-shipments/*/payment-packet', async (route) => {
+    // mocked blob
+    const fakePdfBlob = new Blob(['%PDF-1.4 foo'], { type: 'application/pdf' });
+    const arrayBuffer = await fakePdfBlob.arrayBuffer();
+    // playwright route mocks only want a Buffer or string
+    const bodyBuffer = Buffer.from(arrayBuffer);
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/pdf',
+      body: bodyBuffer,
+    });
+  });
   // Create a move with TestHarness, and then navigate to the move details page for it
   const move = await scPage.testHarness.buildApprovedMoveWithPPMMovingExpenseOffice();
   await scPage.navigateToCloseoutMove(move.locator);
@@ -25,73 +37,11 @@ test('A service counselor can approve/reject moving expenses', async ({ page, sc
   await scPage.waitForPage.reviewDocumentsConfirmation();
 
   // Click "Confirm" on confirmation page, returning to move details page
-  await page.getByRole('button', { name: 'PPM Review Complete' }).click();
+  await page.getByRole('button', { name: 'Preview PPM Payment Packet' }).click();
+  await expect(page.getByTestId('loading-spinner')).not.toBeVisible();
+  await page.getByRole('button', { name: 'Complete PPM Review' }).click();
+  await page.getByRole('button', { name: 'Yes' }).click();
   await scPage.waitForPage.moveDetails();
-
-  // NOTE: Code below is commented out because the feature for the SC to be able to review documents AFTER it has been submitted will be picked up at a future date.
-  // Currently SC is unable to re-review documents after it has been submitted, so these tests were failing.
-
-  // Return to the expenses ticket and verify that it's approved
-  // await page.getByRole('button', { name: 'Review documents' }).click();
-  // await scPage.waitForPage.reviewWeightTicket();
-
-  // // Weight ticket is first. Need to skip over to expense ticket
-  // await page.getByRole('button', { name: 'Continue' }).click();
-  // await expect(page.getByRole('heading', { name: 'Review receipt 1' })).toBeVisible();
-  // await expect(page.getByRole('radio', { name: 'Accept' })).toBeChecked();
-
-  // // Click "Reject" on the expense ticket, provide a reason, then save
-  // await page.getByText('Reject').click();
-  // await page.getByLabel('Reason').fill('Reason for expense rejection');
-  // await page.getByRole('button', { name: 'Continue' }).click();
-
-  // // Verify storage ticket is approved. Then, edit to "Reject" on the storage ticket, provide a reason, then save
-  // await expect(page.getByRole('heading', { name: 'Review storage 2' })).toBeVisible();
-  // await expect(page.getByRole('radio', { name: 'Accept' })).toBeChecked();
-  // await page.getByText('Reject').click();
-  // await page.getByLabel('Reason').fill('Reason for storage rejection');
-  // await page.getByRole('button', { name: 'Continue' }).click();
-
-  // await scPage.waitForPage.reviewDocumentsConfirmation();
-  // await page.getByRole('button', { name: 'Confirm' }).click();
-  // await scPage.waitForPage.moveDetails();
-
-  // // Return to the expense and verify that it's been rejected
-  // await page.getByRole('button', { name: 'Review documents' }).click();
-  // await scPage.waitForPage.reviewWeightTicket();
-  // await page.getByRole('button', { name: 'Continue' }).click();
-
-  // await expect(page.getByRole('heading', { name: 'Review receipt 1' })).toBeVisible();
-  // await expect(page.getByRole('radio', { name: 'Reject' })).toBeChecked();
-  // await expect(page.getByLabel('Reason')).toHaveValue('Reason for expense rejection');
-
-  // // Edit expense ticket to "Exclude", provide a reason, then save
-  // await page.getByText('Exclude').click();
-  // await page.getByLabel('Reason').fill('Reason for excluding expense');
-  // await page.getByRole('button', { name: 'Continue' }).click();
-
-  // // Verify storage ticket, Edit to "Exclude", provide a reason, then save
-  // await page.getByText('Exclude').click();
-  // await page.getByLabel('Reason').fill('Reason for excluding storage');
-  // await page.getByRole('button', { name: 'Continue' }).click();
-
-  // await scPage.waitForPage.reviewDocumentsConfirmation();
-  // await page.getByRole('button', { name: 'Confirm' }).click();
-  // await scPage.waitForPage.moveDetails();
-
-  // // Return to the expense and verify that it's been excluded
-  // await page.getByRole('button', { name: 'Review documents' }).click();
-  // await scPage.waitForPage.reviewWeightTicket();
-  // await page.getByRole('button', { name: 'Continue' }).click();
-
-  // await expect(page.getByRole('heading', { name: 'Review receipt 1' })).toBeVisible();
-  // await expect(page.getByRole('radio', { name: 'Exclude' })).toBeChecked();
-  // await expect(page.getByLabel('Reason')).toHaveValue('Reason for excluding expense');
-
-  // // Return to storage and verify that it's been excluded
-  // await page.getByRole('button', { name: 'Continue' }).click();
-  // await expect(page.getByRole('radio', { name: 'Exclude' })).toBeChecked();
-  // await expect(page.getByLabel('Reason')).toHaveValue('Reason for excluding storage');
 });
 
 test('Review documents page displays correct value for Total days in SIT', async ({ page, scPage }) => {

--- a/playwright/tests/office/servicescounseling/servicesCounselingProGearTickets.spec.js
+++ b/playwright/tests/office/servicescounseling/servicesCounselingProGearTickets.spec.js
@@ -3,6 +3,18 @@ import { test, expect } from './servicesCounselingTestFixture';
 test('A service counselor can approve/reject pro-gear weight tickets', async ({ page, scPage }) => {
   // To solve timeout issues
   test.slow();
+  await page.route('**/ghc/v1/ppm-shipments/*/payment-packet', async (route) => {
+    // mocked blob
+    const fakePdfBlob = new Blob(['%PDF-1.4 foo'], { type: 'application/pdf' });
+    const arrayBuffer = await fakePdfBlob.arrayBuffer();
+    // playwright route mocks only want a Buffer or string
+    const bodyBuffer = Buffer.from(arrayBuffer);
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/pdf',
+      body: bodyBuffer,
+    });
+  });
   // Create a move with TestHarness, and then navigate to the move details page for it
   const move = await scPage.testHarness.buildApprovedMoveWithPPMProgearWeightTicketOffice();
   await scPage.navigateToCloseoutMove(move.locator);
@@ -22,36 +34,11 @@ test('A service counselor can approve/reject pro-gear weight tickets', async ({ 
   await scPage.waitForPage.reviewDocumentsConfirmation();
 
   // Click "Confirm" on confirmation page, returning to move details page
-  await page.getByRole('button', { name: 'PPM Review Complete' }).click();
+  await page.getByRole('button', { name: 'Preview PPM Payment Packet' }).click();
+  await expect(page.getByTestId('loading-spinner')).not.toBeVisible();
+  await page.getByRole('button', { name: 'Complete PPM Review' }).click();
+  await page.getByRole('button', { name: 'Yes' }).click();
   await scPage.waitForPage.moveDetails();
-
-  // NOTE: Code below is commented out because the feature for the SC to be able to review documents AFTER it has been submitted will be picked up at a future date.
-  // Currently SC is unable to re-review documents after it has been submitted, so these tests were failing.
-
-  // Return to the pro-gear ticket and verify that it's approved
-  // await page.getByRole('button', { name: 'Review documents' }).click();
-  // await scPage.waitForPage.reviewWeightTicket();
-
-  // // Weight ticket is first. Need to skip over to Pro-gear ticket
-  // await page.getByRole('button', { name: 'Continue' }).click();
-  // await expect(page.getByRole('heading', { name: 'Review pro-gear 1' })).toBeVisible();
-  // await expect(page.getByRole('radio', { name: 'Accept' })).toBeChecked();
-
-  // // Click "Reject" on the Pro-gear ticket, provide a reason, then save
-  // await page.getByText('Reject').click();
-  // await page.getByLabel('Reason').fill('Reason for rejection');
-  // await page.getByRole('button', { name: 'Continue' }).click();
-  // await scPage.waitForPage.reviewDocumentsConfirmation();
-  // await page.getByRole('button', { name: 'Confirm' }).click();
-  // await scPage.waitForPage.moveDetails();
-
-  // // Return to the pro-gear ticket and verify that it's been edited
-  // await page.getByRole('button', { name: 'Review documents' }).click();
-  // await scPage.waitForPage.reviewWeightTicket();
-  // await page.getByRole('button', { name: 'Continue' }).click();
-
-  // await expect(page.getByRole('radio', { name: 'Reject' })).toBeChecked();
-  // await expect(page.getByLabel('Reason')).toHaveValue('Reason for rejection');
 });
 
 test('A service counselor can see the total for a progear weight ticket regular and spouse after update', async ({

--- a/src/components/Office/PPM/CompletePPMCloseoutConfirmationModal/CompletePPMCloseoutConfirmationModal.jsx
+++ b/src/components/Office/PPM/CompletePPMCloseoutConfirmationModal/CompletePPMCloseoutConfirmationModal.jsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Button } from '@trussworks/react-uswds';
+
+import { ModalContainer, Overlay } from 'components/MigratedModal/MigratedModal';
+import Modal, { connectModal, ModalActions, ModalClose, ModalTitle } from 'components/Modal/Modal';
+
+export const CompletePPMCloseoutConfirmationModal = ({ onClose, onSubmit }) => (
+  <div data-testid="CompletePPMCloseoutConfirmationModal">
+    <Overlay />
+    <ModalContainer>
+      <Modal>
+        <ModalClose handleClick={() => onClose()} data-testid="modalCloseButton" />
+        <ModalTitle>
+          <h2>Are you sure you want to complete the PPM Review?</h2>
+        </ModalTitle>
+        <ModalActions>
+          <Button
+            className="usa-button--tertiary"
+            type="button"
+            onClick={() => onClose()}
+            data-testid="modalBackButton"
+          >
+            No
+          </Button>
+          <Button className="usa-button--submit" type="submit" onClick={() => onSubmit()}>
+            Yes
+          </Button>
+        </ModalActions>
+      </Modal>
+    </ModalContainer>
+  </div>
+);
+
+CompletePPMCloseoutConfirmationModal.propTypes = {
+  onClose: PropTypes.func.isRequired,
+  onSubmit: PropTypes.func.isRequired,
+};
+
+CompletePPMCloseoutConfirmationModal.displayName = 'CompletePPMCloseoutConfirmationModal';
+
+export default connectModal(CompletePPMCloseoutConfirmationModal);

--- a/src/components/Office/PPM/CompletePPMCloseoutConfirmationModal/CompletePPMCloseoutConfirmationModal.stories.jsx
+++ b/src/components/Office/PPM/CompletePPMCloseoutConfirmationModal/CompletePPMCloseoutConfirmationModal.stories.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+
+import CompletePPMCloseoutConfirmationModal from './CompletePPMCloseoutConfirmationModal';
+
+export default {
+  title: 'Office Components/CompletePPMCloseoutConfirmationModal',
+  component: CompletePPMCloseoutConfirmationModal,
+};
+
+export const Basic = () => <CompletePPMCloseoutConfirmationModal onClose={() => {}} onSubmit={() => {}} />;

--- a/src/components/Office/PPM/CompletePPMCloseoutConfirmationModal/CompletePPMCloseoutConfirmationModal.test.jsx
+++ b/src/components/Office/PPM/CompletePPMCloseoutConfirmationModal/CompletePPMCloseoutConfirmationModal.test.jsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import { mount } from 'enzyme';
+
+import { CompletePPMCloseoutConfirmationModal } from 'components/Office/PPM/CompletePPMCloseoutConfirmationModal/CompletePPMCloseoutConfirmationModal';
+
+let onClose;
+let onSubmit;
+beforeEach(() => {
+  onClose = jest.fn();
+  onSubmit = jest.fn();
+});
+
+describe('CompletePPMCloseoutConfirmationModal', () => {
+  it('renders the component', () => {
+    const wrapper = mount(<CompletePPMCloseoutConfirmationModal onSubmit={onSubmit} onClose={onClose} />);
+    expect(wrapper.find('[data-testid="CompletePPMCloseoutConfirmationModal"]').exists()).toBe(true);
+    expect(wrapper.find('ModalTitle').exists()).toBe(true);
+    expect(wrapper.find('ModalActions').exists()).toBe(true);
+    expect(wrapper.find('ModalClose').exists()).toBe(true);
+    expect(wrapper.find('button[data-testid="modalBackButton"]').exists()).toBe(true);
+    expect(wrapper.find('button[type="submit"]').exists()).toBe(true);
+  });
+
+  it('closes the modal when close icon is clicked', () => {
+    const wrapper = mount(<CompletePPMCloseoutConfirmationModal onSubmit={onSubmit} onClose={onClose} />);
+
+    wrapper.find('button[data-testid="modalCloseButton"]').simulate('click');
+
+    expect(onClose.mock.calls.length).toBe(1);
+  });
+
+  it('closes the modal when the cancel button is clicked', () => {
+    const wrapper = mount(<CompletePPMCloseoutConfirmationModal onSubmit={onSubmit} onClose={onClose} />);
+
+    wrapper.find('button[data-testid="modalBackButton"]').simulate('click');
+
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('calls the submit function when submit button is clicked', async () => {
+    const wrapper = mount(<CompletePPMCloseoutConfirmationModal onSubmit={onSubmit} onClose={onClose} />);
+
+    wrapper.find('button[type="submit"]').simulate('click');
+
+    expect(onSubmit).toHaveBeenCalled();
+  });
+});

--- a/src/pages/Office/PPM/ReviewDocuments/ReviewDocuments.jsx
+++ b/src/pages/Office/PPM/ReviewDocuments/ReviewDocuments.jsx
@@ -3,6 +3,7 @@ import { useQueryClient } from '@tanstack/react-query';
 import { Alert, Button, Grid } from '@trussworks/react-uswds';
 import { generatePath, useNavigate, useParams } from 'react-router-dom';
 import classNames from 'classnames';
+import { connect } from 'react-redux';
 
 import styles from './ReviewDocuments.module.scss';
 
@@ -24,8 +25,11 @@ import { calculateWeightRequested } from 'hooks/custom';
 import DocumentViewerFileManager from 'components/DocumentViewerFileManager/DocumentViewerFileManager';
 import { PPM_TYPES, PPM_DOCUMENT_TYPES } from 'shared/constants';
 import { PPM_DOCUMENT_STATUS } from 'constants/ppms';
+import { fetchPaymentPacketBlob } from 'services/ghcApi';
+import CompletePPMCloseoutConfirmationModal from 'components/Office/PPM/CompletePPMCloseoutConfirmationModal/CompletePPMCloseoutConfirmationModal';
+import { setShowLoadingSpinner as setShowLoadingSpinnerAction } from 'store/general/actions';
 
-export const ReviewDocuments = ({ readOnly }) => {
+export const ReviewDocuments = ({ readOnly, setShowLoadingSpinner }) => {
   const { shipmentId, moveCode } = useParams();
   const { orders, mtoShipments } = useReviewShipmentWeightsQuery(moveCode);
   const { mtoShipment, documents, ppmActualWeight, isLoading, isError } = usePPMShipmentDocsQueries(shipmentId);
@@ -42,6 +46,10 @@ export const ReviewDocuments = ({ readOnly }) => {
 
   const [documentSetIndex, setDocumentSetIndex] = useState(0);
   const [moveHasExcessWeight, setMoveHasExcessWeight] = useState(false);
+
+  const [paymentPacketFile, setPaymentPacketFile] = useState(null);
+  const [packetLoading, setPacketLoading] = useState(false);
+  const [isConfirmModalVisible, setIsConfirmModalVisible] = useState(false);
 
   const [allWeightTicketsRejected, setAllWeightTicketsRejected] = useState(false);
   const [allMovingExpensesRejected, setAllMovingExpensesRejected] = useState(false);
@@ -229,6 +237,33 @@ export const ReviewDocuments = ({ readOnly }) => {
     }
   };
 
+  // when a payment packet is previewed in the doc viewer, we can use browser memory to store and view the file using JS "blobs"
+  // this stores the file in the browser memory and then we can point to the blob URL when previewing the file
+  // using React State, we can just load the PDF via the temp URL
+  const handleDownloadPaymentPacket = async () => {
+    try {
+      setPacketLoading(true);
+      setShowLoadingSpinner(true, null);
+      const blob = await fetchPaymentPacketBlob(mtoShipment.ppmShipment.id);
+      const fileUrl = window.URL.createObjectURL(blob);
+
+      setPaymentPacketFile({
+        id: `payment-packet-${shipmentId}`,
+        filename: `payment-packet-${shipmentId}.pdf`,
+        url: fileUrl,
+        createdAt: new Date().toISOString(),
+        rotation: 0,
+        contentType: 'application/pdf',
+      });
+    } catch (error) {
+      const msg = error instanceof Error ? error.message : String(error);
+      setServerError(msg);
+    } finally {
+      setPacketLoading(false);
+      setShowLoadingSpinner(false, null);
+    }
+  };
+
   const currentDocumentSet = documentSets[documentSetIndex];
   const updateDocumentSetAllowableWeight = (newWeight) => {
     currentDocumentSet.documentSet.allowableWeight = newWeight;
@@ -243,12 +278,6 @@ export const ReviewDocuments = ({ readOnly }) => {
   const reviewShipmentWeightsLink = <a href={reviewShipmentWeightsURL}>Review shipment weights</a>;
 
   const formatDocumentSetDisplay = documentSetIndex + 1;
-
-  let nextButton = 'Continue';
-  if (showOverview) {
-    nextButton = readOnly ? 'Close' : 'PPM Review Complete';
-  }
-
   const currentTripNumber = currentDocumentSet?.tripNumber != null ? currentDocumentSet.tripNumber + 1 : 0;
   const currentDocumentCategoryIndex =
     currentDocumentSet?.categoryIndex != null ? currentDocumentSet.categoryIndex + 1 : 0;
@@ -280,13 +309,24 @@ export const ReviewDocuments = ({ readOnly }) => {
 
   const uploads = showOverview ? getAllUploads() : currentDocumentSet?.uploads;
 
+  const filesForViewer = paymentPacketFile ? [paymentPacketFile, ...uploads] : uploads;
+
+  const handleSubmitPPMShipmentModal = () => {
+    onContinue();
+  };
+
   if (isLoading) return <LoadingPlaceholder />;
   if (isError) return <SomethingWentWrong />;
 
   return (
     <div data-testid="ReviewDocuments test" className={styles.ReviewDocuments}>
+      <CompletePPMCloseoutConfirmationModal
+        isOpen={isConfirmModalVisible}
+        onClose={setIsConfirmModalVisible}
+        onSubmit={handleSubmitPPMShipmentModal}
+      />
       <div className={styles.embed}>
-        <DocumentViewer files={uploads} allowDownload isFileUploading={isFileUploading} />
+        <DocumentViewer files={filesForViewer} allowDownload isFileUploading={isFileUploading} />
       </div>
       <DocumentViewerSidebar
         title={readOnly ? 'View documents' : 'Review documents'}
@@ -520,23 +560,79 @@ export const ReviewDocuments = ({ readOnly }) => {
             ))}
         </DocumentViewerSidebar.Content>
         <DocumentViewerSidebar.Footer>
-          <Button className="usa-button--secondary" onClick={onBack} disabled={disableBackButton}>
-            Back
-          </Button>
-          <Button
-            type="submit"
-            onClick={onContinue}
-            data-testid="reviewDocumentsContinueButton"
-            disabled={
-              (showOverview && allWeightTicketsRejected && weightTickets.length > 0) ||
-              (showOverview && allMovingExpensesRejected && movingExpenses.length > 0 && isPPMSPR)
-            }
-          >
-            {nextButton}
-          </Button>
+          {!paymentPacketFile && (
+            <Button className="usa-button--secondary" onClick={onBack} disabled={disableBackButton}>
+              Back
+            </Button>
+          )}
+
+          {showOverview && !paymentPacketFile && !readOnly && (
+            <Button
+              onClick={handleDownloadPaymentPacket}
+              disabled={
+                packetLoading ||
+                (showOverview && allWeightTicketsRejected && weightTickets.length > 0) ||
+                (showOverview && allMovingExpensesRejected && movingExpenses.length > 0 && isPPMSPR)
+              }
+            >
+              Preview PPM Payment Packet
+            </Button>
+          )}
+
+          {showOverview && paymentPacketFile && (
+            <>
+              <Button
+                className="usa-button--secondary"
+                onClick={() => {
+                  // reset back to document review
+                  setPaymentPacketFile(null);
+                  setDocumentSetIndex(0);
+                  setShowOverview(false);
+                }}
+              >
+                Edit PPM
+              </Button>
+              <Button
+                onClick={() => {
+                  setIsConfirmModalVisible(true);
+                }}
+              >
+                Complete PPM Review
+              </Button>
+            </>
+          )}
+
+          {!showOverview && (
+            <Button
+              type="submit"
+              onClick={onContinue}
+              data-testid="reviewDocumentsContinueButton"
+              disabled={
+                (showOverview && allWeightTicketsRejected && weightTickets.length > 0) ||
+                (showOverview && allMovingExpensesRejected && movingExpenses.length > 0 && isPPMSPR)
+              }
+            >
+              Continue
+            </Button>
+          )}
+
+          {readOnly && showOverview && (
+            <Button type="submit" onClick={onClose} data-testid="closeBtn">
+              Close
+            </Button>
+          )}
         </DocumentViewerSidebar.Footer>
       </DocumentViewerSidebar>
     </div>
   );
 };
-export default ReviewDocuments;
+
+ReviewDocuments.defaultProps = {
+  loadingMessage: null,
+};
+
+const mapDispatchToProps = {
+  setShowLoadingSpinner: setShowLoadingSpinnerAction,
+};
+
+export default connect(() => ({}), mapDispatchToProps)(ReviewDocuments);

--- a/src/pages/Office/PPM/ReviewDocuments/ReviewDocuments.test.jsx
+++ b/src/pages/Office/PPM/ReviewDocuments/ReviewDocuments.test.jsx
@@ -23,6 +23,7 @@ import createUpload from 'utils/test/factories/upload';
 import { servicesCounselingRoutes, tooRoutes } from 'constants/routes';
 import { PPM_TYPES } from 'shared/constants';
 import { expenseTypes } from 'constants/ppmExpenseTypes';
+import { fetchPaymentPacketBlob } from 'services/ghcApi';
 
 Element.prototype.scrollTo = jest.fn();
 
@@ -46,6 +47,7 @@ const mockPatchWeightTicket = jest.fn();
 const mockPatchProGear = jest.fn();
 const mockPatchExpense = jest.fn();
 const mockPatchPPMDocumentsSetStatus = jest.fn();
+const setShowLoadingSpinner = jest.fn();
 
 jest.mock('services/ghcApi', () => ({
   ...jest.requireActual('services/ghcApi'),
@@ -53,6 +55,7 @@ jest.mock('services/ghcApi', () => ({
   patchProGearWeightTicket: (options) => mockPatchProGear(options),
   patchExpense: (options) => mockPatchExpense(options),
   patchPPMDocumentsSetStatus: (options) => mockPatchPPMDocumentsSetStatus(options),
+  fetchPaymentPacketBlob: jest.fn(),
 }));
 
 // prevents react-fileviewer from throwing errors without mocking relevant DOM elements
@@ -304,6 +307,10 @@ const mockTooRountingOptions = {
   params: { moveCode: 'READY1' },
 };
 
+beforeEach(() => {
+  global.URL.createObjectURL = jest.fn(() => 'blob://fake-pdf-url');
+});
+
 describe('ReviewDocuments', () => {
   describe('check loading and error component states', () => {
     const loadingReturnValue = {
@@ -430,8 +437,10 @@ describe('ReviewDocuments', () => {
       usePPMShipmentDocsQueries.mockReturnValue(usePPMShipmentDocsQueriesReturnValueWithOneWeightTicket);
       usePPMCloseoutQuery.mockReturnValue(usePPMCloseoutQueryReturnValue);
       useReviewShipmentWeightsQuery.mockReturnValue(useReviewShipmentWeightsQueryReturnValueAll);
+      const fakePdfBlob = new Blob(['%PDF-1.4 foo'], { type: 'application/pdf' });
+      fetchPaymentPacketBlob.mockImplementation(() => Promise.resolve(fakePdfBlob));
 
-      renderWithProviders(<ReviewDocuments />, mockRoutingOptions);
+      renderWithProviders(<ReviewDocuments setShowLoadingSpinner={setShowLoadingSpinner} />, mockRoutingOptions);
 
       const weightTicket = mtoShipmentWithOneWeightTicket.ppmShipment.weightTickets[0];
 
@@ -489,13 +498,115 @@ describe('ReviewDocuments', () => {
 
       expect(await screen.findByRole('heading', { name: 'Send to customer?', level: 3 })).toBeInTheDocument();
 
-      await userEvent.click(screen.getByRole('button', { name: 'PPM Review Complete' }));
+      const previewBtn = await screen.findByRole('button', {
+        name: 'Preview PPM Payment Packet',
+      });
+      expect(previewBtn).toBeInTheDocument();
+
+      await userEvent.click(previewBtn);
+
+      expect(setShowLoadingSpinner).toHaveBeenCalled();
+
+      // wait for the blob fetch and the re‐render
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: 'Complete PPM Review' })).toBeInTheDocument();
+      });
+
+      const completeBtn = screen.getByRole('button', { name: 'Complete PPM Review' });
+      await userEvent.click(completeBtn);
+
+      // modal
+      expect(screen.getByText('Are you sure you want to complete the PPM Review?')).toBeInTheDocument();
+      await userEvent.click(screen.getByRole('button', { name: 'Yes' }));
       const confirmPayload = {
         ppmShipmentId: mtoShipmentWithOneWeightTicket.ppmShipment.id,
         eTag: mtoShipmentWithOneWeightTicket.ppmShipment.eTag,
       };
+
       expect(mockPatchPPMDocumentsSetStatus).toHaveBeenCalledWith(confirmPayload);
       expect(mockNavigate).toHaveBeenCalled();
+    });
+
+    it('renders and handles the Continue button with the appropriate payload', async () => {
+      useEditShipmentQueries.mockReturnValue(useEditShipmentQueriesReturnValue);
+      usePPMShipmentDocsQueries.mockReturnValue(usePPMShipmentDocsQueriesReturnValueWithOneWeightTicket);
+      usePPMCloseoutQuery.mockReturnValue(usePPMCloseoutQueryReturnValue);
+      useReviewShipmentWeightsQuery.mockReturnValue(useReviewShipmentWeightsQueryReturnValueAll);
+      const fakePdfBlob = new Blob(['%PDF-1.4 foo'], { type: 'application/pdf' });
+      fetchPaymentPacketBlob.mockImplementation(() => Promise.resolve(fakePdfBlob));
+
+      renderWithProviders(<ReviewDocuments setShowLoadingSpinner={setShowLoadingSpinner} />, mockRoutingOptions);
+
+      const weightTicket = mtoShipmentWithOneWeightTicket.ppmShipment.weightTickets[0];
+
+      const newEmptyWeight = 14500;
+      const emptyWeightInput = screen.getByTestId('emptyWeight');
+      await userEvent.clear(emptyWeightInput);
+      await userEvent.type(emptyWeightInput, newEmptyWeight.toString());
+
+      const newFullWeight = 18500;
+      const fullWeightInput = screen.getByTestId('fullWeight');
+      await userEvent.clear(fullWeightInput);
+      await userEvent.type(fullWeightInput, newFullWeight.toString());
+
+      const netWeightDisplay = screen.getByTestId('net-weight-display');
+      expect(netWeightDisplay).toHaveTextContent('4,000 lbs');
+
+      const acceptOption = screen.getByTestId('approveRadio');
+      expect(acceptOption).toBeInTheDocument();
+
+      const rejectOption = screen.getByTestId('rejectRadio');
+      expect(rejectOption).toBeInTheDocument();
+      await userEvent.click(rejectOption);
+
+      const rejectionReason = 'Not legible';
+      const reasonTextBox = screen.getByLabelText('Reason');
+      expect(reasonTextBox).toBeInTheDocument();
+      await userEvent.type(reasonTextBox, rejectionReason);
+
+      const continueButton = screen.getByTestId('reviewDocumentsContinueButton');
+      expect(continueButton).toBeInTheDocument();
+      await userEvent.click(continueButton);
+
+      expect(screen.queryByText('Reviewing this weight ticket is required')).not.toBeInTheDocument();
+
+      const expectedPayload = {
+        ppmShipmentId: mtoShipmentWithOneWeightTicket.ppmShipment.id,
+        weightTicketId: weightTicket.id,
+        eTag: weightTicket.eTag,
+        payload: {
+          ppmShipmentId: mtoShipmentWithOneWeightTicket.ppmShipment.id,
+          vehicleDescription: weightTicket.vehicleDescription,
+          emptyWeight: newEmptyWeight,
+          missingEmptyWeightTicket: weightTicket.missingEmptyWeightTicket,
+          fullWeight: newFullWeight,
+          missingFullWeightTicket: weightTicket.missingFullWeightTicket,
+          ownsTrailer: weightTicket.ownsTrailer,
+          trailerMeetsCriteria: weightTicket.trailerMeetsCriteria,
+          status: PPMDocumentsStatus.REJECTED,
+          reason: rejectionReason,
+        },
+      };
+      await waitFor(() => {
+        expect(mockPatchWeightTicket).toHaveBeenCalledWith(expectedPayload);
+      });
+
+      expect(await screen.findByRole('heading', { name: 'Send to customer?', level: 3 })).toBeInTheDocument();
+
+      const preview = await screen.findByRole('button', { name: 'Preview PPM Payment Packet' });
+      await userEvent.click(preview);
+      expect(setShowLoadingSpinner).toHaveBeenCalled();
+
+      const editBtn = await screen.findByRole('button', { name: 'Edit PPM' });
+      expect(editBtn).toBeInTheDocument();
+
+      await userEvent.click(editBtn);
+
+      // should be back at document 1 of 1, and the “Continue” button present again
+      expect(screen.getByTestId('reviewDocumentsContinueButton')).toBeInTheDocument();
+      expect(screen.getByText('1 of 1 Document Sets')).toBeInTheDocument();
+      // and the “Complete PPM Review” button should no longer exist
+      expect(screen.queryByRole('button', { name: /Complete PPM Review/i })).not.toBeInTheDocument();
     });
 
     it('renders and handles the Close button', async () => {
@@ -1005,7 +1116,7 @@ describe('ReviewDocuments', () => {
 
       expect(await screen.findByRole('heading', { name: 'Send to customer?', level: 3 })).toBeInTheDocument();
 
-      const submitButton = screen.getByRole('button', { name: 'PPM Review Complete' });
+      const submitButton = screen.getByRole('button', { name: 'Preview PPM Payment Packet' });
       expect(submitButton).toBeDisabled();
 
       expect(

--- a/src/services/ghcApi.js
+++ b/src/services/ghcApi.js
@@ -938,6 +938,18 @@ export async function downloadPPMPaymentPacket(ppmShipmentId) {
   return makeGHCRequestRaw('ppm.showPaymentPacket', { ppmShipmentId });
 }
 
+// the above downloadPPMPaymentPacket does not return a blob, but a response
+// this call is necessary to download the packet to display in the doc viewer
+export async function fetchPaymentPacketBlob(id) {
+  const res = await fetch(`/ghc/v1/ppm-shipments/${id}/payment-packet`, {
+    credentials: 'include',
+  });
+  if (!res.ok) {
+    throw new Error(`Failed to download packet: ${res.status}`);
+  }
+  return res.blob();
+}
+
 export async function sendPPMToCustomer(params) {
   const operationPath = 'ppm.sendPPMToCustomer';
   return makeGHCRequest(


### PR DESCRIPTION
## [Agility ticket](https://www13.v1host.com/USTRANSCOM38/assetdetail.v1?number=B-23676)

## Summary

We want to let the SC "preview" the SSW prior to completing closeout. We can do this by storing the downloaded SSW in browser memory and adding it onto the files that are being previewed in the doc viewer. This allows the SC to dynamically make changes to the closeout tickets and see those changes on the SSW before completing closeout.

I decided to use [blobs](hhttps://www.geeksforgeeks.org/javascript-blob/) that will allow the application to store the SSW in browser memory, where we can then grab the temp URL and display that in the doc viewer using React `useState`.

The blob stays valid until the page unloads or redirects.

### How to test

1. Create a move with a PPM however you know how
2. Get to where the customer closes out their PPM (uploads docs, receipts, etc)
3. Add 1 of each (weight ticket, pro gear, expense, etc) and have one paid with GTCC and the other not (where applicable)
4. Sign it
5. Go in as SC and begin closeout
6. Accept/reject whatever you want
7. Get to the end of closeout and you should see a new button `Preview PPM Payment Packet`
8. Click that sucker
9. Loading spinner should appear and then you should see the SSW generate in the doc viewer
10. You should then have the option of starting back at the beginning or completing closeout (modal will appear)
11. Confirm nothing is broken with the closeout process with this change - try to break it

## Screenshots
https://github.com/user-attachments/assets/05f1d1c7-65aa-4ee8-aa48-72ab2868e032