### PR TITLE
Main b 22568 sc edit draft moves

### DIFF
--- a/pkg/handlers/ghcapi/mto_shipment_test.go
+++ b/pkg/handlers/ghcapi/mto_shipment_test.go
@@ -5138,10 +5138,13 @@ func (suite *HandlerSuite) TestUpdateShipmentHandler() {
 			sitstatus.NewShipmentSITStatus(),
 		}
 
+		rejectionReason := "test"
+
 		oldShipment := factory.BuildMTOShipment(suite.DB(), []factory.Customization{
 			{
 				Model: models.MTOShipment{
-					Status: models.MTOShipmentStatusDraft,
+					Status:          models.MTOShipmentStatusRejected,
+					RejectionReason: &rejectionReason,
 				},
 			},
 		}, nil)

--- a/pkg/services/mto_shipment/rules.go
+++ b/pkg/services/mto_shipment/rules.go
@@ -101,6 +101,10 @@ func checkUpdateAllowed() validator {
 				if isTOO {
 					return nil
 				}
+			case models.MTOShipmentStatusDraft:
+				if isServiceCounselor {
+					return nil
+				}
 			default:
 				return err
 			}

--- a/pkg/services/mto_shipment/rules_test.go
+++ b/pkg/services/mto_shipment/rules_test.go
@@ -270,6 +270,7 @@ func (suite *MTOShipmentServiceSuite) TestUpdateValidations() {
 					models.MTOShipmentStatusCancellationRequested: false,
 					models.MTOShipmentStatusCanceled:              false,
 					models.MTOShipmentStatusDiversionRequested:    false,
+					models.MTOShipmentStatusDraft:                 true,
 				},
 			},
 			"TOO": {
@@ -280,6 +281,7 @@ func (suite *MTOShipmentServiceSuite) TestUpdateValidations() {
 					models.MTOShipmentStatusCancellationRequested: true,
 					models.MTOShipmentStatusCanceled:              true,
 					models.MTOShipmentStatusDiversionRequested:    true,
+					models.MTOShipmentStatusDraft:                 false,
 				},
 			},
 			"TIO": {
@@ -290,6 +292,7 @@ func (suite *MTOShipmentServiceSuite) TestUpdateValidations() {
 					models.MTOShipmentStatusCancellationRequested: false,
 					models.MTOShipmentStatusCanceled:              false,
 					models.MTOShipmentStatusDiversionRequested:    false,
+					models.MTOShipmentStatusDraft:                 false,
 				},
 			},
 			"Non-office user": {

--- a/src/pages/Office/ServicesCounselingMoveDetails/ServicesCounselingMoveDetails.jsx
+++ b/src/pages/Office/ServicesCounselingMoveDetails/ServicesCounselingMoveDetails.jsx
@@ -303,7 +303,8 @@ const ServicesCounselingMoveDetails = ({
           (shipment.ppmShipment.status === ppmShipmentStatuses.DRAFT ||
             shipment.ppmShipment.status === ppmShipmentStatuses.SUBMITTED ||
             shipment.ppmShipment.status === ppmShipmentStatuses.NEEDS_ADVANCE_APPROVAL)) ||
-        (shipment.ppmShipment.status === ppmShipmentStatuses.WAITING_ON_CUSTOMER && move.status === MOVE_STATUSES.DRAFT)
+        (shipment.ppmShipment?.status === ppmShipmentStatuses.WAITING_ON_CUSTOMER &&
+          move.status === MOVE_STATUSES.DRAFT)
           ? `../${generatePath(servicesCounselingRoutes.SHIPMENT_EDIT_PATH, {
               shipmentId: shipment.id,
             })}`

--- a/src/pages/Office/ServicesCounselingMoveDetails/ServicesCounselingMoveDetails.jsx
+++ b/src/pages/Office/ServicesCounselingMoveDetails/ServicesCounselingMoveDetails.jsx
@@ -296,7 +296,14 @@ const ServicesCounselingMoveDetails = ({
 
     shipmentsInfo = submittedShipmentsNonPPMNeedsCloseout.map((shipment) => {
       const editURL =
-        counselorCanEdit || counselorCanEditNonPPM
+        // This ternary checks if the shipment is a PPM. If so, PPM Shipments are editable at any time based on their ppm status.
+        // If the shipment is not a PPM, it uses the existing counselorCanEdit checks for move status
+        (shipment.shipmentType !== 'PPM' && (counselorCanEdit || counselorCanEditNonPPM)) ||
+        (shipment.shipmentType === 'PPM' &&
+          (shipment.ppmShipment.status === ppmShipmentStatuses.DRAFT ||
+            shipment.ppmShipment.status === ppmShipmentStatuses.SUBMITTED ||
+            shipment.ppmShipment.status === ppmShipmentStatuses.NEEDS_ADVANCE_APPROVAL)) ||
+        (shipment.ppmShipment.status === ppmShipmentStatuses.WAITING_ON_CUSTOMER && move.status === MOVE_STATUSES.DRAFT)
           ? `../${generatePath(servicesCounselingRoutes.SHIPMENT_EDIT_PATH, {
               shipmentId: shipment.id,
             })}`
@@ -770,7 +777,7 @@ const ServicesCounselingMoveDetails = ({
               <h1>Move details</h1>
               {ppmShipmentsInfoNeedsApproval.length > 0 ? null : (
                 <div>
-                  {(counselorCanEdit || counselorCanEditNonPPM) && (
+                  {(counselorCanEdit || (counselorCanEditNonPPM && move.status !== MOVE_STATUSES.DRAFT)) && (
                     <Button
                       disabled={
                         !mtoShipments.length ||

--- a/src/pages/Office/ServicesCounselingMoveDetails/ServicesCounselingMoveDetails.jsx
+++ b/src/pages/Office/ServicesCounselingMoveDetails/ServicesCounselingMoveDetails.jsx
@@ -35,6 +35,7 @@ import {
   SHIPMENT_OPTIONS,
   FEATURE_FLAG_KEYS,
   technicalHelpDeskURL,
+  SHIPMENT_TYPES,
 } from 'shared/constants';
 import { isPPMAboutInfoComplete } from 'utils/shipments';
 import { ppmShipmentStatuses, shipmentStatuses } from 'constants/shipments';
@@ -291,7 +292,7 @@ const ServicesCounselingMoveDetails = ({
     counselorCanCancelMove = move.status !== MOVE_STATUSES.CANCELED && numberOfShipmentsNotAllowedForCancel === 0;
     counselorCanEditNonPPM =
       (move.status === MOVE_STATUSES.NEEDS_SERVICE_COUNSELING || move.status === MOVE_STATUSES.DRAFT) &&
-      shipmentsInfo.shipmentType !== 'PPM';
+      shipmentsInfo.shipmentType !== SHIPMENT_TYPES.PPM;
 
     shipmentsInfo = submittedShipmentsNonPPMNeedsCloseout.map((shipment) => {
       const editURL =

--- a/src/pages/Office/ServicesCounselingMoveDetails/ServicesCounselingMoveDetails.jsx
+++ b/src/pages/Office/ServicesCounselingMoveDetails/ServicesCounselingMoveDetails.jsx
@@ -285,10 +285,13 @@ const ServicesCounselingMoveDetails = ({
 
     counselorCanReview = ppmShipmentsInfoNeedsApproval.length > 0;
     reviewWeightsURL = generatePath(servicesCounselingRoutes.BASE_REVIEW_SHIPMENT_WEIGHTS_PATH, { moveCode });
-    counselorCanEdit = move.status === MOVE_STATUSES.NEEDS_SERVICE_COUNSELING && ppmShipmentsOtherStatuses.length > 0;
+    counselorCanEdit =
+      move.status === (MOVE_STATUSES.NEEDS_SERVICE_COUNSELING || MOVE_STATUSES.DRAFT) &&
+      ppmShipmentsOtherStatuses.length > 0;
     counselorCanCancelMove = move.status !== MOVE_STATUSES.CANCELED && numberOfShipmentsNotAllowedForCancel === 0;
     counselorCanEditNonPPM =
-      move.status === MOVE_STATUSES.NEEDS_SERVICE_COUNSELING && shipmentsInfo.shipmentType !== 'PPM';
+      (move.status === MOVE_STATUSES.NEEDS_SERVICE_COUNSELING || move.status === MOVE_STATUSES.DRAFT) &&
+      shipmentsInfo.shipmentType !== 'PPM';
 
     shipmentsInfo = submittedShipmentsNonPPMNeedsCloseout.map((shipment) => {
       const editURL =
@@ -643,6 +646,7 @@ const ServicesCounselingMoveDetails = ({
   const counselorCanEditOrdersAndAllowances = () => {
     if (counselorCanEdit || counselorCanEditNonPPM) return true;
     if (
+      move.status === MOVE_STATUSES.DRAFT ||
       move.status === MOVE_STATUSES.NEEDS_SERVICE_COUNSELING ||
       move.status === MOVE_STATUSES.SERVICE_COUNSELING_COMPLETED ||
       (move.status === MOVE_STATUSES.APPROVALS_REQUESTED && !move.availableToPrimeAt) // status is set to 'Approval Requested' if customer uploads amended orders.

--- a/src/pages/Office/ServicesCounselingMoveDetails/ServicesCounselingMoveDetails.test.jsx
+++ b/src/pages/Office/ServicesCounselingMoveDetails/ServicesCounselingMoveDetails.test.jsx
@@ -1277,8 +1277,6 @@ describe('MoveDetails page', () => {
 
         renderComponent();
 
-        screen.debug(undefined, 100000);
-
         expect(screen.queryByRole('button', { name: 'Submit move details' })).not.toBeInTheDocument();
         expect(screen.queryByRole('combobox')).not.toBeInTheDocument(); // Add a new shipment ButtonDropdown
         expect(screen.queryByRole('button', { name: 'Edit shipment' })).not.toBeInTheDocument();

--- a/src/pages/Office/ServicesCounselingMoveDetails/ServicesCounselingMoveDetails.test.jsx
+++ b/src/pages/Office/ServicesCounselingMoveDetails/ServicesCounselingMoveDetails.test.jsx
@@ -338,8 +338,110 @@ const newMoveDetailsQuery = {
   isSuccess: true,
 };
 
-const draftMoveDetailsQuery = { ...newMoveDetailsQuery };
-draftMoveDetailsQuery.move.status = MOVE_STATUSES.DRAFT;
+const draftMoveDetailsQuery = {
+  move: {
+    id: '9c7b255c-2981-4bf8-839f-61c7458e2b4d',
+    ordersId: '1',
+    status: MOVE_STATUSES.DRAFT,
+  },
+  closeoutOffice: undefined,
+  customerData: {
+    id: '2468',
+    last_name: 'Kerry',
+    first_name: 'Smith',
+    dodID: '999999999',
+    agency: 'NAVY',
+    backupAddress: {
+      streetAddress1: '813 S 129th St',
+      city: 'San Antonio',
+      state: 'TX',
+      postalCode: '78234',
+    },
+  },
+  order: {
+    id: '1',
+    originDutyLocation: {
+      address: {
+        streetAddress1: '',
+        city: 'Fort Knox',
+        state: 'KY',
+        postalCode: '40121',
+        isOconus: true,
+      },
+    },
+    destinationDutyLocation: {
+      address: {
+        streetAddress1: '',
+        city: 'Fort Irwin',
+        state: 'CA',
+        postalCode: '92310',
+      },
+    },
+    customer: {
+      agency: 'ARMY',
+      backup_contact: {
+        email: 'email@example.com',
+        name: 'name',
+        phone: '555-555-5555',
+      },
+      current_address: {
+        city: 'Beverly Hills',
+        country: 'US',
+        eTag: 'MjAyMS0wMS0yMVQxNTo0MTozNS41Mzg0Njha',
+        id: '3a5f7cf2-6193-4eb3-a244-14d21ca05d7b',
+        postalCode: '90210',
+        state: 'CA',
+        streetAddress1: '123 Any Street',
+        streetAddress2: 'P.O. Box 12345',
+        streetAddress3: 'c/o Some Person',
+      },
+      dodID: '6833908165',
+      eTag: 'MjAyMS0wMS0yMVQxNTo0MTozNS41NjAzNTJa',
+      email: 'combo@ppm.hhg',
+      first_name: 'Submitted',
+      id: 'f6bd793f-7042-4523-aa30-34946e7339c9',
+      last_name: 'Ppmhhg',
+      phone: '555-555-5555',
+    },
+    entitlement: {
+      authorizedWeight: 8000,
+      dependentsAuthorized: true,
+      eTag: 'MjAyMS0wMS0yMVQxNTo0MTozNS41NzgwMzda',
+      id: 'e0fefe58-0710-40db-917b-5b96567bc2a8',
+      nonTemporaryStorage: true,
+      privatelyOwnedVehicle: true,
+      proGearWeight: 1,
+      proGearWeightSpouse: 500,
+      storageInTransit: 2,
+      totalDependents: 1,
+      totalWeight: 8000,
+    },
+    order_number: 'ORDER3',
+    order_type: ORDERS_TYPE.PERMANENT_CHANGE_OF_STATION,
+    order_type_detail: ORDERS_TYPE_DETAILS.HHG_PERMITTED,
+    department_indicator: 'ARMY',
+    tac: '9999',
+  },
+  orderDocuments: {
+    z: {
+      bytes: 2202009,
+      contentType: 'application/pdf',
+      createdAt: '2024-10-23T16:31:21.085Z',
+      filename: 'testFile.pdf',
+      id: 'z',
+      status: 'PROCESSING',
+      updatedAt: '2024-10-23T16:31:21.085Z',
+      uploadType: 'USER',
+      url: '/storage/USER/uploads/z?contentType=application%2Fpdf',
+    },
+  },
+  mtoShipments,
+  mtoServiceItems: [],
+  mtoAgents: [],
+  isLoading: false,
+  isError: false,
+  isSuccess: true,
+};
 
 const zeroIncentiveMoveDetailsQuery = {
   ...newMoveDetailsQuery,
@@ -1175,6 +1277,8 @@ describe('MoveDetails page', () => {
 
         renderComponent();
 
+        screen.debug(undefined, 100000);
+
         expect(screen.queryByRole('button', { name: 'Submit move details' })).not.toBeInTheDocument();
         expect(screen.queryByRole('combobox')).not.toBeInTheDocument(); // Add a new shipment ButtonDropdown
         expect(screen.queryByRole('button', { name: 'Edit shipment' })).not.toBeInTheDocument();
@@ -1190,7 +1294,7 @@ describe('MoveDetails page', () => {
 
         renderComponent();
 
-        expect(await screen.findByRole('button', { name: 'Submit move details' })).toBeInTheDocument();
+        expect(screen.queryByRole('button', { name: 'Submit move details' })).not.toBeInTheDocument();
       });
 
       it('renders submit and view/edit buttons/links', async () => {
@@ -1198,7 +1302,7 @@ describe('MoveDetails page', () => {
 
         renderComponent();
 
-        expect(screen.queryByRole('button', { name: 'Submit move details' })).toBeInTheDocument();
+        expect(screen.queryByRole('button', { name: 'Submit move details' })).not.toBeInTheDocument();
         expect(screen.queryByRole('combobox')).toBeInTheDocument(); // Add a new shipment ButtonDropdown
         const shipmentEditButtons = await screen.findAllByRole('button', { name: 'Edit shipment' });
         expect(shipmentEditButtons.length).toBe(2);

--- a/src/pages/Office/ServicesCounselingMoveDetails/ServicesCounselingMoveDetails.test.jsx
+++ b/src/pages/Office/ServicesCounselingMoveDetails/ServicesCounselingMoveDetails.test.jsx
@@ -338,6 +338,9 @@ const newMoveDetailsQuery = {
   isSuccess: true,
 };
 
+const draftMoveDetailsQuery = { ...newMoveDetailsQuery };
+draftMoveDetailsQuery.move.status = MOVE_STATUSES.DRAFT;
+
 const zeroIncentiveMoveDetailsQuery = {
   ...newMoveDetailsQuery,
   move: {
@@ -1175,6 +1178,30 @@ describe('MoveDetails page', () => {
         expect(screen.queryByRole('button', { name: 'Submit move details' })).not.toBeInTheDocument();
         expect(screen.queryByRole('combobox')).not.toBeInTheDocument(); // Add a new shipment ButtonDropdown
         expect(screen.queryByRole('button', { name: 'Edit shipment' })).not.toBeInTheDocument();
+        expect(screen.queryByRole('link', { name: 'View and edit orders' })).toBeInTheDocument();
+        expect(screen.queryByRole('link', { name: 'Edit allowances' })).toBeInTheDocument();
+        expect(screen.queryByRole('link', { name: 'Edit customer info' })).toBeInTheDocument();
+      });
+    });
+
+    describe('move in draft status', () => {
+      it('submit move details button is on page', async () => {
+        useMoveDetailsQueries.mockReturnValue(draftMoveDetailsQuery);
+
+        renderComponent();
+
+        expect(await screen.findByRole('button', { name: 'Submit move details' })).toBeInTheDocument();
+      });
+
+      it('renders submit and view/edit buttons/links', async () => {
+        useMoveDetailsQueries.mockReturnValue(draftMoveDetailsQuery);
+
+        renderComponent();
+
+        expect(screen.queryByRole('button', { name: 'Submit move details' })).toBeInTheDocument();
+        expect(screen.queryByRole('combobox')).toBeInTheDocument(); // Add a new shipment ButtonDropdown
+        const shipmentEditButtons = await screen.findAllByRole('button', { name: 'Edit shipment' });
+        expect(shipmentEditButtons.length).toBe(2);
         expect(screen.queryByRole('link', { name: 'View and edit orders' })).toBeInTheDocument();
         expect(screen.queryByRole('link', { name: 'Edit allowances' })).toBeInTheDocument();
         expect(screen.queryByRole('link', { name: 'Edit customer info' })).toBeInTheDocument();


### PR DESCRIPTION
## [Agility ticket](https://www13.v1host.com/USTRANSCOM38/assetdetail.v1?number=B-22568)

## Summary

Allows the SC to edit moves that are in draft status the same way that they would with moves that are submitted. I.e. edit orders, add a shipment, edit a shipment, delete a shipment, upload order docs, etc. should now work as an SC with a move that is in DRAFT status.

### How to test

1. Create a move as a customer, upload your orders then stop the process.
2. Login as an SC and search for the move code in the "Move Search" tab.
3. Try clicking "add a shipment" with various shipment types and verify that each works as they should.
4. Edit the shipments and verify that the information is saved.
5. Delete a shipment and verify that it is actually deleted.
6. Click on "Edit Orders" and verify that you can upload documents and edit the fields SC normally needs to submit a move, like TAC codes, type of move, etc.
7. Click Edit Allowances and verify that info is saved.
