### PR TITLE
Int b 23333

### DIFF
--- a/pkg/gen/adminapi/embedded_spec.go
+++ b/pkg/gen/adminapi/embedded_spec.go
@@ -3515,6 +3515,12 @@ func init() {
         "otherUniqueId": {
           "type": "string"
         },
+        "privileges": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OfficeUserPrivilege"
+          }
+        },
         "rejectionReason": {
           "type": "string"
         },
@@ -7564,6 +7570,12 @@ func init() {
         },
         "otherUniqueId": {
           "type": "string"
+        },
+        "privileges": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OfficeUserPrivilege"
+          }
         },
         "rejectionReason": {
           "type": "string"

--- a/pkg/gen/adminmessages/requested_office_user_update.go
+++ b/pkg/gen/adminmessages/requested_office_user_update.go
@@ -41,6 +41,9 @@ type RequestedOfficeUserUpdate struct {
 	// other unique Id
 	OtherUniqueID string `json:"otherUniqueId,omitempty"`
 
+	// privileges
+	Privileges []*OfficeUserPrivilege `json:"privileges"`
+
 	// rejection reason
 	RejectionReason string `json:"rejectionReason,omitempty"`
 
@@ -67,6 +70,10 @@ func (m *RequestedOfficeUserUpdate) Validate(formats strfmt.Registry) error {
 	var res []error
 
 	if err := m.validateEmail(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validatePrivileges(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -99,6 +106,32 @@ func (m *RequestedOfficeUserUpdate) validateEmail(formats strfmt.Registry) error
 
 	if err := validate.Pattern("email", "body", *m.Email, `^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$`); err != nil {
 		return err
+	}
+
+	return nil
+}
+
+func (m *RequestedOfficeUserUpdate) validatePrivileges(formats strfmt.Registry) error {
+	if swag.IsZero(m.Privileges) { // not required
+		return nil
+	}
+
+	for i := 0; i < len(m.Privileges); i++ {
+		if swag.IsZero(m.Privileges[i]) { // not required
+			continue
+		}
+
+		if m.Privileges[i] != nil {
+			if err := m.Privileges[i].Validate(formats); err != nil {
+				if ve, ok := err.(*errors.Validation); ok {
+					return ve.ValidateName("privileges" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("privileges" + "." + strconv.Itoa(i))
+				}
+				return err
+			}
+		}
+
 	}
 
 	return nil
@@ -200,6 +233,10 @@ func (m *RequestedOfficeUserUpdate) validateTransportationOfficeID(formats strfm
 func (m *RequestedOfficeUserUpdate) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
 	var res []error
 
+	if err := m.contextValidatePrivileges(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
 	if err := m.contextValidateRoles(ctx, formats); err != nil {
 		res = append(res, err)
 	}
@@ -207,6 +244,31 @@ func (m *RequestedOfficeUserUpdate) ContextValidate(ctx context.Context, formats
 	if len(res) > 0 {
 		return errors.CompositeValidationError(res...)
 	}
+	return nil
+}
+
+func (m *RequestedOfficeUserUpdate) contextValidatePrivileges(ctx context.Context, formats strfmt.Registry) error {
+
+	for i := 0; i < len(m.Privileges); i++ {
+
+		if m.Privileges[i] != nil {
+
+			if swag.IsZero(m.Privileges[i]) { // not required
+				return nil
+			}
+
+			if err := m.Privileges[i].ContextValidate(ctx, formats); err != nil {
+				if ve, ok := err.(*errors.Validation); ok {
+					return ve.ValidateName("privileges" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("privileges" + "." + strconv.Itoa(i))
+				}
+				return err
+			}
+		}
+
+	}
+
 	return nil
 }
 

--- a/pkg/handlers/adminapi/api.go
+++ b/pkg/handlers/adminapi/api.go
@@ -52,6 +52,7 @@ func NewAdminAPI(handlerConfig handlers.HandlerConfig) *adminops.MymoveAPI {
 	officeUpdater := officeuser.NewOfficeUserUpdater(queryBuilder)
 	adminUpdater := adminuser.NewAdminUserUpdater(queryBuilder)
 	ppmEstimator := ppmshipment.NewEstimatePPM(handlerConfig.DTODPlanner(), &paymentrequest.RequestPaymentHelper{})
+	userPrivilegesCreator := usersprivileges.NewUsersPrivilegesCreator()
 
 	adminAPI.ServeError = handlers.ServeCustomError
 
@@ -71,6 +72,7 @@ func NewAdminAPI(handlerConfig handlers.HandlerConfig) *adminops.MymoveAPI {
 	adminAPI.RequestedOfficeUsersGetRequestedOfficeUserHandler = GetRequestedOfficeUserHandler{
 		handlerConfig,
 		requestedofficeusers.NewRequestedOfficeUserFetcher(queryBuilder),
+		userPrivilegesCreator,
 		newRolesFetcher,
 		query.NewQueryFilter,
 	}
@@ -78,6 +80,7 @@ func NewAdminAPI(handlerConfig handlers.HandlerConfig) *adminops.MymoveAPI {
 	adminAPI.RequestedOfficeUsersUpdateRequestedOfficeUserHandler = UpdateRequestedOfficeUserHandler{
 		handlerConfig,
 		requestedofficeusers.NewRequestedOfficeUserUpdater(queryBuilder),
+		userPrivilegesCreator,
 		userRolesCreator,
 		newRolesFetcher,
 	}
@@ -109,7 +112,6 @@ func NewAdminAPI(handlerConfig handlers.HandlerConfig) *adminops.MymoveAPI {
 		query.NewQueryFilter,
 	}
 
-	userPrivilegesCreator := usersprivileges.NewUsersPrivilegesCreator()
 	transportationOfficeAssignmentUpdater := transportationofficeassignments.NewTransportationOfficeAssignmentUpdater()
 	adminAPI.OfficeUsersCreateOfficeUserHandler = CreateOfficeUserHandler{
 		handlerConfig,

--- a/pkg/handlers/adminapi/requested_office_users.go
+++ b/pkg/handlers/adminapi/requested_office_users.go
@@ -21,11 +21,13 @@ import (
 	"github.com/transcom/mymove/pkg/handlers"
 	"github.com/transcom/mymove/pkg/handlers/authentication/okta"
 	"github.com/transcom/mymove/pkg/models"
+	"github.com/transcom/mymove/pkg/models/roles"
 	"github.com/transcom/mymove/pkg/notifications"
 	"github.com/transcom/mymove/pkg/services"
 	"github.com/transcom/mymove/pkg/services/query"
 )
 
+// payloadForRequestedOfficeUserModel converts an OfficeUser model to an OfficeUser payload
 func payloadForRequestedOfficeUserModel(o models.OfficeUser) *adminmessages.OfficeUser {
 	var user models.User
 	if o.UserID != nil {
@@ -54,6 +56,9 @@ func payloadForRequestedOfficeUserModel(o models.OfficeUser) *adminmessages.Offi
 		if userIDFmt != nil {
 			payload.UserID = *userIDFmt
 		}
+	}
+	for _, privilege := range user.Privileges {
+		payload.Privileges = append(payload.Privileges, payloadForPrivilege(privilege))
 	}
 	for _, role := range user.Roles {
 		payload.Roles = append(payload.Roles, payloadForRole(role))
@@ -251,6 +256,7 @@ func (h IndexRequestedOfficeUsersHandler) Handle(params requested_office_users.I
 type GetRequestedOfficeUserHandler struct {
 	handlers.HandlerConfig
 	services.RequestedOfficeUserFetcher
+	services.UserPrivilegeAssociator
 	services.RoleFetcher
 	services.NewQueryFilter
 }
@@ -268,6 +274,10 @@ func (h GetRequestedOfficeUserHandler) Handle(params requested_office_users.GetR
 			if err != nil {
 				return handlers.ResponseForError(appCtx.Logger(), err), err
 			}
+			privileges, err := roles.FetchPrivilegesForUser(appCtx.DB(), *requestedOfficeUser.UserID)
+			if err != nil {
+				appCtx.Logger().Error("Error retreiving user privileges", zap.Error(err))
+			}
 
 			roles, err := h.RoleFetcher.FetchRolesForUser(appCtx, *requestedOfficeUser.UserID)
 			if err != nil {
@@ -276,6 +286,7 @@ func (h GetRequestedOfficeUserHandler) Handle(params requested_office_users.GetR
 			}
 
 			requestedOfficeUser.User.Roles = roles
+			requestedOfficeUser.User.Privileges = privileges
 
 			payload := payloadForRequestedOfficeUserModel(requestedOfficeUser)
 
@@ -287,6 +298,7 @@ func (h GetRequestedOfficeUserHandler) Handle(params requested_office_users.GetR
 type UpdateRequestedOfficeUserHandler struct {
 	handlers.HandlerConfig
 	services.RequestedOfficeUserUpdater
+	services.UserPrivilegeAssociator
 	services.UserRoleAssociator
 	services.RoleFetcher
 }
@@ -349,12 +361,26 @@ func (h UpdateRequestedOfficeUserHandler) Handle(params requested_office_users.U
 					}
 				}
 
+				if requestedOfficeUser.UserID != nil && body.Privileges != nil {
+					updatedPrivileges := privilegesPayloadToModel(body.Privileges)
+					if _, err := h.UserPrivilegeAssociator.UpdateUserPrivileges(txAppCtx, *requestedOfficeUser.UserID, updatedPrivileges); err != nil {
+						txAppCtx.Logger().Error("Error updating user privileges", zap.Error(err))
+						return err
+					}
+				}
+				privileges, err := roles.FetchPrivilegesForUser(appCtx.DB(), *requestedOfficeUser.UserID)
+				if err != nil {
+					appCtx.Logger().Error("Error retreiving user privileges", zap.Error(err))
+				}
+
 				roles, err := h.RoleFetcher.FetchRolesForUser(txAppCtx, *requestedOfficeUser.UserID)
 				if err != nil {
 					txAppCtx.Logger().Error("Error fetching user roles", zap.Error(err))
 					return err
 				}
+
 				requestedOfficeUser.User.Roles = roles
+				requestedOfficeUser.User.Privileges = privileges
 
 				// send email notification if request was rejected
 				if params.Body.Status == "REJECTED" {

--- a/pkg/handlers/adminapi/requested_office_users_test.go
+++ b/pkg/handlers/adminapi/requested_office_users_test.go
@@ -69,7 +69,7 @@ func (suite *HandlerSuite) TestIndexRequestedOfficeUsersHandler() {
 					Name: "JPPO Test Office",
 				},
 			},
-		}, nil)
+		}, []factory.Trait{})
 		transportationOffice2 := factory.BuildTransportationOffice(suite.DB(), []factory.Customization{
 			{
 				Model: models.TransportationOffice{
@@ -523,6 +523,7 @@ func (suite *HandlerSuite) TestGetRequestedOfficeUserHandler() {
 		}
 
 		mockRoleFetcher := &mocks.RoleFetcher{}
+		userPrivilegeAssociator := &mocks.UserPrivilegeAssociator{}
 		mockRoles := roles.Roles{
 			roles.Role{
 				ID:        uuid.Must(uuid.NewV4()),
@@ -542,6 +543,7 @@ func (suite *HandlerSuite) TestGetRequestedOfficeUserHandler() {
 		handler := GetRequestedOfficeUserHandler{
 			suite.NewHandlerConfig(),
 			requestedofficeusers.NewRequestedOfficeUserFetcher(queryBuilder),
+			userPrivilegeAssociator,
 			mockRoleFetcher,
 			query.NewQueryFilter,
 		}
@@ -567,6 +569,8 @@ func (suite *HandlerSuite) TestGetRequestedOfficeUserHandler() {
 		).Return(requestedOfficeUser, nil).Once()
 
 		mockRoleFetcher := &mocks.RoleFetcher{}
+		userPrivilegeAssociator := &mocks.UserPrivilegeAssociator{}
+
 		mockRoles := roles.Roles{
 			roles.Role{
 				ID:        uuid.Must(uuid.NewV4()),
@@ -585,6 +589,7 @@ func (suite *HandlerSuite) TestGetRequestedOfficeUserHandler() {
 		handler := GetRequestedOfficeUserHandler{
 			suite.NewHandlerConfig(),
 			requestedOfficeUserFetcher,
+			userPrivilegeAssociator,
 			mockRoleFetcher,
 			newMockQueryFilterBuilder(&mocks.QueryFilter{}),
 		}
@@ -611,6 +616,8 @@ func (suite *HandlerSuite) TestGetRequestedOfficeUserHandler() {
 		).Return(models.OfficeUser{}, expectedError).Once()
 
 		mockRoleFetcher := &mocks.RoleFetcher{}
+		userPrivilegeAssociator := &mocks.UserPrivilegeAssociator{}
+
 		mockRoles := roles.Roles{
 			roles.Role{
 				ID:        uuid.Must(uuid.NewV4()),
@@ -629,6 +636,7 @@ func (suite *HandlerSuite) TestGetRequestedOfficeUserHandler() {
 		handler := GetRequestedOfficeUserHandler{
 			suite.NewHandlerConfig(),
 			requestedOfficeUserFetcher,
+			userPrivilegeAssociator,
 			mockRoleFetcher,
 			newMockQueryFilterBuilder(&mocks.QueryFilter{}),
 		}
@@ -640,6 +648,288 @@ func (suite *HandlerSuite) TestGetRequestedOfficeUserHandler() {
 			Err:  expectedError,
 		}
 		suite.Equal(expectedResponse, response)
+	})
+
+	suite.Run("test - get requested office user handler with privileges", func() {
+		requestedOfficeUser := factory.BuildOfficeUserWithPrivileges(suite.DB(), []factory.Customization{
+			{
+				Model: models.User{
+					Privileges: []roles.Privilege{
+						{
+							PrivilegeType: roles.PrivilegeTypeSupervisor,
+						},
+					},
+					Roles: []roles.Role{
+						{
+							RoleType: roles.RoleTypeServicesCounselor,
+						},
+					},
+				},
+			},
+		}, nil)
+
+		params := requestedofficeuserop.GetRequestedOfficeUserParams{
+			HTTPRequest:  suite.setupAuthenticatedRequest("GET", fmt.Sprintf("/requested_office_users/%s", requestedOfficeUser.ID)),
+			OfficeUserID: strfmt.UUID(requestedOfficeUser.ID.String()),
+		}
+
+		requestedOfficeUserFetcher := &mocks.RequestedOfficeUserFetcher{}
+		requestedOfficeUserFetcher.On("FetchRequestedOfficeUser",
+			mock.AnythingOfType("*appcontext.appContext"),
+			mock.Anything,
+		).Return(requestedOfficeUser, nil).Once()
+
+		mockRoleFetcher := &mocks.RoleFetcher{}
+		userPrivilegeAssociator := &mocks.UserPrivilegeAssociator{}
+
+		mockPrivileges := []roles.Privilege{
+			{
+				ID:            uuid.Must(uuid.NewV4()),
+				PrivilegeType: roles.PrivilegeTypeSupervisor,
+				PrivilegeName: "Supervisor",
+				CreatedAt:     time.Now(),
+				UpdatedAt:     time.Now(),
+			},
+		}
+
+		mockRoles := roles.Roles{
+			roles.Role{
+				ID:        uuid.Must(uuid.NewV4()),
+				RoleType:  roles.RoleTypeTOO,
+				RoleName:  "Task Ordering Officer",
+				CreatedAt: time.Now(),
+				UpdatedAt: time.Now(),
+			},
+		}
+		mockRoleFetcher.On(
+			"FetchRolesForUser",
+			mock.AnythingOfType("*appcontext.appContext"),
+			mock.Anything,
+		).Return(mockRoles, nil)
+
+		userPrivilegeAssociator.On(
+			"FetchPrivilegesForUser",
+			mock.AnythingOfType("*appcontext.appContext"),
+			mock.Anything,
+		).Return(mockPrivileges, nil)
+
+		handler := GetRequestedOfficeUserHandler{
+			suite.HandlerConfig(),
+			requestedOfficeUserFetcher,
+			userPrivilegeAssociator,
+			mockRoleFetcher,
+			newMockQueryFilterBuilder(&mocks.QueryFilter{}),
+		}
+
+		response := handler.Handle(params)
+		suite.IsType(&requestedofficeuserop.GetRequestedOfficeUserOK{}, response)
+		okResponse := response.(*requestedofficeuserop.GetRequestedOfficeUserOK)
+		suite.Equal(requestedOfficeUser.ID.String(), okResponse.Payload.ID.String())
+		suite.Len(okResponse.Payload.Privileges, 1)
+		suite.Equal("Supervisor", okResponse.Payload.Privileges[0].PrivilegeName)
+		suite.Equal(string(roles.PrivilegeTypeSupervisor), okResponse.Payload.Privileges[0].PrivilegeType)
+	})
+
+}
+
+func (suite *HandlerSuite) TestGetRequestedOfficeUserHandler_WithSupervisorPrivilege() {
+	suite.Run("test - get requested office user handler with privileges", func() {
+		requestedOfficeUser := factory.BuildOfficeUserWithPrivileges(suite.DB(), []factory.Customization{
+			{
+				Model: models.User{
+					Privileges: []roles.Privilege{
+						{
+							PrivilegeType: roles.PrivilegeTypeSupervisor,
+						},
+					},
+					Roles: []roles.Role{
+						{
+							RoleType: roles.RoleTypeServicesCounselor,
+						},
+					},
+				},
+			},
+		}, nil)
+
+		params := requestedofficeuserop.GetRequestedOfficeUserParams{
+			HTTPRequest:  suite.setupAuthenticatedRequest("GET", fmt.Sprintf("/requested_office_users/%s", requestedOfficeUser.ID)),
+			OfficeUserID: strfmt.UUID(requestedOfficeUser.ID.String()),
+		}
+
+		requestedOfficeUserFetcher := &mocks.RequestedOfficeUserFetcher{}
+		requestedOfficeUserFetcher.On("FetchRequestedOfficeUser",
+			mock.AnythingOfType("*appcontext.appContext"),
+			mock.Anything,
+		).Return(requestedOfficeUser, nil).Once()
+
+		mockRoleFetcher := &mocks.RoleFetcher{}
+		userPrivilegeAssociator := &mocks.UserPrivilegeAssociator{}
+
+		mockPrivileges := []roles.Privilege{
+			{
+				ID:            uuid.Must(uuid.NewV4()),
+				PrivilegeType: roles.PrivilegeTypeSupervisor,
+				PrivilegeName: "Supervisor",
+				CreatedAt:     time.Now(),
+				UpdatedAt:     time.Now(),
+			},
+		}
+
+		mockRoles := roles.Roles{
+			roles.Role{
+				ID:        uuid.Must(uuid.NewV4()),
+				RoleType:  roles.RoleTypeTOO,
+				RoleName:  "Task Ordering Officer",
+				CreatedAt: time.Now(),
+				UpdatedAt: time.Now(),
+			},
+		}
+		mockRoleFetcher.On(
+			"FetchRolesForUser",
+			mock.AnythingOfType("*appcontext.appContext"),
+			mock.Anything,
+		).Return(mockRoles, nil)
+
+		userPrivilegeAssociator.On(
+			"FetchPrivilegesForUser",
+			mock.AnythingOfType("*appcontext.appContext"),
+			mock.Anything,
+		).Return(mockPrivileges, nil)
+
+		handler := GetRequestedOfficeUserHandler{
+			suite.HandlerConfig(),
+			requestedOfficeUserFetcher,
+			userPrivilegeAssociator,
+			mockRoleFetcher,
+			newMockQueryFilterBuilder(&mocks.QueryFilter{}),
+		}
+
+		response := handler.Handle(params)
+		suite.IsType(&requestedofficeuserop.GetRequestedOfficeUserOK{}, response)
+		okResponse := response.(*requestedofficeuserop.GetRequestedOfficeUserOK)
+		suite.Equal(requestedOfficeUser.ID.String(), okResponse.Payload.ID.String())
+		suite.Len(okResponse.Payload.Privileges, 1)
+		suite.Equal("Supervisor", okResponse.Payload.Privileges[0].PrivilegeName)
+		suite.Equal(string(roles.PrivilegeTypeSupervisor), okResponse.Payload.Privileges[0].PrivilegeType)
+	})
+
+}
+
+func (suite *HandlerSuite) TestUpdateRequestedOfficeUserHandler_WithSupervisorPrivilege() {
+	suite.Run("test - update requested office user handler with privileges", func() {
+		tooRoleName := "Task Ordering Officer"
+		tooRoleType := string(roles.RoleTypeTOO)
+		supervisorPrivilegeName := "Supervisor"
+		supervisorPrivilegeType := string(roles.PrivilegeTypeSupervisor)
+		requestedOfficeUser := factory.BuildOfficeUserWithPrivileges(suite.DB(), []factory.Customization{
+			{
+				Model: models.User{
+					Privileges: []roles.Privilege{
+						{
+							PrivilegeType: roles.PrivilegeTypeSupervisor,
+						},
+					},
+					Roles: []roles.Role{
+						{
+							RoleType: roles.RoleTypeTOO,
+						},
+					},
+				},
+			},
+		}, nil)
+
+		officeUser := models.OfficeUser{ID: requestedOfficeUser.ID, FirstName: "Billy", LastName: "Bob", UserID: requestedOfficeUser.UserID, CreatedAt: time.Now(),
+			UpdatedAt: time.Now()}
+
+		mockUserRoleAssociator := &mocks.UserRoleAssociator{}
+		mockRoleFetcher := &mocks.RoleFetcher{}
+		requestedOfficeUserUpdater := &mocks.RequestedOfficeUserUpdater{}
+		userPrivilegeAssociator := &mocks.UserPrivilegeAssociator{}
+
+		params := requestedofficeuserop.UpdateRequestedOfficeUserParams{
+			HTTPRequest: suite.setupAuthenticatedRequest("PATCH", fmt.Sprintf("/requested_office_users/%s", requestedOfficeUser.ID)),
+			Body: &adminmessages.RequestedOfficeUserUpdate{
+				Roles: []*adminmessages.OfficeUserRole{
+					{
+						Name:     &tooRoleName,
+						RoleType: &tooRoleType,
+					},
+				},
+				Privileges: []*adminmessages.OfficeUserPrivilege{
+					{
+						Name:          &supervisorPrivilegeName,
+						PrivilegeType: &supervisorPrivilegeType,
+					},
+				},
+			},
+			OfficeUserID: strfmt.UUID(requestedOfficeUser.ID.String()),
+		}
+
+		requestedOfficeUserUpdater.On("UpdateRequestedOfficeUser",
+			mock.AnythingOfType("*appcontext.appContext"),
+			mock.Anything,
+			mock.Anything,
+		).Return(&officeUser, nil, nil).Once()
+
+		mockRoles := roles.Roles{
+			roles.Role{
+				ID:        uuid.Must(uuid.NewV4()),
+				RoleType:  roles.RoleTypeTOO,
+				RoleName:  "Task Ordering Officer",
+				CreatedAt: time.Now(),
+				UpdatedAt: time.Now(),
+			},
+		}
+		mockPrivileges := []roles.Privilege{
+			{
+				ID:            uuid.Must(uuid.NewV4()),
+				PrivilegeType: roles.PrivilegeTypeSupervisor,
+				PrivilegeName: "Supervisor",
+				CreatedAt:     time.Now(),
+				UpdatedAt:     time.Now(),
+			},
+		}
+
+		mockUserRoleAssociator.On(
+			"UpdateUserRoles",
+			mock.AnythingOfType("*appcontext.appContext"),
+			mock.Anything,
+			mock.Anything,
+		).Return(nil, nil, nil).Once()
+
+		userPrivilegeAssociator.On(
+			"UpdateUserPrivileges",
+			mock.AnythingOfType("*appcontext.appContext"),
+			mock.Anything,
+			mock.Anything,
+		).Return(nil, nil, nil).Once()
+
+		userPrivilegeAssociator.On(
+			"FetchPrivilegesForUser",
+			mock.AnythingOfType("*appcontext.appContext"),
+			mock.Anything,
+		).Return(mockPrivileges, nil)
+		mockRoleFetcher.On(
+			"FetchRolesForUser",
+			mock.AnythingOfType("*appcontext.appContext"),
+			mock.Anything,
+		).Return(mockRoles, nil)
+
+		handler := UpdateRequestedOfficeUserHandler{
+			suite.HandlerConfig(),
+			requestedOfficeUserUpdater,
+			userPrivilegeAssociator,
+			mockUserRoleAssociator,
+			mockRoleFetcher,
+		}
+
+		response := handler.Handle(params)
+		suite.IsType(&requestedofficeuserop.UpdateRequestedOfficeUserOK{}, response)
+		okResponse := response.(*requestedofficeuserop.UpdateRequestedOfficeUserOK)
+		suite.Equal(officeUser.ID.String(), okResponse.Payload.ID.String())
+		suite.Len(okResponse.Payload.Privileges, 1)
+		suite.Equal(supervisorPrivilegeName, okResponse.Payload.Privileges[0].PrivilegeName)
+		suite.Equal(supervisorPrivilegeType, okResponse.Payload.Privileges[0].PrivilegeType)
 	})
 }
 
@@ -667,6 +957,16 @@ func (suite *HandlerSuite) TestUpdateRequestedOfficeUserHandlerWithoutOktaAccoun
 			},
 		}, []roles.RoleType{roles.RoleTypeTOO})
 
+		requestedOfficeUser.User.Privileges = []roles.Privilege{
+			{
+				ID:            uuid.Must(uuid.NewV4()),
+				PrivilegeType: roles.PrivilegeTypeSupervisor,
+				PrivilegeName: "Supervisor",
+				CreatedAt:     time.Now(),
+				UpdatedAt:     time.Now(),
+			},
+		}
+
 		officeUserID := requestedOfficeUser.ID
 		officeUser := models.OfficeUser{ID: officeUserID, FirstName: "Billy", LastName: "Bob", UserID: requestedOfficeUser.UserID, CreatedAt: time.Now(),
 			UpdatedAt: time.Now()}
@@ -674,6 +974,7 @@ func (suite *HandlerSuite) TestUpdateRequestedOfficeUserHandlerWithoutOktaAccoun
 		mockUserRoleAssociator := &mocks.UserRoleAssociator{}
 		mockRoleFetcher := &mocks.RoleFetcher{}
 		requestedOfficeUserUpdater := &mocks.RequestedOfficeUserUpdater{}
+		userPrivilegeAssociator := &mocks.UserPrivilegeAssociator{}
 
 		params := requestedofficeuserop.UpdateRequestedOfficeUserParams{
 			HTTPRequest: suite.setupAuthenticatedRequest("PATCH", fmt.Sprintf("/requested_office_users/%s", officeUserID)),
@@ -723,6 +1024,7 @@ func (suite *HandlerSuite) TestUpdateRequestedOfficeUserHandlerWithoutOktaAccoun
 		handler := UpdateRequestedOfficeUserHandler{
 			suite.NewHandlerConfig(),
 			requestedOfficeUserUpdater,
+			userPrivilegeAssociator,
 			mockUserRoleAssociator,
 			mockRoleFetcher,
 		}
@@ -778,6 +1080,7 @@ func (suite *HandlerSuite) TestUpdateRequestedOfficeUserHandlerWithOktaAccountCr
 		mockUserRoleAssociator := &mocks.UserRoleAssociator{}
 		mockRoleFetcher := &mocks.RoleFetcher{}
 		requestedOfficeUserUpdater := &mocks.RequestedOfficeUserUpdater{}
+		userPrivilegeAssociator := &mocks.UserPrivilegeAssociator{}
 
 		status := "APPROVED"
 		email := "example@example.com"
@@ -838,6 +1141,7 @@ func (suite *HandlerSuite) TestUpdateRequestedOfficeUserHandlerWithOktaAccountCr
 		handler := UpdateRequestedOfficeUserHandler{
 			suite.NewHandlerConfig(),
 			requestedOfficeUserUpdater,
+			userPrivilegeAssociator,
 			mockUserRoleAssociator,
 			mockRoleFetcher,
 		}
@@ -886,6 +1190,7 @@ func (suite *HandlerSuite) TestUpdateRequestedOfficeUserHandlerWithOktaAccountCr
 		mockUserRoleAssociator := &mocks.UserRoleAssociator{}
 		mockRoleFetcher := &mocks.RoleFetcher{}
 		requestedOfficeUserUpdater := &mocks.RequestedOfficeUserUpdater{}
+		userPrivilegeAssociator := &mocks.UserPrivilegeAssociator{}
 
 		status := "APPROVED"
 		email := "example@example.com"
@@ -946,6 +1251,7 @@ func (suite *HandlerSuite) TestUpdateRequestedOfficeUserHandlerWithOktaAccountCr
 		handler := UpdateRequestedOfficeUserHandler{
 			suite.NewHandlerConfig(),
 			requestedOfficeUserUpdater,
+			userPrivilegeAssociator,
 			mockUserRoleAssociator,
 			mockRoleFetcher,
 		}

--- a/pkg/testdatagen/testharness/dispatch.go
+++ b/pkg/testdatagen/testharness/dispatch.go
@@ -248,6 +248,9 @@ var actionDispatcher = map[string]actionFunc{
 	"RequestedOfficeUser": func(appCtx appcontext.AppContext) testHarnessResponse {
 		return MakeRequestedOfficeUserWithTOO(appCtx)
 	},
+	"RequestedOfficeUserWithPrivilege": func(appCtx appcontext.AppContext) testHarnessResponse {
+		return MakeRequestedOfficeUserWithPrivilege(appCtx)
+	},
 	"RejectedOfficeUser": func(appCtx appcontext.AppContext) testHarnessResponse {
 		return MakeRejectedOfficeUserWithTOO(appCtx)
 	},

--- a/pkg/testdatagen/testharness/make_office_user.go
+++ b/pkg/testdatagen/testharness/make_office_user.go
@@ -71,7 +71,8 @@ func MakeRequestedOfficeUserWithTOO(appCtx appcontext.AppContext) models.User {
 
 	email := strings.ToLower(fmt.Sprintf("fred_office_%s@example.com",
 		testdatagen.MakeRandomString(5)))
-
+	dodID := testdatagen.MakeRandomNumberString(10)
+	otherUniqueID := testdatagen.MakeRandomNumberString(10)
 	user := factory.BuildUser(appCtx.DB(), []factory.Customization{
 		{
 			Model: models.User{
@@ -81,23 +82,37 @@ func MakeRequestedOfficeUserWithTOO(appCtx appcontext.AppContext) models.User {
 			},
 		},
 	}, nil)
+	transportationOffice := factory.BuildTransportationOffice(appCtx.DB(), nil, nil)
 	requestedStatus := models.OfficeUserStatusREQUESTED
 	factory.BuildOfficeUserWithRoles(appCtx.DB(), []factory.Customization{
 		{
 			Model: models.OfficeUser{
-				Email:  email,
-				Active: true,
-				UserID: &user.ID,
-				Status: &requestedStatus,
+				Email:         email,
+				Active:        true,
+				UserID:        &user.ID,
+				Status:        &requestedStatus,
+				EDIPI:         models.StringPointer(dodID),
+				OtherUniqueID: models.StringPointer(otherUniqueID),
 			},
+		},
+		{
+			Model:    transportationOffice,
+			LinkOnly: true,
 		},
 		{
 			Model:    user,
 			LinkOnly: true,
 		},
-	}, []roles.RoleType{roles.RoleTypeTOO, roles.RoleTypeTIO})
+	}, []roles.RoleType{roles.RoleTypeTOO, roles.RoleTypeServicesCounselor})
 
 	factory.BuildServiceMember(appCtx.DB(), []factory.Customization{
+		{
+			Model:    user,
+			LinkOnly: true,
+		},
+	}, nil)
+
+	factory.BuildTransportationOffice(appCtx.DB(), []factory.Customization{
 		{
 			Model:    user,
 			LinkOnly: true,
@@ -391,5 +406,61 @@ func MakeOfficeUserWithGSR(appCtx appcontext.AppContext) models.User {
 		},
 	}, nil)
 
+	return user
+}
+
+func MakeRequestedOfficeUserWithPrivilege(appCtx appcontext.AppContext) models.User {
+	email := strings.ToLower(fmt.Sprintf("leo_spaceman_%s@example.mil", testdatagen.MakeRandomString(5)))
+	dodID := testdatagen.MakeRandomNumberString(10)
+	otherUniqueID := testdatagen.MakeRandomNumberString(10)
+
+	user := factory.BuildUser(appCtx.DB(), []factory.Customization{
+		{
+			Model: models.User{
+				OktaEmail: email,
+				Active:    true,
+				Roles: []roles.Role{{
+					RoleType: roles.RoleTypeServicesCounselor,
+				},
+					{
+						RoleType: roles.RoleTypeTOO,
+					},
+				},
+				Privileges: []roles.Privilege{{
+					PrivilegeType: roles.PrivilegeTypeSupervisor,
+				}},
+			},
+		},
+	}, nil)
+
+	transportationOffice := factory.BuildTransportationOffice(appCtx.DB(), nil, nil)
+	requestedStatus := models.OfficeUserStatusREQUESTED
+	factory.BuildOfficeUserWithPrivileges(appCtx.DB(), []factory.Customization{
+		{
+			Model: models.OfficeUser{
+				Email:         email,
+				Active:        true,
+				UserID:        &user.ID,
+				Status:        &requestedStatus,
+				EDIPI:         models.StringPointer(dodID),
+				OtherUniqueID: models.StringPointer(otherUniqueID),
+			},
+		},
+		{
+			Model:    transportationOffice,
+			LinkOnly: true,
+		},
+		{
+			Model:    user,
+			LinkOnly: true,
+		},
+	}, nil)
+
+	factory.BuildServiceMember(appCtx.DB(), []factory.Customization{
+		{
+			Model:    user,
+			LinkOnly: true,
+		},
+	}, nil)
 	return user
 }

--- a/playwright/tests/admin/officeUsers.spec.js
+++ b/playwright/tests/admin/officeUsers.spec.js
@@ -161,77 +161,28 @@ test.describe('Office User Create Page', () => {
     // Define constants for privileges
     const supervisorCheckbox = page.getByLabel('Supervisor', { exact: true });
 
-    // Check roles that cannot have supervisor priveleges
-    await customerCheckbox.click();
-    await supervisorCheckbox.click();
-    await expect(customerCheckbox).toBeChecked();
-    await expect(supervisorCheckbox).not.toBeChecked();
-    await customerCheckbox.click();
-    await contractingOfficerCheckbox.click();
-    await supervisorCheckbox.click();
-    await expect(contractingOfficerCheckbox).toBeChecked();
-    await expect(supervisorCheckbox).not.toBeChecked();
-    await contractingOfficerCheckbox.click();
-    await primeSimulatorCheckbox.click();
-    await supervisorCheckbox.click();
-    await expect(primeSimulatorCheckbox).toBeChecked();
-    await expect(supervisorCheckbox).not.toBeChecked();
-    await primeSimulatorCheckbox.click();
-    await qualityAssuranceEvaluatorCheckbox.click();
-    await supervisorCheckbox.click();
-    await expect(qualityAssuranceEvaluatorCheckbox).toBeChecked();
-    await expect(supervisorCheckbox).not.toBeChecked();
-    await qualityAssuranceEvaluatorCheckbox.click();
-    await customerServiceRepersentativeCheckbox.click();
-    await supervisorCheckbox.click();
-    await expect(customerServiceRepersentativeCheckbox).toBeChecked();
-    await expect(supervisorCheckbox).not.toBeChecked();
-    await customerServiceRepersentativeCheckbox.click();
-    await governmentSurveillanceRepresentativeCheckbox.click();
-    await supervisorCheckbox.click();
-    await expect(governmentSurveillanceRepresentativeCheckbox).toBeChecked();
-    await expect(supervisorCheckbox).not.toBeChecked();
-    await governmentSurveillanceRepresentativeCheckbox.click();
-    await headquartersCheckbox.click();
-    await supervisorCheckbox.click();
-    await expect(headquartersCheckbox).toBeChecked();
-    await expect(supervisorCheckbox).not.toBeChecked();
-    await headquartersCheckbox.click();
-
-    // Check roles that can have supervisor priveleges
-    await taskOrderingOfficerCheckbox.click();
-    await supervisorCheckbox.click();
-    await expect(taskOrderingOfficerCheckbox).toBeChecked();
-    await expect(supervisorCheckbox).toBeChecked();
-    await taskOrderingOfficerCheckbox.click();
-    await supervisorCheckbox.click();
-    await taskInvoicingOfficerCheckbox.click();
-    await supervisorCheckbox.click();
-    await expect(taskInvoicingOfficerCheckbox).toBeChecked();
-    await expect(supervisorCheckbox).toBeChecked();
-    await taskInvoicingOfficerCheckbox.click();
-    await supervisorCheckbox.click();
-    await servicesCounselorCheckbox.click();
-    await supervisorCheckbox.click();
-    await expect(servicesCounselorCheckbox).toBeChecked();
-    await expect(supervisorCheckbox).toBeChecked();
-    await servicesCounselorCheckbox.click();
-
-    // Check selecting roles after having supervisor selected for unallowed roles
-    await customerCheckbox.click();
-    await expect(customerCheckbox).not.toBeChecked();
-    await contractingOfficerCheckbox.click();
-    await expect(contractingOfficerCheckbox).not.toBeChecked();
-    await primeSimulatorCheckbox.click();
-    await expect(primeSimulatorCheckbox).not.toBeChecked();
-    await qualityAssuranceEvaluatorCheckbox.click();
-    await expect(qualityAssuranceEvaluatorCheckbox).not.toBeChecked();
-    await customerServiceRepersentativeCheckbox.click();
-    await expect(customerServiceRepersentativeCheckbox).not.toBeChecked();
-    await governmentSurveillanceRepresentativeCheckbox.click();
-    await expect(governmentSurveillanceRepresentativeCheckbox).not.toBeChecked();
-    await headquartersCheckbox.click();
-    await expect(headquartersCheckbox).not.toBeChecked();
+    // Test that each role can be selected together with Supervisor, and both checkboxes reflect the checked state
+    const allRoleCheckboxes = [
+      customerCheckbox,
+      contractingOfficerCheckbox,
+      servicesCounselorCheckbox,
+      primeSimulatorCheckbox,
+      qualityAssuranceEvaluatorCheckbox,
+      customerServiceRepersentativeCheckbox,
+      governmentSurveillanceRepresentativeCheckbox,
+      headquartersCheckbox,
+      taskOrderingOfficerCheckbox,
+      taskInvoicingOfficerCheckbox,
+    ];
+    for (const roleCheckbox of allRoleCheckboxes) {
+      await roleCheckbox.click();
+      await supervisorCheckbox.click();
+      await expect(roleCheckbox).toBeChecked();
+      await expect(supervisorCheckbox).toBeChecked();
+      // Uncheck for next iteration
+      await supervisorCheckbox.click();
+      await roleCheckbox.click();
+    }
 
     // Check selecting roles after having supervisor selected for allowed roles
     await taskOrderingOfficerCheckbox.click();
@@ -459,77 +410,28 @@ test.describe('Office Users Edit Page', () => {
     await taskOrderingOfficerCheckbox.click();
     await taskInvoicingOfficerCheckbox.click();
 
-    // Check roles that cannot have supervisor priveleges
-    await customerCheckbox.click();
-    await supervisorCheckbox.click();
-    await expect(customerCheckbox).toBeChecked();
-    await expect(supervisorCheckbox).not.toBeChecked();
-    await customerCheckbox.click();
-    await contractingOfficerCheckbox.click();
-    await supervisorCheckbox.click();
-    await expect(contractingOfficerCheckbox).toBeChecked();
-    await expect(supervisorCheckbox).not.toBeChecked();
-    await contractingOfficerCheckbox.click();
-    await primeSimulatorCheckbox.click();
-    await supervisorCheckbox.click();
-    await expect(primeSimulatorCheckbox).toBeChecked();
-    await expect(supervisorCheckbox).not.toBeChecked();
-    await primeSimulatorCheckbox.click();
-    await qualityAssuranceEvaluatorCheckbox.click();
-    await supervisorCheckbox.click();
-    await expect(qualityAssuranceEvaluatorCheckbox).toBeChecked();
-    await expect(supervisorCheckbox).not.toBeChecked();
-    await qualityAssuranceEvaluatorCheckbox.click();
-    await customerServiceRepersentativeCheckbox.click();
-    await supervisorCheckbox.click();
-    await expect(customerServiceRepersentativeCheckbox).toBeChecked();
-    await expect(supervisorCheckbox).not.toBeChecked();
-    await customerServiceRepersentativeCheckbox.click();
-    await governmentSurveillanceRepresentativeCheckbox.click();
-    await supervisorCheckbox.click();
-    await expect(governmentSurveillanceRepresentativeCheckbox).toBeChecked();
-    await expect(supervisorCheckbox).not.toBeChecked();
-    await governmentSurveillanceRepresentativeCheckbox.click();
-    await headquartersCheckbox.click();
-    await supervisorCheckbox.click();
-    await expect(headquartersCheckbox).toBeChecked();
-    await expect(supervisorCheckbox).not.toBeChecked();
-    await headquartersCheckbox.click();
-
-    // Check roles that can have supervisor priveleges
-    await taskOrderingOfficerCheckbox.click();
-    await supervisorCheckbox.click();
-    await expect(taskOrderingOfficerCheckbox).toBeChecked();
-    await expect(supervisorCheckbox).toBeChecked();
-    await taskOrderingOfficerCheckbox.click();
-    await supervisorCheckbox.click();
-    await taskInvoicingOfficerCheckbox.click();
-    await supervisorCheckbox.click();
-    await expect(taskInvoicingOfficerCheckbox).toBeChecked();
-    await expect(supervisorCheckbox).toBeChecked();
-    await taskInvoicingOfficerCheckbox.click();
-    await supervisorCheckbox.click();
-    await servicesCounselorCheckbox.click();
-    await supervisorCheckbox.click();
-    await expect(servicesCounselorCheckbox).toBeChecked();
-    await expect(supervisorCheckbox).toBeChecked();
-    await servicesCounselorCheckbox.click();
-
-    // Check selecting roles after having supervisor selected for unallowed roles
-    await customerCheckbox.click();
-    await expect(customerCheckbox).not.toBeChecked();
-    await contractingOfficerCheckbox.click();
-    await expect(contractingOfficerCheckbox).not.toBeChecked();
-    await primeSimulatorCheckbox.click();
-    await expect(primeSimulatorCheckbox).not.toBeChecked();
-    await qualityAssuranceEvaluatorCheckbox.click();
-    await expect(qualityAssuranceEvaluatorCheckbox).not.toBeChecked();
-    await customerServiceRepersentativeCheckbox.click();
-    await expect(customerServiceRepersentativeCheckbox).not.toBeChecked();
-    await governmentSurveillanceRepresentativeCheckbox.click();
-    await expect(governmentSurveillanceRepresentativeCheckbox).not.toBeChecked();
-    await headquartersCheckbox.click();
-    await expect(headquartersCheckbox).not.toBeChecked();
+    // Test that each role can be selected together with Supervisor, and both checkboxes reflect the checked state
+    const allRoleCheckboxes = [
+      customerCheckbox,
+      contractingOfficerCheckbox,
+      servicesCounselorCheckbox,
+      primeSimulatorCheckbox,
+      qualityAssuranceEvaluatorCheckbox,
+      customerServiceRepersentativeCheckbox,
+      governmentSurveillanceRepresentativeCheckbox,
+      headquartersCheckbox,
+      taskOrderingOfficerCheckbox,
+      taskInvoicingOfficerCheckbox,
+    ];
+    for (const roleCheckbox of allRoleCheckboxes) {
+      await roleCheckbox.click();
+      await supervisorCheckbox.click();
+      await expect(roleCheckbox).toBeChecked();
+      await expect(supervisorCheckbox).toBeChecked();
+      // Uncheck for next iteration
+      await supervisorCheckbox.click();
+      await roleCheckbox.click();
+    }
 
     // Check selecting roles after having supervisor selected for allowed roles
     await taskOrderingOfficerCheckbox.click();

--- a/playwright/tests/admin/requestedOfficeUser.spec.js
+++ b/playwright/tests/admin/requestedOfficeUser.spec.js
@@ -1,0 +1,286 @@
+import { test, expect } from '../utils/admin/adminTest';
+
+const requestAccountPrivileges = process.env.FEATURE_FLAG_REQUEST_ACCOUNT_PRIVILEGES;
+// Helper function to search for a user by email
+async function searchForUserByEmail(page, email) {
+  await page.getByPlaceholder('Search').click();
+  await page.getByPlaceholder('Search').fill(email);
+  await page.getByPlaceholder('Search').press('Enter');
+}
+
+// Helper function to verify no privileges assigned for an office user
+async function verifyNoPrivilegesAssigned(page, adminPage, email) {
+  await page.goto('/system/office-users');
+  await searchForUserByEmail(page, email);
+  await page.getByText(email).click();
+  await adminPage.waitForPage.adminPage();
+  await expect(page.getByText(/No privileges assigned to this office user/i)).toBeVisible();
+}
+
+// Helper function to verify privilege assigned for an office user
+async function verifyPrivilegeAssigned(page, adminPage, email, privilege = 'supervisor') {
+  await page.goto('/system/office-users');
+  await searchForUserByEmail(page, email);
+  await page.getByText(email).click();
+  await adminPage.waitForPage.adminPage();
+  await expect(page.getByText(/privilege name/i)).toBeVisible();
+  // Use a case-insensitive string match for privilege
+  await expect(page.getByText(privilege, { exact: false })).toBeVisible();
+}
+
+test.describe('RequestedOfficeUserShow', () => {
+  test('approve requested office user with out privilege ', async ({ page, adminPage }) => {
+    // Build a requested office user with a privilege request
+    const officeUser = await adminPage.testHarness.buildRequestedOfficeUser();
+    const testEmail = officeUser.okta_email;
+
+    // Sign in as a new admin user
+    await adminPage.signInAsNewAdminUser();
+
+    // Navigate to the requested office users admin page
+    await page.goto('/system/requested-office-users');
+
+    // Search for the test office user by email
+    await searchForUserByEmail(page, testEmail);
+
+    // Click on the user's email to go to their detail page
+    await page.getByText(testEmail).click();
+    await adminPage.waitForPage.adminPage();
+
+    // Click the Approve button to open the privilege confirm dialog
+    await page
+      .getByRole('button', { name: /approve/i })
+      .first()
+      .click();
+
+    // Assert the privilege confirm dialog is closed
+    await expect(page.locator('[data-testid="RequestedOfficeUserPrivilegeConfirm"]')).toBeHidden();
+
+    // Use helper to verify no privileges assigned
+    await verifyNoPrivilegesAssigned(page, adminPage, testEmail);
+  });
+
+  test('approve and verify rejected requested privilege not assigned to office user', async ({ page, adminPage }) => {
+    test.skip(requestAccountPrivileges === 'false', 'Skip if request account privileges feature flag is disabled');
+    // Build a requested office user with a privilege request
+    const officeUser = await adminPage.testHarness.buildRequestedOfficeUserWithPrivilege();
+    const testEmail = officeUser.okta_email;
+
+    // Sign in as a new admin user
+    await adminPage.signInAsNewAdminUser();
+
+    // Navigate to the requested office users admin page
+    await page.goto('/system/requested-office-users');
+
+    // Search for the test office user by email
+    await searchForUserByEmail(page, testEmail);
+
+    // Click on the user's email to go to their detail page
+    await page.getByText(testEmail).click();
+    await adminPage.waitForPage.adminPage();
+
+    // Click the Approve button to open the privilege confirm dialog
+    await page
+      .getByRole('button', { name: /approve/i })
+      .first()
+      .click();
+
+    // Assert the privilege confirm dialog is visible
+    await expect(page.locator('[data-testid="RequestedOfficeUserPrivilegeConfirm"]')).toBeVisible();
+
+    // Find the checkbox labeled 'Supervisor' and uncheck it if checked
+    const supervisorCheckbox = page.getByRole('checkbox', { name: /supervisor/i });
+    if (await supervisorCheckbox.isChecked()) {
+      await supervisorCheckbox.uncheck();
+    }
+
+    // Click the Confirm button to approve the privilege (with checkbox unchecked)
+    await page.getByRole('button', { name: /confirm/i }).click();
+
+    await expect(page.locator('[data-testid="RequestedOfficeUserPrivilegeConfirm"]')).toBeHidden();
+    await verifyNoPrivilegesAssigned(page, adminPage, testEmail);
+  });
+
+  test('approve and verify privilege assigned to office user', async ({ page, adminPage }) => {
+    test.skip(requestAccountPrivileges === 'false', 'Skip if request account privileges feature flag is disabled');
+    // Build a requested office user with a privilege request
+    const officeUser = await adminPage.testHarness.buildRequestedOfficeUserWithPrivilege();
+    const testEmail = officeUser.okta_email;
+
+    // Sign in as a new admin user
+    await adminPage.signInAsNewAdminUser();
+
+    // Navigate to the requested office users admin page
+    await page.goto('/system/requested-office-users');
+
+    // Search for the test office user by email
+    await searchForUserByEmail(page, testEmail);
+
+    // Click on the user's email to go to their detail page
+    await page.getByText(testEmail).click();
+    await adminPage.waitForPage.adminPage();
+
+    // Click the Approve button to open the privilege confirm dialog
+    await page
+      .getByRole('button', { name: /approve/i })
+      .first()
+      .click();
+
+    // Assert the privilege confirm dialog is visible
+    await expect(page.locator('[data-testid="RequestedOfficeUserPrivilegeConfirm"]')).toBeVisible();
+
+    // Find the checkbox labeled 'Supervisor' and check it if not already checked
+    const supervisorCheckbox = page.getByRole('checkbox', { name: /supervisor/i });
+    await expect(supervisorCheckbox).toBeVisible();
+    await expect(await supervisorCheckbox.isChecked()).toBeTruthy();
+
+    // Click the Confirm button to approve the privilege
+    await page.getByRole('button', { name: /confirm/i }).click();
+
+    // Assert the privilege confirm dialog is closed
+    await expect(page.locator('[data-testid="RequestedOfficeUserPrivilegeConfirm"]')).toBeHidden();
+
+    // Use helper to verify privilege assigned
+    await verifyPrivilegeAssigned(page, adminPage, testEmail);
+  });
+});
+
+test.describe('RequestedOfficeUserEdit', () => {
+  test('assign privilege and approve a requested office user who initially has no privileges', async ({
+    page,
+    adminPage,
+  }) => {
+    // Build a requested office user with no privileges
+    const officeUser = await adminPage.testHarness.buildRequestedOfficeUser();
+    const testEmail = officeUser.okta_email;
+
+    // Sign in as a new admin user
+    await adminPage.signInAsNewAdminUser();
+
+    // Go to the requested office users admin page
+    await page.goto('/system/requested-office-users');
+
+    // Search for the office user by email
+    await searchForUserByEmail(page, testEmail);
+
+    // Open the user's detail page
+    await page.getByText(testEmail).click();
+    await adminPage.waitForPage.adminPage();
+
+    // Open the Edit page for the user
+    await page.getByRole('link', { name: 'Edit' }).first().click();
+    await adminPage.waitForPage.adminPage();
+
+    // Ensure Supervisor privilege is not checked, then check it
+    const supervisorCheckbox = page.getByRole('checkbox', { name: /supervisor/i });
+    await expect(supervisorCheckbox).toBeVisible();
+    await expect(await supervisorCheckbox.isChecked()).toBeFalsy();
+    await supervisorCheckbox.check();
+
+    await page
+      .getByRole('button', { name: /approve/i })
+      .first()
+      .click();
+
+    // Verify Supervisor privilege is assigned
+    await verifyPrivilegeAssigned(page, adminPage, testEmail);
+  });
+
+  test('approve and verify requested office user with privilege', async ({ page, adminPage }) => {
+    test.skip(requestAccountPrivileges === 'false', 'Skip if request account privileges feature flag is disabled');
+    // Build a requested office user with Supervisor privilege requested
+    const officeUser = await adminPage.testHarness.buildRequestedOfficeUserWithPrivilege();
+    const testEmail = officeUser.okta_email;
+
+    // Sign in as a new admin user
+    await adminPage.signInAsNewAdminUser();
+
+    // Go to the requested office users admin page
+    await page.goto('/system/requested-office-users');
+
+    // Search for the office user by email
+    await searchForUserByEmail(page, testEmail);
+
+    // Open the user's detail page
+    await page.getByText(testEmail).click();
+    await adminPage.waitForPage.adminPage();
+
+    // Open the Edit page for the user
+    await page.getByRole('link', { name: 'Edit' }).first().click();
+    await adminPage.waitForPage.adminPage();
+
+    // Ensure Supervisor privilege is checked
+    const supervisorEditCheckbox = page.getByRole('checkbox', { name: /supervisor/i });
+    await expect(supervisorEditCheckbox).toBeVisible();
+    await expect(await supervisorEditCheckbox.isChecked()).toBeTruthy();
+
+    // Open the privilege confirm dialog
+    await page
+      .getByRole('button', { name: /approve/i })
+      .first()
+      .click();
+
+    // Assert the privilege confirm dialog is visible
+    await expect(page.locator('[data-testid="RequestedOfficeUserPrivilegeConfirm"]')).toBeVisible();
+
+    // Ensure Supervisor privilege is checked in the dialog
+    const supervisorDialogCheckbox = page.getByRole('checkbox', { name: /supervisor/i });
+    if (await !supervisorDialogCheckbox.isChecked()) {
+      await supervisorDialogCheckbox.check();
+    }
+
+    // Confirm the privilege assignment
+    await page.getByRole('button', { name: /confirm/i }).click();
+
+    // Assert the dialog is closed and privilege is assigned
+    await expect(page.locator('[data-testid="RequestedOfficeUserPrivilegeConfirm"]')).toBeHidden();
+    await verifyPrivilegeAssigned(page, adminPage, testEmail);
+  });
+
+  // Reject privilege and approve requested office user who requested a privilege
+  test('reject privilege and approve requested office user who requested a privilege', async ({ page, adminPage }) => {
+    test.skip(requestAccountPrivileges === 'false', 'Skip if request account privileges feature flag is disabled');
+    // Build a requested office user with Supervisor privilege requested
+    const officeUser = await adminPage.testHarness.buildRequestedOfficeUserWithPrivilege();
+    const testEmail = officeUser.okta_email;
+
+    // Sign in as a new admin user
+    await adminPage.signInAsNewAdminUser();
+
+    // Go to the requested office users admin page
+    await page.goto('/system/requested-office-users');
+
+    // Search for the office user by email
+    await searchForUserByEmail(page, testEmail);
+
+    // Open the user's detail page
+    await page.getByText(testEmail).click();
+    await adminPage.waitForPage.adminPage();
+
+    // Open the Edit page for the user
+    await page.getByRole('link', { name: 'Edit' }).first().click();
+    await adminPage.waitForPage.adminPage();
+
+    // Open the privilege confirm dialog
+    await page
+      .getByRole('button', { name: /approve/i })
+      .first()
+      .click();
+
+    // Assert the privilege confirm dialog is visible
+    await expect(page.locator('[data-testid="RequestedOfficeUserPrivilegeConfirm"]')).toBeVisible();
+
+    // Uncheck Supervisor privilege in the dialog if checked
+    const supervisorCheckbox = page.getByRole('checkbox', { name: /supervisor/i });
+    if (await supervisorCheckbox.isChecked()) {
+      await supervisorCheckbox.uncheck();
+    }
+
+    // Confirm the privilege rejection
+    await page.getByRole('button', { name: /confirm/i }).click();
+
+    // Assert the dialog is closed and no privileges are assigned
+    await expect(page.locator('[data-testid="RequestedOfficeUserPrivilegeConfirm"]')).toBeHidden();
+    await verifyNoPrivilegesAssigned(page, adminPage, testEmail);
+  });
+});

--- a/playwright/tests/utils/testharness.js
+++ b/playwright/tests/utils/testharness.js
@@ -101,6 +101,14 @@ export class TestHarness {
   }
 
   /**
+   * build requested office user with a privilege request
+   * @returns {Promise<User>}
+   */
+  async buildRequestedOfficeUserWithPrivilege() {
+    return this.buildDefault('RequestedOfficeUserWithPrivilege');
+  }
+
+  /**
    * @returns {Promise<User>}
    */
   async buildRejectedOfficeUser() {

--- a/src/pages/Admin/RequestedOfficeUsers/RequestedOfficeUserEdit.jsx
+++ b/src/pages/Admin/RequestedOfficeUsers/RequestedOfficeUserEdit.jsx
@@ -1,5 +1,5 @@
 import { Alert } from '@trussworks/react-uswds';
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import {
   Edit,
   SimpleForm,
@@ -9,25 +9,46 @@ import {
   SaveButton,
   AutocompleteInput,
   ReferenceInput,
-  useRecordContext,
   useRedirect,
   DeleteButton,
   Confirm,
+  useRecordContext,
 } from 'react-admin';
 
 import adminStyles from '../adminStyles.module.scss';
 
 import styles from './RequestedOfficeUserShow.module.scss';
+import RequestedOfficeUserPrivilegeConfirm from './RequestedOfficeUserPrivilegeConfirm';
 
+import { isBooleanFlagEnabled } from 'utils/featureFlags';
 import { RolesPrivilegesCheckboxInput } from 'scenes/SystemAdmin/shared/RolesPrivilegesCheckboxes';
 import { edipiValidator, phoneValidators } from 'scenes/SystemAdmin/shared/form_validators';
 import { deleteOfficeUser, updateRequestedOfficeUser } from 'services/adminApi';
 import { roleTypes } from 'constants/userRoles';
+import { elevatedPrivilegeTypes } from 'constants/userPrivileges';
+import { FEATURE_FLAG_KEYS } from 'shared/constants';
 
 const RequestedOfficeUserShowTitle = () => {
   const record = useRecordContext();
 
   return <span>{`${record?.firstName} ${record?.lastName}`}</span>;
+};
+
+// Helper to filter only SUPERVISOR privileges from a privileges array
+function getFilteredPrivileges(privileges) {
+  return (privileges || []).filter((priv) => priv.privilegeType === elevatedPrivilegeTypes.SUPERVISOR);
+}
+
+// RecordInitializer: Initializes userData and isOfficeUserRequestedPrivileges state from the current record context.
+// Sets userData to the current record and sets isOfficeUserRequestedPrivileges to true if privileges(Supervisor) was requested/exist.
+const RecordInitializer = ({ setUserData, setIsOfficeUserRequestedPrivileges }) => {
+  const record = useRecordContext();
+  useEffect(() => {
+    const filteredPrivileges = getFilteredPrivileges(record?.privileges);
+    setUserData(record || {});
+    setIsOfficeUserRequestedPrivileges(filteredPrivileges.length > 0);
+  }, [record, setUserData, setIsOfficeUserRequestedPrivileges]);
+  return null;
 };
 
 const validateForm = (values) => {
@@ -68,9 +89,16 @@ const RequestedOfficeUserEdit = () => {
   const [validationCheck, setValidationCheck] = useState('');
   const [open, setOpen] = useState(false);
   const [userData, setUserData] = useState({});
-
+  const [checkedPrivileges, setCheckedPrivileges] = useState([]);
+  const [isOfficeUserRequestedPrivileges, setIsOfficeUserRequestedPrivileges] = useState(false);
+  const [isRequestAccountPrivilegesFF, setRequestAccountPrivilegesFF] = useState(false);
   const handleClick = () => setOpen(true);
   const handleDialogClose = () => setOpen(false);
+  const [approveDialogOpen, setApproveDialogOpen] = useState(false);
+
+  useEffect(() => {
+    isBooleanFlagEnabled(FEATURE_FLAG_KEYS.REQUEST_ACCOUNT_PRIVILEGES).then(setRequestAccountPrivilegesFF);
+  }, []);
 
   // rejects the user with all relevant updates made by admin
   // performs validation to ensure the rejection reason was provided
@@ -88,6 +116,7 @@ const RequestedOfficeUserEdit = () => {
         otherUniqueId: user.otherUniqueId,
         rejectionReason: user.rejectionReason,
         roles: user.roles,
+        privileges: user.privileges,
         status: 'REJECTED',
         telephone: user.telephone,
         transportationOfficeId: user.transportationOfficeId,
@@ -119,6 +148,7 @@ const RequestedOfficeUserEdit = () => {
         otherUniqueId: user.otherUniqueId,
         rejectionReason: user.rejectionReason,
         roles: user.roles,
+        privileges: user.privileges,
         status: 'APPROVED',
         telephone: user.telephone,
         transportationOfficeId: user.transportationOfficeId,
@@ -150,6 +180,27 @@ const RequestedOfficeUserEdit = () => {
   const handleConfirm = () => {
     deleteUser();
     setOpen(false);
+  };
+
+  // Approve button success handler
+  const handleOnClickApprove = async (data) => {
+    const filteredPrivileges = getFilteredPrivileges(data.privileges);
+    if (isRequestAccountPrivilegesFF && filteredPrivileges.length > 0 && isOfficeUserRequestedPrivileges) {
+      setUserData(data);
+      setCheckedPrivileges(filteredPrivileges.map((priv) => priv.id));
+      setApproveDialogOpen(true);
+      return;
+    }
+    await approve(data);
+  };
+
+  // Handler for privilege confirmation dialog
+  const handlePrivilegeConfirm = async () => {
+    setApproveDialogOpen(false);
+    // Only include checked privileges in approval, and only SUPERVISOR privilege
+    const filteredPrivileges = getFilteredPrivileges(userData.privileges);
+    const approvedPrivileges = filteredPrivileges.filter((priv) => checkedPrivileges.includes(priv.id)) || [];
+    await approve({ ...userData, privileges: approvedPrivileges });
   };
 
   // rendering tool bar with added error/validation alerts
@@ -210,9 +261,7 @@ const RequestedOfficeUserEdit = () => {
               alwaysEnable
               label="Approve"
               mutationOptions={{
-                onSuccess: async (data) => {
-                  await approve(data);
-                },
+                onSuccess: handleOnClickApprove,
               }}
             />
           </div>
@@ -230,6 +279,23 @@ const RequestedOfficeUserEdit = () => {
         onConfirm={handleConfirm}
         onClose={handleDialogClose}
       />
+
+      <RequestedOfficeUserPrivilegeConfirm
+        dialogId="edit-approve-privilege-dialog"
+        isOpen={approveDialogOpen}
+        privileges={userData?.privileges || []}
+        checkedPrivileges={checkedPrivileges}
+        setCheckedPrivileges={setCheckedPrivileges}
+        onConfirm={handlePrivilegeConfirm}
+        onClose={() => setApproveDialogOpen(false)}
+      />
+
+      {isRequestAccountPrivilegesFF && (
+        <RecordInitializer
+          setUserData={setUserData}
+          setIsOfficeUserRequestedPrivileges={setIsOfficeUserRequestedPrivileges}
+        />
+      )}
       <SimpleForm
         toolbar={renderToolBar()}
         sx={{ '& .MuiInputBase-input': { width: 232 } }}

--- a/src/pages/Admin/RequestedOfficeUsers/RequestedOfficeUserPrivilegeConfirm.jsx
+++ b/src/pages/Admin/RequestedOfficeUsers/RequestedOfficeUserPrivilegeConfirm.jsx
@@ -1,0 +1,84 @@
+import React from 'react';
+import { Confirm } from 'react-admin';
+
+import { elevatedPrivilegeTypes } from 'constants/userPrivileges';
+
+const RequestedOfficeUserPrivilegeConfirm = ({
+  dialogId,
+  isOpen,
+  title = 'Attention: The user has requested the selected privilege(s)',
+  privileges = [],
+  checkedPrivileges = [],
+  setCheckedPrivileges,
+  onConfirm,
+  onClose,
+}) => {
+  const filteredPrivileges = (privileges || []).filter(
+    (priv) => priv.privilegeType === elevatedPrivilegeTypes.SUPERVISOR,
+  );
+
+  return (
+    <Confirm
+      isOpen={isOpen}
+      title={title}
+      content={
+        <div id={dialogId} data-testid="RequestedOfficeUserPrivilegeConfirm">
+          <p id="privilege-dialog-desc" aria-labelledby="privilege-dialog-legend">
+            If the user is not qualified for a selected privilege, please deselect it before approval.
+            <br />
+            If you want to halt the approval process, select Cancel.
+          </p>
+          <fieldset
+            aria-labelledby="privilege-dialog-legend privilege-dialog-desc"
+            aria-describedby="privilege-dialog-desc"
+            style={{ margin: '1rem 0', border: 0, padding: 0 }}
+          >
+            <legend id="privilege-dialog-legend" className="usa-sr-only">
+              Requested privileges
+            </legend>
+            {filteredPrivileges.length > 0 && (
+              <>
+                {filteredPrivileges.map((priv) => (
+                  <div key={priv.id} style={{ display: 'flex', alignItems: 'center', marginBottom: 4 }}>
+                    <input
+                      type="checkbox"
+                      id={`privilege-${priv.id}`}
+                      name="privileges"
+                      value={priv.id}
+                      checked={checkedPrivileges.includes(priv.id)}
+                      aria-labelledby={`privilege-label-${priv.id}`}
+                      aria-describedby="privilege-dialog-desc"
+                      tabIndex={0}
+                      onKeyDown={(e) => {
+                        if (e.key === ' ' || e.key === 'Enter') {
+                          e.preventDefault();
+                          setCheckedPrivileges((prev) =>
+                            prev.includes(priv.id) ? prev.filter((id) => id !== priv.id) : [...prev, priv.id],
+                          );
+                        }
+                      }}
+                      onChange={(e) => {
+                        setCheckedPrivileges((prev) =>
+                          e.target.checked ? [...prev, priv.id] : prev.filter((id) => id !== priv.id),
+                        );
+                      }}
+                    />
+                    <label id={`privilege-label-${priv.id}`} htmlFor={`privilege-${priv.id}`} style={{ marginLeft: 8 }}>
+                      {priv.privilegeName && String(priv.privilegeName).trim().length > 0
+                        ? priv.privilegeName
+                        : 'Supervisor'}
+                    </label>
+                  </div>
+                ))}
+              </>
+            )}
+          </fieldset>
+        </div>
+      }
+      onConfirm={onConfirm}
+      onClose={onClose}
+    />
+  );
+};
+
+export default RequestedOfficeUserPrivilegeConfirm;

--- a/src/pages/Admin/RequestedOfficeUsers/RequestedOfficeUserShow.jsx
+++ b/src/pages/Admin/RequestedOfficeUsers/RequestedOfficeUserShow.jsx
@@ -1,5 +1,5 @@
+import React, { useState, useEffect } from 'react';
 import { Alert, Button, Label, TextInput } from '@trussworks/react-uswds';
-import React, { useState } from 'react';
 import {
   ArrayField,
   Datagrid,
@@ -12,10 +12,19 @@ import {
 } from 'react-admin';
 import { useNavigate } from 'react-router';
 
+import RequestedOfficeUserPrivilegeConfirm from './RequestedOfficeUserPrivilegeConfirm';
 import styles from './RequestedOfficeUserShow.module.scss';
 
+import { isBooleanFlagEnabled } from 'utils/featureFlags';
 import { updateRequestedOfficeUser } from 'services/adminApi';
 import { adminRoutes } from 'constants/routes';
+import { FEATURE_FLAG_KEYS } from 'shared/constants';
+import { elevatedPrivilegeTypes } from 'constants/userPrivileges';
+
+// Helper to filter only SUPERVISOR privileges from a privileges array
+export function getFilteredPrivileges(privileges) {
+  return (privileges || []).filter((priv) => priv.privilegeType === elevatedPrivilegeTypes.SUPERVISOR);
+}
 
 const RequestedOfficeUserShowTitle = () => {
   const record = useRecordContext();
@@ -23,15 +32,29 @@ const RequestedOfficeUserShowTitle = () => {
   return <span>{`${record?.firstName} ${record?.lastName}`}</span>;
 };
 
-const RequestedOfficeUserShowRoles = () => {
+/**
+ * Displays a list of requested roles or privileges for an office user.
+ * If displaying privileges, only shows those with privilegeType 'SUPERVISOR'.
+ * If no items are present after filtering, displays a message indicating none were requested.
+ * Used in the Requested Office User Show view for both roles and privileges.
+ */
+const RequestedOfficeUserShowRolesPrivileges = ({ recordSource, recordLabel, recordField }) => {
   const record = useRecordContext();
-  if (!record?.roles) return <p>This user has not requested any roles.</p>;
+  const sourceLabel = typeof recordSource === 'string' ? recordSource.toLowerCase() : '';
+  if (!record?.[recordSource]) return <p>{`This user has not requested any ${sourceLabel}.`}</p>;
+  let items = record[recordSource] || [];
+  if (recordSource === 'privileges') {
+    items = getFilteredPrivileges(items);
+  }
+  if (!items.length) return <p>{`This user has not requested any ${sourceLabel}.`}</p>;
 
   return (
-    <ArrayField source="roles">
-      <span>Requested roles:</span>
-      <Datagrid bulkActionButtons={false}>
-        <TextField source="roleName" />
+    <ArrayField source={recordSource} record={{ ...record, [recordSource]: items }}>
+      <span id={`${recordSource}-label`}>
+        <strong>{recordLabel}:</strong>
+      </span>
+      <Datagrid bulkActionButtons={false} aria-labelledby={`${recordSource}-label`}>
+        <TextField source={recordField} />
       </Datagrid>
     </ArrayField>
   );
@@ -44,9 +67,15 @@ const RequestedOfficeUserActionButtons = () => {
   const [serverError, setServerError] = useState('');
   const [rejectionReason, setRejectionReason] = useState('');
   const [rejectionReasonCheck, setRejectionReasonCheck] = useState('');
+  const [approveDialogOpen, setApproveDialogOpen] = useState(false);
+  const [checkedPrivileges, setCheckedPrivileges] = useState([]);
   const navigate = useNavigate();
   const record = useRecordContext();
+  const [isRequestAccountPrivilegesFF, setRequestAccountPrivilegesFF] = useState(false);
 
+  useEffect(() => {
+    isBooleanFlagEnabled(FEATURE_FLAG_KEYS.REQUEST_ACCOUNT_PRIVILEGES).then(setRequestAccountPrivilegesFF);
+  }, []);
   // if approved here, all values are good, but we want to change status to APPROVED
   const approve = async (user) => {
     setRejectionReasonCheck('');
@@ -59,6 +88,7 @@ const RequestedOfficeUserActionButtons = () => {
       otherUniqueId: user.otherUniqueId,
       rejectionReason: null,
       roles: user.roles,
+      privileges: user.privileges,
       status: 'APPROVED',
       telephone: user.telephone,
       transportationOfficeId: user.transportationOfficeId,
@@ -86,6 +116,7 @@ const RequestedOfficeUserActionButtons = () => {
         otherUniqueId: user.otherUniqueId,
         rejectionReason: rejectionReasonInput,
         roles: user.roles,
+        privileges: user.privileges,
         status: 'REJECTED',
         telephone: user.telephone,
         transportationOfficeId: user.transportationOfficeId,
@@ -98,6 +129,26 @@ const RequestedOfficeUserActionButtons = () => {
           setServerError(error);
         });
     }
+  };
+
+  // Handler for privilege confirmation dialog
+  const handlePrivilegeConfirm = async () => {
+    setApproveDialogOpen(false);
+    // Only include checked privileges in approval, and only SUPERVISOR privilege
+    const filteredPrivileges = getFilteredPrivileges(record.privileges);
+    const approvedPrivileges = filteredPrivileges.filter((priv) => checkedPrivileges.includes(priv.id)) || [];
+    await approve({ ...record, privileges: approvedPrivileges });
+  };
+
+  // Handler for Approve button click
+  const handleOnClickApprove = () => {
+    const filteredPrivileges = getFilteredPrivileges(record.privileges);
+    if (isRequestAccountPrivilegesFF && filteredPrivileges.length) {
+      setCheckedPrivileges(filteredPrivileges.map((priv) => priv.id));
+      setApproveDialogOpen(true);
+      return;
+    }
+    approve(record);
   };
 
   return (
@@ -113,9 +164,11 @@ const RequestedOfficeUserActionButtons = () => {
         </Alert>
       )}
       <div className={styles.rejectionInput}>
-        <Label>Rejection reason (required if rejecting)</Label>
+        <Label htmlFor="show-rejection-reason-input">Rejection reason (required if rejecting)</Label>
         <TextInput
+          id="show-rejection-reason-input"
           label="Rejection reason"
+          aria-label="Rejection reason"
           source="rejectionReason"
           value={rejectionReason}
           onChange={(e) => {
@@ -134,20 +187,29 @@ const RequestedOfficeUserActionButtons = () => {
         >
           Reject
         </Button>
-        <Button
-          className={styles.approveBtn}
-          onClick={async () => {
-            await approve(record);
-          }}
-        >
+        <Button className={styles.approveBtn} onClick={handleOnClickApprove}>
           Approve
         </Button>
       </div>
+      <RequestedOfficeUserPrivilegeConfirm
+        dialogId="show-approve-privilege-dialog"
+        isOpen={approveDialogOpen}
+        privileges={record?.privileges || []}
+        checkedPrivileges={checkedPrivileges}
+        setCheckedPrivileges={setCheckedPrivileges}
+        onConfirm={handlePrivilegeConfirm}
+        onClose={() => setApproveDialogOpen(false)}
+      />
     </>
   );
 };
 
 const RequestedOfficeUserShow = () => {
+  const [isRequestAccountPrivilegesFF, setRequestAccountPrivilegesFF] = useState(false);
+  useEffect(() => {
+    isBooleanFlagEnabled(FEATURE_FLAG_KEYS.REQUEST_ACCOUNT_PRIVILEGES).then(setRequestAccountPrivilegesFF);
+  }, []);
+
   return (
     <Show title={<RequestedOfficeUserShowTitle />}>
       <SimpleShowLayout>
@@ -161,7 +223,18 @@ const RequestedOfficeUserShow = () => {
         <TextField source="telephone" />
         <TextField source="edipi" label="DODID#" />
         <TextField source="otherUniqueId" label="Other unique Id" />
-        <RequestedOfficeUserShowRoles />
+        <RequestedOfficeUserShowRolesPrivileges
+          recordSource="roles"
+          recordLabel="Requested roles"
+          recordField="roleName"
+        />
+        {isRequestAccountPrivilegesFF && (
+          <RequestedOfficeUserShowRolesPrivileges
+            recordSource="privileges"
+            recordLabel="Requested privileges"
+            recordField="privilegeName"
+          />
+        )}
         <ReferenceField label="Transportation Office" source="transportationOfficeId" reference="offices" sortBy="name">
           <TextField component="pre" source="name" />
         </ReferenceField>

--- a/src/pages/Admin/RequestedOfficeUsers/RequestedOfficeUserShow.module.scss
+++ b/src/pages/Admin/RequestedOfficeUsers/RequestedOfficeUserShow.module.scss
@@ -2,14 +2,22 @@
 
 .btnContainer {
     display: flex;
-    justify-content: flex-end;
+    justify-content: flex-start;
     align-self: center;
     gap: 10px;
 
     .approveBtn {
-        background-color: $color-blue;
+        width: 100px;
         height: 38px;
-        min-width: 120px;
+        margin-left: 15px;
+        background-color: $primary;
+
+        &:active,
+        &:hover,
+        &:focus {
+          background-color:  $primary;
+          opacity: 80%;
+        }
     }
 
     .rejectBtn {

--- a/src/scenes/SystemAdmin/Home.jsx
+++ b/src/scenes/SystemAdmin/Home.jsx
@@ -106,7 +106,7 @@ const theme = deepmerge(defaultTheme, {
             opacity: '0.8',
           },
           '&:visited': {
-            color: '#FFFFF',
+            color: '##2491ff !important',
           },
         },
       },
@@ -143,6 +143,7 @@ const theme = deepmerge(defaultTheme, {
             color: '#fff',
             '&:hover': {
               opacity: '0.8',
+              backgroundColor: '#1a4480',
             },
           },
           '& .MuiDialogActions-root > button:nth-of-type(1)': {

--- a/swagger-def/admin.yaml
+++ b/swagger-def/admin.yaml
@@ -931,6 +931,10 @@ definitions:
         type: array
         items:
           $ref: '#/definitions/OfficeUserRole'
+      privileges:
+        type: array
+        items:
+          $ref: '#/definitions/OfficeUserPrivilege'
       transportationOfficeId:
         type: string
         format: uuid

--- a/swagger/admin.yaml
+++ b/swagger/admin.yaml
@@ -938,6 +938,10 @@ definitions:
         type: array
         items:
           $ref: '#/definitions/OfficeUserRole'
+      privileges:
+        type: array
+        items:
+          $ref: '#/definitions/OfficeUserPrivilege'
       transportationOfficeId:
         type: string
         format: uuid


### PR DESCRIPTION
## [B-23333](https://www13.v1host.com/USTRANSCOM38/story.mvc/Summary?oidToken=Story%3A1098292&RoomContext=TeamRoom%3A1007470&concept=TeamRoom)

## Summary
These changes adds the functionality for an **Admin user** **Approving** a  **Requested Office User** requesting a **Supervisor** privilege. When an office user requests an account with supervisor privilege we want to prompt the Admin user upon clicking the Approve button before confirming the approval. 
They will have the ability to reject(uncheck) the privilege being requested before approving or approve the request with the requested privilege.
Is there anything you would like reviewers to give additional scrutiny?

[this article](tbd) explains more about the approach used.

## Verification Steps for the Author

These are to be checked by the author.

- [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
- [ ] Have the Agility acceptance criteria been met for this change?

## Verification Steps for Reviewers

These are to be checked by a reviewer.

- [ ] Has the branch been pulled in and checked out?
- [ ] Have the BL acceptance criteria been met for this change?
- [ ] Was the CircleCI build successful?
- [ ] Has the code been reviewed from a standards and best practices point of view?

### Setup to Run the Code

- [Instructions for starting storybook](https://transcom.github.io/mymove-docs/docs/frontend/setup/storybook)
- [Instructions for starting the MilMove application](https://transcom.github.io/mymove-docs/docs/getting-started/application-setup/)
- [Instructions for running tests](https://transcom.github.io/mymove-docs/docs/getting-started/development/testing)

### How to test
**FEATURE_FLAG_REQUEST_ACCOUNT_PRIVILEGES=true**
 **Requested office user **View / Edit****
1. Access the Office app
2. Click "Request Account"
3. Fill out all the required fields , select "Supervisor" privilege and Submit.
4. Access the Admin app and login as an admin user
5. Navigate to the "Requested Office Users" page and click on the Office user requested in 1-3 (you can search for it e.g by email).
6. On the Requested Office Users "Show" page, "Requested privileges:" section should display with the requested privilege (i.e Supervisor)
7. Click on the "Approve" button
8. The confirmation dialog opens with checkbox (Supervisor) checked.
9. Uncheck the selected privilege "Supervisor" and click the Confirm button
10. Navigate to the "Office Users" page, search for that record and  click on it.
11. On the Office Users  page (show and edit), verify the privilege "Supervisor" is **NOT Assigned** to the office user.
12. Repeat steps 1-8, this time **DO NOT** uncheck the checkbox (Supervisor) and click the confirm button.
13. Navigate to the "Office Users" page, search for that record and  click on it.
14. On the Office Users page (show and edit), verify the privilege "Supervisor" **is Assigned**  to the office user.

**Regression Test**
**NOTE**: Repeat the above steps WITHOUT selecting a privilege (i.e Supervisor) when requesting the account. 
1. Verify clicking the approve button do not open the dialog and also the Office user is not assigned a privilege.
2. Edit,  check the "Supervisor" checkbox and approve ( Should not open the dialog and also verify the office user is assigned the privilege)
**NOTE**: Test out when FEATURE_FLAG_REQUEST_ACCOUNT_PRIVILEGES=false you shouldn't be able to request a privilege so we don't want dialog to open when the "Approve" button is clicked. 
### Frontend

- [ ] There are no aXe warnings for UI.
- [ ] This works in [Supported Browsers and their phone views](https://transcom.github.io/mymove-docs/docs/adrs/Browser-Support/#minimum-browser-requirements) (Chrome, Firefox, Edge).
- [ ] There are no new console errors in the browser devtools.
- [ ] There are no new console errors in the test output.
- [ ] If this PR adds a new component to Storybook, it ensures the component is fully responsive, OR if it is intentionally not, a wrapping div using the `officeApp` class or custom `min-width` styling is used to hide any states the would not be visible to the user.
- [ ] This change meets the standards for [Section 508 compliance](https://www.ssa.gov/accessibility/andi/help/install.html).

### Backend

- [ ] Code follows the guidelines for [Logging](https://transcom.github.io/mymove-docs/docs/getting-started/development/logging).
- [ ] The requirements listed in [Querying the Database Safely](https://transcom.github.io/mymove-docs/docs/backend/guides/golang-guide#querying-the-database-safely) have been satisfied.

### Database

#### Any new migrations/schema changes:

- [ ] Follows our guidelines for [Zero-Downtime Deploys](https://transcom.github.io/mymove-docs/docs/backend/setup/database-migrations#zero-downtime-migrations).
- [ ] Have been communicated to #g-database.
- [ ] Secure migrations have been tested following the instructions in our [docs](https://transcom.github.io/mymove-docs/docs/backend/setup/database-migrations#secure-migrations).

## Screenshots

https://github.com/user-attachments/assets/f87a99e9-2ec0-461f-b812-77c444884227

![B-23333-show-no-priv-requested](https://github.com/user-attachments/assets/c8856261-652b-49f8-94d5-38e3c1b14320)
![B-23333-show-requested-dialog](https://github.com/user-attachments/assets/580f791c-b1d8-4de9-846f-1084331d857b)
![B-23333-show-requested-section](https://github.com/user-attachments/assets/747fd84d-477e-4c03-9a67-fb733736cbdd)
![B-23333-edit-requested](https://github.com/user-attachments/assets/9770d5b3-a3f3-42cb-8b19-90c6ff5b108d)
![B-23333-edit-requested-dialog](https://github.com/user-attachments/assets/879de403-fab8-4e5b-bb72-23d37a8cf460)
