### PR TITLE
B 23713 upload av status int

### DIFF
--- a/src/components/DocumentViewerFileManager/DocumentViewerFileManager.jsx
+++ b/src/components/DocumentViewerFileManager/DocumentViewerFileManager.jsx
@@ -48,6 +48,12 @@ const DocumentViewerFileManager = ({
   const [isExpandedView, setIsExpandedView] = useState(false);
   const [buttonHeaderText, setButtonHeaderText] = useState(title !== null ? title : 'Manage Documents');
   const [buttonHeaderChevron, setButtonHeaderChevron] = useState('chevron-up');
+  const [pendingIDs, setPendingIDs] = useState(() => new Set());
+
+  // Files are already established from the backend
+  // When appending a new file, it will not be accessible until processing has completed, thus we filter it.
+  // This makes sure we do not show processing files by watching their IDs
+  const visibleFiles = React.useMemo(() => files.filter((f) => !pendingIDs.has(f.id)), [files, pendingIDs]);
 
   const moveId = move?.id;
   const moveCode = move?.locator;
@@ -110,7 +116,6 @@ const DocumentViewerFileManager = ({
       })
       .finally(() => {
         queryClient.invalidateQueries([ORDERS_DOCUMENTS, documentId]);
-        setIsFileProcessing(false);
       });
   };
 
@@ -127,7 +132,6 @@ const DocumentViewerFileManager = ({
       })
       .finally(() => {
         queryClient.invalidateQueries([DOCUMENTS, mtoShipment.Id]);
-        setIsFileProcessing(false);
       });
   };
 
@@ -184,7 +188,6 @@ const DocumentViewerFileManager = ({
       })
       .finally(() => {
         queryClient.invalidateQueries([MOVES, moveCode]);
-        setIsFileProcessing(false);
       });
   };
 
@@ -216,23 +219,47 @@ const DocumentViewerFileManager = ({
 
   const handleUpload = async (file) => {
     setIsFileProcessing(true);
+    let uploadPromise;
     if (documentType === MOVE_DOCUMENT_TYPE.ORDERS) {
-      uploadOrders(file);
+      uploadPromise = uploadOrders(file);
     } else if (documentType === MOVE_DOCUMENT_TYPE.AMENDMENTS) {
-      uploadAmdendedOrders(file);
+      uploadPromise = uploadAmdendedOrders(file);
     } else if (documentType === MOVE_DOCUMENT_TYPE.SUPPORTING) {
-      uploadSupportingDocuments(file);
+      uploadPromise = uploadSupportingDocuments(file);
     } else if (documentType === PPM_DOCUMENT_TYPES.WEIGHT_TICKET) {
-      handleCreateUpload(file, true);
+      uploadPromise = handleCreateUpload(file, true);
     } else if (documentType === PPM_DOCUMENT_TYPES.MOVING_EXPENSE) {
-      handleCreateUpload(file, false);
+      uploadPromise = handleCreateUpload(file, false);
     } else if (documentType === PPM_DOCUMENT_TYPES.PROGEAR_WEIGHT_TICKET) {
-      handleCreateUpload(file, false);
-    }
+      uploadPromise = handleCreateUpload(file, false);
+    } else uploadPromise = handleCreateUpload(file, false);
+    // Upload is complete, but the processing is not.
+    // The next step will be waiting for the antivirus, which we must wait for FilePond
+    // to have its `load` func called. The FileUpload component will not let FilePond call `load`
+    // until the AV is done, hence until we handleChange of the file, we are still processing.
+    // Add this file to the pending IDs
+    uploadPromise.then((upload) => {
+      if (upload?.id) {
+        setPendingIDs((old) => new Set(old).add(upload.id));
+      }
+    });
+    return uploadPromise;
   };
 
-  const handleChange = () => {
-    filePondEl.current?.removeFiles();
+  const handleChange = (err, file) => {
+    // FilePond `load` called
+    // Processing complete
+    setIsFileProcessing(false);
+    if (file?.serverId) {
+      // FilePond provided file can now be removed from "Pending"
+      setPendingIDs((old) => {
+        const next = new Set(old);
+        next.delete(file.serverId);
+        return next;
+      });
+    }
+    filePondEl.current?.removeFile(file.id);
+    // filePondEl.current?.removeFiles(); // TODO: Parallel bug here?
     queryClient.invalidateQueries([ORDERS_DOCUMENTS, documentId]);
     setServerError('');
   };
@@ -280,7 +307,7 @@ const DocumentViewerFileManager = ({
                 {serverError}
               </Alert>
             )}
-            <UploadsTable className={styles.sectionWrapper} uploads={files} onDelete={openDeleteFileModal} />
+            <UploadsTable className={styles.sectionWrapper} uploads={visibleFiles} onDelete={openDeleteFileModal} />
             <div className={classnames(styles.upload, className)}>
               {fileUploadRequired && (
                 <Alert type="error" id="fileRequiredAlert" data-testid="fileRequiredAlert">

--- a/src/components/FileUpload/FileUpload.jsx
+++ b/src/components/FileUpload/FileUpload.jsx
@@ -1,4 +1,4 @@
-import React, { forwardRef } from 'react';
+import React, { forwardRef, useRef } from 'react';
 import { func, string, arrayOf, bool, number } from 'prop-types';
 import isMobile from 'is-mobile';
 import { FilePond, registerPlugin } from 'react-filepond';
@@ -11,7 +11,8 @@ import FilePondImagePreview from 'filepond-plugin-image-preview';
 import 'filepond-plugin-image-preview/dist/filepond-plugin-image-preview.css';
 
 import 'shared/Uploader/index.css';
-import { createUpload as createUploadApi, deleteUpload } from 'services/internalApi';
+import { UPLOAD_SCAN_STATUS } from 'shared/constants';
+import { createUpload as createUploadApi, deleteUpload, waitForAvScan } from 'services/internalApi';
 
 registerPlugin(
   FilepondPluginFileValidateType,
@@ -19,6 +20,18 @@ registerPlugin(
   FilepondPluginImageExifOrientation,
   FilePondImagePreview,
 );
+
+// Helper func to take in a root html element and search it for
+// a FilePond listing by original file upload name
+const getFilePondItemByFilename = (root, originalName) => {
+  if (!root) return null;
+  return (
+    Array.from(root.querySelectorAll('.filepond--item')).find((item) => {
+      const nameEl = item.querySelector('.filepond--file-info-main');
+      return nameEl && nameEl.textContent.trim() === originalName;
+    }) || null
+  );
+};
 
 const FileUpload = forwardRef(
   (
@@ -37,22 +50,60 @@ const FileUpload = forwardRef(
       labelFileTypeNotAllowed,
       required,
     },
-    ref,
+    refFromParent,
   ) => {
+    // This helps prevent faulty err signals from the sse
+    const internalRef = useRef(null);
+    const pondRef = refFromParent ?? internalRef;
+
     const handleOnChange = (err, file) => {
       if (onChange) onChange(err, file);
     };
 
-    const processFile = (fieldName, file, metadata, load, error, progress, abort) => {
-      createUpload(file)
+    const processFile = (fieldName, file, metadata, load, error) => {
+      // Setup abort controller to enable future enhancements.
+      // As of right now it is not utilized, it should be possible for client-side only
+      const controller = new AbortController();
+      const { signal } = controller;
+
+      createUpload(file, { signal })
         .then((response) => {
-          load(response);
+          // eslint-disable-next-line no-underscore-dangle
+          const rootEl = pondRef.current._pond.element; // Grab FilePond HTML
+          const itemEl = getFilePondItemByFilename(rootEl, file.name); // Grab our file's HTML entry
+          if (itemEl) {
+            // Manually adjust status as we have successfully uploaded
+            const fileProcessingLabel = itemEl.querySelector('.filepond--file-status-main');
+            const subLabelWhenProcessing = itemEl.querySelector('.filepond--file-status-sub');
+            if (fileProcessingLabel) fileProcessingLabel.textContent = 'Scanning for viruses…'; // FilePond doesn't offer a state/api to change it mid-processing
+            if (subLabelWhenProcessing) subLabelWhenProcessing.textContent = ''; // Change from FilePond's click to abort -> nothing. You can't abort after it's uploaded
+          }
+          return waitForAvScan(response.id, { signal }).then(() => response);
         })
-        .catch(error);
+        .then((response) => {
+          // This only triggers on an AV clean response
+          load(response.id); // Make FilePond store the server id
+        })
+        .catch((err) => {
+          if (err.name === 'AbortError') return;
+          if (err.message === UPLOAD_SCAN_STATUS.INFECTED) {
+            pondRef.current?.setOptions({
+              labelFileProcessing: 'File failed virus scan',
+            });
+            error('File failed virus scan');
+          } else {
+            error(err);
+          }
+        });
 
       // TODO - in order to handle abort, we need to pass an AbortController to SwaggerRequest, implement this as a future story (it's not working as-is)
       // https://github.com/swagger-api/swagger-js/blob/master/docs/usage/http-client.md#browser
-      return { abort };
+      return {
+        abort: () => {
+          // Send the abort signal (Not yet functional)
+          controller.abort();
+        },
+      };
     };
 
     const revertFile = (uploadId, load, error) => {
@@ -78,7 +129,9 @@ const FileUpload = forwardRef(
     /**
      * Default FilePond instance props
      * If these need to be overwritten, they can be exposed as a prop on this
-     * component and passed through (like labelIdle)
+     * component and passed through (like labelIdle).
+     * Note that FilePond does not support api/state changing of labels
+     * if we want the labels to change mid-processing we must adjust the HTML manually
      */
     const filePondProps = {
       server: serverConfig,
@@ -92,7 +145,7 @@ const FileUpload = forwardRef(
     return (
       <FilePond
         required={required}
-        ref={ref}
+        ref={pondRef}
         {...filePondProps}
         className={className}
         allowMultiple={allowMultiple}

--- a/src/components/FileUpload/FileUpload.test.jsx
+++ b/src/components/FileUpload/FileUpload.test.jsx
@@ -1,16 +1,138 @@
 /* eslint-disable react/jsx-props-no-spreading */
 import React from 'react';
 import { mount } from 'enzyme';
+import { act } from 'react-dom/test-utils';
 
 import FileUpload from './FileUpload';
 
-describe('FileUpload component', () => {
-  const testProps = {
-    createUpload: jest.fn(() => Promise.resolve({ id: 'testFileId' })),
+import { UPLOAD_SCAN_STATUS } from 'shared/constants';
+import { waitForAvScan } from 'services/internalApi';
+
+const mockSetOptions = jest.fn();
+
+jest.mock('react-filepond', () => {
+  // Mock is before imports, give scope to react or it'll err
+  // eslint-disable-next-line global-require
+  const MockReact = require('react');
+
+  const setupFilePondMock = () => {
+    const root = global.document.createElement('div');
+
+    const item = global.document.createElement('div');
+    item.className = 'filepond--item';
+
+    const name = global.document.createElement('span');
+    name.className = 'filepond--file-info-main';
+    name.textContent = 'dummy.jpg';
+
+    const statusMain = global.document.createElement('span');
+    statusMain.className = 'filepond--file-status-main';
+    statusMain.textContent = 'Uploading';
+
+    const statusSub = global.document.createElement('span');
+    statusSub.className = 'filepond--file-status-sub';
+    statusSub.textContent = 'Tap to abort';
+
+    item.append(name, statusMain, statusSub);
+    root.appendChild(item);
+    return { root, statusMain, statusSub };
   };
 
-  it('renders the FilePond component without errors', () => {
-    const component = mount(<FileUpload {...testProps} />);
-    expect(component.find('FilePond').length).toBe(1);
+  const FilePond = MockReact.forwardRef((props, ref) => {
+    const fake = MockReact.useMemo(setupFilePondMock, []);
+
+    // Filepond API
+    MockReact.useImperativeHandle(ref, () => ({
+      _pond: {
+        element: fake.root,
+        setOptions: mockSetOptions,
+      },
+      setOptions: mockSetOptions,
+    }));
+
+    return <div data-testid="filepond-stub" ref={(node) => node && node.appendChild(fake.root)} />;
+  });
+
+  FilePond.displayName = 'FilePond';
+
+  return { FilePond, registerPlugin: jest.fn() };
+});
+
+jest.mock('services/internalApi', () => {
+  return {
+    waitForAvScan: jest.fn(),
+    deleteUpload: jest.fn(),
+  };
+});
+
+const flushPromises = () =>
+  new Promise((resolve) => {
+    setTimeout(resolve, 0);
+  });
+
+const returnNewDummyFile = () => new File(['123'], 'dummy.jpg', { type: 'image/jpeg', lastModified: Date.now() });
+
+describe('FileUpload processing', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('changes status label from Uploading -> Scanning for viruses', async () => {
+    const createUpload = jest.fn(() => Promise.resolve({ id: 'abc123' }));
+    waitForAvScan.mockResolvedValueOnce({ status: 'CLEAN' });
+
+    const wrapper = mount(<FileUpload createUpload={createUpload} />);
+
+    // initial state should read "Uploading"
+    const statusBefore = wrapper
+      .find('[data-testid="filepond-stub"]')
+      .getDOMNode()
+      .querySelector('.filepond--file-status-main').textContent;
+    expect(statusBefore).toBe('Uploading');
+
+    const { process } = wrapper.find('FilePond').prop('server');
+
+    const loadFunc = jest.fn();
+    const errorFunc = jest.fn();
+
+    await act(async () => {
+      process('file', returnNewDummyFile(), {}, loadFunc, errorFunc, jest.fn(), jest.fn());
+      await flushPromises();
+    });
+
+    wrapper.update();
+
+    // grab the new status from stubbed filepond
+    const statusAfter = wrapper
+      .find('[data-testid="filepond-stub"]')
+      .getDOMNode()
+      .querySelector('.filepond--file-status-main').textContent;
+
+    // assertions
+    expect(statusAfter).toBe('Scanning for viruses…');
+    expect(createUpload).toHaveBeenCalledTimes(1);
+    expect(waitForAvScan).toHaveBeenCalledTimes(1);
+    expect(loadFunc).toHaveBeenCalledWith('abc123');
+    expect(errorFunc).not.toHaveBeenCalled();
+  });
+
+  it('it shows file failure when av scan returns INFECTED', async () => {
+    const createUpload = jest.fn(() => Promise.resolve({ id: 'abc123' }));
+    waitForAvScan.mockRejectedValueOnce(new Error(UPLOAD_SCAN_STATUS.INFECTED));
+
+    const wrapper = mount(<FileUpload createUpload={createUpload} />);
+
+    const { process } = wrapper.find('FilePond').prop('server');
+    const errorFunc = jest.fn();
+
+    await act(async () => {
+      process('file', returnNewDummyFile(), {}, jest.fn(), errorFunc, jest.fn(), jest.fn());
+      await flushPromises();
+    });
+
+    expect(errorFunc).toHaveBeenCalledWith('File failed virus scan');
+    expect(mockSetOptions).toHaveBeenCalledWith({
+      labelFileProcessing: 'File failed virus scan',
+    });
   });
 });

--- a/src/services/internalApi.js
+++ b/src/services/internalApi.js
@@ -2,6 +2,8 @@ import Swagger from 'swagger-client';
 
 import { makeSwaggerRequest, requestInterceptor, responseInterceptor, makeSwaggerRequestRaw } from './swaggerRequest';
 
+import { UPLOAD_SCAN_STATUS } from 'shared/constants';
+
 let internalClient = null;
 
 // setting up the same config from Swagger/api.js
@@ -289,6 +291,73 @@ export async function createUploadForPPMDocument(ppmShipmentId, documentId, file
       normalize: false,
     },
   );
+}
+
+// Subscribes to the server sent event for the antivirus status
+// This is needed because files, while uploaded, will be inaccessible
+// until the AV scan has cleared it
+export function waitForAvScan(uploadId, { signal } = {}) {
+  return new Promise((resolve, reject) => {
+    // Catch if the server event aborted before starting the func
+    if (signal?.aborted) {
+      reject(new DOMException('aborted', 'AbortError'));
+      return;
+    }
+
+    // Init server sent event
+    const es = new EventSource(`/ghc/v1/uploads/${uploadId}/status`, {
+      withCredentials: true,
+    });
+
+    // Catch user cancellation helper
+    // this is to close the currently running sse
+    function abortListener() {
+      es.close();
+      signal?.removeEventListener('abort', abortListener);
+      reject(new DOMException('aborted', 'AbortError'));
+    }
+
+    // Cleanup helper for the sse
+    function cleanup() {
+      es.close();
+      signal?.removeEventListener('abort', abortListener);
+    }
+
+    // Add listener for if the user cancels the event
+    signal?.addEventListener('abort', abortListener);
+
+    // Handle incremental SSE messages
+    // these cases are all provided by the
+    // CustomGetUploadStatusResponse from the backend
+    // See pkg/handlers/ghcapi/uploads.go
+    es.onmessage = ({ data }) => {
+      switch (data) {
+        case UPLOAD_SCAN_STATUS.PROCESSING:
+          break;
+        case UPLOAD_SCAN_STATUS.CLEAN:
+          cleanup();
+          resolve(UPLOAD_SCAN_STATUS.CLEAN);
+          break;
+        case UPLOAD_SCAN_STATUS.INFECTED:
+          cleanup();
+          reject(new Error(UPLOAD_SCAN_STATUS.INFECTED));
+          break;
+        case UPLOAD_SCAN_STATUS.CONNECTION_CLOSED:
+          cleanup();
+          reject(new Error(UPLOAD_SCAN_STATUS.CONNECTION_CLOSED));
+          break;
+        default:
+          cleanup();
+          reject(new Error('Unknown server response from antivirus scan'));
+      }
+    };
+
+    // Network SSE responded an error, close the sse
+    es.onerror = (err) => {
+      cleanup();
+      reject(err ?? new Error('Server sent event error when listening for antivirus status'));
+    };
+  });
 }
 
 export async function deleteUpload(uploadId, orderId, ppmId) {

--- a/src/shared/constants.js
+++ b/src/shared/constants.js
@@ -78,6 +78,7 @@ export const UPLOAD_SCAN_STATUS = {
   CLEAN: 'CLEAN',
   INFECTED: 'INFECTED',
   PROCESSING: 'PROCESSING',
+  CONNECTION_CLOSED: 'Connection closed',
 };
 
 export const UPLOAD_DOC_STATUS = {


### PR DESCRIPTION
## [B-23713](https://www13.v1host.com/USTRANSCOM38/story.mvc/Summary?oidToken=Story%3A1111792&RoomContext=TeamRoom%3A808731&concept=TeamRoom)

## Summary
Utilizes filepond to inform the user of "Uploading" and "Scanning for viruses" statuses. For AC:
`Uploading: Establishing the file for viewing`, this is handled in the DocumentViewer for the office app. Since the customer's don't use the document viewer, they can't view it at all, only download.

### How to test

1. Connect to dev AWS `export STORAGE_BACKEND=s3`
2. Update env vars `direnv allow`
3. Open up the app and test uploading
4. Also test that uploading multiple files at once get marked correctly for virus scanning

## Screenshots
