### PR TITLE
B23301-INT-KB1B-Split backup contact name

### DIFF
--- a/migrations/app/ddl_migrations/ddl_tables/20250528192635_tbl_backup_contacts.up.sql
+++ b/migrations/app/ddl_migrations/ddl_tables/20250528192635_tbl_backup_contacts.up.sql
@@ -7,5 +7,15 @@ ALTER TABLE backup_contacts
 COMMENT ON COLUMN backup_contacts.first_name IS 'First name of the backup contact';
 COMMENT ON COLUMN backup_contacts.last_name IS 'Last name of the backup contact';
 
-ALTER TABLE backup_contacts
-ALTER COLUMN name DROP NOT NULL;
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1
+        FROM information_schema.columns
+        WHERE table_name = 'backup_contacts'
+        AND column_name = 'name'
+        AND is_nullable = 'NO'
+    ) THEN
+        EXECUTE 'ALTER TABLE backup_contacts ALTER COLUMN name DROP NOT NULL';
+    END IF;
+END $$ LANGUAGE plpgsql;

--- a/src/components/Office/DefinitionLists/CustomerInfoList.jsx
+++ b/src/components/Office/DefinitionLists/CustomerInfoList.jsx
@@ -6,17 +6,14 @@ import styles from './OfficeDefinitionLists.module.scss';
 import { BackupContactShape } from 'types/backupContact';
 import descriptionListStyles from 'styles/descriptionList.module.scss';
 import { AddressShape } from 'types/address';
-import { formatCustomerContactFullAddress, formatLastNameFirstName } from 'utils/formatters';
+import { formatCustomerContactFullAddress } from 'utils/formatters';
 import departmentIndicators from 'constants/departmentIndicators';
 
 const CustomerInfoList = ({ customerInfo }) => {
   const emDash = '\u2014';
 
-  const lastNameFirstName = formatLastNameFirstName(
-    customerInfo.backupContact?.firstName,
-    customerInfo.backupContact?.lastName,
-  );
-  const backupContactName = lastNameFirstName.length > 0 ? lastNameFirstName : emDash;
+  const fullName = `${customerInfo.backupContact?.firstName} ${customerInfo.backupContact?.lastName}`.trim();
+  const backupContactName = fullName.length > 0 ? fullName : emDash;
 
   return (
     <div className={styles.OfficeDefinitionLists}>

--- a/src/components/Office/DefinitionLists/CustomerInfoList.test.jsx
+++ b/src/components/Office/DefinitionLists/CustomerInfoList.test.jsx
@@ -59,7 +59,7 @@ describe('CustomerInfoList', () => {
 
   it('renders formatted backup contact name', () => {
     render(<CustomerInfoList customerInfo={info} />);
-    expect(screen.getByText('Ocampo, Quinn')).toBeInTheDocument();
+    expect(screen.getByText('Quinn Ocampo')).toBeInTheDocument();
   });
 
   it('renders formatted backup contact email', () => {

--- a/src/components/Office/DetailsPanel/DetailsPanel.stories.jsx
+++ b/src/components/Office/DetailsPanel/DetailsPanel.stories.jsx
@@ -127,7 +127,8 @@ const info = {
     postalCode: '78234',
   },
   backupContact: {
-    name: 'Quinn Ocampo',
+    firstName: 'Quinn',
+    lastName: 'Ocampo',
     email: 'quinnocampo@myemail.com',
     phone: '999-999-9999',
   },


### PR DESCRIPTION
## Agility ticket
[B23301](https://www13.v1host.com/USTRANSCOM38/assetdetail.v1?number=B-23301)

## Previous INT PR's:
[15615](https://github.com/transcom/mymove/pull/15615)
[15712](https://github.com/transcom/mymove/pull/15712)

## Issue:
[I-14320](https://www13.v1host.com/USTRANSCOM38/Issue.mvc/Summary?oidToken=Issue%3A1119294)

## Summary
!!Note:  This is a recreation of int pr 15712 ("B23301-INT-KB1-Split backup contact name").  The branch got corrupted and had to be recreated by copying integrationTesting and remerging the main with the changes.

As an office user, on the move details tab, this changes set the backup contact name to "first name last name" format.

### How to test
Setup:
* none

Testing
* As a customer, create a ppm move and submit it.
* As a SC, open the move and go to the "Move Details" tab.  Confirm the backup contact name is in the format:  first name last name.
