### PR TITLE
508 output text for screen reader

### DIFF
--- a/src/components/DocumentViewerFileManager/DocumentViewerFileManager.jsx
+++ b/src/components/DocumentViewerFileManager/DocumentViewerFileManager.jsx
@@ -310,7 +310,7 @@ const DocumentViewerFileManager = ({
                 createUpload={handleUpload}
                 onChange={handleChange}
                 onAddFile={onAddFile}
-                labelIdle='Drag files here or <span class="filepond--label-action">click</span> to upload'
+                labelIdle='Drag files here or <span class="filepond--label-action" aria-label="Click to upload a document" role="button">click</span> to upload'
               />
               <Hint>PDF, JPG, or PNG only. Maximum file size 25MB. Each page must be clear and legible</Hint>
               {!isExpandedView && (


### PR DESCRIPTION
## [INTEGRATION PR](https://github.com/transcom/mymove/pull/15605)

- The Andi output should be "Click to upload a document" rather than just "click"

