### PR TITLE
B-23581-INT 2 Update moves table migrations file

### DIFF
--- a/migrations/app/ddl_migrations/ddl_tables/20250224162949_B-22706_tbl_update_moves.up.sql
+++ b/migrations/app/ddl_migrations/ddl_tables/20250224162949_B-22706_tbl_update_moves.up.sql
@@ -5,18 +5,27 @@ ALTER TABLE moves
             REFERENCES office_users;
 
 ALTER TABLE moves
+    ADD COLUMN IF NOT EXISTS too_task_order_assigned_id uuid
+        CONSTRAINT moves_too_task_order_assigned_id_fkey
+            REFERENCES office_users;
+
+ALTER TABLE moves
     ADD COLUMN IF NOT EXISTS sc_closeout_assigned_id uuid
         CONSTRAINT moves_sc_closeout_assigned_id_fkey
             REFERENCES office_users;
 
-DO $$
-BEGIN
-    IF EXISTS (SELECT 1 FROM information_schema.columns
-               WHERE table_name = 'moves' AND column_name = 'sc_assigned_id') THEN
-        ALTER TABLE moves RENAME COLUMN sc_assigned_id TO sc_counseling_assigned_id;
-    END IF;
-END $$;
+ALTER TABLE moves
+    ADD COLUMN IF NOT EXISTS sc_counseling_assigned_id uuid
+        CONSTRAINT moves_sc_counseling_assigned_id_fkey
+            REFERENCES office_users;
 
-COMMENT ON COLUMN moves.too_destination_assigned_id IS 'A foreign key that points to the ID of the Task Ordering Officer on the office_users table';
+ALTER TABLE moves
+    ADD COLUMN IF NOT EXISTS tio_payment_requests_assigned_id uuid
+        CONSTRAINT moves_tio_payment_requests_assigned_id_fkey
+            REFERENCES office_users;
+
+COMMENT ON COLUMN moves.too_destination_assigned_id IS 'A foreign key that points to the ID on the office_users table of the destination requests queue assigned office user';
+COMMENT ON COLUMN moves.too_task_order_assigned_id IS 'A foreign key that points to the ID on the office_users table of the task order queue assigned office user';
 COMMENT ON COLUMN moves.sc_counseling_assigned_id IS 'A foreign key that points to the ID on the office_users table of the counseling queue assigned office user';
 COMMENT ON COLUMN moves.sc_closeout_assigned_id IS 'A foreign key that points to the ID on the office_users table of the closeout queue assigned office user';
+COMMENT ON COLUMN moves.tio_payment_requests_assigned_id IS 'A foreign key that points to the ID on the office_users table of the payment requests queue assigned office user';


### PR DESCRIPTION
## [Agility ticket](https://www13.v1host.com/USTRANSCOM38/assetdetail.v1?number=B-23581)

## Summary

In my previous [PR for this work](https://github.com/transcom/mymove/pull/15445) I renamed a column, which would cause downtime if released. I've updated the migration to only ADD columns, and included adding columns for other work in this feature as well. Once the feature is complete or near complete, we will remove the sc_assigned_id, too_assigned_id, and tio_assigned_id columns.

Since we aren't renaming/removing any columns, we don't have concerns about causing an outage due to the models looking for deleted columns until the application is deployed. 

Since the queue management work is feature flagged off in production, we don't have concerns about data getting out of sync, and don't have to follow[ steps 2-5 in the documentation](https://transcom.github.io/mymove-docs/docs/backend/setup/database-migrations/#zero-downtime-migrations)
