### PR TITLE
SAC

### DIFF
--- a/src/components/Office/OrdersDetailForm/OrdersDetailForm.jsx
+++ b/src/components/Office/OrdersDetailForm/OrdersDetailForm.jsx
@@ -148,7 +148,7 @@ const OrdersDetailForm = ({
         <MaskedTextField
           name="sac"
           label="SAC"
-          mask="****"
+          mask={/[A-Za-z0-9]*/}
           id="hhgSacInput"
           inputTestId="hhgSacInput"
           data-testid="hhgSacInput"
@@ -192,7 +192,7 @@ const OrdersDetailForm = ({
           name="ntsSac"
           label="SAC"
           id="ntsSacInput"
-          mask="****"
+          mask={/[A-Za-z0-9]*/}
           isDisabled={formIsDisabled}
           inputTestId="ntsSacInput"
           data-testid="ntsSacInput"

--- a/src/components/Office/OrdersDetailForm/OrdersDetailForm.test.jsx
+++ b/src/components/Office/OrdersDetailForm/OrdersDetailForm.test.jsx
@@ -2,6 +2,7 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 import { Formik } from 'formik';
+import userEvent from '@testing-library/user-event';
 
 import OrdersDetailForm from './OrdersDetailForm';
 
@@ -273,5 +274,23 @@ describe('OrdersDetailForm', () => {
   it('renders dependents authorized checkbox field', async () => {
     renderOrdersDetailForm();
     expect(await screen.findByTestId('dependentsAuthorizedInput')).toBeInTheDocument();
+  });
+
+  it('allows typing more than 4 characters into a SAC field', async () => {
+    renderOrdersDetailForm();
+
+    // there are two SAC fields (HHG SAC and NTS SAC)
+    const sacInputs = screen.getAllByLabelText('SAC');
+    expect(sacInputs.length).toBeGreaterThanOrEqual(1);
+
+    const firstSacInput = sacInputs[0];
+    await userEvent.type(firstSacInput, 'ABCDE');
+    // Sac is already in the initial values, so we can confirm we can append to that
+    expect(firstSacInput).toHaveValue('SacABCDE');
+
+    // NTS SAC is not in the initial values, so we can check for exactly what we put in
+    const secondSacInput = sacInputs[1];
+    await userEvent.type(secondSacInput, 'FGHIJ123');
+    expect(secondSacInput).toHaveValue('FGHIJ123');
   });
 });

--- a/src/pages/Office/Orders/Orders.test.jsx
+++ b/src/pages/Office/Orders/Orders.test.jsx
@@ -331,6 +331,26 @@ describe('Orders page', () => {
         expect(screen.getByText('NTS SAC cannot contain * or " characters')).toBeInTheDocument();
       });
     });
+
+    it('SAC fields can be more than 4 digits', async () => {
+      useOrdersDocumentQueries.mockReturnValue(useOrdersDocumentQueriesReturnValue);
+
+      render(
+        <MockProviders permissions={[permissionTypes.updateOrders]}>
+          <Orders {...ordersMockProps} />
+        </MockProviders>,
+      );
+
+      // SAC
+      const hhgSacInput = screen.getByTestId('hhgSacInput');
+      await userEvent.type(hhgSacInput, 'MoreThan4Digits');
+      expect(hhgSacInput).toHaveValue('E2P3MoreThan4Digits');
+
+      // NTS SAC
+      const ntsSacInput = screen.getByTestId('ntsSacInput');
+      await userEvent.type(ntsSacInput, '4DigitsOrMore');
+      expect(ntsSacInput).toHaveValue('22224DigitsOrMore');
+    });
   });
 
   describe('LOA validation', () => {

--- a/src/pages/Office/ServicesCounselingOrders/ServicesCounselingOrders.test.jsx
+++ b/src/pages/Office/ServicesCounselingOrders/ServicesCounselingOrders.test.jsx
@@ -483,7 +483,7 @@ describe('Orders page', () => {
       const hhgSacInput = screen.getByTestId('hhgSacInput');
       await userEvent.clear(hhgSacInput);
       await userEvent.type(hhgSacInput, '****');
-      hhgSacInput.blur();
+      await userEvent.tab();
       await waitFor(() => {
         // no *
         expect(screen.getByText('SAC cannot contain * or " characters')).toBeInTheDocument();
@@ -510,6 +510,31 @@ describe('Orders page', () => {
       await waitFor(() => {
         expect(screen.getByText('NTS SAC cannot contain * or " characters')).toBeInTheDocument();
       });
+    });
+
+    it('SAC fields can be more than 4 digits', async () => {
+      const props = {
+        ...ordersMockProps,
+        sac: '',
+        ntsSac: '',
+      };
+      useOrdersDocumentQueries.mockReturnValue(useOrdersDocumentQueriesReturnValue);
+
+      render(
+        <MockProviders>
+          <ServicesCounselingOrders {...props} />
+        </MockProviders>,
+      );
+
+      // SAC
+      const hhgSacInput = screen.getByTestId('hhgSacInput');
+      await userEvent.type(hhgSacInput, 'MoreThan4Digits');
+      expect(hhgSacInput).toHaveValue('E2P3MoreThan4Digits');
+
+      // NTS SAC
+      const ntsSacInput = screen.getByTestId('ntsSacInput');
+      await userEvent.type(ntsSacInput, '4DigitsOrMore');
+      expect(ntsSacInput).toHaveValue('R6X14DigitsOrMore');
     });
   });
 


### PR DESCRIPTION
## [Agility ticket](https://www13.v1host.com/USTRANSCOM38/assetdetail.v1?number=B-23757)

## Summary

When doing the work of not allowing `*` or `"` in the SAC fields, I ended up using the `MaskedTextField` component and copy/pasted what was used in the TAC fields. Unknowingly, there was a `mask=****` prop used in theirs that limited the field to 4 characters. Adjusted that to use regex and all good now.

### How to test

1. Access office app
2. Find a move
3. Go to the orders section
4. Test out the SAC fields, validations should still fire and should not be limited in characters

## Screenshots
<img width="314" alt="Screenshot 2025-06-05 at 10 00 46 AM" src="https://github.com/user-attachments/assets/caac4938-7282-44a4-87fe-ac3677422cda" />
<img width="315" alt="Screenshot 2025-06-05 at 10 00 54 AM" src="https://github.com/user-attachments/assets/027a3b0e-a9d5-4a2a-aab1-1399a36196b9" />
