### PR TITLE
INT I-14234 B-23446

### DIFF
--- a/src/pages/Office/Orders/Orders.jsx
+++ b/src/pages/Office/Orders/Orders.jsx
@@ -322,7 +322,12 @@ const Orders = ({ files, amendedDocumentId, updateAmendedDocument, onAddFile }) 
 
   return (
     <div className={styles.sidebar}>
-      <Formik initialValues={initialValues} validationSchema={ordersFormValidationSchema} onSubmit={onSubmit}>
+      <Formik
+        initialValues={initialValues}
+        validationSchema={ordersFormValidationSchema}
+        onSubmit={onSubmit}
+        validateOnChange
+      >
         {(formik) => {
           // onBlur, if the value has 4 digits, run validator and show warning if invalid
           const hhgTacWarning = tacValidationState[LOA_TYPE.HHG].isValid ? '' : tacWarningMsg;

--- a/src/pages/Office/ServicesCounselingOrders/ServicesCounselingOrders.jsx
+++ b/src/pages/Office/ServicesCounselingOrders/ServicesCounselingOrders.jsx
@@ -333,7 +333,12 @@ const ServicesCounselingOrders = ({ files, amendedDocumentId, updateAmendedDocum
 
   return (
     <div className={styles.sidebar}>
-      <Formik initialValues={initialValues} validationSchema={ordersFormValidationSchema} onSubmit={onSubmit}>
+      <Formik
+        initialValues={initialValues}
+        validationSchema={ordersFormValidationSchema}
+        onSubmit={onSubmit}
+        validateOnChange
+      >
         {(formik) => {
           const hhgTacWarning = tacValidationState[LOA_TYPE.HHG].isValid ? '' : tacWarningMsg;
           const ntsTacWarning = tacValidationState[LOA_TYPE.NTS].isValid ? '' : tacWarningMsg;


### PR DESCRIPTION
## [Previous INT PR](https://github.com/transcom/mymove/pull/15495)
## [Issue ticket](https://www13.v1host.com/USTRANSCOM38/Issue.mvc/Summary?oidToken=Issue%3A1111020)

## Summary

Validating on change for all fields. Since `tac` is required, `Formik` does that automatically. For optional fields, we have to set `validateOnChange`

### How to test

1. Access the orders as an office user, both TOO and SC
2. Verify that the validation for no " or * hits as soon as you enter text into the TAC & SAC fields