### PR TITLE
B 22549 C financial acknowledgement update Linter Fix

### DIFF
--- a/playwright/tests/my/mymove/hhg.spec.js
+++ b/playwright/tests/my/mymove/hhg.spec.js
@@ -247,10 +247,10 @@ test.describe('(MultiMove) HHG', () => {
 
     // Fill in form to create HHG shipment
     await customerPage.waitForPage.hhgShipment();
-    await page.getByLabel('Preferred pickup date').fill('25 Dec 2022');
+    await page.getByLabel('Preferred pickup date').fill('29 May 2025');
     await page.getByLabel('Preferred pickup date').blur();
     await page.getByText('Use my current address').click();
-    await page.getByLabel('Preferred delivery date').fill('25 Dec 2022');
+    await page.getByLabel('Preferred delivery date').fill('29 May 2025');
     await page.getByLabel('Preferred delivery date').blur();
     await page.getByTestId('remarks').fill('Going to Alaska');
     await customerPage.navigateForward();
@@ -300,11 +300,13 @@ test.describe('(MultiMove) HHG', () => {
 
     // Gradual scroll to bottom to trigger the React onScroll logic
     await scrollBox.evaluate(async (el) => {
-      // eslint-disable-next-line no-promise-executor-return
-      const delay = (ms) => new Promise((res) => setTimeout(res, ms));
-      for (let i = 0; i <= el.scrollHeight; i += 100) {
-        // eslint-disable-next-line no-param-reassign
-        el.scrollTop = i;
+      const scrWindow = el;
+      const delay = (ms) =>
+        new Promise((res) => {
+          setTimeout(res, ms);
+        });
+      for (let i = 0; i <= scrWindow.scrollHeight; i += 100) {
+        scrWindow.scrollTop = i;
         await delay(50);
       }
     });

--- a/src/pages/MyMove/Agreement.test.jsx
+++ b/src/pages/MyMove/Agreement.test.jsx
@@ -81,9 +81,6 @@ describe('Agreement page', () => {
     expect(signatureInput).toBeEnabled();
     await userEvent.type(signatureInput, 'Sofia Clark-Nuñez');
 
-    // eslint-disable-next-line no-restricted-globals
-    print(signatureInput.value);
-
     await waitFor(() => {
       expect(completeButton).toBeEnabled();
     });


### PR DESCRIPTION
## [B-22549](https://www13.v1host.com/USTRANSCOM38/assetdetail.v1?number=B-22549)
## [INT PR](https://github.com/transcom/mymove/pull/15267)
## [OG INT PR](https://github.com/transcom/mymove/pull/15417)
## Summary

>[!NOTE]
> This PR adds in the fix for the linter fail issue. Running the playwright test case and it passing should be sufficient.

Updated the Signature confirmation page to include a checkbox confirmation which is only enabled when scrolling to the bottom of the agreement. This is required to be able to sign before submitting the move.

### How to test

1. Login as a user to begin creating a new move Click on create move
2. Fill out all fields and proceed with creating a new move until reaching the submit screen with agreeement
3. "I have read and understand the agreement as shown above" and signature box, complete should be disabled,
4. Scroll to the bottom of the legal text, checkbox should enable then, but onlly if the bottom of the scroll box is reached (halfway, 3/4 the way should not work)
5. Click the agreement checkbox to enable the Signature box
7. Filling out the signature box exactly as the user name below it should allow the "Complete" button to be enabled
8. Try to misspell the name on the signature box, this should prevent the complete button from being enabled
9. Fill back in the correct name, complete button should re-enable then.

## Screenshots
Before
![image](https://github.com/user-attachments/assets/a694df1a-9684-4bf7-8a41-b79b071c545f)
After
![image](https://github.com/user-attachments/assets/f0f71c0f-3eff-4619-8cc4-6c7fe81d6d49)
